### PR TITLE
[P0] fix(overseer): alert-drain declared a routing ALIAS as its API model (I4471)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -154,7 +154,7 @@ playbooks:
     tier: T2
     routed: true
     enabled: true
-    model: deepseek-v4-pro-max   # config-I3293 — registry-declared, router-injected; charter may spawn complexity-matched sub-agents (Brian ruling 2026-07-22)
+    model: deepseek-v4-pro   # config-I3293 — registry-declared, router-injected; charter may spawn complexity-matched sub-agents (Brian ruling 2026-07-22)
     wake:
       - "scheduler:alpha-engine-alert-drain-0400utc/1000utc/1600utc/2200utc (4x-daily non-urgent queue drain, Brian ruling 2026-07-22)"
       - "event-time: freshness-monitor CRITICAL page -> router (trigger=freshness-critical, config-I3282)"

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -404,3 +404,39 @@ def test_registry_model_passes_its_executor_validator():
         )
         checked += 1
     assert checked >= 3, f"expected >=3 routed playbooks with models, checked {checked}"
+
+
+# Fleet ROUTING-TIER suffixes. These are LiteLLM/registry group aliases
+# (LLM_MODEL_REGISTRY ids like `deepseek-v4-pro-max`, whose own `model:` field
+# resolves to the real provider name `deepseek-v4-pro`). They are NOT provider
+# API model names.
+_ROUTING_ALIAS_SUFFIXES = ("-max", "-low", "-mid", "-high")
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(k for k, v in REGISTRY["playbooks"].items() if v.get("routed") and v.get("model")),
+)
+def test_registry_model_is_a_provider_name_not_a_routing_alias(name):
+    """A routed playbook's `model` is passed STRAIGHT to `claude -p --model` on
+    the spot box, which talks directly to the provider through the local egress
+    proxy — there is no LiteLLM hop to resolve a fleet routing alias.
+
+    alpha-engine-config-I4471: alert-drain shipped `deepseek-v4-pro-max` (a
+    registry TIER id, not an API model) and every run died on
+
+        400 The supported API model names are deepseek-v4-pro or
+        deepseek-v4-flash, but you passed deepseek-v4-pro-max.
+
+    The alias resolves to `deepseek-v4-pro` in LLM_MODEL_REGISTRY, but nothing
+    performed that resolution on this path.
+    """
+    model = REGISTRY["playbooks"][name]["model"]
+    bad = [s for s in _ROUTING_ALIAS_SUFFIXES if model.endswith(s)]
+    assert not bad, (
+        f"routed playbook {name!r} declares model {model!r}, which ends in the "
+        f"routing-tier suffix {bad[0]!r} — that is a fleet registry ALIAS, not a "
+        f"provider API model name. The spot box passes this value directly to "
+        f"the provider and the call will 400. Use the resolved provider model "
+        f"(e.g. 'deepseek-v4-pro')."
+    )


### PR DESCRIPTION
Refs nousergon/alpha-engine-config#4471

## What happened

The first real drain run after the DLP root-cause fix (alpha-engine-config-PR4506) **got past the proxy** — confirming that fix works — and then died on the provider:

```
[alert-drain-bootstrap] DeepSeek egress proxy healthy (pid=26951)
API Error: 400 The supported API model names are deepseek-v4-pro or
deepseek-v4-flash, but you passed deepseek-v4-pro-max.
```

`deepseek-v4-pro-max` is an `LLM_MODEL_REGISTRY` **tier id** whose own `model:` field resolves to `deepseek-v4-pro`. It is a fleet *routing alias*, not a provider API model name.

A routed playbook's `model` is passed **straight** to `claude -p --model` on the spot box, which talks to the provider through the local egress proxy — there is no LiteLLM hop on that path to resolve an alias.

My own doing: the bad value came from `alert_drain_run.sh`'s inline default, and I propagated it into the registry in #1063 without checking it against the provider's accepted names.

## Changes

- alert-drain registry model: `deepseek-v4-pro-max` → `deepseek-v4-pro`
- **New test** rejecting any routed playbook whose model ends in a routing-tier suffix (`-max`/`-low`/`-mid`/`-high`), so an alias can never again ship as an API model name on this direct-provider path.

## Companion

`alpha-engine-config` carries the same latent bug in the run-script defaults (`alert_drain_run.sh`, `ci_watch_run.sh` both default to `deepseek-v4-pro-max`) — fixed in a paired PR there. ci-watch is already effectively covered because the router injects the registry value, which #1063 set to `deepseek-v4-pro`; the script default only applies on non-router paths.

## Testing

`tests/test_overseer_playbook_registry.py` → **40 passed** (was 37).

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)