### PR TITLE
fix(iam): broaden health-gate SSM resource to instance/* for spot dispatch

### DIFF
--- a/infrastructure/lambdas/substrate-health-gate/iam-policy.json
+++ b/infrastructure/lambdas/substrate-health-gate/iam-policy.json
@@ -10,8 +10,7 @@
       ],
       "Resource": [
         "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
-        "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
-        "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf",
+        "arn:aws:ec2:us-east-1:711398986525:instance/*",
         "arn:aws:ssm:us-east-1:711398986525:*"
       ]
     },


### PR DESCRIPTION
## Root cause

The `alpha-engine-substrate-health-gate` Lambda's IAM policy hardcoded two specific instance ARNs (`i-09b539c844515d549`, `i-018eb3307a21329bf`) for `ssm:SendCommand` + `ssm:GetCommandInvocation`. The weekly pipeline launches a **fresh spot instance** each run (`DispatchWeeklyFreshnessSpot`), whose instance ID is never in the hardcoded list — every spot-launched execution fails with `AccessDeniedException` on `SendCommand`.

The 2026-07-27 off-cycle shell run (`offcycle-shell-20260727-152841`) failed at `SubstrateHealthGate` — the first state to probe the freshly-launched spot instance `i-020b1ec53bf232ecb`.

Prior runs on the persistent dashboard/trading boxes (e.g. 2026-07-18, 2026-07-25) happened to be in the hardcoded list, so the spot gap was latent.

## Fix

Replace the two hardcoded instance ARNs with `arn:aws:ec2:us-east-1:711398986525:instance/*` — matching the SF's own role which already has separate `SendCommandWeeklyFreshnessSpot` / `SendCommandDailyDataSpot` statement blocks with `instance/*`. The security boundary is already enforced by the SF gating Lambda invocation.

## Guard

This is an **IAM policy resource change** — the deploy.sh `--apply-iam` path was designed for exactly this (`config#2825`). The existing test suite (`test_handler.py`) mocks the SSM client so the IAM resource scope is not covered by unit tests; the real guard is the `--smoke` deploy step that issues a live `df` probe.

## IAM — requires operator apply

This is an IAM change. After merge, an operator must run:
```bash
bash infrastructure/lambdas/substrate-health-gate/deploy.sh --apply-iam
```
to put the updated inline policy on `alpha-engine-substrate-health-gate-role`. The Lambda code itself is unchanged, so a code redeploy is not needed.

Fleet-SF Watch incident: `offcycle-shell-20260727-152841` / `2026-07-27`

🤖 Generated with [Claude Code](https://claude.com/claude-code)