### PR TITLE
[P0/mid] fix(sf): pass --correlation-id to every krepis ssm_log_capture call

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -569,7 +569,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -739,7 +739,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -1149,7 +1149,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "21600"
                   ]
@@ -2217,7 +2217,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2541,7 +2541,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train.sh --model-zoo-spec {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]
@@ -2702,7 +2702,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_train.sh --model-zoo-select{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2994,7 +2994,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -3139,7 +3139,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -3284,7 +3284,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -3429,7 +3429,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -3574,7 +3574,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity{}',$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -215,7 +215,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --slug snapshot --log /var/log/snapshot.log -- python executor/snapshot_capturer.py --date {}', $.run_date))",
+          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --correlation-id {} --slug snapshot --log /var/log/snapshot.log -- python executor/snapshot_capturer.py --date {}', $$.Execution.Name, $.run_date))",
           "executionTimeout": [
             "120"
           ]
@@ -346,7 +346,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --slug eod --log /var/log/eod.log -- python executor/eod_reconcile.py --date {}', $.run_date))",
+          "commands.$": "States.Array('set -o pipefail', 'cd /home/ec2-user/alpha-engine', 'export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1', 'export ALPHA_ENGINE_DEPLOYED=1', 'export FLOW_DOCTOR_ENABLED=1', 'source .venv/bin/activate', States.Format('python -m krepis.ssm_log_capture run --correlation-id {} --slug eod --log /var/log/eod.log -- python executor/eod_reconcile.py --date {}', $$.Execution.Name, $.run_date))",
           "executionTimeout": [
             "600"
           ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,4 +69,14 @@ nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nouse
 # directly (not via a nousergon-lib bump, which would drag the in-flight,
 # 7/3-cutover SF-rename refs in lib 0.74.0 into this repo). Floor guarantees
 # the upgrade even on a non-fresh venv.
-krepis>=0.14.0
+#
+# Floor raised to 0.18.8 (2026-07-27): the weekly + EOD SF definitions now pass
+# `--correlation-id` to `krepis.ssm_log_capture run`, an argument that does not
+# exist before 0.18.8 — an older krepis rejects it with `unrecognized
+# arguments` and the stage dies at launch. The floor is what makes the
+# definition's use of the flag safe; without it a non-fresh venv (verified: a
+# local 0.16.2 venv still satisfied `>=0.14.0`) resolves to a krepis that
+# cannot run the commands the SF emits. 0.18.8 is also the version that made
+# the correlation id MANDATORY (`run` exits 2 without it), so this floor pins
+# both halves of the same contract. See tests/test_sf_krepis_correlation_id.py.
+krepis>=0.18.8

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -6,7 +6,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtest.sh --mode=param-sweep --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "DataPhase1": [
     "set -eo pipefail",
@@ -14,7 +14,7 @@
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
@@ -31,7 +31,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator --log /var/log/evaluator.log -- bash infrastructure/spot_backtest.sh --no-pit-parity --skip-stages=backtest,parity"
   ],
   "MorningEnrich": [
     "set -eo pipefail",
@@ -39,7 +39,7 @@
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_data_weekly.sh --morning-enrich-only"
   ],
   "Parity": [
     "set -eo pipefail",
@@ -48,7 +48,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity --log /var/log/parity.log -- bash infrastructure/spot_backtest.sh --pit-parity-enabled=1 --skip-stages=backtest,evaluator"
   ],
   "PortfolioOptimizerBacktest": [
     "set -eo pipefail",
@@ -57,7 +57,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_backtest.sh --mode=portfolio-optimizer-backtest --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "PredictorBacktest": [
     "set -eo pipefail",
@@ -66,7 +66,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_backtest.sh --mode=predictor-backtest --no-pit-parity --skip-stages=parity,evaluator"
   ],
   "PredictorTraining": [
     "set -eo pipefail",
@@ -78,13 +78,13 @@
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
     "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_train.sh --full-only"
   ],
   "RAGIngestion": [
     "set -eo pipefail",
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_data_weekly.sh --rag-only"
   ]
 }

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -301,12 +301,24 @@ def _eval_intrinsic_args(s: str) -> list[str]:
     return args
 
 
+# Context-object values the spot commands reference via `$$.`. Bound to a
+# stable sentinel so byte-identity comparisons stay deterministic; the real
+# value is the SF execution name, which krepis uses as the correlation id
+# (see tests/test_sf_krepis_correlation_id.py).
+_CONTEXT_OBJECT = {"Execution.Name": "test-execution-name"}
+
+
 def _eval_expr(e: str, ctx: dict):
     """Resolve the subset of ASL intrinsics the spot commands.$ use:
-    string literals, $.var refs, States.Array(...), States.Format(...)."""
+    string literals, $.var refs, $$.context refs, States.Array(...),
+    States.Format(...)."""
     e = e.strip()
     if e.startswith("'") and e.endswith("'"):
         return e[1:-1].replace("\\'", "'")
+    if e.startswith("$$."):
+        key = e[3:]
+        assert key in _CONTEXT_OBJECT, f"unbound context-object ref: {e}"
+        return _CONTEXT_OBJECT[key]
     if e.startswith("$."):
         return ctx[e[2:]]
     if e.startswith("States.Array("):
@@ -390,6 +402,16 @@ def orig_spot_cmds() -> dict:
       scope). `MorningEnrich`/`DataPhase1`/`RAGIngestion` are unchanged
       (they invoke `spot_data_weekly.sh`, which self-exports the region via
       its own `ENV_SOURCE` heredoc and never sourced `.env` directly).
+
+    - **Regenerated 2026-07-27** as part of the krepis `--correlation-id`
+      fix. krepis 0.18.8 made the correlation id mandatory (`run` exits 2
+      without `--correlation-id` or `$RUN_TOKEN`), which failed all 11
+      weekly SSM workload states on 2026-07-25. Every krepis call now
+      passes `--correlation-id {}` bound to `$$.Execution.Name`, so the
+      resolved command gains that argument immediately after `run`.
+      `_eval_expr` learned the `$$.` context-object form; the baseline
+      resolves it via `_CONTEXT_OBJECT` so byte-identity stays
+      deterministic. See `tests/test_sf_krepis_correlation_id.py`.
 
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
@@ -727,6 +749,7 @@ class TestByteIdenticalAbsentPath:
         expected = (
             "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python "
             "-m krepis.ssm_log_capture run "
+            f"--correlation-id {_CONTEXT_OBJECT['Execution.Name']} "
             f"--slug {slug} --log {log} -- "
             f"{token} --preflight-only"
         )

--- a/tests/test_sf_krepis_correlation_id.py
+++ b/tests/test_sf_krepis_correlation_id.py
@@ -1,0 +1,142 @@
+"""Every SF krepis ``ssm_log_capture run`` call must pass ``--correlation-id``.
+
+Bug class this guards (2026-07-25 weekly-SF incident): krepis 0.18.8 made the
+correlation id mandatory — ``ssm_log_capture run`` exits 2 when neither
+``--correlation-id`` nor ``$RUN_TOKEN`` is present. No SF definition passed
+either, so all 11 weekly SSM workload states failed at launch. The pipeline
+burned 8h26m and 20 operator reruns before completing degraded.
+
+The incident was unblocked by setting ``RUN_TOKEN`` in the dashboard box's
+systemd manager environment (``systemctl set-environment``). That value lives
+**in memory only** — nothing under ``/etc/systemd/`` persists it — so the next
+reboot or SSM-agent replacement reproduces the failure exactly. Depending on
+box-local environment state for a hard CLI precondition is the defect; passing
+the argument from the definition is the fix.
+
+``$$.Execution.Name`` is the correlation value: krepis uses it as the S3 log
+key suffix (``{hostname}-{HHMMSSZ}-{correlation_id}.log``) and as a
+``# correlation-id:`` header line, so keying on the execution name groups every
+stage's logs under the run that produced them — including reruns, which get
+their own name and therefore their own log set.
+
+This test walks the definitions themselves rather than pinning strings, so a
+newly-added SSM workload state is covered automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INFRA = _REPO_ROOT / "infrastructure"
+
+# Every state-machine definition in this repo. A definition with no krepis
+# call simply yields no sites — it is not an error.
+_SF_DEFINITIONS = [
+    _INFRA / "step_function.json",
+    _INFRA / "step_function_daily.json",
+    _INFRA / "step_function_eod.json",
+    _INFRA / "step_function_groom.json",
+]
+
+_KREPIS_CALL = "ssm_log_capture run"
+_STATES_FORMAT = re.compile(r"States\.Format\('((?:[^'\\]|\\.)*)'((?:,\s*[^,()]+)*)\)")
+
+
+def _iter_command_sites(node, definition: str, path: str = ""):
+    """Yield (definition, state, command_string) for every krepis SSM command."""
+    if isinstance(node, dict):
+        for key, val in node.items():
+            if (
+                key == "commands.$"
+                and isinstance(val, str)
+                and _KREPIS_CALL in val
+            ):
+                state = path.split("/States/")[-1].split("/")[0] or path
+                yield definition, state, val
+            else:
+                yield from _iter_command_sites(val, definition, f"{path}/{key}")
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            yield from _iter_command_sites(item, definition, f"{path}[{i}]")
+
+
+def _all_sites():
+    sites = []
+    for path in _SF_DEFINITIONS:
+        if not path.exists():
+            continue
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        sites.extend(_iter_command_sites(doc, path.name))
+    return sites
+
+
+_SITES = _all_sites()
+
+
+def test_definitions_contain_krepis_sites():
+    """Guard the guard: if the walker stops finding sites, this test is inert."""
+    assert _SITES, "no krepis ssm_log_capture sites found — walker or definitions changed"
+
+
+@pytest.mark.parametrize(
+    "definition,state,command",
+    _SITES,
+    ids=[f"{d}:{s}" for d, s, _ in _SITES],
+)
+def test_krepis_call_passes_correlation_id(definition: str, state: str, command: str):
+    """Each krepis invocation passes --correlation-id explicitly.
+
+    ``$RUN_TOKEN`` is deliberately NOT accepted as a substitute here: it is the
+    box-local environment dependency the 2026-07-25 incident proved fragile.
+    """
+    assert "--correlation-id" in command, (
+        f"{definition}:{state} invokes `{_KREPIS_CALL}` without --correlation-id. "
+        "krepis exits 2 without it; do not rely on $RUN_TOKEN being set on the box."
+    )
+
+
+@pytest.mark.parametrize(
+    "definition,state,command",
+    _SITES,
+    ids=[f"{d}:{s}" for d, s, _ in _SITES],
+)
+def test_correlation_id_is_the_execution_name(definition: str, state: str, command: str):
+    """The correlation value is the SF execution name, not a static literal.
+
+    A static token would collide across runs in the S3 log key, defeating the
+    grouping the correlation id exists to provide.
+    """
+    assert "--correlation-id {}" in command, (
+        f"{definition}:{state} does not pass --correlation-id as a States.Format "
+        "placeholder — a hardcoded correlation id collides across runs"
+    )
+    assert "$$.Execution.Name" in command, (
+        f"{definition}:{state} passes --correlation-id but not $$.Execution.Name"
+    )
+
+
+@pytest.mark.parametrize(
+    "definition,state,command",
+    _SITES,
+    ids=[f"{d}:{s}" for d, s, _ in _SITES],
+)
+def test_states_format_arity_matches(definition: str, state: str, command: str):
+    """Every States.Format placeholder count equals its argument count.
+
+    Inserting a leading placeholder without prepending its argument yields a
+    States.Runtime error at execution time, not at deploy time — exactly the
+    class that killed two reruns during the incident.
+    """
+    for match in _STATES_FORMAT.finditer(command):
+        template, raw_args = match.group(1), match.group(2)
+        placeholders = template.count("{}")
+        args = [a for a in raw_args.split(",") if a.strip()]
+        assert placeholders == len(args), (
+            f"{definition}:{state} States.Format arity mismatch — "
+            f"{placeholders} placeholder(s) vs {len(args)} argument(s): {args}"
+        )

--- a/tests/test_sf_krepis_correlation_id.py
+++ b/tests/test_sf_krepis_correlation_id.py
@@ -44,7 +44,11 @@ _SF_DEFINITIONS = [
 ]
 
 _KREPIS_CALL = "ssm_log_capture run"
-_STATES_FORMAT = re.compile(r"States\.Format\('((?:[^'\\]|\\.)*)'((?:,\s*[^,()]+)*)\)")
+# NOTE: no `\s*` after the comma — `[^,()]+` already matches spaces, and having
+# both makes the argument-list group ambiguous, which CodeQL correctly flags as
+# exponential backtracking (py/redos). Leading whitespace on each argument is
+# stripped in code instead.
+_STATES_FORMAT = re.compile(r"States\.Format\('((?:[^'\\]|\\.)*)'((?:,[^,()]+)*)\)")
 
 
 def _iter_command_sites(node, definition: str, path: str = ""):


### PR DESCRIPTION
**Priority:** P0 · **Complexity:** mid

Root-cause fix for the headline failure of the 2026-07-25 weekly SF incident (8h26m to first failure, 20 operator reruns, degraded completion).

## The defect

krepis 0.18.8 made the correlation id **mandatory** — `ssm_log_capture run` exits 2 when neither `--correlation-id` nor `$RUN_TOKEN` is present. No SF definition passed either, so all 11 weekly SSM workload states died at launch.

The incident was unblocked by `systemctl set-environment RUN_TOKEN=...` on the dashboard box. **That value lives in memory only** — verified live: `systemctl show-environment` reports it, and nothing under `/etc/systemd/` persists it. The next reboot or SSM-agent replacement reproduces the failure exactly. Depending on box-local environment state for a hard CLI precondition is the defect; passing the argument from the definition is the fix.

## What changed

| File | Change |
|---|---|
| `infrastructure/step_function.json` | All 11 krepis sites pass `--correlation-id {}` bound to `$$.Execution.Name` |
| `infrastructure/step_function_eod.json` | Same fix for `CaptureSnapshot` + `EODReconcile` — same latent defect, **not yet fired** |
| `requirements.txt` | krepis floor `0.14.0` → `0.18.8` |
| `tests/test_sf_krepis_correlation_id.py` | New structural guard (new file) |
| `tests/test_sf_friday_shell_run_wiring.py` | `_eval_expr` learns `$$.`; golden fixture regenerated per its stated contract |

**Why `$$.Execution.Name`:** krepis uses the correlation id as the S3 log key suffix (`{hostname}-{HHMMSSZ}-{id}.log`) and as a `# correlation-id:` header. Keying on the execution name groups every stage's logs under the run that produced them, and each rerun gets its own set. A static literal would collide across runs and defeat the grouping.

**Why the floor bump is part of the fix, not housekeeping:** `--correlation-id` does not exist before 0.18.8. Without the floor, the definition emits a flag an older krepis rejects with `unrecognized arguments` — trading one launch failure for another. Verified concretely: a local venv on krepis 0.16.2 still satisfied `>=0.14.0` and rejects the flag. 0.18.8 is also the release that made the id mandatory, so the floor pins both halves of one contract.

**Why EOD is in scope:** the same defect exists in `ne-postclose-trading-pipeline` and simply hasn't fired yet. Fixing the class rather than the one consumer that happened to break.

## Verification

- `aws stepfunctions validate-state-machine-definition` → `OK`, 0 diagnostics, on **both** changed definitions.
- New guard is provably non-inert: **26 failed / 14 passed** on the unpatched tree, **40/40 passed** patched.
- Dashboard box confirmed live on krepis **0.18.8** with `--correlation-id` supported — the fix is safe against what is actually deployed.
- `test_ssm_log_capture_wrapper_executes.py` passes 3/3 against a clean venv at the new floor (it fails on a stale local venv at 0.16.2 — that failure is the floor doing its job).
- Full suite: **3653 passed**, 8 skipped. The 4 local failures are stale-venv artifacts, not regressions: 2 need krepis ≥0.18.8 (this PR's floor), 2 need `nousergon-lib` v0.124.9 (already pinned in `requirements.txt`; local venv had 0.124.6). CI installs at the pins.

## Deploy

Merge button alone. `deploy-infrastructure.sh` stamps and updates all four state machines on every push to `main` — no post-merge step.

## Not covered here

The structural items from the same audit — splitting `spot_backtest.sh` (alpha-engine-config-I4442), wiring `sf_preflight.py` into the pipeline, and the IAM/memory preflight classes — are filed separately against epic `alpha-engine-config-I2283`. Policy context: `nous-ergon-ops` PR #63.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)