### PR TITLE
fix(overseer): isolate per-check liveness failures — one AccessDenied no longer blinds the probe (I4473)

### DIFF
--- a/infrastructure/lambdas/overseer-liveness-probe/index.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/index.py
@@ -741,23 +741,65 @@ def _iter_check_specs(registry: dict) -> list[tuple[str, dict]]:
     return specs
 
 
-def _run_checks(now: datetime) -> tuple[list[str], dict[str, str]]:
+def _run_checks(now: datetime) -> tuple[list[str], dict[str, str], int, int]:
     """Run every registry-declared liveness check, aggregating problems +
-    reported kill-switches. An unknown check type RAISES (_RegistryError,
-    fail-loud) — a registry that outran the probe's checker table is a
-    packaging bug, not a silent skip."""
+    reported kill-switches.
+
+    An unknown check type RAISES (_RegistryError, fail-loud) — a registry that
+    outran the probe's checker table is a packaging bug that makes the WHOLE
+    registry untrustworthy, not a silent skip.
+
+    A checker that raises at RUNTIME (an AWS API error — most often an IAM
+    grant that drifted from the repo policy) is ISOLATED: it becomes its own
+    problem line and every other check still runs (alpha-engine-config-I4473).
+    Before this, one `AccessDenied` on one check aborted the handler and
+    erased the coverage of all ~25 — a 2026-07-23 scheduler IAM drift left the
+    probe reporting nothing at all for four days while the alert-drain plane
+    died underneath it, unseen. Fail-loud is right; losing every *other*
+    check's coverage to one check's failure is not, because a probe's whole
+    job is to report N independent findings.
+
+    Returns (problems, kill_switches, checks_run, checks_failed)."""
     registry = _registry()
     problems: list[str] = []
     kill_switches: dict[str, str] = {}
+    checks_run = 0
+    checks_failed = 0
     for label, spec in _iter_check_specs(registry):
         ctype = spec.get("type")
         checker = CHECKERS.get(ctype)
         if checker is None:
             raise _RegistryError(f"{label}: unknown liveness check type {ctype!r}")
-        p, ks = checker(spec, now)
+        checks_run += 1
+        try:
+            p, ks = checker(spec, now)
+        except Exception as exc:  # noqa: BLE001 — isolated per I4473; recorded as a problem line below, never swallowed
+            checks_failed += 1
+            logger.error(
+                "liveness check FAILED to run: %s type=%s: %s: %s",
+                label, ctype, type(exc).__name__, exc,
+            )
+            problems.append(
+                f"{label}: liveness check '{ctype}' FAILED TO RUN "
+                f"({type(exc).__name__}: {exc}) — this check's coverage is ABSENT; "
+                "the component it watches is unverified, not healthy"
+            )
+            continue
         problems.extend(p)
         kill_switches.update(ks)
-    return problems, kill_switches
+
+    if checks_run and checks_failed == checks_run:
+        # Distinct, loudest case: the probe is structurally unable to observe
+        # anything (blanket IAM/credential/network failure). Reporting this
+        # identically to N individual check failures would understate it —
+        # the plane is not degraded, it is BLIND.
+        problems.insert(
+            0,
+            f"PROBE BLIND: all {checks_run} liveness checks failed to run — "
+            "the watch plane is unobserved, not healthy. Check the probe role's "
+            "IAM against infrastructure/lambdas/overseer-liveness-probe/iam-policy.json.",
+        )
+    return problems, kill_switches, checks_run, checks_failed
 
 
 # ── Dedup + alert (content-fingerprint, ported from sf-watch-reclaim-sweep-handler) ──
@@ -796,13 +838,26 @@ def _save_alerted_fingerprint(s3, fingerprint: str | None) -> None:
         logger.warning("could not persist overseer liveness state %s: %s", STATE_KEY, exc)
 
 
-def _alert(problems: list[str], kill_switches: dict[str, str] | None = None) -> bool:
+def _alert(
+    problems: list[str],
+    kill_switches: dict[str, str] | None = None,
+    checks_run: int = 0,
+    checks_failed: int = 0,
+) -> bool:
     lines = [
         "\U0001f6f0️ *Overseer Liveness Probe — WATCH-PLANE PROBLEM*",
         f"{len(problems)} wiring/liveness issue(s) found across the fleet watch plane "
         "(the WATCHERS' own wiring, NOT a pipeline failure):",
     ]
     lines.extend(f"• {p}" for p in problems)
+    if checks_failed:
+        # I4473: coverage caveat, stated BEFORE the closing advice — a reader
+        # must not read this report as a complete picture when part of the
+        # plane went unobserved.
+        lines.append(
+            f"⚠️ *Coverage incomplete:* {checks_failed} of {checks_run} checks could not "
+            "run — the components they watch are UNVERIFIED, not confirmed healthy."
+        )
     lines.append(
         "_A watcher may not catch (or repair) a real failure right now. Check the "
         "named rules / Step Functions / dispatcher Lambdas / intake queue._"
@@ -817,7 +872,12 @@ def _alert(problems: list[str], kill_switches: dict[str, str] | None = None) -> 
             flow_name=_FLOW_NAME,
             topics=_OPS_TOPICS,
             db_basename=_DB_BASENAME,
-            context={"problems": len(problems), "kill_switches": kill_switches or {}},
+            context={
+                "problems": len(problems),
+                "kill_switches": kill_switches or {},
+                "checks_run": checks_run,
+                "checks_failed": checks_failed,
+            },
             # No playbooks.yaml alert_classes row exists yet for this Lambda's
             # own identity (config-I3513 audit finding) — note this is
             # DISTINCT from the registered `overseer_dispatch_escalation`
@@ -835,11 +895,14 @@ def _alert(problems: list[str], kill_switches: dict[str, str] | None = None) -> 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """Scheduled (EventBridge) entrypoint. Iterates the playbook registry,
     runs every declared liveness check read-only, dedups by problem-set content,
