### PR TITLE
[P0/low] fix(dispatcher): provision backtester config.yaml on the launcher box

### DIFF
--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -264,6 +264,18 @@ git clone --depth 1 --branch {DASHBOARD_BRANCH} \\
 chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-data /home/ec2-user/alpha-engine-config \\
   /home/ec2-user/alpha-engine-backtester /home/ec2-user/alpha-engine-dashboard \\
   /home/ec2-user/alpha-engine-predictor || fail "chown failed"
+# crucible-backtester's config.yaml is gitignored (the .example pattern), and
+# spot_backtest.sh hard-exits without it: "ERROR: config.yaml not found".
+# The canonical provisioning is a symlink into alpha-engine-config's TRACKED
+# backtester/config.yaml -- the same shape the long-lived dashboard box has
+# carried by hand since 2026-04-11, and the shape spot_backtest.sh's own
+# pre-launch check expects (it warns when the target is NOT inside a git repo,
+# because operator flags outside version control have no audit trail).
+# Without this, every backtest-family stage dies on a freshly-built box.
+echo "[weekly-freshness-spot-bootstrap] linking backtester config.yaml..."
+ln -sfn /home/ec2-user/alpha-engine-config/backtester/config.yaml \\
+  /home/ec2-user/alpha-engine-backtester/config.yaml || fail "config.yaml symlink failed"
+chown -h ec2-user:ec2-user /home/ec2-user/alpha-engine-backtester/config.yaml || fail "config.yaml chown failed"
 echo "[weekly-freshness-spot-bootstrap] building alpha-engine-dashboard venv..."
 cd /home/ec2-user/alpha-engine-dashboard
 "$PYTHON_BIN" -m venv .venv || fail "venv create failed"

