### PR TITLE
[P0/mid] fix(deploy): converge data-collector Lambda memory/timeout on every deploy

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -4,8 +4,25 @@
 # Container image deployment (ECR) — same pattern as research + predictor.
 # Function: alpha-engine-data-collector
 #   - Timeout: 600s (10 min, ~30 tickers of alternative data)
-#   - Memory: 512 MB
+#   - Memory: 1024 MB (see LAMBDA_MEMORY_MB below)
 #   - Triggered by Step Functions (Saturday pipeline)
+#
+# Memory/timeout are applied on EVERY deploy, not just on create (2026-07-27).
+# Previously they were passed only to `create-function`, so on an existing
+# function the values were whatever someone last set by hand — un-versioned
+# live state that silently drifts from this file.
+#
+# That drift caused the 2026-07-25 DataPhase2 failure. Memory had been raised
+# to 1024 MB on $LATEST, but `publish-version` snapshots configuration at
+# publish time and the `live` alias still pointed at version 269 — published
+# at 512 MB. The Saturday SF invokes `alpha-engine-data-collector:live`, so it
+# kept running at 512 MB and hit Runtime.OutOfMemory twice (REPORT lines show
+# maxMemoryUsed == memorySize == 512 on two ~460s invocations). The raise was
+# real, and completely invisible to the pipeline.
+#
+# Hence the ordering below: update code -> wait -> update CONFIG -> wait ->
+# publish-version -> repoint alias. Configuration must land on $LATEST before
+# the version is cut, or the alias serves a version that never saw it.
 #
 # Prerequisites:
 #   1. AWS CLI configured with appropriate credentials
@@ -24,6 +41,18 @@ set -euo pipefail
 FUNCTION_NAME="alpha-engine-data-collector"
 REGION="${AWS_REGION:-us-east-1}"
 BUCKET="alpha-engine-research"
+
+# Declared runtime envelope — the single source of truth for this function's
+# memory/timeout. Overridable for one-off experiments, but the committed
+# default is what every deploy converges the live function to.
+#
+# 1024 MB: phase-2 invocations OOM'd at 512 MB (2026-07-25). Non-phase-2 runs
+# sit at 236-341 MB observed, so 512 was adequate for them and masked the
+# phase-2 requirement. Sized at 2x the OOM ceiling rather than a hair above it
+# because the OOM'd invocations were also running ~460s of a 600s timeout, and
+# Lambda scales CPU with memory — the headroom buys margin on both axes.
+LAMBDA_MEMORY_MB="${LAMBDA_MEMORY_MB:-1024}"
+LAMBDA_TIMEOUT="${LAMBDA_TIMEOUT:-600}"
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION" 2>/dev/null || echo "ACCOUNT_ID")
 ROLE_ARN="${LAMBDA_ROLE_ARN:-arn:aws:iam::${ACCOUNT_ID}:role/alpha-engine-data-role}"
@@ -63,6 +92,18 @@ if aws lambda get-function --function-name "$FUNCTION_NAME" --region "$REGION" &
       --function-name "$FUNCTION_NAME" \
       --image-uri "$IMAGE_URI" \
       --region "$REGION" > /dev/null
+
+    # Converge configuration to the declared envelope on every deploy. Must
+    # complete BEFORE publish-version below, which snapshots $LATEST's config
+    # into the version the `live` alias will serve.
+    aws lambda wait function-updated \
+      --function-name "$FUNCTION_NAME" --region "$REGION" 2>/dev/null || sleep 5
+    echo "  Applying declared config: ${LAMBDA_MEMORY_MB}MB / ${LAMBDA_TIMEOUT}s..."
+    aws lambda update-function-configuration \
+      --function-name "$FUNCTION_NAME" \
+      --timeout "$LAMBDA_TIMEOUT" \
+      --memory-size "$LAMBDA_MEMORY_MB" \
+      --region "$REGION" > /dev/null
   else
     echo "  Migrating from zip to container image..."
     aws lambda delete-function --function-name "$FUNCTION_NAME" --region "$REGION"
@@ -72,8 +113,8 @@ if aws lambda get-function --function-name "$FUNCTION_NAME" --region "$REGION" &
       --package-type Image \
       --code "ImageUri=$IMAGE_URI" \
       --role "$ROLE_ARN" \
