### PR TITLE
[P0] fix(overseer): registry can finally express the fleet's model policy — 4 layers hardcoded claude- (I4478)

### DIFF
--- a/infrastructure/lambdas/alert-drain-dispatcher/index.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/index.py
@@ -105,7 +105,14 @@ _BOOL_RE = re.compile(r"^(true|false)$")
 _TRIGGER_RE = re.compile(r"^[a-z0-9_-]{0,64}$")
 # config-I3293 — optional registry-declared model, injected by the overseer
 # router from playbooks.yaml. Empty = absent = run-script inline default.
-_MODEL_RE = re.compile(r"^(claude-[a-z0-9.-]{1,60})?$")
+# alpha-engine-config-I4478/I4516: provider-agnostic, mirroring
+# scheduled-groom-dispatcher's long-standing pattern. Was `^claude-...$`, which
+# structurally could NOT carry the DeepSeek model IDs the fleet actually runs
+# (2026-07-24 zero-Anthropic-model ruling) — so the registry, which is the
+# declared SSoT for each playbook's model, could not express the live policy.
+# Still a strict anchored allow-list of shell-safe characters: the value is
+# interpolated into the bootstrap command, so the injection guard is the point.
+_MODEL_RE = re.compile(r"^([a-z0-9][a-z0-9._-]{0,63})?$")
 
 
 class _InvalidEvent(ValueError):

--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -358,7 +358,14 @@ _BRANCH_RE = re.compile(r"^[A-Za-z0-9_./-]{1,200}$")
 _WORKFLOW_RE = re.compile(r"^[A-Za-z0-9 _./:()-]{1,200}$")
 _BOOL_RE = re.compile(r"^(true|false)$")
 # config-I3293 — registry-declared agent model (router-injected); optional.
-_MODEL_RE = re.compile(r"^claude-[a-z0-9.-]{1,60}$")
+# alpha-engine-config-I4478/I4516: provider-agnostic, mirroring
+# scheduled-groom-dispatcher's long-standing pattern. Was `^claude-...$`, which
+# structurally could NOT carry the DeepSeek model IDs the fleet actually runs
+# (2026-07-24 zero-Anthropic-model ruling) — so the registry, which is the
+# declared SSoT for each playbook's model, could not express the live policy.
+# Still a strict anchored allow-list of shell-safe characters: the value is
+# interpolated into the bootstrap command, so the injection guard is the point.
+_MODEL_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 
 
 class _InvalidEvent(ValueError):

--- a/infrastructure/lambdas/overseer-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/overseer-dispatcher/test_handler.py
@@ -243,7 +243,13 @@ class TestModelInjection:
         sent = json.loads(lam.invoke.call_args.kwargs["Payload"])
         reg_model = index._registry()["playbooks"]["sf-watch"]["model"]
         assert sent["model"] == reg_model
-        assert reg_model.startswith("claude-")
+        # alpha-engine-config-I4478: was `startswith("claude-")`. The fleet runs
+        # NO Anthropic models and NO Claude Plan in the system (Brian ruling
+        # 2026-07-24, reaffirmed 2026-07-27) — assert the injected model is a
+        # real declared value and is not Anthropic, rather than pinning it to
+        # the vendor this arc is removing.
+        assert reg_model
+        assert not reg_model.startswith(("claude-", "anthropic"))
 
     def test_caller_model_override_wins(self, index_mod):
         index, fake_boto3 = index_mod

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -235,7 +235,14 @@ _FAILED_STATE_RE = re.compile(r"^[A-Za-z0-9 _.:()/-]{0,200}$")
 _WATCH_LOG_KEY_RE = re.compile(r"^[A-Za-z0-9_./-]{0,300}$")
 _BOOL_RE = re.compile(r"^(true|false)$")
 # config-I3293 — registry-declared agent model (router-injected); optional.