--- a/tests/test_weekly_spot_bootstrap_config_provisioning.py
+++ b/tests/test_weekly_spot_bootstrap_config_provisioning.py
@@ -1,0 +1,80 @@
+"""The weekly spot bootstrap must provision gitignored configs the stages need.
+
+Bug class this guards (rehearsal run 4, 2026-07-27): the launcher box cloned
+every repo it needed and still could not run the backtest family::
+
+    ERROR: config.yaml not found — copy from config.yaml.example
+    ssm_log_capture: ERROR: [backtester] failed (rc=1)
+
+``crucible-backtester``'s ``config.yaml`` is gitignored (the ``.example``
+pattern), so cloning the repo does not produce it. The long-lived dashboard box
+had carried a hand-made symlink since 2026-04-11::
+
+    alpha-engine-backtester/config.yaml -> alpha-engine-config/backtester/config.yaml
+
+Nobody wrote that down, so a box built from scratch lacked it.
+
+This is the same shape as the missing predictor clone
+(``test_weekly_spot_bootstrap_repo_coverage.py``) one layer down: **cloning the
+right repos is necessary but not sufficient — the stages also need files that
+deliberately are not in those repos.** Both are only observable on a fresh box,
+which is why they survived review and why the invariants belong in CI.
+
+The symlink target must be the TRACKED copy in ``alpha-engine-config``, not a
+loose file: ``spot_backtest.sh``'s own pre-launch check warns when the target
+is not inside a git repo, because operator flags without an audit trail vanish
+on rebuild.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DISPATCHER = (
+    Path(__file__).resolve().parents[1]
+    / "infrastructure"
+    / "lambdas"
+    / "weekly-freshness-spot-dispatcher"
+    / "index.py"
+)
+_SRC = _DISPATCHER.read_text(encoding="utf-8")
+
+# Gitignored files a stage hard-requires, mapped to the tracked path the
+# bootstrap must link them to. Add a row whenever a launcher grows a
+# `if [ ! -f <config> ]; then exit` style precondition.
+_REQUIRED_LINKS = {
+    "/home/ec2-user/alpha-engine-backtester/config.yaml": (
+        "/home/ec2-user/alpha-engine-config/backtester/config.yaml"
+    ),
+}
+
+
+def test_bootstrap_provisions_every_required_config():
+    for link, target in _REQUIRED_LINKS.items():
+        assert target in _SRC and link in _SRC, (
+            f"bootstrap never provisions {link}. It is gitignored, so cloning "
+            f"the repo does not create it, and the stage that needs it hard-exits "
+            f"on a freshly-launched box. Link it to {target}."
+        )
+
+
+def test_config_links_point_at_a_tracked_repo():
+    """Targets must live inside a cloned git repo, not a loose path.
+
+    spot_backtest.sh warns when config.yaml resolves outside a git repo:
+    operator flags with no audit trail vanish on rebuild.
+    """
+    for link, target in _REQUIRED_LINKS.items():
+        assert "/alpha-engine-config/" in target, (
+            f"{link} -> {target} does not resolve into the version-controlled "
+            f"alpha-engine-config checkout"
+        )
+
+
+def test_symlink_ownership_is_set():
+    """`ln -s` as root leaves a root-owned link; stages run as ec2-user."""
+    assert re.search(r"chown -h ec2-user:ec2-user", _SRC), (
+        "bootstrap creates config symlinks but never `chown -h` them to "
+        "ec2-user — the bootstrap runs as root and every stage runs as ec2-user"
+    )


### PR DESCRIPTION
**Priority:** P0 · **Complexity:** low · **The entire backtest family fails on Saturday without this.**

## What rehearsal run 4 found

Run 4 got further than any run today — predictor arm complete through `ModelZooSelect`, research branch through `Counterfactual` — then died at the backtest family:

```
ERROR: config.yaml not found — copy from config.yaml.example
ssm_log_capture: ERROR: [backtester] failed (rc=1)
```

`crucible-backtester`'s `config.yaml` is **gitignored** (the `.example` pattern), so cloning the repo doesn't produce it. The long-lived dashboard box carried a hand-made symlink dated **2026-04-11**:

```
alpha-engine-backtester/config.yaml -> alpha-engine-config/backtester/config.yaml
```

Nobody wrote it down, so a box built from scratch lacked it. Blast radius: `Backtester`, `PredictorBacktest`, `PortfolioOptimizerBacktest`, `Parity`, `Evaluator`.

## Same shape as #1068, one layer down

That PR fixed *"the SF needs a repo the bootstrap doesn't clone."* This is *"the SF needs a file that deliberately isn't in any repo."* **Cloning the right repos is necessary but not sufficient.**

Both are invisible except on a freshly-built box, which is exactly why they survived review and why the invariants belong in CI rather than in someone's memory of what they once ran by hand.

## Fix

- Symlink `config.yaml` to `alpha-engine-config`'s **tracked** `backtester/config.yaml`, which the bootstrap already clones. The target choice isn't incidental — `spot_backtest.sh`'s own pre-launch check warns when the target resolves outside a git repo, because operator flags with no audit trail vanish on rebuild.
- `chown -h` to `ec2-user`: the bootstrap runs as root, every stage runs as `ec2-user`, and `ln -s` as root leaves a root-owned link.
- `tests/test_weekly_spot_bootstrap_config_provisioning.py` pins the invariant **as a table**, so a launcher growing a new `if [ ! -f <config> ]; then exit` precondition costs one row rather than another live-only discovery.

## Verification

Guard is non-inert — against `origin/main` it catches both halves independently:

```
AssertionError: bootstrap never provisions .../config.yaml. It is gitignored, so
cloning the repo does not create it, and the stage that needs it hard-exits...

AssertionError: bootstrap creates config symlinks but never `chown -h` them to
ec2-user — the bootstrap runs as root and every stage runs as ec2-user
```

3/3 pass after. Full suite **3721 passed** (5 known stale-venv artifacts, unchanged).

Provisioning derived from the live working box, not guessed: enumerated every symlink under the five checkouts on `i-09b539c844515d549`; exactly one is a config link, the rest are venv internals.

## Deploy

Merge alone — `deploy-weekly-freshness-spot-dispatcher.yml` is path-filtered on this Lambda's directory.

## Rehearsal tally

Sixth Saturday-fatal defect found today by `run_weekly_offcycle.sh shell`. Run 4 cleared every stage that failed in runs 1–3; the backtest family was the last unexercised territory and this was waiting in it.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)