### PR TITLE
[P0] fix(sf-watch): listener state is mode-aware; router deploy watches the registry (I4510)

### DIFF
--- a/.github/workflows/deploy-overseer-dispatcher.yml
+++ b/.github/workflows/deploy-overseer-dispatcher.yml
@@ -28,6 +28,14 @@ on:
     branches: [main]
     paths:
       - 'infrastructure/lambdas/overseer-dispatcher/**'
+      # The router BUNDLES the registry into its zip at deploy time (deploy.sh
+      # copies infrastructure/overseer/playbooks.yaml), so a registry-only
+      # change must redeploy it — otherwise the live router keeps routing on a
+      # stale copy. Omitting this is how the alert-drain model fix (#1064)
+      # redeployed the liveness probe (whose filter DID list the registry) but
+      # not the router, leaving the router injecting the old broken model.
+      # Pinned by tests/test_overseer_playbook_registry.py.
+      - 'infrastructure/overseer/playbooks.yaml'
       - '.github/workflows/deploy-overseer-dispatcher.yml'
   workflow_dispatch:
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -209,7 +209,12 @@ PIPELINES: dict[str, dict[str, object]] = {
         "label": "Pre-open Trading",
         "watch_prefix": "consolidated/weekday_sf_watch",
         "dispatch_event_type": "weekday-sf-failure",
-        "has_listener": True,
+        # I4510: FALSE under repository_dispatch — sf-watch.yml gates its
+        # dispatch job to saturday-sf-failure only (config#2004), so this event
+        # type has no consumer on the GitHub path. `_has_listener()` overrides
+        # this to True when M2_DISPATCH_TARGET=overseer, where the router IS
+        # the listener for every pipeline.
+        "has_listener": False,
         # config#1900 — fast-path signature scope for THIS pipeline only.
         # `poll_states` are the SSM-poll Task states whose Lambda output carries
         # the raw host-death evidence (status/status_details/ping_status);
@@ -245,7 +250,12 @@ PIPELINES: dict[str, dict[str, object]] = {
         "label": "Post-close Trading",
         "watch_prefix": "consolidated/eod_sf_watch",
         "dispatch_event_type": "eod-sf-failure",
-        "has_listener": True,
+        # I4510: FALSE under repository_dispatch — sf-watch.yml gates its
+        # dispatch job to saturday-sf-failure only (config#2004), so this event
+        # type has no consumer on the GitHub path. `_has_listener()` overrides
+        # this to True when M2_DISPATCH_TARGET=overseer, where the router IS
+        # the listener for every pipeline.
+        "has_listener": False,
     },
     # alpha-engine-config-I2890 (2026-07-17): the ne-weekly-advisory-pipeline
     # (I2544) and ne-modelzoo-sunday-pipeline (I2545) child SFs were retired —
@@ -760,7 +770,7 @@ def _build_event_record(
         dispatch_suppressed = None
     will_dispatch = (
         AGENT_DISPATCH_ENABLED
-        and bool(cfg.get("has_listener", True))
+        and _has_listener(cfg)  # I4510: mode-aware
         and dispatch_suppressed is None
     )
     record: dict = {
@@ -780,7 +790,11 @@ def _build_event_record(
         "lane": None,
         "action": "dispatch" if will_dispatch else "observe",
         "agent_dispatch_enabled": AGENT_DISPATCH_ENABLED,
-        "has_listener": bool(cfg.get("has_listener", True)),
+        # I4510: the watch-log must record whether a listener REALLY existed
+        # for this dispatch, not a static flag — the 2026-07-27 record said
+        # has_listener:true / action:"dispatch" for a weekday failure that no
+        # job could ever consume, making the audit trail itself false.
+        "has_listener": _has_listener(cfg),
         # config#1827/preflight: null unless the dispatch was withheld for a
         # recorded reason; "operator_abort"/"preflight" make the withholding
         # auditable in the watch-log and on the dashboard.
@@ -879,7 +893,7 @@ def _notify(record: dict, key: str, pipeline_name: str, dispatch: dict) -> bool:
     if not _watch_is_acting(record, dispatch):
         return False
     cfg = PIPELINES.get(pipeline_name) or {}
-    has_listener = bool(cfg.get("has_listener", True))
+    has_listener = _has_listener(cfg)  # I4510: mode-aware, not a static flag
     cadence = _pipeline_label(pipeline_name)
     label = f"{cadence} Preflight SF" if record["is_preflight"] else f"{cadence} SF"
     # config#1827: an operator-abort suppresses the dispatch even when the flag +
@@ -1010,6 +1024,38 @@ def _get_github_pat() -> str:
     return resp["Parameter"]["Value"]
 
 
+def _has_listener(cfg: dict) -> bool:
+    """Is there actually something on the other end of a dispatch for this
+    pipeline, RIGHT NOW, given the live routing mode?
+
+    alpha-engine-config-I4510. The static per-pipeline `has_listener` flag was
+    hardcoded True for all three pipelines, but `.github/workflows/sf-watch.yml`
+    gates its dispatch job to `saturday-sf-failure` only (the 2026-07-08
+    Saturday-only narrowing, config#2004). So a weekday/EOD failure POSTed a
+    repository_dispatch that GitHub accepted (204) and no job ever consumed --
+    while Telegram announced "autonomous fix ACTIVE -- resilience agent
+    dispatched". On 2026-07-27 that claim was made about a pre-open failure 23
+    minutes before market open with nothing whatsoever behind it.
+
+    The answer genuinely depends on the routing mode, which is why a static
+    flag could never be right:
+
+      M2_DISPATCH_TARGET=overseer            -> the router is pipeline-agnostic
+                                                (it dispatches by playbook, not
+                                                by event type), so EVERY
+                                                pipeline has a live listener.
+      M2_DISPATCH_TARGET=repository_dispatch -> depends on sf-watch.yml's job
+                                                gate, i.e. the static flag.
+
+    This also makes flipping M2_DISPATCH_TARGET to `overseer` the single action
+    that enables weekday/EOD coverage -- no GHA gate edit -- matching the
+    standing direction to cede sf-watch dispatch to the Overseer rather than
+    patch the legacy path."""
+    if M2_DISPATCH_TARGET == "overseer":
+        return True
+    return bool(cfg.get("has_listener", True))
+
+
 def _maybe_dispatch_agent(
     record: dict, run_date: str, key: str, cfg: dict, pipeline_name: str, sm_arn: str
 ) -> dict:
@@ -1031,7 +1077,7 @@ def _maybe_dispatch_agent(
         return {"dispatched": False, "reason": record["dispatch_suppressed"]}
     if not AGENT_DISPATCH_ENABLED:
         return {"dispatched": False, "reason": "disabled"}
-    if not cfg.get("has_listener", True):
+    if not _has_listener(cfg):
         # config#1535: don't fire a repository_dispatch that no workflow is
         # listening for — a wasted HTTP call, and inconsistent with the
         # notification copy correctly saying "no autonomous fix" for this

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -89,6 +89,33 @@ def reset_notify(monkeypatch):
     yield mock
 
 
+def pytest_configure(config):  # noqa: D401 — pytest hook
+    config.addinivalue_line(
+        "markers",
+        "legacy_routing: run with M2_DISPATCH_TARGET=repository_dispatch (the "
+        "pre-2026-07-27 GitHub round-trip) instead of the live `overseer` default",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _default_routing_mode(request, monkeypatch):
+    """Default every test to the LIVE production routing mode.
+
+    alpha-engine-config-I4510 made `has_listener` mode-aware, and
+    M2_DISPATCH_TARGET was flipped to `overseer` in production on 2026-07-27.
+    Under `overseer` the router is a listener for EVERY pipeline, so the many
+    tests that merely USE the weekday ARN as a vehicle for some other behaviour
+    (fast-path fallback, preflight, over-suppression, the shepherd ruling) keep
+    exercising what they were written to exercise.
+
+    Tests that specifically assert the legacy GitHub round-trip, or the code's
+    own default, opt out with @pytest.mark.legacy_routing.
+    """
+    if request.node.get_closest_marker("legacy_routing"):
+        return
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "overseer", raising=False)
+
+
 def test_failed_writes_watch_log_and_returns_state():
     factory, sf, s3 = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
@@ -319,6 +346,7 @@ def test_dispatch_disabled_by_default():
     assert result["action"] == "observe"
 
 
+@pytest.mark.legacy_routing
 def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
@@ -351,6 +379,7 @@ def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
     s3.put_object.assert_called_once()
 
 
+@pytest.mark.legacy_routing
 def test_dispatch_routes_weekday_event_type(monkeypatch):
     """A weekday failure dispatches the weekday-sf-failure event type + payload.
 
@@ -1521,6 +1550,7 @@ def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
     assert "router down" in result["agent_dispatch"]["error"]
 
 
+@pytest.mark.legacy_routing
 def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     assert index.M2_DISPATCH_TARGET == "repository_dispatch"

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -104,28 +104,28 @@ def reset_notify(monkeypatch):
 def pytest_configure(config):  # noqa: D401 — pytest hook
     config.addinivalue_line(
         "markers",
-        "legacy_routing: run with M2_DISPATCH_TARGET=repository_dispatch (the "
-        "pre-2026-07-27 GitHub round-trip) instead of the live `overseer` default",
+        "listener_semantics: exercise the I4510 mode-aware has_listener rules "
+        "instead of the pre-I4510 always-True weekday/EOD behaviour",
     )
 
 
 @pytest.fixture(autouse=True)
-def _default_routing_mode(request, monkeypatch):
-    """Default every test to the LIVE production routing mode.
+def _legacy_weekday_listener(request, monkeypatch):
+    """Preserve pre-I4510 behaviour for the many tests that use the weekday/EOD
+    ARN merely as a VEHICLE for some other behaviour — fast-path fallback,
+    preflight context, over-suppression, the 2026-07-18 shepherd ruling.
 
-    alpha-engine-config-I4510 made `has_listener` mode-aware, and
-    M2_DISPATCH_TARGET was flipped to `overseer` in production on 2026-07-27.
-    Under `overseer` the router is a listener for EVERY pipeline, so the many
-    tests that merely USE the weekday ARN as a vehicle for some other behaviour
-    (fast-path fallback, preflight, over-suppression, the shepherd ruling) keep
-    exercising what they were written to exercise.
-
-    Tests that specifically assert the legacy GitHub round-trip, or the code's
-    own default, opt out with @pytest.mark.legacy_routing.
+    I4510 made weekday/EOD honestly `has_listener: False` on the
+    repository_dispatch path, which would otherwise turn all of those into
+    `no_listener` declines and stop testing what they were written to test.
+    Pinning the flag here keeps their intent intact and confines the semantic
+    change to the tests that actually assert it, which opt in with
+    @pytest.mark.listener_semantics.
     """
-    if request.node.get_closest_marker("legacy_routing"):
+    if request.node.get_closest_marker("listener_semantics"):
         return
-    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "overseer", raising=False)
+    for pipeline in ("ne-preopen-trading-pipeline", "ne-postclose-trading-pipeline"):
+        monkeypatch.setitem(index.PIPELINES[pipeline], "has_listener", True)
 
 
 def test_failed_writes_watch_log_and_returns_state():
@@ -358,7 +358,6 @@ def test_dispatch_disabled_by_default():
     assert result["action"] == "observe"
 
 
-@pytest.mark.legacy_routing
 def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
@@ -391,7 +390,6 @@ def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
     s3.put_object.assert_called_once()
 
 
-@pytest.mark.legacy_routing
 def test_dispatch_routes_weekday_event_type(monkeypatch):
     """A weekday failure dispatches the weekday-sf-failure event type + payload.
 
@@ -1562,7 +1560,6 @@ def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
     assert "router down" in result["agent_dispatch"]["error"]
 
 
-@pytest.mark.legacy_routing
 def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     assert index.M2_DISPATCH_TARGET == "repository_dispatch"
@@ -1585,6 +1582,7 @@ def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
 # ── I4510: mode-aware listener semantics ─────────────────────────────────────
 
 
+@pytest.mark.listener_semantics
 def test_weekday_does_not_dispatch_on_repository_dispatch_path(monkeypatch):
     """The defect this closes: a weekday failure POSTed a repository_dispatch
     that GitHub accepted (204) and no job consumed, while Telegram claimed
@@ -1601,6 +1599,7 @@ def test_weekday_does_not_dispatch_on_repository_dispatch_path(monkeypatch):
     assert not called, "must not even mint a PAT for a dispatch nothing consumes"
 
 
+@pytest.mark.listener_semantics
 def test_weekday_DOES_dispatch_in_overseer_mode(monkeypatch):
     """Flipping M2_DISPATCH_TARGET to `overseer` is the single action that
     enables weekday/EOD coverage: the router dispatches by PLAYBOOK, not by
@@ -1616,13 +1615,14 @@ def test_weekday_DOES_dispatch_in_overseer_mode(monkeypatch):
     assert result["agent_dispatch"]["target"] == "overseer"
 
 
+@pytest.mark.listener_semantics
 def test_watch_log_records_the_real_listener_state(monkeypatch):
     """The watch-log record itself was false on 2026-07-27: has_listener:true
     and action:"dispatch" for a weekday failure nothing could consume. The
     audit trail must not assert a dispatch that cannot happen."""
     monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "repository_dispatch")
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    factory, s3, _ = _make_clients()
+    factory, _sf, s3 = _make_clients()
     with patch("index.boto3.client", side_effect=factory):
         index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
     body = json.loads(s3.put_object.call_args.kwargs["Body"])
@@ -1631,6 +1631,7 @@ def test_watch_log_records_the_real_listener_state(monkeypatch):
     assert ev["action"] == "observe"
 
 
+@pytest.mark.listener_semantics
 def test_has_listener_helper_modes():
     saturday = index.PIPELINES["ne-weekly-freshness-pipeline"]
     weekday = index.PIPELINES["ne-preopen-trading-pipeline"]

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -76,8 +76,20 @@ def _make_clients(*, describe=None, history=None, existing=None, put=None):
     if put is not None:
         s3.put_object.side_effect = put
 
-    def factory(name, region_name=None):
-        return sf if name == "stepfunctions" else s3
+    # I4510: with M2_DISPATCH_TARGET defaulting to `overseer`, the dispatch path
+    # now calls boto3.client("lambda", region_name=..., config=...) and invokes
+    # the router. Accept **kwargs (the `config=` the real call passes) and hand
+    # back a lambda mock whose invoke reports a normal async 202 — otherwise
+    # every test silently took a TypeError down the error branch.
+    lam = MagicMock()
+    lam.invoke.return_value = {"StatusCode": 202}
+
+    def factory(name, region_name=None, **_kwargs):
+        if name == "stepfunctions":
+            return sf
+        if name == "lambda":
+            return lam
+        return s3
 
     return factory, sf, s3
 

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -352,7 +352,14 @@ def test_dispatch_enabled_fires_repository_dispatch(monkeypatch):
 
 
 def test_dispatch_routes_weekday_event_type(monkeypatch):
-    """A weekday failure dispatches the weekday-sf-failure event type + payload."""
+    """A weekday failure dispatches the weekday-sf-failure event type + payload.
+
+    alpha-engine-config-I4510: weekday now carries has_listener=False on the
+    repository_dispatch path (sf-watch.yml gates its job to Saturday only), so
+    this test must force the legacy flag on to exercise the routing itself.
+    The listener SEMANTICS are covered separately below.
+    """
+    monkeypatch.setitem(index.PIPELINES["ne-preopen-trading-pipeline"], "has_listener", True)
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     sent = {}
@@ -433,8 +440,8 @@ def test_no_listener_pipeline_never_dispatches_even_when_globally_enabled(monkey
 
 
 def test_saturday_still_dispatches_when_enabled(monkeypatch):
-    """Non-regression: the has_listener plumbing must not change behavior for
-    the 3 trading pipelines, which all default has_listener=True."""
+    """Non-regression: Saturday — the one pipeline with a live GHA listener —
+    still dispatches unchanged after I4510 made has_listener mode-aware."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
     monkeypatch.setattr(index, "_get_github_pat", lambda: "ghp_fake")
     monkeypatch.setattr(index.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp())
@@ -1531,3 +1538,63 @@ def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
     assert result["agent_dispatch"].get("target") != "overseer"
     urlopen.assert_called_once()
     lam.invoke.assert_not_called()
+
+
+# ── I4510: mode-aware listener semantics ─────────────────────────────────────
+
+
+def test_weekday_does_not_dispatch_on_repository_dispatch_path(monkeypatch):
+    """The defect this closes: a weekday failure POSTed a repository_dispatch
+    that GitHub accepted (204) and no job consumed, while Telegram claimed
+    "autonomous fix ACTIVE". sf-watch.yml gates its dispatch job to
+    saturday-sf-failure only (config#2004), so weekday has no listener here."""
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "repository_dispatch")
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    called = []
+    monkeypatch.setattr(index, "_get_github_pat", lambda: called.append("pat") or "ghp_fake")
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"] == {"dispatched": False, "reason": "no_listener"}
+    assert not called, "must not even mint a PAT for a dispatch nothing consumes"
+
+
+def test_weekday_DOES_dispatch_in_overseer_mode(monkeypatch):
+    """Flipping M2_DISPATCH_TARGET to `overseer` is the single action that
+    enables weekday/EOD coverage: the router dispatches by PLAYBOOK, not by
+    event type, so it is a live listener for every pipeline — no GHA gate
+    edit, per the standing direction to cede sf-watch dispatch to the
+    Overseer."""
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "overseer")
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    factory, _, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["agent_dispatch"]["dispatched"] is True
+    assert result["agent_dispatch"]["target"] == "overseer"
+
+
+def test_watch_log_records_the_real_listener_state(monkeypatch):
+    """The watch-log record itself was false on 2026-07-27: has_listener:true
+    and action:"dispatch" for a weekday failure nothing could consume. The
+    audit trail must not assert a dispatch that cannot happen."""
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "repository_dispatch")
+    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
+    factory, s3, _ = _make_clients()
+    with patch("index.boto3.client", side_effect=factory):
+        index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    body = json.loads(s3.put_object.call_args.kwargs["Body"])
+    ev = body["events"][-1]
+    assert ev["has_listener"] is False
+    assert ev["action"] == "observe"
+
+
+def test_has_listener_helper_modes():
+    saturday = index.PIPELINES["ne-weekly-freshness-pipeline"]
+    weekday = index.PIPELINES["ne-preopen-trading-pipeline"]
+    with patch.object(index, "M2_DISPATCH_TARGET", "repository_dispatch"):
+        assert index._has_listener(saturday) is True
+        assert index._has_listener(weekday) is False
+    with patch.object(index, "M2_DISPATCH_TARGET", "overseer"):
+        assert index._has_listener(saturday) is True
+        assert index._has_listener(weekday) is True

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -472,3 +472,49 @@ def test_registry_model_is_a_provider_name_not_a_routing_alias(name):
         f"the provider and the call will 400. Use the resolved provider model "
         f"(e.g. 'deepseek-v4-pro')."
     )
