### PR TITLE
fix: systemd drift check's reporter was broken (I4509)

### DIFF
--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import socket
 import sys
 from pathlib import Path
 
@@ -128,26 +129,62 @@ def main() -> int:
     if findings:
         print(f"DRIFT: {len(findings)} unit(s) diverged from repo.", file=sys.stderr)
         if args.report:
-            _flow_doctor_report(findings)
+            _report_drift(findings)
     else:
         print("Systemd unit drift check PASSED (installed units match repo).")
 
     return exit_code
 
 
-def _flow_doctor_report(findings: list[str]) -> None:
-    try:
-        sys.path.insert(0, str(REPO_ROOT))
-        import flow_doctor
+def _report_drift(findings: list[str]) -> None:
+    """Alert on detected systemd unit drift.
 
-        fd = flow_doctor.init(config_path=str(REPO_ROOT / "flow-doctor.yaml"))
-        fd.report(
-            RuntimeError(f"systemd unit drift: {'; '.join(findings)}"),
+    This used to construct flow-doctor by hand and had been BROKEN for an
+    unknown length of time (alpha-engine-config-I4509). Two independent faults,
+    either one fatal:
+
+      1. `flow_doctor.init()` does not exist. flow-doctor 0.8.7 exports
+         FlowDoctor / FlowDoctorBuilder and no `init`, so the call raised
+         AttributeError every time.
+      2. The env hydration was incomplete anyway -- flow-doctor.yaml references
+         more ${VAR}s than were being set, so even with (1) fixed, construction
+         raises ConfigError.
+
+    Neither was noticed because this function only runs when drift is FOUND,
+    and the daily check normally passes -- the same reason boot-pull's copy of
+    this bug survived. A reporting path that is only exercised on failure needs
+    a test that exercises failure; see the accompanying test module.
+
+    `krepis.alerts` is the canonical alert CLI (config#1649). It resolves its
+    own secrets, so there is no hydration list here to drift out of sync with
+    flow-doctor.yaml.
+    """
+    message = (
+        f"systemd unit drift on {socket.gethostname()}: "
+        f"installed units no longer match the repo -- {'; '.join(findings)}"
+    )
+    try:
+        from krepis.alerts import publish
+
+        publish(
+            message=message,
             severity="error",
-            context={"site": "check-systemd-unit-drift", "findings": findings},
+            source="check-systemd-unit-drift",
+            # Dedup on the FINDINGS, not the message: the same drift persisting
+            # alerts once a day, while a new finding changes the key and pages.
+            dedup_key="unit-drift-" + hashlib.sha256(
+                "|".join(sorted(findings)).encode()
+            ).hexdigest()[:16],
+            dedup_window_min=1440,
         )