-      --timeout 600 \
-      --memory-size 512 \
+      --timeout "$LAMBDA_TIMEOUT" \
+      --memory-size "$LAMBDA_MEMORY_MB" \
       --region "$REGION" > /dev/null
   fi
 else
@@ -82,8 +123,8 @@ else
     --package-type Image \
     --code "ImageUri=$IMAGE_URI" \
     --role "$ROLE_ARN" \
-    --timeout 600 \
-    --memory-size 512 \
+    --timeout "$LAMBDA_TIMEOUT" \
+    --memory-size "$LAMBDA_MEMORY_MB" \
     --region "$REGION" > /dev/null
 fi
 echo "  $FUNCTION_NAME deployed."

--- a/tests/test_deploy_lambda_config_converges.py
+++ b/tests/test_deploy_lambda_config_converges.py
@@ -1,0 +1,100 @@
+"""`infrastructure/deploy.sh` must converge Lambda config on EVERY deploy.
+
+Bug class this guards (2026-07-25 weekly-SF incident): memory and timeout were
+passed only to ``create-function``. On an existing function the update path
+touched code alone, so the live configuration was whatever someone had last set
+by hand — un-versioned state with nothing reconciling it to this repo.
+
+That is how DataPhase2 died. Memory had been raised to 1024 MB on ``$LATEST``,
+but ``publish-version`` snapshots configuration at publish time and the ``live``
+alias still pointed at version 269, published at 512 MB. The Saturday SF
+invokes ``alpha-engine-data-collector:live``, so it kept running at 512 MB and
+hit ``Runtime.OutOfMemory`` twice. The raise was real and entirely invisible to
+the pipeline.
+
+Two invariants therefore matter, and the ordering one is the subtle half:
+
+1. The update path applies ``update-function-configuration``.
+2. It does so BEFORE ``publish-version`` — a config change applied after the
+   version is cut never reaches the alias the pipeline actually invokes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DEPLOY = Path(__file__).resolve().parents[1] / "infrastructure" / "deploy.sh"
+_SRC = _DEPLOY.read_text(encoding="utf-8")
+
+# Comment-stripped view. The header documents the incident in prose and names
+# the same commands the code calls, so any positional reasoning must run
+# against executable lines only.
+_CODE = "\n".join(
+    line for line in _SRC.splitlines() if not line.lstrip().startswith("#")
+)
+
+
+def test_deploy_script_exists():
+    assert _DEPLOY.is_file(), f"missing {_DEPLOY}"
+
+
+def test_update_path_applies_configuration():
+    """The existing-function branch must reconcile config, not just code."""
+    assert "update-function-configuration" in _CODE, (
+        "deploy.sh updates function CODE but never CONFIG — memory/timeout on an "
+        "existing function will drift from this file, and the drift is invisible "
+        "to the SF because it invokes the `live` alias"
+    )
+
+
+def test_configuration_is_applied_before_version_is_published():
+    """Ordering invariant: config must land on $LATEST before the version cut."""
+    cfg = _CODE.index("update-function-configuration")
+    pub = _CODE.index("publish-version")
+    assert cfg < pub, (
+        "update-function-configuration appears AFTER publish-version — the "
+        "published version (and therefore the `live` alias the SF invokes) "
+        "would not carry the declared memory/timeout"
+    )
+
+
+@pytest.mark.parametrize("var", ["LAMBDA_MEMORY_MB", "LAMBDA_TIMEOUT"])
+def test_runtime_envelope_is_declared_once(var: str):
+    """Memory/timeout come from a named variable, not scattered literals."""
+    assert re.search(rf'^{var}="\$\{{{var}:-\d+\}}"$', _CODE, re.MULTILINE), (
+        f"{var} must be declared once with an overridable default so every "
+        f"create/update path converges to the same declared value"
+    )
+
+
+@pytest.mark.parametrize("flag,var", [("--memory-size", "LAMBDA_MEMORY_MB"),
+                                      ("--timeout", "LAMBDA_TIMEOUT")])
+def test_no_hardcoded_config_literals(flag: str, var: str):
+    """Every --memory-size/--timeout passes the variable, never a literal.
+
+    A literal left behind in one branch reintroduces exactly the drift this
+    guards: create and update converging on different values.
+    """
+    for match in re.finditer(rf"{flag}\s+(\S+)", _CODE):
+        value = match.group(1).strip('"')
+        assert value == f"${{{var}}}" or value == f"${var}", (
+            f"{flag} is passed a hardcoded {value!r} — use ${var} so all paths "
+            f"converge on the declared envelope"
+        )
+
+
+def test_memory_is_above_the_observed_oom_ceiling():
+    """1024 MB floor: phase-2 OOM'd at 512 MB on 2026-07-25.
+
+    Guards against a well-meaning 'right-size it down' that lands back on the
+    value the incident already disproved.
+    """
+    match = re.search(r'LAMBDA_MEMORY_MB="\$\{LAMBDA_MEMORY_MB:-(\d+)\}"', _CODE)
+    assert match, "could not parse LAMBDA_MEMORY_MB default"
+    assert int(match.group(1)) >= 1024, (
+        f"memory default {match.group(1)}MB is at or below the 512MB that OOM'd "
+        "on 2026-07-25 plus its margin — do not reduce without new profiling"
+    )


### PR DESCRIPTION
**Priority:** P0 · **Complexity:** mid

Root-cause fix for the failure that actually killed the 2026-07-25 weekly run: `DataPhase2` → `Runtime.OutOfMemory` after 8h26m.

## The defect

The memory raise had **already been applied** — and never reached the pipeline.

`publish-version` snapshots configuration at publish time. Memory was raised to 1024 MB on `$LATEST`, but the `live` alias still pointed at version 269, published at 512 MB. The Saturday SF invokes `alpha-engine-data-collector:live`, so it kept running at 512 MB.

Verified live:

```
$LATEST         : 1024 MB
live alias      : -> version 269
version 269     : 512 MB      <- what the SF actually gets
```

CloudWatch REPORT lines for the two failing ~460s invocations show `maxMemoryUsed == memorySize == 512` — the OOM signature.

The underlying defect: `deploy.sh` passed `--memory-size`/`--timeout` only to `create-function`. On an existing function the update path touched **code alone**, so live configuration was whatever someone last set by hand, with nothing reconciling it to this repo. **This is still true in production right now** — next Saturday's `DataPhase2` OOMs again without this.

## What changed

- Runtime envelope declared once — `LAMBDA_MEMORY_MB=1024`, `LAMBDA_TIMEOUT=600` — overridable for one-off experiments. Every create and update path passes those variables instead of literals.
- The update path applies `update-function-configuration` **before** `publish-version`. **Ordering is the subtle half of the fix**: config applied after the version is cut never reaches the alias the pipeline invokes — which is precisely how the original raise got lost.
- New guard `tests/test_deploy_lambda_config_converges.py` covering both invariants, the single-declaration rule, and a floor so the memory default can't be lowered back to the value the incident disproved.

**Why 1024 and not 640:** the OOM'd invocations were also ~460s into a 600s timeout, and Lambda scales CPU with memory — headroom buys margin on both axes. Other phases sit at 236–341 MB observed, which is why 512 looked adequate and masked the phase-2 requirement.

## Verification

- Guard is provably non-inert: **7 failed / 1 passed** against the pre-change script, **8/8 passed** after.
- `bash -n` clean. `shellcheck` clean apart from a pre-existing `SC2034` on `BUCKET` (untouched).
- Full suite: **3621 passed**, 8 skipped. The 4 local failures are stale-venv artifacts, not regressions — krepis 0.16.2 and `nousergon-lib` 0.124.6 against pins of `>=0.18.8` and `v0.124.9`. CI installs at the pins.

## Deploy

Merge button alone. `infrastructure/deploy.sh` is in `deploy.yml`'s path filter, so merging rebuilds, applies the config, publishes a new version, and repoints `live` at a version carrying 1024 MB.

## Related

- Sibling P0 from the same audit: #1056 (krepis `--correlation-id`).
- Policy context: `nous-ergon-ops` PR #63 — this is §2.4 (repo is the only writer) and §4 (right-size to the actual profile).

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)