### PR TITLE
[P2] fix(sf): warn when the drift check runs from a stale checkout

### DIFF
--- a/infrastructure/step-functions/check-definition-drift.py
+++ b/infrastructure/step-functions/check-definition-drift.py
@@ -205,6 +205,69 @@ def _fetch_s3_definition(key: str) -> dict | None:
     return json.loads(out)
 
 
+def _git(*args: str) -> str | None:
+    """``git`` output, or ``None`` if git is unavailable / the command fails
+    (not a git checkout, no remote-tracking ref, shallow clone). Never raises:
+    the staleness note is an aid, and its absence must never break a real
+    drift check."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            capture_output=True, text=True, check=False,
+        )
+    except (OSError, ValueError):
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def stale_definition_files(entries) -> list[str]:
+    """Definition files whose WORKING-TREE bytes differ from ``origin/HEAD``'s.
+
+    This script's entire premise is "the repo file is the intended truth" — so
+    when the working tree does not match the pushed branch, every finding it
+    produces is suspect: the difference may be local staleness rather than live
+    drift. On 2026-07-27 a checkout 9 commits behind origin produced four
+    confident findings (an alleged 18-state divergence in the weekly trading
+    pipeline) that were entirely the local delta; live, S3 and origin/main all
+    agreed. A tool whose job is comparing repo bytes to live must not report
+    drift from bytes it cannot vouch for.
+
+    Deliberately does NOT fetch — a checker must not mutate git state, and a
+    stale remote-tracking ref still catches the common case (a checkout that
+    was never pulled). Deliberately does NOT fail: comparing an in-flight
+    branch's definitions against live before merging is a legitimate use, and
+    that case would trip this every time. It annotates instead.
+
+    Returns repo-relative paths, sorted. Empty when git is unavailable — an
+    unknown answer is reported as "no note", never as a false reassurance,
+    because ``main()`` prints the note only when this is non-empty."""
+    if _git("rev-parse", "--is-inside-work-tree") != "true":
+        return []
+    # Resolve the tracked remote branch rather than assuming "origin/main".
+    upstream = (_git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+                or "origin/main")
+    stale: list[str] = []
+    for entry in SF_DEFINITIONS:
+        rel = (INFRA_DIR / entry["definition_file"]).relative_to(REPO_ROOT)
+        local = _git("hash-object", str(rel))
+        remote = _git("rev-parse", f"{upstream}:{rel}")
+        if local and remote and local != remote:
+            stale.append(str(rel))
+    return sorted(set(stale))
+
+
+def stale_checkout_note(stale: list[str], upstream: str = "origin/main") -> str:
+    """The operator-facing warning. Pure / testable."""
+    files = ", ".join(stale)
+    return (
+        f"⚠️  LOCAL CHECKOUT MAY BE STALE — {len(stale)} definition file(s) "
+        f"differ from {upstream}: {files}\n"
+        f"    Findings below compare LOCAL bytes against live/S3, so a "
+        f"'drift' here may be your checkout, not the deployment.\n"
+        f"    Run `git pull` and re-check before acting on anything below."
+    )
+
+
 def _check_sf(entry: dict) -> list[str]:
     sf_name = entry["sf_name"]
     definition_path = INFRA_DIR / entry["definition_file"]
@@ -329,6 +392,12 @@ def main() -> int:
         total_findings.extend(_check_sf(entry))
 
     if total_findings:
+        # Printed BEFORE the findings, so it cannot be missed by someone who
+        # reads the first line and starts acting (which is exactly what
+        # happened on 2026-07-27).
+        stale = stale_definition_files(entries)
+        if stale:
+            print(stale_checkout_note(stale))
         print(f"SF definition drift detected ({len(total_findings)} finding(s)):")
         for f in total_findings:
             print(f"  - {f}")

--- a/tests/test_sf_definition_check_drift.py
+++ b/tests/test_sf_definition_check_drift.py
@@ -465,3 +465,79 @@ def test_main_no_alert_flag_suppresses_alert_even_on_drift(cd, monkeypatch, fake
     monkeypatch.setattr("sys.argv", ["check-definition-drift.py", "--no-alert"])
     assert cd.main() == 1
     assert fake_nousergon_lib_alerts == []
+
+
+# ── stale-checkout guard (2026-07-27) ───────────────────────────────────────
+#
+# A checkout 9 commits behind origin produced four confident findings — an
+# alleged 18-state divergence in the weekly trading pipeline — that were
+# entirely the local delta. Live, S3 and origin/main all agreed. This script
+# compares REPO bytes to live, so stale repo bytes yield confident false drift.
+
+
+def test_stale_note_names_every_stale_file_and_the_fix(cd):
+    note = cd.stale_checkout_note(
+        ["infrastructure/step_function.json",
+         "infrastructure/step_function_eod.json"])
+    assert "STALE" in note
+    assert "infrastructure/step_function.json" in note
+    assert "infrastructure/step_function_eod.json" in note
+    assert "git pull" in note
+    # Must say the finding may be the CHECKOUT, not the deployment — that is
+    # the whole point of the note.
+    assert "may be your checkout" in note
+
+
+def test_stale_note_respects_a_non_default_upstream(cd):
+    note = cd.stale_checkout_note(["a.json"], upstream="origin/release")
+    assert "origin/release" in note
+
+
+def test_no_stale_files_when_working_tree_matches_upstream(cd, monkeypatch):
+    def fake_git(*args):
+        if args[0] == "rev-parse" and "--is-inside-work-tree" in args:
+            return "true"
+        if args[0] == "hash-object":
+            return "deadbeef"
+        if args[0] == "rev-parse":
+            return "deadbeef"          # upstream blob == working tree blob
+        return None
+    monkeypatch.setattr(cd, "_git", fake_git)
+    assert cd.stale_definition_files(cd.SF_DEFINITIONS) == []
+
+
+def test_stale_files_detected_when_blobs_differ(cd, monkeypatch):
+    def fake_git(*args):
+        if args[0] == "rev-parse" and "--is-inside-work-tree" in args:
+            return "true"
+        if args[0] == "rev-parse" and "--abbrev-ref" in args:
+            return "origin/main"
+        if args[0] == "hash-object":
+            return "local-sha"
+        if args[0] == "rev-parse":
+            return "remote-sha"
+        return None
+    monkeypatch.setattr(cd, "_git", fake_git)
+    stale = cd.stale_definition_files(cd.SF_DEFINITIONS)
+    assert stale, "differing blobs must be reported as stale"
+    assert stale == sorted(set(stale)), "output must be sorted + deduped"
+
+
+def test_no_note_outside_a_git_checkout(cd, monkeypatch):
+    """CI images and vendored copies are not always git checkouts — an
+    unknown answer must degrade to 'no note', never to a crash."""
+    monkeypatch.setattr(cd, "_git", lambda *a: None)
+    assert cd.stale_definition_files(cd.SF_DEFINITIONS) == []
+
+
+def test_git_helper_never_raises_when_git_is_missing(cd, monkeypatch):
+    def boom(*a, **k):
+        raise OSError("git not found")
+    monkeypatch.setattr(cd.subprocess, "run", boom)
+    assert cd._git("rev-parse", "HEAD") is None
+
+
+def test_git_helper_returns_none_on_nonzero_exit(cd, monkeypatch):
+    monkeypatch.setattr(cd.subprocess, "run",
+                        lambda *a, **k: MagicMock(returncode=1, stdout="x"))
+    assert cd._git("rev-parse", "nope") is None


### PR DESCRIPTION
## What happened

`check-definition-drift.py`'s premise is *"the repo file is the intended truth"*. So when the working tree doesn't match the pushed branch, **every finding it produces is suspect** — the difference may be local staleness rather than live drift.

On 2026-07-27 that produced four confident findings from a checkout **9 commits behind origin**:

```
- ne-weekly-freshness-pipeline: definition drift (LIVE vs infrastructure/step_function.json)
    Diverges at: States (18 differing: AcquireMutex, Backtester, CheckMutexRole, …)
- ne-weekly-freshness-pipeline: S3 staged copy stale (config#2273 rollback hazard)
- ne-postclose-trading-pipeline: definition drift (LIVE vs …_eod.json) — 2 states
- ne-postclose-trading-pipeline: S3 staged copy stale
```

I filed those as a P1 issue against the weekly *trading* pipeline. An independent three-way canonical comparison then showed:

```
live == s3   : True
repo == live : True      (repo = origin/main bytes)
states: repo=118 live=118 s3=118
DIFFERING STATES (0)
```

The "drift" was entirely the local 193-line delta. The deployment was never wrong. Issue closed as invalid (alpha-engine-config-I4769).

## Why the tool changes, not just my habits

The tool wasn't inaccurate — it accurately compared what it was handed. The defect is that **its output is indistinguishable between "live drifted" and "your checkout is behind"**, and only the first reading prompts action. So it now says which it might be:

```
⚠️  LOCAL CHECKOUT MAY BE STALE — 2 definition file(s) differ from origin/main:
    infrastructure/step_function.json, infrastructure/step_function_eod.json
    Findings below compare LOCAL bytes against live/S3, so a 'drift' here may be
    your checkout, not the deployment.
    Run `git pull` and re-check before acting on anything below.
```

Printed **before** the findings — someone reading the first line and acting on it is precisely what happened.

## Three deliberate non-behaviours

| | |
|---|---|
| **Does not fetch** | A checker must not mutate git state. A stale remote-tracking ref still catches the common case: a checkout that was never pulled. |
| **Does not fail the run** | Comparing an in-flight branch's definitions against live *before* merging is a legitimate use and would trip this every time. It annotates; it does not block. |
| **Does not assume `origin/main`** | Resolves the tracked upstream via `@{upstream}`, falling back only when there is none. |

Degrades to no-note outside a git checkout or when git is missing — an unknown answer is reported as *no note*, never as false reassurance.

## Verification — the original scenario, reproduced

Reverting the two definition files to the 9-commits-behind blobs reproduces **all four findings byte-for-byte**, now with the warning above them:

```
⚠️  LOCAL CHECKOUT MAY BE STALE — 2 definition file(s) differ from origin/main: …
SF definition drift detected (4 finding(s)):
  - ne-weekly-freshness-pipeline: … States (18 differing: AcquireMutex, Backtester, …)
  …
```

On a current checkout: no note, `OK: repo, live, and S3 staged definitions all match`.

## Tests

7 new cases in `tests/test_sf_definition_check_drift.py` (38 pass total): note content and the named fix, non-default upstream, matching blobs → no note, differing blobs → stale + sorted/deduped, not-a-git-checkout, git-missing, and git-nonzero-exit.

**Note on local runs:** the full `tests/` collection errors on missing deps (`bs4`, `krepis`, `tenacity`, `yfinance`) in this bare worktree — no venv. Environmental; CI installs them. The target suite and ruff both pass.

## Related

The permission fix that surfaced this — `crucible-executor-PR440`, `saturday-sf-watch-role` lacking `states:DescribeStateMachine` on `alpha-engine-groom-dispatch` — was real and is merged. `gate-due-sweep` had genuinely been red since 2026-07-25. Only the drift *findings* were bogus.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
