### PR TITLE
[P1/low] fix(iam): substrate-health-gate can probe the dynamic weekly-freshness spot

### DIFF
--- a/infrastructure/lambdas/substrate-health-gate/iam-policy.json
+++ b/infrastructure/lambdas/substrate-health-gate/iam-policy.json
@@ -16,6 +16,19 @@
       ]
     },
     {
+      "Sid": "SsmDiskProbeWeeklyFreshnessSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand"
+      ],
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringLike": {
+          "ssm:resourceTag/Name": "alpha-engine-weekly-freshness-spot"
+        }
+      }
+    },
+    {
       "Sid": "Logs",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** low · Found by the post-#975 rehearsal.

## What happened

The first shell-run rehearsal after #975 merged (`offcycle-shell-20260727-152841`) failed at `SubstrateHealthGate`:

```
AccessDeniedException: alpha-engine-substrate-health-gate-role is not authorized
to perform: ssm:SendCommand on resource: .../instance/i-020b1ec53bf232ecb
```

## The gap

#975 anticipated this class — its own body says *"the prior grant was hardcoded to two specific instance ARNs and would have `AccessDenied`'d against any dynamically-launched box"* — and fixed it for `alpha-engine-step-functions-role` via a tag-scoped `SendCommandWeeklyFreshnessSpot` statement.

**It missed the sibling.** `substrate-health-gate` is a *second* role that sends SSM commands to the same box, and its `SsmDiskProbe` statement still enumerates only the two static instance ARNs (dashboard `i-09b539c844515d549`, executor `i-018eb3307a21329bf`). Both roles needed the same treatment; only one got it.

## Fix

Adds `SsmDiskProbeWeeklyFreshnessSpot`, mirroring the SF role's grant exactly:

```json
{
  "Sid": "SsmDiskProbeWeeklyFreshnessSpot",
  "Effect": "Allow",
  "Action": ["ssm:SendCommand"],
  "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
  "Condition": { "StringLike": { "ssm:resourceTag/Name": "alpha-engine-weekly-freshness-spot" } }
}
```

Tag-scoped rather than instance-scoped precisely because the box is now per-execution and has no stable id.

## The rehearsal worked as designed

Worth stating plainly: **the dispatch itself succeeded.** The SF reached `DispatchWeeklyFreshnessSpot`, launched `c5.large i-020b1ec53bf232ecb`, saw SSM come Online in 16s, and polled bootstrap:

```
15:28:50  ec2_spot: launched c5.large as i-020b1ec53bf232ecb in subnet-a61ec0fb
15:29:06  SSM agent Online
15:29:06  dispatched: instance=i-020b1ec53bf232ecb run_token=e2bd6bde...
          Duration 19.6s · Max Memory Used 108 MB / 256 MB
```

The dashboard-box SPOF is genuinely retired. This failure is the *next gate along* — and finding it in a rehearsal on a Monday rather than at 02:00 Saturday is exactly what the off-cycle shell run is for. It also settles #975's founding caveat: the change never needed a live Saturday to validate.

## Verification

Applied live **before** this PR opened, so merge remains the final step:

```
simulate ssm:SendCommand on instance/i-020b1ec53bf232ecb
  with ssm:resourceTag/Name=alpha-engine-weekly-freshness-spot  ->  allowed
```

Re-running the rehearsal to confirm the pipeline advances past `SubstrateHealthGate`.

## Related

`alpha-engine-config-I4504` (dashboard-box dispatcher SIGTERM — the reason #975 exists) · `alpha-engine-config-I4494` (preflight would assert per-stage IAM before spend — this exact failure class)

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)