-    except Exception as e:  # pragma: no cover - best-effort side channel
-        print(f"[check-systemd-unit-drift] flow-doctor report failed: {e}", file=sys.stderr)
+    except Exception as e:
+        # Fail LOUD. A silent failure here is the exact defect this rewrite
+        # fixes: the drift was detected and the telling threw.
+        print(
+            f"[check-systemd-unit-drift] ALERT PUBLISH FAILED — drift is "
+            f"UNREPORTED: {e}",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -109,3 +109,105 @@ def test_main_reports_drift_exit_code_via_cli(cd, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert exit_code == 1
     assert "drift" in out.lower()
+
+
+class TestDriftReportingPath:
+    """The FAILURE path must actually report (alpha-engine-config-I4509).
+
+    These are the tests that were missing. `_report_drift` (formerly
+    `_flow_doctor_report`) was broken for an unknown length of time and nobody
+    noticed, because it only runs when drift is FOUND and the daily check
+    normally passes. Two independent faults were live simultaneously:
+    `flow_doctor.init()` does not exist in flow-doctor 0.8.7, and the env
+    hydration for flow-doctor.yaml was incomplete regardless.
+
+    A reporting path exercised only on failure needs a test that exercises
+    failure. That is the whole lesson.
+    """
+
+    def test_report_publishes_via_krepis(self, cd, monkeypatch):
+        module, _, _ = cd
+        captured = {}
+
+        def fake_publish(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setitem(
+            __import__("sys").modules, "krepis.alerts",
+            type("M", (), {"publish": staticmethod(fake_publish)})
+        )
+        module._report_drift(["daily-news.service: DIVERGED"])
+
+        assert captured, "drift must publish an alert, not just print"
+        assert captured["severity"] == "error"
+        assert captured["source"] == "check-systemd-unit-drift"
+        assert "daily-news.service" in captured["message"], (
+            "the alert must name the drifting unit — an alert that says "
+            "'drift detected' sends you to the box to find out what"
+        )
+
+    def test_report_dedups_on_findings_not_message(self, cd, monkeypatch):
+        # Same drift persisting should alert once a day; DIFFERENT drift must
+        # produce a different key so it pages immediately.
+        module, _, _ = cd
+        keys = []
+
+        def fake_publish(**kwargs):
+            keys.append(kwargs["dedup_key"])
+
+        monkeypatch.setitem(
+            __import__("sys").modules, "krepis.alerts",
+            type("M", (), {"publish": staticmethod(fake_publish)})
+        )
+        module._report_drift(["a.service: DIVERGED"])
+        module._report_drift(["a.service: DIVERGED"])
+        module._report_drift(["b.service: DIVERGED"])
+
+        assert keys[0] == keys[1], "identical findings must share a dedup key"
+        assert keys[2] != keys[0], "different findings must not be deduped together"
+
+    def test_publish_failure_is_loud_not_swallowed(self, cd, monkeypatch, capsys):
+        # The exact defect this rewrite fixes: drift was detected and the
+        # telling threw, silently.
+        module, _, _ = cd
+
+        def boom(**kwargs):
+            raise RuntimeError("simulated transport failure")
+
+        monkeypatch.setitem(
+            __import__("sys").modules, "krepis.alerts",
+            type("M", (), {"publish": staticmethod(boom)})
+        )
+        module._report_drift(["a.service: DIVERGED"])
+
+        err = capsys.readouterr().err
+        assert "UNREPORTED" in err, (
+            "a failure to publish must be loud — silent failure here is "
+            "indistinguishable from no drift"
+        )
+
+    def test_flow_doctor_init_is_not_resurrected(self):
+        """`flow_doctor.init` has not existed for some time -- guard the CALL.
+
+        Parsed with `ast` rather than grepped, deliberately. A source-text
+        guard trips on the module's own docstring explaining why this API is
+        gone, which pushes the next person to delete the explanation rather
+        than keep the guard. Matching a real Call node means prose is free to
+        name the dead API as often as it is useful to.
+        """
+        import ast
+
+        tree = ast.parse(_SCRIPT_PATH.read_text())
+        bad = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "init"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "flow_doctor"
+        ]
+        assert not bad, (
+            "flow_doctor.init() does not exist in flow-doctor 0.8.7 -- it "
+            "exports FlowDoctor/FlowDoctorBuilder. Use krepis.alerts (the "
+            "canonical CLI, config#1649)."
+        )


### PR DESCRIPTION
Third instance of the same defect, after `crucible-dashboard` #562 and `crucible-executor` #444. This script runs on **both** boxes.

## Summary

`_flow_doctor_report()` detected drift correctly and then **the reporting call raised** — so drift was found and never told.

Neither fault was noticed because this function only runs when drift is **found**, and the daily check normally passes. That's the same reason `boot-pull`'s copy survived: a reporting path exercised only on failure is never exercised at all.

## Two independent faults, either one fatal

**1. `flow_doctor.init()` does not exist.** flow-doctor 0.8.7 exports `FlowDoctor` / `FlowDoctorBuilder` and no `init`. `AttributeError` every time.

**2. The env hydration was incomplete anyway.** `flow-doctor.yaml` references more `${VAR}`s than were being set, so even with (1) fixed, construction raises `ConfigError` — verified live on the dashboard box:

```
ConfigError: Unresolved environment variable(s) in flow-doctor config: TELEGRAM_BOT_TOKEN.
```

## Fix

Replaced with `krepis.alerts.publish` — the canonical alert interface (config#1649), **imported lazily** so this script stays importable on a box without krepis. It resolves its own secrets, so no hydration list remains to drift out of sync with `flow-doctor.yaml`.

- **Dedup on a hash of the findings**, not the message — persistent drift alerts once a day; new drift pages immediately.
- **A publish failure prints `UNREPORTED` loudly** instead of being swallowed.

## The tests that were missing

Four added to the existing module:

| Test | Guards |
|---|---|
| `test_report_publishes_via_krepis` | drift publishes at all, and the alert **names the drifting unit** — "drift detected" alone sends you to the box to find out what |
| `test_report_dedups_on_findings_not_message` | identical findings share a key; **different** findings don't get deduped together |
| `test_publish_failure_is_loud_not_swallowed` | the exact defect — silent failure here is indistinguishable from no drift |
| `test_flow_doctor_init_is_not_resurrected` | the dead API can't come back |

That last guard is written with **`ast`** against a real `Call` node, not as a text grep. A text guard trips on the module's own docstring explaining why the API is gone — which pressures the next person to delete the explanation rather than keep the guard. I hit exactly that on the first run. Verified it still fails when a real `flow_doctor.init()` call is reintroduced.

## Note

Local suite has 84 pre-existing collection errors from missing deps (`krepis` isn't installed in my local env) — unrelated to this change. The target module passes 10/10 locally; CI is authoritative.

Refs nousergon/alpha-engine-config#4509

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