-    and LOUD-alerts only on a NEW/changed problem set. Raises on an unexpected
-    AWS API failure (or an unknown registry check type) so the probe can never
-    silently no-op."""
+    and LOUD-alerts only on a NEW/changed problem set.
+
+    A runtime AWS failure in ONE check is isolated into its own problem line so
+    the rest of the plane is still observed (alpha-engine-config-I4473); an
+    unknown registry check type still RAISES, so the probe can never silently
+    no-op on a registry that outran its checker table."""
     now = datetime.now(timezone.utc)
-    problems, kill_switches = _run_checks(now)
+    problems, kill_switches, checks_run, checks_failed = _run_checks(now)
     fingerprint = _problem_fingerprint(problems) if problems else None
 
     # Always surfaced (record + log), never alerted: a deliberate operator
@@ -852,7 +915,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     alerted = False
     if problems and fingerprint != already:
         logger.warning("overseer liveness: %d NEW problem(s): %s", len(problems), problems)
-        alerted = _alert(problems, kill_switches)
+        alerted = _alert(problems, kill_switches, checks_run, checks_failed)
         if alerted:
             _save_alerted_fingerprint(s3, fingerprint)
     elif problems:
@@ -870,4 +933,10 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "alerted": alerted,
         "clean": not problems,
         "kill_switches": kill_switches,
+        # I4473: coverage accounting. `clean: true` with checks_failed > 0 is
+        # impossible by construction (a failed check IS a problem line), but
+        # these make "how much did we actually observe" answerable from the
+        # return payload alone, without reading logs.
+        "checks_run": checks_run,
+        "checks_failed": checks_failed,
     }

--- a/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
@@ -717,10 +717,98 @@ def test_run_checks_aggregates_problems_and_kill_switches():
     sqs.get_queue_url.side_effect = FakeClientError("QueueDoesNotExist")
     with patch("index._registry", return_value=reg), \
          patch("index.boto3.client", side_effect=_client_factory(**{"lambda": lam, "sqs": sqs})):
-        problems, ks = index._run_checks(NOW)
+        problems, ks, run, failed = index._run_checks(NOW)
     assert any("not Active" in p for p in problems)
     assert any("does NOT EXIST" in p for p in problems)
     assert ks == {"SF_WATCH_DISPATCH_ENABLED": "true"}
