### PR TITLE
[P1/low] fix(sf): keep SNS Subjects inside the 100-char limit

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2054,7 +2054,7 @@
               "Resource": "arn:aws:states:::sns:publish",
               "Parameters": {
                 "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — Branch A FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — Branch A FAILED (early signal)', $.pipeline_label)",
                 "Message.$": "States.Format('Branch A (RAGIngestion or SignalsEnvelope) hard-failed inside ResearchPredictorParallel. The sibling PredictorTraining branch is still running and will complete its own work; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
               },
               "ResultPath": null,
@@ -2351,7 +2351,7 @@
               "Resource": "arn:aws:states:::sns:publish",
               "Parameters": {
                 "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — PredictorTraining FAILED (early signal — SF will fail at join)', $.pipeline_label)",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — PredictorTraining FAILED (early signal)', $.pipeline_label)",
                 "Message.$": "States.Format('PredictorTraining branch failed inside ResearchPredictorParallel. The sibling Research branch is still running and will complete its eval-judge / RollingMean / Counterfactual work independently; the SF will fail at the parallel-join aggregation via CheckBranchOutcomes once both branches terminate. This is an EARLY-SIGNAL alert so you do not have to wait for the join. Error: {}', States.JsonToString($.error))"
               },
               "ResultPath": null,
@@ -2834,7 +2834,7 @@
               "Resource": "arn:aws:states:::sns:publish",
               "Parameters": {
                 "TopicArn.$": "$.sns_topic_arn",
-                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — ModelZooRotation FAILED (zoo digest email may be missing)', $.pipeline_label)",
+                "Subject.$": "States.Format('Alpha Engine Saturday{} Pipeline — ModelZooRotation FAILED (zoo digest may be missing)', $.pipeline_label)",
                 "Message.$": "States.Format('The model-zoo rotation failed or timed out. The base champion-arch retrain already trained+promoted and DEFERRED its training email to the zoo digest (PREDICTOR_DEFER_TRAINING_EMAIL=1), so the consolidated digest email may NOT have been sent for this run — review predictor-model-zoo.log on the spot and predictor/model_zoo/leaderboard/. The branch will still complete (the champion is live); the rotation is best-effort. Error: {}', States.JsonToString($.model_zoo_error))"
               },
               "ResultPath": null,