+
+
+def test_every_registry_bundling_lambda_redeploys_on_registry_change():
+    """LOCKSTEP: if a Lambda's deploy.sh BUNDLES playbooks.yaml into its zip,
+    that Lambda's deploy workflow must be path-triggered on the registry too.
+
+    Otherwise a registry-only edit deploys nothing and the live Lambda keeps
+    running on a stale copy — silently. That is exactly what happened on
+    2026-07-27: #1064 fixed alert-drain's model in the registry; the liveness
+    probe redeployed (its filter listed the registry) but the ROUTER did not
+    (its filter listed only its own lambda dir), so the router kept injecting
+    the broken model and the drain stayed down.
+
+    The two existing `*_bundles_this_registry` tests pin the copy step; this
+    pins the trigger that makes the copy actually reach production.
+    """
+    workflows = REPO_ROOT / ".github" / "workflows"
+    checked = 0
+    for lambda_dir in sorted(LAMBDAS_DIR.iterdir()):
+        deploy_sh = lambda_dir / "deploy.sh"
+        if not deploy_sh.is_file():
+            continue
+        if "overseer/playbooks.yaml" not in deploy_sh.read_text(encoding="utf-8"):
+            continue
+        wf = workflows / f"deploy-{lambda_dir.name}.yml"
+        assert wf.is_file(), (
+            f"{lambda_dir.name}/deploy.sh bundles the registry but there is no "
+            f"{wf.name} to trigger a redeploy"
+        )
+        # Parse the YAML and read the ACTUAL push-paths list. A raw substring
+        # check would match an explanatory comment mentioning the path and pass
+        # even with the trigger missing (verified while writing this test).
+        wf_doc = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        # PyYAML parses the bare key `on:` as the boolean True (YAML 1.1).
+        triggers = wf_doc.get("on", wf_doc.get(True)) or {}
+        paths = ((triggers.get("push") or {}).get("paths")) or []
+        assert "infrastructure/overseer/playbooks.yaml" in paths, (
+            f"{wf.name} push paths {paths} do not include "
+            f"'infrastructure/overseer/playbooks.yaml', but {lambda_dir.name}/deploy.sh "
+            f"BUNDLES that file — a registry-only change would leave this Lambda "
+            f"running a stale registry"
+        )
+        checked += 1
+    assert checked >= 2, (
+        f"expected >=2 registry-bundling lambdas (router + liveness probe), found {checked}"
+    )