-_MODEL_RE = re.compile(r"^claude-[a-z0-9.-]{1,60}$")
+# alpha-engine-config-I4478/I4516: provider-agnostic, mirroring
+# scheduled-groom-dispatcher's long-standing pattern. Was `^claude-...$`, which
+# structurally could NOT carry the DeepSeek model IDs the fleet actually runs
+# (2026-07-24 zero-Anthropic-model ruling) — so the registry, which is the
+# declared SSoT for each playbook's model, could not express the live policy.
+# Still a strict anchored allow-list of shell-safe characters: the value is
+# interpolated into the bootstrap command, so the injection guard is the point.
+_MODEL_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 
 
 class _InvalidEvent(ValueError):

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -40,8 +40,8 @@
           "kill_switch_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
           "model": {
             "type": "string",
-            "pattern": "^claude-[a-z0-9.-]+$",
-            "description": "config-I3293 — the Claude model this playbook's agent runs. LIVE config, not documentation: the overseer-dispatcher injects it into the executor payload as `model`; executors thread it to the run script. The run script's inline default is the fallback only for non-router invocation paths. Required (via registry test, not schema) on every routed playbook whose executor launches a claude-CLI agent."
+            "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$",
+            "description": "config-I3293 — the model this playbook's agent runs (provider-agnostic since alpha-engine-config-I4478; was claude-only, which could not express the fleet's DeepSeek-primary policy). LIVE config, not documentation: the overseer-dispatcher injects it into the executor payload as `model`; executors thread it to the run script. The run script's inline default is the fallback only for non-router invocation paths. Required (via registry test, not schema) on every routed playbook whose executor launches a claude-CLI agent."
           },
           "wake": {
             "type": "array",

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -38,7 +38,7 @@ playbooks:
     # overseer-dispatcher injects it into the executor payload and the
     # executor threads it to the run script's `--model`; the run script's
     # inline default is the fallback ONLY for non-router invocation paths.
-    model: claude-opus-4-8
+    model: deepseek-v4-pro
     wake:
       - "eventbridge:alpha-engine-saturday-sf-watch-failed (fleet SF terminal failure -> triage Lambda -> router, M2)"
       - "eventbridge:alpha-engine-sf-watch-spot-interruption + alpha-engine-sf-watch-instance-terminated (reclaim/relaunch)"
@@ -118,7 +118,7 @@ playbooks:
     tier: T2
     routed: true
     enabled: true
-    model: claude-opus-4-8   # config-I3293 — registry-declared, router-injected
+    model: deepseek-v4-pro   # config-I3293 — registry-declared, router-injected
     wake:
       - "gha:nousergon-lib notify-ci-failure.yml -> repository_dispatch -> sf-watch.yml ci-watch-dispatch job -> this router (main-branch CI failure)"
     cadence: "event-driven only — no scheduled wake (deprecation to drain intake tracked: config-I2845)"
@@ -154,7 +154,7 @@ playbooks:
     tier: T2
     routed: true
     enabled: true
-    model: claude-sonnet-5   # config-I3293 — registry-declared, router-injected; charter may spawn complexity-matched sub-agents (Brian ruling 2026-07-22)
+    model: deepseek-v4-pro-max   # config-I3293 — registry-declared, router-injected; charter may spawn complexity-matched sub-agents (Brian ruling 2026-07-22)
     wake:
       - "scheduler:alpha-engine-alert-drain-0400utc/1000utc/1600utc/2200utc (4x-daily non-urgent queue drain, Brian ruling 2026-07-22)"
       - "event-time: freshness-monitor CRITICAL page -> router (trigger=freshness-critical, config-I3282)"

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -289,10 +289,20 @@ def test_every_routed_playbook_declares_model_wake_cadence():
     for name, spec in REGISTRY["playbooks"].items():
         if not spec.get("routed"):
             continue
-        assert spec.get("model", "").startswith("claude-"), (
+        assert spec.get("model"), (
             f"routed playbook {name!r} missing a registry-declared model "
             f"(config-I3293) — the run script's inline default would silently "
             f"become undeclared live config"
+        )
+        # alpha-engine-config-I4478: was `.startswith("claude-")`. That, the
+        # schema pattern, and each executor's `_MODEL_RE` all independently
+        # hardcoded Anthropic — four layers making it structurally impossible
+        # for the registry (the declared SSoT for "what model runs this agent")
+        # to express the fleet's own 2026-07-24 zero-Anthropic-model ruling.
+        assert not spec["model"].startswith(("claude-", "anthropic")), (
+            f"routed playbook {name!r} declares Anthropic model "
+            f"{spec['model']!r} — forbidden fleet-wide by the 2026-07-24 ruling "
+            f"(nous-ergon-ops/policies/llm-provider-model-policy.md)"
         )
         assert spec.get("wake"), f"routed playbook {name!r} missing wake declaration"
         assert spec.get("cadence"), f"routed playbook {name!r} missing cadence declaration"
@@ -365,3 +375,32 @@ def test_known_bus_sources_have_rows():
                   "alpha-engine-backtester/optimizer/live_key_reconciliation.py",
                   "cloudwatch-alarm:*"):
         assert known in sources, f"known emitter {known!r} has no alert-class row"
+
+
+def test_registry_model_passes_its_executor_validator():
+    """LOCKSTEP: every routed playbook's declared `model` must actually be
+    accepted by the executor Lambda that receives it.
+
+    alpha-engine-config-I4478/I4516: the registry declared `claude-*` models
+    while the run scripts had migrated to DeepSeek, and each executor's
+    `_MODEL_RE` accepted ONLY `claude-*`. Nothing tied the three together, so
+    the drift was invisible until an agent died on a spot box at 04:00 UTC.
+    This test makes that class of drift a CI failure instead.
+    """
+    checked = 0
+    for name, spec in REGISTRY["playbooks"].items():
+        if not spec.get("routed") or not spec.get("model"):
+            continue
+        exec_dir = spec.get("executor_lambda_dir")
+        assert exec_dir, f"routed playbook {name!r} has no executor_lambda_dir"
+        src = (LAMBDAS_DIR / exec_dir / "index.py").read_text(encoding="utf-8")
+        m = re.search(r'_MODEL_RE\s*=\s*re\.compile\(r"([^"]+)"\)', src)
+        assert m, f"{exec_dir}/index.py has no _MODEL_RE to validate against"
+        assert re.compile(m.group(1)).match(spec["model"]), (
+            f"registry declares model {spec['model']!r} for playbook {name!r}, "
+            f"but {exec_dir}'s _MODEL_RE ({m.group(1)!r}) REJECTS it — the "
+            f"router would inject a value the executor refuses, and the agent "
+            f"never launches"
+        )
+        checked += 1
+    assert checked >= 3, f"expected >=3 routed playbooks with models, checked {checked}"


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#4478
Refs nousergon/alpha-engine-config#4516, nousergon/alpha-engine-config#4471

## Problem

**Four independent layers** each hardcoded `claude-`, making it structurally impossible for the playbook registry — the declared SSoT for *"what model runs this agent"* — to express the fleet's own 2026-07-24 zero-Anthropic-model ruling:

| # | Layer |
|---|---|
| 1 | `sf-watch-spot-dispatcher` `_MODEL_RE = ^claude-[a-z0-9.-]{1,60}$` |
| 2 | `ci-watch-dispatcher` — same |
| 3 | `alert-drain-dispatcher` — same (optional variant) |
| 4 | `playbooks.schema.json` `"pattern": "^claude-[a-z0-9.-]+$"` |
| + | a registry test asserting `model.startswith("claude-")` |

Meanwhile every run script had migrated to DeepSeek. Nothing tied the surfaces together, so the drift was invisible.

**Live consequence.** The router injects the registry's declared model into the executor payload, and the run scripts wire the local egress proxy **only** for a `deepseek-*` model string. A `claude-*` value therefore skipped the proxy and went straight at Anthropic — whose org spend limit has been exhausted since 2026-07-23, which is the first of the three causes behind the alert-drain outage (alpha-engine-config-I4471).

This is also on the critical path for routing weekday/EOD SF failures through the Overseer: with the registry declaring `claude-opus-4-8`, every sf-watch agent dispatched via the router would bypass its proxy and die on the spend limit.

## Changes

- All three executor regexes adopt `scheduled-groom-dispatcher`'s long-standing provider-agnostic pattern `^[a-z0-9][a-z0-9._-]{0,63}$`. Still a strict, anchored allow-list of shell-safe characters — the value is interpolated into the bootstrap command, so the injection guard is the entire point; **only the vendor-prefix assumption is removed**, not the guard.
- Schema pattern widened to match.
- Registry models updated to what each run script already defaults to, so router-injected and non-router paths finally agree:
  - `sf-watch`, `ci-watch`: `claude-opus-4-8` → `deepseek-v4-pro`
  - `alert-drain`: `claude-sonnet-5` → `deepseek-v4-pro-max`
- The registry test now asserts a model is **declared** and is **not Anthropic**, instead of asserting it starts with `claude-`.
- **New lockstep test** `test_registry_model_passes_its_executor_validator`: every routed playbook's declared model must actually be accepted by the `_MODEL_RE` of the executor that receives it, read out of that Lambda's source. This drift class becomes a CI failure instead of a 04:00-UTC spot-box death.

## Testing

- `tests/test_overseer_playbook_registry.py` → **37 passed** (was 36)
- `alert-drain-dispatcher/test_handler.py` → **11 passed**
- `sf-watch-spot-dispatcher` / `ci-watch-dispatcher` suites fail locally on `ModuleNotFoundError: krepis` — verified **identical on clean `origin/main`**, so pre-existing local-environment gap, not a regression. CI installs it.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)