+    assert (run, failed) == (2, 0)
+
+
+# ── I4473: per-check isolation ───────────────────────────────────────────────
+
+
+def _isolation_registry():
+    """One check that will blow up (scheduler) + two that will report normally."""
+    return {
+        "playbooks": {
+            "sf-watch": {"liveness": {"checks": [
+                {"type": "lambda_active", "function": "alpha-engine-spot",
+                 "report_kill_switch": "SF_WATCH_DISPATCH_ENABLED"},
+            ]}},
+        },
+        "watch_plane_liveness": {"checks": [
+            {"type": "scheduler_schedule_exists",
+             "schedule_name": "alpha-engine-alert-drain-0400utc"},
+            {"type": "sqs_queue_exists", "queue_name": "nousergon-overseer-intake"},
+        ]},
+    }
+
+
+def test_run_checks_isolates_a_raising_check_and_still_runs_the_others():
+    """The 2026-07-23 regression: an AccessDenied on ONE check aborted the whole
+    handler, erasing ~25 checks' coverage for four days."""
+    lam = MagicMock()
+    lam.get_function_configuration.return_value = _lambda_cfg(
+        state="Pending", env={"SF_WATCH_DISPATCH_ENABLED": "true"})
+    sched = MagicMock()
+    sched.get_schedule.side_effect = FakeClientError("AccessDeniedException")
+    sqs = MagicMock()
+    sqs.get_queue_url.side_effect = FakeClientError("QueueDoesNotExist")
+    with patch("index._registry", return_value=_isolation_registry()), \
+         patch("index.boto3.client", side_effect=_client_factory(
+             **{"lambda": lam, "scheduler": sched, "sqs": sqs})):
+        problems, ks, run, failed = index._run_checks(NOW)
+
+    # the raising check became its own problem line...
+    assert any("FAILED TO RUN" in p and "scheduler_schedule_exists" in p for p in problems)
+    # ...and BOTH other checks still reported their real findings
+    assert any("not Active" in p for p in problems)
+    assert any("does NOT EXIST" in p for p in problems)
+    assert ks == {"SF_WATCH_DISPATCH_ENABLED": "true"}
+    assert (run, failed) == (3, 1)
+    assert not any("PROBE BLIND" in p for p in problems)
+
+
+def test_run_checks_unknown_type_still_raises_not_isolated():
+    """An unknown check type is a packaging bug that invalidates the whole
+    registry — it must stay fail-loud, NOT be isolated like a runtime error."""
+    reg = {"playbooks": {"x": {"liveness": {"checks": [{"type": "bogus_check"}]}}}}
+    with patch("index._registry", return_value=reg):
+        with pytest.raises(index._RegistryError):
+            index._run_checks(NOW)
+
+
+def test_run_checks_all_failing_reports_probe_blind_first():
+    reg = {"watch_plane_liveness": {"checks": [
+        {"type": "scheduler_schedule_exists", "schedule_name": "s-one"},
+        {"type": "scheduler_schedule_exists", "schedule_name": "s-two"},
+    ]}}
+    sched = MagicMock()
+    sched.get_schedule.side_effect = FakeClientError("AccessDeniedException")
+    with patch("index._registry", return_value=reg), \
+         patch("index.boto3.client", side_effect=_client_factory(scheduler=sched)):
+        problems, _ks, run, failed = index._run_checks(NOW)
+    assert run == failed == 2
+    assert problems[0].startswith("PROBE BLIND")
+    assert "all 2 liveness checks failed to run" in problems[0]
+
+
+def test_run_checks_partial_failure_is_not_probe_blind():
+    reg = {"watch_plane_liveness": {"checks": [
+        {"type": "scheduler_schedule_exists", "schedule_name": "s-one"},
+        {"type": "sqs_queue_exists", "queue_name": "nousergon-overseer-intake"},
+    ]}}
+    sched = MagicMock()
+    sched.get_schedule.side_effect = FakeClientError("AccessDeniedException")
+    sqs = MagicMock()
+    sqs.get_queue_url.return_value = {"QueueUrl": "https://q"}
+    sqs.get_queue_attributes.return_value = {"Attributes": {"RedrivePolicy": json.dumps(
+        {"deadLetterTargetArn": "arn:aws:sqs:us-east-1:711398986525:nousergon-overseer-intake-dlq"})}}
+    with patch("index._registry", return_value=reg), \
+         patch("index.boto3.client", side_effect=_client_factory(scheduler=sched, sqs=sqs)):
+        problems, _ks, run, failed = index._run_checks(NOW)
+    assert (run, failed) == (2, 1)
+    assert not any("PROBE BLIND" in p for p in problems)
 
 
 def test_registry_malformed_raises():
@@ -731,7 +819,8 @@ def test_registry_malformed_raises():
     index._REGISTRY_CACHE = None
 
 
-def _handler_with(problems, kill_switches=None, state_fingerprint=None):
+def _handler_with(problems, kill_switches=None, state_fingerprint=None,
+                  checks_run=None, checks_failed=0):
     """Drive handler with _run_checks + S3 dedup state stubbed."""
     s3 = MagicMock()
     if state_fingerprint is None:
@@ -739,11 +828,36 @@ def _handler_with(problems, kill_switches=None, state_fingerprint=None):
     else:
         s3.get_object.return_value = {"Body": _Body(json.dumps({"fingerprint": state_fingerprint}).encode())}
     notify = MagicMock(return_value=True)
-    with patch("index._run_checks", return_value=(problems, kill_switches or {})), \
+    if checks_run is None:
+        checks_run = max(len(problems), 1)
+    with patch("index._run_checks",
+               return_value=(problems, kill_switches or {}, checks_run, checks_failed)), \
          patch("index._s3_client", return_value=s3), \
          patch("index.notify_via_flow_doctor", notify):
         result = index.handler({}, None)
     return result, s3, notify
+
+
+def test_handler_reports_check_coverage_counts():
+    result, _s3, _notify = _handler_with([], checks_run=25, checks_failed=0)
+    assert result["checks_run"] == 25 and result["checks_failed"] == 0
+
+
+def test_handler_alert_names_incomplete_coverage():
+    result, _s3, notify = _handler_with(
+        ["watch_plane: liveness check 'scheduler_schedule_exists' FAILED TO RUN (X: y)"],
+        checks_run=25, checks_failed=1,
+    )
+    assert result["checks_failed"] == 1
+    text = notify.call_args[0][0]
+    assert "Coverage incomplete" in text and "1 of 25" in text
+    assert "UNVERIFIED, not confirmed healthy" in text
+
+
+def test_handler_clean_run_alert_omits_coverage_caveat():
+    _result, _s3, notify = _handler_with(["some unrelated finding"],
+                                         checks_run=25, checks_failed=0)
+    assert "Coverage incomplete" not in notify.call_args[0][0]
 
 
 def test_handler_clean_no_alert():


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#4473

## Problem

`overseer-liveness-probe/index.py::_run_checks` ran every registry-declared check in a bare loop — any exception from any checker propagated out of `handler`. One misconfigured IAM grant therefore erased the coverage of all ~25 other checks.

**Live impact:** an `AccessDeniedException` on `scheduler:GetSchedule` for `alpha-engine-alert-drain-0400utc` has aborted the probe on **100% of invocations since 2026-07-23** (last 24h: Invocations=6, Errors=6). Zero liveness checks have run for four days. During that window the alert-drain plane died (last ledger `drain-2026-07-23T1600Z`), 362 messages backed up on the intake queue, and nothing observed any of it.

The IAM grant itself was merged in nousergon-data#1014 but never applied live, because applying it needs a manual operator step — tracked separately as alpha-engine-config-I4472 (deploy atomicity) and alpha-engine-config-I4471 (recovery).

Fail-loud is the right default. Losing every *other* check's coverage to one check's failure is not — a probe's entire job is to report N independent findings.

## Changes

- **Runtime failures are isolated.** A checker that raises becomes its own problem line (`… liveness check '<type>' FAILED TO RUN (<exc>) — this check's coverage is ABSENT; the component it watches is unverified, not healthy`), and every other check still runs.
- **Unknown check *type* still raises** `_RegistryError`. Deliberately a different class: a registry that outran the probe's checker table is a packaging bug invalidating the whole registry, not one check's transient AWS error.
- **All-checks-failed is its own loudest finding** — a `PROBE BLIND: all N liveness checks failed to run` line inserted first. Reporting a blind probe identically to N ordinary findings understates it: the plane is *unobserved*, not *degraded*.
- **Coverage accounting** — `checks_run` / `checks_failed` in the return payload, in the flow-doctor `context`, and as an explicit `⚠️ Coverage incomplete: N of M checks could not run` caveat in the alert body, placed before the closing advice so a reader cannot mistake a partial report for a complete one.

## Behaviour on the current live state

This restores coverage **without** waiting on the IAM fix: the scheduler check will report itself failed, and the other ~24 checks will run and report normally — including the ones that would have caught the alert-drain outage on 7/23.

## Testing

`python3 -m pytest test_handler.py -q` → **60 passed** (8 new).

New cases: raising check is isolated while others still report; unknown type still raises; `PROBE BLIND` on total failure; partial failure is *not* PROBE BLIND; coverage counts in payload; alert caveat present when `checks_failed > 0` and absent when 0.

Also ran `tests/test_overseer_playbook_registry.py` → 36 passed (registry contract unaffected). No callers of `_run_checks` outside this Lambda.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)