--- a/tests/test_sns_subject_limits.py
+++ b/tests/test_sns_subject_limits.py
@@ -1,0 +1,99 @@
+"""Every SF SNS Subject must render inside SNS's 100-character limit.
+
+Bug class this guards (found by the 2026-07-27 rehearsal,
+offcycle-shell-20260727-155656): `PublishPredictorFailureImmediate` rendered
+105 characters and SNS rejected the publish outright::
+
+    SNS.InvalidParameterException: Invalid parameter: Subject
+
+The predictor branch had genuinely failed, and the alert designed to tell us
+so **could not send**. That is the worst shape a defect can take: the failure
+is real, and the thing whose entire job is to surface it fails silently
+alongside it.
+
+All three offenders were the ``*FailureImmediate`` early-warning notifiers —
+exactly the states that only ever run when something is already wrong, and so
+are the least likely to be exercised in a healthy run.
+
+The limit is on the RENDERED string, not the template. These Subjects are
+``States.Format`` templates interpolating ``$.pipeline_label``, which is empty
+on a normal weekly run but ``" Preflight"`` on a shell run — ten characters
+that pushed one Subject over. A template that looks fine in the repo can still
+fail live, so this test renders with the longest known label.
+
+Note: em-dashes are fine. An earlier pass of this analysis flagged all 14
+Subjects as non-ASCII violations; that was wrong — ``HandleFailure`` (49 chars,
+em-dash) published successfully in the same run. Length is the operative
+constraint.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+# SNS caps Subject at 100 characters. Held one below to leave no boundary doubt.
+_SNS_SUBJECT_MAX = 99
+
+# Longest value $.pipeline_label takes. "" on a cadence run, " Preflight" on a
+# shell run — the variant that actually broke.
+_LONGEST_PIPELINE_LABEL = " Preflight"
+
+_SF_JSON = Path(__file__).resolve().parents[1] / "infrastructure" / "step_function.json"
+_FORMAT_RE = re.compile(r"States\.Format\('((?:[^'\\]|\\.)*)'")
+
+
+def _collect_subjects(states: dict, out: list | None = None) -> list[tuple[str, str]]:
+    """(state_name, rendered_subject) for every SNS publish, at any nesting."""
+    if out is None:
+        out = []
+    for name, body in states.items():
+        params = body.get("Parameters") or {}
+        subject = params.get("Subject") or params.get("Subject.$")
+        if subject:
+            match = _FORMAT_RE.search(subject)
+            literal = match.group(1) if match else subject.strip("'")
+            out.append((name, literal.replace("{}", _LONGEST_PIPELINE_LABEL)))
+        if body.get("Type") == "Parallel":
+            for branch in body.get("Branches", []):
+                _collect_subjects(branch["States"], out)
+        for key in ("Iterator", "ItemProcessor"):
+            if key in body:
+                _collect_subjects(body[key]["States"], out)
+    return out
+
+
+_SUBJECTS = _collect_subjects(json.loads(_SF_JSON.read_text(encoding="utf-8"))["States"])
+
+
+def test_subjects_were_found():
+    """Guard the guard — a broken collector must not silently pass."""
+    assert _SUBJECTS, "no SNS Subjects found in the weekly SF definition"
+
+
+@pytest.mark.parametrize(
+    "state,subject", _SUBJECTS, ids=[name for name, _ in _SUBJECTS]
+)
+def test_subject_fits_sns_limit(state: str, subject: str):
+    assert len(subject) <= _SNS_SUBJECT_MAX, (
+        f"{state}: Subject renders to {len(subject)} chars with "
+        f"pipeline_label={_LONGEST_PIPELINE_LABEL!r}, over SNS's 100-char limit — "
+        f"the publish fails with InvalidParameterException and the notification "
+        f"is never sent. Shorten the template; detail belongs in Message, which "
+        f"has no such limit.\n  {subject}"
+    )
+
+
+@pytest.mark.parametrize(
+    "state,subject", _SUBJECTS, ids=[name for name, _ in _SUBJECTS]
+)
+def test_subject_has_no_newlines_or_control_characters(state: str, subject: str):
+    """SNS also rejects line feeds and control characters in Subject."""
+    offenders = [c for c in subject if c == "\n" or c == "\r" or ord(c) < 32]
+    assert not offenders, (
+        f"{state}: Subject contains newline/control characters {offenders!r}, "
+        f"which SNS rejects"
+    )


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** low · Found by the 2026-07-27 rehearsal.

## The defect

`offcycle-shell-20260727-155656` hit:

```
SNS.InvalidParameterException: Invalid parameter: Subject
  in state PublishPredictorFailureImmediate
```

That Subject renders to **105 characters** on a shell run, over SNS's 100-char cap, so the publish was rejected.

**The predictor branch had genuinely failed, and the alert whose only job is to say so could not send.** That's the worst shape a defect takes: the failure is real and its detector fails silently alongside it.

## All three offenders are the early-warning notifiers

| Rendered | State | |
|---:|---|---|
| 105 | `PublishPredictorFailureImmediate` | **over** |
| 100 | `PublishModelZooFailureImmediate` | **at the cap** |
| 96 | `PublishResearchFailureImmediate` | one label change away |

These are precisely the states that run *only when something is already wrong* — the least likely to be exercised in a healthy run, and the most costly to have broken.

Shortened all three by dropping the trailing clause; that detail already appears in `Message`, which has no length limit. Max rendered Subject across the definition is now **94**.

## Why the repo looked fine

The limit applies to the **rendered** string. These are `States.Format` templates interpolating `$.pipeline_label` — empty on a cadence run, `" Preflight"` on a shell run. Ten characters pushed one over. A template that reads fine in the repo can still fail live, so the new test renders with the longest known label.

`tests/test_sns_subject_limits.py` pins the invariant for every SNS publish in the definition, including nested Parallel/Map states, plus the newline/control-character rule SNS also enforces.

## Correcting my own first pass

I initially flagged **all 14** Subjects as non-ASCII violations because they contain em-dashes. **That was wrong** — `HandleFailure` (49 chars, em-dash) published successfully in the same execution. Length is the operative constraint, and the test asserts that rather than a character set. The docstring records the correction so the next reader doesn't repeat it.

## Verification

Guard is provably non-inert — against `origin/main` it names both real offenders with their exact rendered strings:

```
E  where 105 = len('Alpha Engine Saturday Preflight Pipeline — PredictorTraining FAILED (early signal — SF will fail at join)')
```

29/29 pass after. `aws stepfunctions validate-state-machine-definition` → `OK`. Full suite **3693 passed** (5 known stale-venv artifacts, unchanged).

## Deploy

Merge alone — `deploy-infrastructure.sh` restamps all four state machines on every push to `main`.

## Related

`nousergon-data#1068` (the predictor-repo clone that caused the branch failure this notifier failed to report) · `alpha-engine-config#1819` (notifier-totality class)

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)