### PR TITLE
[P0/low] fix(dispatcher): clone alpha-engine-predictor onto the weekly launcher box

### DIFF
--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -165,6 +165,8 @@ BACKTESTER_REPO = os.environ.get("WEEKLY_SPOT_BACKTESTER_REPO", "nousergon/cruci
 BACKTESTER_BRANCH = os.environ.get("WEEKLY_SPOT_BACKTESTER_BRANCH", "main")
 DASHBOARD_REPO = os.environ.get("WEEKLY_SPOT_DASHBOARD_REPO", "nousergon/crucible-dashboard")
 DASHBOARD_BRANCH = os.environ.get("WEEKLY_SPOT_DASHBOARD_BRANCH", "main")
+PREDICTOR_REPO = os.environ.get("WEEKLY_SPOT_PREDICTOR_REPO", "nousergon/crucible-predictor")
+PREDICTOR_BRANCH = os.environ.get("WEEKLY_SPOT_PREDICTOR_BRANCH", "main")
 
 # alpha-engine-config is private; the box reads the fleet PAT from SSM via its
 # instance profile — same pattern data-spot-dispatcher/scheduled-groom-
@@ -249,13 +251,19 @@ rm -rf /home/ec2-user/alpha-engine-backtester
 git clone --depth 1 --branch {BACKTESTER_BRANCH} \\
   "https://x-access-token:${{PAT}}@github.com/{BACKTESTER_REPO}.git" \\
   /home/ec2-user/alpha-engine-backtester || fail "alpha-engine-backtester clone failed"
+echo "[weekly-freshness-spot-bootstrap] cloning alpha-engine-predictor..."
+rm -rf /home/ec2-user/alpha-engine-predictor
+git clone --depth 1 --branch {PREDICTOR_BRANCH} \\
+  "https://x-access-token:${{PAT}}@github.com/{PREDICTOR_REPO}.git" \\
+  /home/ec2-user/alpha-engine-predictor || fail "alpha-engine-predictor clone failed"
 echo "[weekly-freshness-spot-bootstrap] cloning alpha-engine-dashboard..."
 rm -rf /home/ec2-user/alpha-engine-dashboard
 git clone --depth 1 --branch {DASHBOARD_BRANCH} \\
   "https://x-access-token:${{PAT}}@github.com/{DASHBOARD_REPO}.git" \\
   /home/ec2-user/alpha-engine-dashboard || fail "alpha-engine-dashboard clone failed"
 chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-data /home/ec2-user/alpha-engine-config \\
-  /home/ec2-user/alpha-engine-backtester /home/ec2-user/alpha-engine-dashboard || fail "chown failed"
+  /home/ec2-user/alpha-engine-backtester /home/ec2-user/alpha-engine-dashboard \\
+  /home/ec2-user/alpha-engine-predictor || fail "chown failed"
 echo "[weekly-freshness-spot-bootstrap] building alpha-engine-dashboard venv..."
 cd /home/ec2-user/alpha-engine-dashboard
 "$PYTHON_BIN" -m venv .venv || fail "venv create failed"

--- a/tests/test_weekly_spot_bootstrap_repo_coverage.py
+++ b/tests/test_weekly_spot_bootstrap_repo_coverage.py
@@ -1,0 +1,108 @@
+"""The weekly spot bootstrap must clone every repo the SF actually uses.
+
+Bug class this guards (found by the 2026-07-27 post-#975 rehearsal): the
+per-execution launcher box's bootstrap cloned four repos —
+``alpha-engine-{data,config,backtester,dashboard}`` — while the weekly SF's
+command strings ``cd`` into **five**. ``alpha-engine-predictor`` was never
+cloned, so `PredictorTraining` died at launch:
+
+    fatal: cannot change to '/home/ec2-user/alpha-engine-predictor':
+    No such file or directory
+    failed to run commands: exit status 128
+
+That took out the whole predictor arm — `PredictorTraining`, `ResolveZooSpecs`,
+`TrainSpecDispatch`, `ModelZooSelect`, and therefore the live-champion
+promotion.
+
+It was invisible before #975 because the long-lived dashboard box had all five
+repos provisioned by hand years of runs ago. Only a box built from scratch
+exposes the gap — which is exactly why the rehearsal exists, and why pinning
+the invariant in CI matters more than fixing the one missing clone.
+
+The assertion is derived from BOTH sides — the SF definition's own command
+strings and the dispatcher's bootstrap script — so adding a stage that uses a
+sixth repo fails here rather than at 02:00 on a Saturday.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SF_JSON = _REPO_ROOT / "infrastructure" / "step_function.json"
+_DISPATCHER = (
+    _REPO_ROOT
+    / "infrastructure"
+    / "lambdas"
+    / "weekly-freshness-spot-dispatcher"
+    / "index.py"
+)
+
+# Checkout paths under /home/ec2-user that the bootstrap creates.
+_CHECKOUT_RE = re.compile(r"/home/ec2-user/(alpha-engine-[a-z-]+)")
+
+
+def _repos_the_sf_uses() -> set[str]:
+    """Every alpha-engine-* checkout path referenced by an SF command string."""
+    doc = json.loads(_SF_JSON.read_text(encoding="utf-8"))
+    found: set[str] = set()
+
+    def walk(node) -> None:
+        if isinstance(node, dict):
+            for key, val in node.items():
+                if key == "commands.$" and isinstance(val, str):
+                    found.update(_CHECKOUT_RE.findall(val))
+                else:
+                    walk(val)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(doc)
+    return found
+
+
+def _repos_the_bootstrap_clones() -> set[str]:
+    """Every checkout path the dispatcher's bootstrap script git-clones."""
+    src = _DISPATCHER.read_text(encoding="utf-8")
+    # Each clone ends with the destination path on its own continuation line.
+    return set(re.findall(r"/home/ec2-user/(alpha-engine-[a-z-]+) \|\| fail", src))
+
+
+def test_sf_references_at_least_one_repo():
+    """Guard the guard — a broken walker must not silently pass."""
+    assert _repos_the_sf_uses(), "no alpha-engine-* checkout paths found in the SF"
+
+
+def test_bootstrap_clones_every_repo_the_sf_uses():
+    used = _repos_the_sf_uses()
+    cloned = _repos_the_bootstrap_clones()
+    missing = used - cloned
+    assert not missing, (
+        f"the weekly SF cds into {sorted(missing)} but the launcher-box bootstrap "
+        f"never clones {'it' if len(missing) == 1 else 'them'}. Every stage using "
+        f"{'that repo' if len(missing) == 1 else 'those repos'} will die with "
+        f"\"cannot change to ...: No such file or directory\" (exit 128) on a "
+        f"freshly-launched box. Add the clone (and the chown) in "
+        f"infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py. "
+        f"SF uses {sorted(used)}; bootstrap clones {sorted(cloned)}."
+    )
+
+
+def test_every_cloned_repo_is_chowned_to_ec2_user():
+    """A clone the box cannot write to is as broken as a missing one.
+
+    The bootstrap runs as root; every stage runs as ec2-user and does a
+    ``git pull``, which needs write access to the checkout.
+    """
+    src = _DISPATCHER.read_text(encoding="utf-8")
+    chown_block = re.search(r"chown -R ec2-user:ec2-user(.*?)\|\| fail", src, re.S)
+    assert chown_block, "bootstrap has no chown block"
+    chowned = set(_CHECKOUT_RE.findall(chown_block.group(1)))
+    missing = _repos_the_bootstrap_clones() - chowned
+    assert not missing, (
+        f"{sorted(missing)} cloned but never chowned to ec2-user — stages run as "
+        f"ec2-user and `git pull` needs write access"
+    )


### PR DESCRIPTION
**Priority:** P0 · **Complexity:** low · **The predictor arm fails on Saturday without this.**

## What the rehearsal found

Run 3 (`offcycle-shell-20260727-155656`) reached the predictor branch and died:

```
fatal: cannot change to '/home/ec2-user/alpha-engine-predictor': No such file or directory
failed to run commands: exit status 128
```

The launcher-box bootstrap clones **four** repos. The weekly SF's command strings `cd` into **five**:

| Repo | SF references | Cloned by bootstrap |
|---|---|---|
| alpha-engine-dashboard | 16 | ✅ |
| alpha-engine-backtester | 10 | ✅ |
| **alpha-engine-predictor** | **10** | ❌ |
| alpha-engine-data | 9 | ✅ |
| alpha-engine-config | 8 | ✅ |

**Blast radius:** the entire predictor arm — `PredictorTraining`, `ResolveZooSpecs`, `TrainSpecDispatch`, `ModelZooSelect` — and therefore live-champion promotion, since `ModelZooSelect` is the sole writer of `predictor/weights/meta/`.

Invisible before #975 because the long-lived dashboard box had all five repos provisioned by hand. Only a box built from scratch exposes it.

## Fix

- `PREDICTOR_REPO` / `PREDICTOR_BRANCH` constants (`nousergon/crucible-predictor`, `main`), env-overridable like every sibling.
- Clone step mirroring the backtester block, plus the repo added to the bootstrap's `chown` — stages run as `ec2-user` and `git pull` needs write access, so a clone the box can't write to is as broken as a missing one.
- **`tests/test_weekly_spot_bootstrap_repo_coverage.py`** — derives the invariant from **both** sides: every `alpha-engine-*` checkout path the SF definition `cd`s into must be cloned, and every cloned repo must be chowned.

**The guard matters more than the missing clone.** This class is only observable on a freshly-built box — it cannot be caught by reading either file alone, which is why it survived review. Now a sixth repo added to any stage fails in CI instead of at 02:00 Saturday.

## Verification

The guard is provably non-inert — against `origin/main` it reproduces the production failure verbatim:

```
AssertionError: the weekly SF cds into ['alpha-engine-predictor'] but the
launcher-box bootstrap never clones it. Every stage using that repo will die
with "cannot change to ...: No such file or directory" (exit 128) on a
freshly-launched box.
```

3/3 pass after the fix. Dispatcher `test_handler` 13/13. Shared launcher guard 7/7. Full suite **3667 passed** — the 5 local failures are the known stale-venv artifacts (3 need lib `v0.124.19`, 2 need krepis `>=0.18.8`), unchanged by this PR.

## Deploy

Merge alone. `deploy-weekly-freshness-spot-dispatcher.yml` is path-filtered on this Lambda's directory.

## Rehearsal tally

Fourth Saturday-fatal defect found today by `run_weekly_offcycle.sh shell`, after the `--bootstrap` em-dash, the substrate-health-gate IAM gap (#1065), and the krepis pin (`crucible-dashboard#554`). Run 3 has otherwise cleared every stage that failed earlier and is currently in `RAGIngestion`.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)