### PR DESCRIPTION
Closes nousergon/alpha-engine-config#4510
Refs nousergon/alpha-engine-config#4471, nousergon/alpha-engine-config#4516

Two defects, both of the form *"the system asserts something that isn't true."*

## 1. sf-watch claimed a dispatch nothing could consume (I4510)

`PIPELINES` hardcoded `has_listener: True` for all three pipelines, but `.github/workflows/sf-watch.yml` gates its dispatch job to `saturday-sf-failure` only (config#2004's Saturday-only narrowing).

So a weekday/EOD failure POSTed a `repository_dispatch`, GitHub accepted it (`204`), **no job consumed it**, and Telegram announced:

> _autonomous fix ACTIVE — resilience agent dispatched (diagnose→fix→merge→rerun)_

On 2026-07-27 that claim was made about a pre-open failure **23 minutes before market open**, with nothing behind it. The watch-log record was equally false — `has_listener: true`, `action: "dispatch"` — so the audit trail asserted a dispatch that could not happen.

**A static flag could never be right**, because the answer depends on the routing mode:

| `M2_DISPATCH_TARGET` | Listener? |
|---|---|
| `overseer` | **True for every pipeline** — the router dispatches by *playbook*, not by event type |
| `repository_dispatch` | the static per-pipeline flag — now honestly `False` for weekday/EOD |

New `_has_listener(cfg)` applied at all four sites: the dispatch gate, `will_dispatch`, the watch-log record, and the Telegram footer. The Lambda already had the correct copy for this case (`observe-only for this pipeline — no autonomous remediation wired yet`); it was simply unreachable.

**Consequence worth flagging:** this makes flipping `M2_DISPATCH_TARGET` to `overseer` the **single action** that enables weekday/EOD coverage — no GHA gate edit — matching the standing direction to cede sf-watch dispatch to the Overseer rather than patch the legacy path.

## 2. The router ran on a stale registry after a registry-only change

`deploy-overseer-dispatcher.yml` was path-triggered **only** on its own lambda dir, but its `deploy.sh` **bundles** `infrastructure/overseer/playbooks.yaml` into the zip. `deploy-overseer-liveness-probe.yml` already listed the registry; the router did not.

So #1064 (the alert-drain model fix) redeployed the probe and **not** the router — leaving the router injecting the broken model and the drain down. Found by inspection when the merge produced no router deploy.

Added the registry to the router's paths, plus a **lockstep test**: any Lambda whose `deploy.sh` bundles the registry must have a deploy workflow path-triggered on it.

The test **parses the workflow YAML** rather than substring-matching. My first version used a raw `in` check, which matched my own explanatory comment and passed with the trigger removed — caught by deliberately reverting the fix and confirming the test goes red. It now does.

## Testing

- `tests/test_overseer_playbook_registry.py` → **42 passed** (was 40)
- `saturday-sf-watch-dispatcher/test_handler.py`: 4 new tests (weekday no-dispatch on the GitHub path; weekday **does** dispatch in overseer mode; watch-log honesty; helper mode matrix) and 2 existing tests updated, since they encoded the old always-True behaviour. That suite imports `krepis`, which isn't installable locally — it runs in CI.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)