### PR TITLE
[P0] fix(groom): restore the dispatch SF — unresolvable ItemSelector, phantom heartbeat, dead relaunch path

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -43,4 +43,16 @@ boto3>=1.34.0
 # dedicated box at its tier's model. This is the BEHAVIORAL change this bump
 # delivers: today's deployed v0.124.13 still applies floor=8 gates, which
 # is why the three daily slots launch different tier sets.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.15
+# 2026-07-27 — THIS PIN NOW TRACKS THE ROOT requirements.txt PIN.
+# Everything above is a historical record of FLOORS ("bumped to vX because the
+# Lambda needs feature Y"), but the pin was enforced as an EQUALITY exemption in
+# tests/test_lib_pin_lockstep.py, which turned each floor into a ceiling: the
+# Lambda froze at the version of its last feature need and never saw another lib
+# fix. nousergon-lib v0.124.16 moved TIER_MODELS["high"] to deepseek-v4-pro; this
+# file stayed at v0.124.15, so every live complexity:high groom kept dispatching
+# claude-sonnet-5 against groom-sweep-policy §5 and §7 — with root at v0.124.19
+# and CI green throughout. A floor is not an exemption; root >= floor satisfies it.
+# The exemption is removed and the tier-model floor is asserted explicitly in
+# tests/test_lib_pin_lockstep.py::test_groom_dispatcher_pin_can_express_the_policy_tier_table.
+# Bump this in lockstep with the root pin.
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.19

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -24,6 +24,13 @@ from pathlib import Path
 
 import pytest
 
+# groom-sweep-policy §2.3: `nousergon_lib.groom_eligibility.TIER_MODELS` is the
+# SINGLE OWNER of the tier->model assignment. Derive expectations from it rather
+# than restating the model names here — a second hardcoded copy is exactly how
+# this Lambda came to dispatch claude-sonnet-5 for the high tier for days after
+# v0.124.16 moved it to deepseek-v4-pro (alpha-engine-config-I4796).
+from nousergon_lib.groom_eligibility import TIER_MODELS
+
 sys.path.insert(0, os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -770,11 +777,11 @@ def test_symmetric_trigger_brians_8_9_10_launches_three_boxes(monkeypatch):
     g = out["groom"]
     assert g["trigger"] == "demand-all"
     launched = {(l["issue_filter"], l["model"]) for l in g["launches"]}
-    # groom-primary-deepseek (v0.124.15): every tier launches independently at
-    # its tier's model — low=deepseek-v4-flash, mid=deepseek-v4-flash, high=claude-sonnet-5
-    assert launched == {("high-only", "claude-sonnet-5"),
-                        ("mid-only", "deepseek-v4-flash"),
-                        ("low-only", "deepseek-v4-flash")}
+    # Every tier launches independently at its OWN tier's model, read from the
+    # lib that owns the assignment (groom-sweep-policy §5 tier table).
+    assert launched == {("high-only", TIER_MODELS["high"]),
+                        ("mid-only", TIER_MODELS["mid"]),
+                        ("low-only", TIER_MODELS["low"])}
     cmds = [c["Parameters"]["commands"][0] for c in idx._test_ssm.sent]
     assert len(cmds) == 3
     # config#2201: groom boxes are pure issue-coverage workers — the
@@ -797,7 +804,7 @@ def test_symmetric_trigger_all_tiers_launch_when_any_issues(monkeypatch):
     issue_filters = {l["issue_filter"] for l in launches}
     assert issue_filters == {"low-only", "mid-only", "high-only"}
     models = {l["model"] for l in launches}
-    assert models == {"deepseek-v4-flash", "claude-sonnet-5"}
+    assert models == {TIER_MODELS["low"], TIER_MODELS["mid"], TIER_MODELS["high"]}
     assert len(idx._test_ssm.sent) == 3
 
 

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -80,10 +80,6 @@
         "fod": {
           "force_on_demand": false,
           "launch_decided": true
-        },
-        "retryState": {
-          "retry_count.$": "$.retry_count",
-          "max_retries.$": "$.max_retries"
         }
       },
       "Catch": [
@@ -104,7 +100,7 @@
         "States": {
           "LaunchGroomSpot": {
             "Type": "Task",
-            "Comment": "config#2129 + alpha-engine-config-I4333 (task-token callback): invoke the Lambda's launch_decided operation with .waitForTaskToken so the SF pauses here until the box calls send-task-success (sub-second) instead of polling SSM every 15s for hours. The Lambda launches the box, embeds the task token in the SSM command, and returns immediately \u2014 the SF ignores the return value; the callback payload IS the state output. Timeout (6h, matching the box's watchdog) routes to the existing CheckCompletionMarker / relaunch loop.",
+            "Comment": "config#2129 + alpha-engine-config-I4333 (task-token callback): invoke the Lambda's launch_decided operation with .waitForTaskToken so the SF pauses here until the box calls send-task-success (sub-second) instead of polling SSM every 15s for hours. The Lambda launches the box, embeds the task token in the SSM command, and returns immediately \u2014 the SF ignores the return value; the callback payload IS the state output. TimeoutSeconds (6h, matching the box's own watchdog) is the SOLE authoritative bound on a lane \u2014 groom-sweep-policy \u00a72.1. A HeartbeatSeconds was declared here until 2026-07-27 with NO SendTaskHeartbeat emitter on the box, which silently made 3600s the real lane timeout and killed every run longer than an hour; do not re-add a liveness interval without a proven emitter and its states:SendTaskHeartbeat grant. Timeout routes to CheckCompletionMarkerTaskToken / the bounded relaunch loop.",
             "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
             "Parameters": {
               "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
@@ -142,8 +138,7 @@
               }
             ],
             "ResultPath": "$.callbackOutput",
-            "Next": "RelaunchNotifyGate",
-            "HeartbeatSeconds": 3600
+            "Next": "RelaunchNotifyGate"
           },
           "RelaunchNotifyGate": {
             "Type": "Choice",
@@ -179,7 +174,7 @@
                   "Variable": "$.callbackOutput.groomLaunch.Payload.groom.launched",
                   "IsPresent": true
                 },
-                "Next": "GroomRetriesExhausted"
+                "Next": "GroomLaunchStateUnknown"
               }
             ],
             "Default": "GroomSkipped"
@@ -208,7 +203,8 @@
                 "Next": "CheckRetryBudget",
                 "ResultPath": "$.markerCheckError"
               }
-            ]
+            ],
+            "TimeoutSeconds": 360
           },
           "CheckRetryBudget": {
             "Type": "Choice",
@@ -224,15 +220,13 @@
           },
           "PrepRelaunch": {
             "Type": "Pass",
-            "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token \u2014 the old attempt's absent marker is never confused with the new attempt's). MUST preserve groomPoll/groomLaunch/launchDecision through the relaunch path \u2014 NotifyRelaunch (best-effort) and audit trails reference groomPoll/groomLaunch; LaunchGroomSpot's Payload merge references launchDecision on every attempt, not just the first.",
+            "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token \u2014 the old attempt's absent marker is never confused with the new attempt's). Emits EXACTLY the shape LaunchGroomSpot needs (schedInput/launchDecision/fod for its Payload merge, retry_count for RelaunchNotifyGate, max_retries for CheckRetryBudget) and nothing else. Until 2026-07-27 this also carried groomPoll/groomLaunch, retired with the SSM poll loop by I4333 \u2014 the dangling reference raised an UNCATCHABLE States.Runtime here and killed the entire bounded-relaunch loop (groom-sweep-policy \u00a72.2). Every field referenced below must be produced by a predecessor on the path that reaches this state.",
             "Parameters": {
               "schedInput.$": "$.schedInput",
               "launchDecision.$": "$.launchDecision",
-              "retry_count.$": "States.MathAdd($.retry_count, 1)",
               "max_retries.$": "$.max_retries",
-              "fod.$": "$.fod",
-              "groomPoll.$": "$.groomPoll",
-              "groomLaunch.$": "$.groomLaunch"
+              "retry_count.$": "States.MathAdd($.retry_count, 1)",
+              "fod.$": "$.fod"
             },
             "Next": "CheckForceOnDemand"
           },
@@ -250,29 +244,27 @@
           },
           "SetForceOnDemand": {
             "Type": "Pass",
-            "Comment": "Final relaunch attempt \u2014 escalate to on-demand. Preserves groomPoll/groomLaunch/launchDecision for downstream visibility and the next LaunchGroomSpot's Payload merge.",
+            "Comment": "Final relaunch attempt \u2014 escalate to on-demand so a bad spot-capacity window still guarantees completion. Same field discipline as PrepRelaunch: emits only what LaunchGroomSpot and its downstream Choices actually read.",
             "Parameters": {
               "schedInput.$": "$.schedInput",
               "launchDecision.$": "$.launchDecision",
-              "retry_count.$": "$.retry_count",
               "max_retries.$": "$.max_retries",
+              "retry_count.$": "$.retry_count",
               "fod": {
                 "force_on_demand": true,
                 "launch_decided": true
-              },
-              "groomPoll.$": "$.groomPoll",
-              "groomLaunch.$": "$.groomLaunch"
+              }
             },
             "Next": "LaunchGroomSpot"
           },
           "NotifyRelaunch": {
             "Type": "Task",
-            "Comment": "config#1645: best-effort WARNING-level ping AFTER the relaunch box is already launching (LaunchGroomSpot -> RelaunchNotifyGate -> here). A States.Format intrinsic error in Parameters is NOT catchable (States.Runtime) \u2014 groomPoll is preserved through PrepRelaunch/SetForceOnDemand for this message. SNS publish failures ARE catchable and route to CheckLaunched so a notify hiccup never blocks polling the new run.",
+            "Comment": "config#1645: best-effort WARNING-level ping AFTER the relaunch box is already launching (LaunchGroomSpot -> RelaunchNotifyGate -> here). A States.Format intrinsic error in Parameters is NOT catchable (States.Runtime), so this message may reference ONLY fields PrepRelaunch/SetForceOnDemand emit \u2014 it referenced the retired $.groomPoll.Status until 2026-07-27. SNS publish failures ARE catchable and route to CheckLaunchedCallback so a notify hiccup never blocks the new run.",
             "Resource": "arn:aws:states:::sns:publish",
             "Parameters": {
               "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
               "Subject": "Alpha Engine Backlog Groom \u2014 spot interrupted, auto-relaunching",
-              "Message.$": "States.Format('Backlog groom box died mid-run (SSM status={}, no completion marker). Relaunched automatically: attempt {} of {} (force_on_demand={}).', $.groomPoll.Status, $.retry_count, $.max_retries, States.JsonToString($.fod.force_on_demand))"
+              "Message.$": "States.Format('Backlog groom box died mid-run (task token never fired; no completion marker). Tier: {}. Relaunched automatically: attempt {} of {} (force_on_demand={}).', $.launchDecision.issue_filter, $.retry_count, $.max_retries, States.JsonToString($.fod.force_on_demand))"
             },
             "ResultPath": "$.relaunch_notify",
             "Catch": [
@@ -284,7 +276,8 @@
                 "ResultPath": "$.relaunch_notify_error"
               }
             ],
-            "Next": "CheckLaunchedCallback"
+            "Next": "CheckLaunchedCallback",
+            "TimeoutSeconds": 60
           },
           "GroomSucceeded": {
             "Type": "Succeed"
@@ -300,16 +293,14 @@
           },
           "GroomRetriesExhausted": {
             "Type": "Pass",
-            "Comment": "config#1645: the completion marker was absent on every attempt (box died mid-run each time) and the bounded relaunch budget (including the forced-on-demand final attempt) is spent \u2014 a genuine escalation, not a routine spot hiccup.",
+            "Comment": "config#1645: the task token never fired on any attempt (box died mid-run each time) and the bounded relaunch budget \u2014 including the forced-on-demand final attempt \u2014 is spent. A genuine escalation, not a routine spot hiccup. Reached ONLY from CheckRetryBudget, so $.timeoutError is always present; the CheckLaunchedCallback path has its own terminal (GroomLaunchStateUnknown) because its input shape is disjoint from this one.",
             "Parameters": {
               "source": "groom_status",
               "reason": "spot_interruption_retries_exhausted",
-              "status.$": "$.groomPoll.Status",
-              "status_details.$": "$.groomPoll.StatusDetails",
+              "issue_filter.$": "$.launchDecision.issue_filter",
               "retry_count.$": "$.retry_count",
               "max_retries.$": "$.max_retries",
-              "command_id.$": "$.groomLaunch.Payload.groom.command_id",
-              "instance_id.$": "$.groomLaunch.Payload.groom.instance_id"
+              "last_error.$": "$.timeoutError"
             },
             "ResultPath": "$.error",
             "Next": "HandleFailure"
@@ -334,7 +325,21 @@
                 "ResultPath": "$.failure_notify_error"
               }
             ],
-            "Next": "FailExecution"
+            "Next": "FailExecution",
+            "TimeoutSeconds": 60
+          },
+          "GroomLaunchStateUnknown": {
+            "Type": "Pass",
+            "Comment": "config-I4333: the task-token callback returned but its payload carries no groom.launched flag \u2014 the box called send-task-success with an unrecognised shape. Distinct from the retries-exhausted path above: this one has $.callbackOutput and no $.timeoutError, so it needs its own terminal rather than sharing one whose Parameters cannot resolve here (groom-sweep-policy \u00a72.2).",
+            "Parameters": {
+              "source": "groom_status",
+              "reason": "callback_payload_missing_launch_flag",
+              "issue_filter.$": "$.launchDecision.issue_filter",
+              "retry_count.$": "$.retry_count",
+              "callback.$": "$.callbackOutput"
+            },
+            "ResultPath": "$.error",
+            "Next": "HandleFailure"
           }
         }
       },
@@ -421,7 +426,8 @@
           "ResultPath": "$.sweep_notify_error"
         }
       ],
-      "Next": "CheckMapLaunchOutcome"
+      "Next": "CheckMapLaunchOutcome",
+      "TimeoutSeconds": 60
     },
     "CheckMapLaunchOutcome": {
       "Type": "Choice",
@@ -464,12 +470,14 @@
           "ResultPath": "$.failure_notify_error"
         }
       ],
-      "Next": "DecideFailExecution"
+      "Next": "DecideFailExecution",
+      "TimeoutSeconds": 60
     },
     "DecideFailExecution": {
       "Type": "Fail",
       "Error": "GroomDispatchFailure",
       "Cause": "Backlog groom dispatch failed during the decide phase \u2014 see the SNS alert / Lambda logs for detail."
     }
-  }
+  },
+  "TimeoutSeconds": 72000
 }

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -148,19 +148,15 @@ _LAMBDA_PIN_EXEMPTIONS = {
         "v0.83.0",
         "flow-doctor forum-topic routing (config#1742)",
     ),
-    "scheduled-groom-dispatcher": (
-        "v0.124.15",
-        "spot_dispatch + SlotDecision + label-exclude parity (config#2146/2106/2129); "
-        "bumped for TIER_MODELS[\"high\"] Opus->Sonnet (config#2409); "
-        "v0.124.0 for nousergon_lib.github_app — _github_token() mints the "
-        "ne-groomer App installation token first, PAT fallback (config-I2785, "
-        "nousergon-lib#220, incident config-I2784); bumped to v0.124.5 for config#2698 "
-        "SpotQuotaExceededError on-demand fallback, first available at v0.124.1; "
-        "bumped to v0.124.10 for ge.RULING_PENDING_LABEL — org-wide "
-        "ruling:pending-exec PR demand counting (config-I3227, nousergon-lib#232); "
-        "bumped to v0.124.15 for nousergon-lib#241 (unconditional decide_trigger "
-        "— no floor gates, no thin-tier bundling) — replaces the v0.124.13 pin",
-    ),
+# scheduled-groom-dispatcher: EXEMPTION REMOVED 2026-07-27. Every reason it ever
+# carried was a FLOOR ("bumped to vX for feature Y"), but exemptions are enforced
+# as EQUALITY below — so the entry silently froze the Lambda at the version of its
+# last feature need and turned a minimum into a ceiling. nousergon-lib v0.124.16
+# moved TIER_MODELS["high"] to deepseek-v4-pro; the exemption held the Lambda at
+# v0.124.15, so every live complexity:high groom kept dispatching claude-sonnet-5
+# — violating groom-sweep-policy §5 and §7 — while root sat at v0.124.19 and CI
+# stayed green. It now tracks root, with the floor pinned explicitly below.
+# A floor is not an exemption: root >= floor already satisfies it.
     "sf-telegram-notifier": (
         "v0.83.0",
         "flow-doctor forum-topic routing (config#1742)",
@@ -233,3 +229,54 @@ def test_lambda_pins_match_or_are_explicitly_exempted():
             assert (
                 lambda_pin == root_pin
             ), f"{lambda_name}: pin {lambda_pin!r} must match root pin {root_pin!r}, or be added to _LAMBDA_PIN_EXEMPTIONS with a contract reason"
+
+
+# --------------------------------------------------------------------------- #
+# Tier→model conformance floor (groom-sweep-policy §2.3 / §5).
+#
+# The groom dispatcher's launch decisions come from the *pinned lib*, not from
+# the Lambda's own code — `nousergon_lib.groom_eligibility.TIER_MODELS` is the
+# single owner of the tier→model assignment. So the policy's tier table is only
+# true in production if the pinned lib is new enough to contain it.
+# --------------------------------------------------------------------------- #
+
+#: First nousergon-lib release where TIER_MODELS["high"] == "deepseek-v4-pro"
+#: (nousergon-lib#252). Below this, live high-tier grooms dispatch claude-sonnet-5,
+#: violating groom-sweep-policy §5 (tier table) and §7 (no Claude for groom traffic).
+_TIER_MODEL_FLOOR = (0, 124, 16)
+
+
+def _version_tuple(pin: str) -> tuple[int, int, int]:
+    return tuple(int(part) for part in pin.lstrip("v").split("."))
+
+
+def test_groom_dispatcher_pin_can_express_the_policy_tier_table():
+    """The dispatcher must bundle a lib new enough to know high == deepseek-v4-pro.
+
+    This is the check groom-sweep-policy §2.3 demands for the §5 tier table: it
+    fails if the pin regresses below the release that carries the assignment,
+    however that regression happens (manual edit, revived exemption, bad merge).
+    """
+    pin = _read_pin(
+        "infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt",
+        _LAMBDA_PIN_RE,
+    )
+    assert _version_tuple(pin) >= _TIER_MODEL_FLOOR, (
+        f"scheduled-groom-dispatcher pins nousergon-lib {pin}, which predates "
+        f"TIER_MODELS['high'] = 'deepseek-v4-pro'. Live complexity:high grooms "
+        f"would dispatch claude-sonnet-5, violating groom-sweep-policy §5 and §7."
+    )
+
+
+def test_groom_dispatcher_is_not_exempted_from_the_root_pin():
+    """Regression guard for the removed exemption.
+
+    Re-adding `scheduled-groom-dispatcher` to `_LAMBDA_PIN_EXEMPTIONS` would
+    reinstate equality-pinning and let the lib go stale silently again. If it ever
+    genuinely needs a CEILING (a real incompatibility with root, not a floor),
+    that is a deliberate change that must also update this test and say why.
+    """
+    assert "scheduled-groom-dispatcher" not in _LAMBDA_PIN_EXEMPTIONS, (
+        "the groom dispatcher must track the root pin — its historical exemption "
+        "reasons were all floors, and equality-pinning them froze the lib"
+    )

--- a/tests/test_sf_groom_field_reachability.py
+++ b/tests/test_sf_groom_field_reachability.py
@@ -1,0 +1,277 @@
+"""Static dataflow guard for the groom dispatch SF (groom-sweep-policy §2.2).
+
+A `States.Runtime` raised while evaluating a state's `Parameters` is NOT catchable
+by any `Catch` block — no runtime guard can exist for it. Correctness of parameter
+references is therefore a *static* obligation, and this module is where it is met.
+
+Origin (2026-07-27): three separate live-fatal defects, all of the same shape —
+a JSONPath referencing a field that no predecessor on the reaching path produces:
+
+  * `MapLaunches.ItemSelector.retryState` read `$.retry_count` / `$.max_retries` at
+    the Map's *input* level, where neither exists. Fatal on entry to the Map.
+  * `PrepRelaunch`, `SetForceOnDemand`, `NotifyRelaunch` and `GroomRetriesExhausted`
+    read `$.groomPoll` / `$.groomLaunch` — retired along with the SSM poll loop by
+    alpha-engine-config-I4333. The entire bounded-relaunch loop was dead.
+  * `GroomRetriesExhausted` had two callers whose input shapes were disjoint, so it
+    could not resolve on both.
+
+The analysis walks each state graph from its entry point, propagating the set of
+top-level field names available at each state, and asserts that every field a state
+references is present on **every** path that reaches it. Only the first path segment
+is modelled (`$.foo.bar.baz` -> `foo`), which is sufficient: every defect above was a
+missing top-level field, and deeper modelling would require the Lambda's response
+schema, which is not statically knowable here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_SF_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "infrastructure"
+    / "step_function_groom.json"
+)
+
+# `$.foo` / `$.foo.bar` but never `$$.Map.Item.Value` (the context object, always
+# available) and never a bare `$`.
+_REF = re.compile(r"(?<!\$)\$\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+def _refs(node) -> set[str]:
+    """Every top-level field name referenced anywhere inside `node`."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "Comment":
+                continue
+            found |= _refs(value)
+    elif isinstance(node, list):
+        for value in node:
+            found |= _refs(value)
+    elif isinstance(node, str):
+        found |= set(_REF.findall(node))
+    return found
+
+
+def _param_keys(params: dict) -> set[str]:
+    """The field names a Pass/Task `Parameters` block *produces* at the top level."""
+    return {k[:-2] if k.endswith(".$") else k for k in params}
+
+
+def _guarded_vars(rule: dict) -> set[str]:
+    """Variables an `IsPresent` in this Choice rule makes safe to reference.
+
+    A rule may legitimately test a field that does not exist on every path, provided
+    the test is (or is guarded by) an `IsPresent` — that is the standard ASL idiom
+    and does not raise. `CheckLaunchedCallback` depends on it.
+    """
+    safe: set[str] = set()
+    if "IsPresent" in rule and "Variable" in rule:
+        safe |= set(_REF.findall(rule["Variable"]))
+    for key in ("And", "Or"):
+        for sub in rule.get(key, []):
+            safe |= _guarded_vars(sub)
+    if "Not" in rule:
+        safe |= _guarded_vars(rule["Not"])
+    return safe
+
+
+#: Keys whose contents are NOT references evaluated in this state's scope.
+#: `ItemProcessor`/`Iterator` are a nested scope (checked separately, seeded by
+#: `ItemSelector`); `ItemSelector` is evaluated at the Map's input and has its own
+#: test; `Catch`/`Retry` describe routing; `ResultPath` is a write target.
+_NOT_A_READ = ("ItemProcessor", "Iterator", "ItemSelector", "Catch", "Retry", "ResultPath")
+
+
+def _state_refs(state: dict) -> set[str]:
+    """Fields this state reads, excluding IsPresent-guarded Choice variables."""
+    if state.get("Type") == "Choice":
+        needed: set[str] = set()
+        for rule in state.get("Choices", []):
+            needed |= _refs(rule) - _guarded_vars(rule)
+        return needed
+    if state.get("Type") == "Fail":
+        # `Error`/`Cause` are literal strings — only the *Path variants dereference.
+        return _refs({k: state[k] for k in ("ErrorPath", "CausePath") if k in state})
+    return _refs({k: v for k, v in state.items() if k not in _NOT_A_READ})
+
+
+def _successors(name: str, state: dict) -> list[tuple[str, str | None]]:
+    """(next_state, result_path_written_on_that_edge) for every outgoing edge."""
+    out: list[tuple[str, str | None]] = []
+    result_path = state.get("ResultPath")
+    written = None
+    if isinstance(result_path, str) and result_path.startswith("$."):
+        written = result_path[2:].split(".")[0]
+
+    if "Next" in state:
+        # A Pass with Parameters and no ResultPath REPLACES the input entirely; that
+        # is modelled in _walk, not here.
+        out.append((state["Next"], written))
+    for rule in state.get("Choices", []):
+        if "Next" in rule:
+            out.append((rule["Next"], None))
+    if "Default" in state:
+        out.append((state["Default"], None))
+    for catch in state.get("Catch", []):
+        caught = catch.get("ResultPath")
+        cw = (
+            caught[2:].split(".")[0]
+            if isinstance(caught, str) and caught.startswith("$.")
+            else None
+        )
+        out.append((catch["Next"], cw))
+    return out
+
+
+def _walk(states: dict, start: str, seed: set[str]) -> dict[str, set[str]]:
+    """Fields guaranteed available at each reachable state (intersection of paths)."""
+    available: dict[str, set[str]] = {}
+    queue: list[tuple[str, frozenset[str]]] = [(start, frozenset(seed))]
+
+    while queue:
+        name, incoming = queue.pop()
+        state = states[name]
+        if name in available:
+            merged = available[name] & incoming
+            if merged == available[name]:
+                continue  # no new constraint; stop
+            available[name] = merged
+        else:
+            available[name] = set(incoming)
+
+        current = set(available[name])
+        params = state.get("Parameters")
+        if state.get("Type") == "Pass" and params is not None and not state.get(
+            "ResultPath"
+        ):
+            outgoing_base = _param_keys(params)  # Parameters replace the input
+        elif state.get("Type") == "Pass" and params is not None:
+            outgoing_base = current  # ResultPath merges the result back in
+        else:
+            outgoing_base = current
+
+        for nxt, written in _successors(name, state):
+            fields = set(outgoing_base)
+            if written:
+                fields.add(written)
+            queue.append((nxt, frozenset(fields)))
+
+    return available
+
+
+def _check(states: dict, start: str, seed: set[str], scope: str) -> list[str]:
+    available = _walk(states, start, seed)
+    problems: list[str] = []
+    for name, fields in sorted(available.items()):
+        missing = _state_refs(states[name]) - fields
+        if missing:
+            problems.append(
+                f"{scope}/{name} references {sorted(missing)} which no predecessor "
+                f"produces on every reaching path (available: {sorted(fields)})"
+            )
+    return problems
+
+
+def test_top_level_fields_are_all_producible(sf):
+    """Every field the top-level states read is produced before they read it."""
+    problems = _check(sf["States"], sf["StartAt"], {"schedInput", "decideMarker"}, "top")
+    assert not problems, "\n".join(problems)
+
+
+def test_map_item_processor_fields_are_all_producible(sf):
+    """Every field a lane's states read is produced on EVERY path reaching them.
+
+    This is the guard that would have caught the I4333 relaunch breakage: the
+    timeout path reaches `PrepRelaunch` with no `groomPoll`, so a reference to it
+    is a defect no matter how the success path looks.
+    """
+    map_state = sf["States"]["MapLaunches"]
+    processor = map_state["ItemProcessor"]
+    seed = _param_keys(map_state["ItemSelector"])
+    problems = _check(processor["States"], processor["StartAt"], seed, "MapLaunches")
+    assert not problems, "\n".join(problems)
+
+
+def test_item_selector_only_reads_fields_present_at_map_input(sf):
+    """`ItemSelector` is evaluated against the Map's INPUT, not the item.
+
+    `retryState` read `$.retry_count` there — a field that only exists *inside* an
+    iteration, because `ItemSelector` itself creates it. Fatal on entry to the Map.
+    """
+    available = _walk(sf["States"], sf["StartAt"], {"schedInput", "decideMarker"})
+    at_map = available["MapLaunches"]
+    referenced = _refs(sf["States"]["MapLaunches"]["ItemSelector"])
+    missing = referenced - at_map
+    assert not missing, (
+        f"MapLaunches.ItemSelector references {sorted(missing)} at the Map's input "
+        f"level, where only {sorted(at_map)} exist"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Detector self-verification.
+#
+# A guard that passes on a healthy definition proves nothing on its own — the
+# guard this one replaces was green for weeks while defending a live crash. These
+# reintroduce each historical defect into an in-memory copy and assert the
+# analysis rejects it, so the detector cannot silently stop detecting.
+# --------------------------------------------------------------------------- #
+
+
+def _lane_problems(doc: dict) -> list[str]:
+    map_state = doc["States"]["MapLaunches"]
+    processor = map_state["ItemProcessor"]
+    return _check(
+        processor["States"],
+        processor["StartAt"],
+        _param_keys(map_state["ItemSelector"]),
+        "MapLaunches",
+    )
+
+
+def test_detector_rejects_item_selector_reading_iteration_fields(sf):
+    """The `retryState` defect: ItemSelector reading fields it itself creates."""
+    doc = json.loads(json.dumps(sf))
+    doc["States"]["MapLaunches"]["ItemSelector"]["retryState"] = {
+        "retry_count.$": "$.retry_count",
+        "max_retries.$": "$.max_retries",
+    }
+    available = _walk(doc["States"], doc["StartAt"], {"schedInput", "decideMarker"})
+    missing = _refs(doc["States"]["MapLaunches"]["ItemSelector"]) - available["MapLaunches"]
+    assert missing == {"retry_count", "max_retries"}
+
+
+def test_detector_rejects_a_reference_to_a_retired_producer(sf):
+    """The `groomPoll` defect: a field whose producer was removed by I4333."""
+    doc = json.loads(json.dumps(sf))
+    doc["States"]["MapLaunches"]["ItemProcessor"]["States"]["PrepRelaunch"][
+        "Parameters"
+    ]["groomPoll.$"] = "$.groomPoll"
+    assert any(
+        "PrepRelaunch" in p and "groomPoll" in p for p in _lane_problems(doc)
+    ), "reintroducing the groomPoll reference must be rejected"
+
+
+def test_detector_rejects_one_terminal_shared_by_disjoint_paths(sf):
+    """The merged-terminal defect: two callers whose input shapes do not intersect."""
+    doc = json.loads(json.dumps(sf))
+    states = doc["States"]["MapLaunches"]["ItemProcessor"]["States"]
+    for rule in states["CheckLaunchedCallback"]["Choices"]:
+        if rule.get("Next") == "GroomLaunchStateUnknown":
+            rule["Next"] = "GroomRetriesExhausted"
+    del states["GroomLaunchStateUnknown"]
+    assert any(
+        "GroomRetriesExhausted" in p and "timeoutError" in p
+        for p in _lane_problems(doc)
+    ), "collapsing the two terminals must be rejected"

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -7,7 +7,6 @@ NotifyRelaunch with States.Runtime because PrepRelaunch dropped $.groomPoll
 HeadObject). Recovery never launched a second box.
 
 This test catches regressions like:
-- PrepRelaunch / SetForceOnDemand stripping groomPoll (relaunch notify/runtime)
 - NotifyRelaunch blocking LaunchGroomSpot (notify must follow launch)
 - SF execution role missing s3:HeadObject for the completion-marker check
 
@@ -15,11 +14,24 @@ config#2129: the per-box relaunch lifecycle (LaunchGroomSpot/PrepRelaunch/
 SetForceOnDemand/NotifyRelaunch/...) moved from the SF's TOP-LEVEL states into
 MapLaunches's ItemProcessor (one iteration per co-launched tier) — the
 `states` fixture below now reads that nested processor, not the top level.
+
+2026-07-27 — INVERTED GUARD REMOVED. Until today this module asserted that
+PrepRelaunch and SetForceOnDemand *must preserve* `groomPoll.$`/`groomLaunch.$`.
+That was correct while the SSM poll loop produced those fields. I4333 replaced
+the poll loop with a task-token callback and removed the producer — but the
+assertions stayed, so CI stayed green **because** the dangling reference was
+still present, while every live run died on an uncatchable States.Runtime at
+PrepRelaunch. A regression guard is scoped to the design it guards; when a
+migration retires a producer, every guard asserting its output goes with it
+(groom-sweep-policy §9). The general form of this check now lives in
+`test_sf_groom_field_reachability.py`, which derives what each state may
+reference instead of hardcoding a field list.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -34,7 +46,22 @@ _IAM_PATH = (
     / "sf-execution-iam-policy.json"
 )
 
-_PRESERVE_PATHS = ("groomPoll.$", "groomLaunch.$", "launchDecision.$")
+#: What a relaunch-path Pass state MUST carry forward, post-I4333. These are
+#: exactly the fields the states downstream of it read: LaunchGroomSpot's Payload
+#: merge (schedInput/launchDecision/fod), RelaunchNotifyGate's Choice
+#: (retry_count) and CheckRetryBudget's Choice (max_retries).
+_PRESERVE_PATHS = (
+    "schedInput.$",
+    "launchDecision.$",
+    "retry_count.$",
+    "max_retries.$",
+)
+
+#: Retired with the SSM poll loop by I4333. Nothing produces these any more, so a
+#: reference to either is an uncatchable States.Runtime on the path that reads it.
+#: `$.callbackOutput.groomLaunch` is a DIFFERENT thing — the box's send-task-success
+#: payload — and is legitimate.
+_RETIRED_FIELDS = ("$.groomPoll", "$.groomLaunch")
 
 
 @pytest.fixture(scope="module")
@@ -70,21 +97,39 @@ def test_sf_role_grants_head_object_on_completion_marker(iam_policy):
     assert "s3:GetObject" in actions
 
 
-def test_prep_relaunch_preserves_poll_context_and_routes_to_force_on_demand_gate(states):
+def test_prep_relaunch_carries_the_fields_its_successors_read(states):
     st = states["PrepRelaunch"]
     params = st["Parameters"]
     for key in _PRESERVE_PATHS:
-        assert key in params, f"PrepRelaunch must preserve {key} through relaunch"
+        assert key in params, f"PrepRelaunch must carry {key} through relaunch"
+    assert params["retry_count.$"] == "States.MathAdd($.retry_count, 1)"
+    assert "fod.$" in params
     assert st["Next"] == "CheckForceOnDemand"
 
 
-def test_set_force_on_demand_preserves_poll_context(states):
+def test_set_force_on_demand_carries_the_fields_its_successors_read(states):
     st = states["SetForceOnDemand"]
     params = st["Parameters"]
     for key in _PRESERVE_PATHS:
         assert key in params
     assert st["Next"] == "LaunchGroomSpot"
     assert params["fod"] == {"force_on_demand": True, "launch_decided": True}
+
+
+def test_no_state_references_a_retired_poll_loop_field(states):
+    """The I4333 regression, pinned so it cannot return.
+
+    `$.callbackOutput.groomLaunch` is explicitly allowed — that is the task-token
+    payload the box sends, not the retired SSM-poll field.
+    """
+    offenders = []
+    for name, state in states.items():
+        blob = json.dumps({k: v for k, v in state.items() if k != "Comment"})
+        blob = blob.replace("$.callbackOutput.groomLaunch", "")
+        for field in _RETIRED_FIELDS:
+            if field in blob:
+                offenders.append(f"{name} references {field}")
+    assert not offenders, "; ".join(offenders)
 
 
 def test_relaunch_critical_path_launch_before_notify(states):
@@ -99,7 +144,64 @@ def test_relaunch_critical_path_launch_before_notify(states):
     assert states["NotifyRelaunch"]["Catch"][0]["Next"] == "CheckLaunchedCallback"
 
 
-def test_notify_relaunch_message_uses_preserved_groom_poll_status(states):
+def test_notify_relaunch_message_uses_only_fields_prep_relaunch_emits(states):
+    """A States.Format intrinsic error in Parameters is NOT catchable, so this
+    message may reference only what PrepRelaunch/SetForceOnDemand actually emit."""
     msg = states["NotifyRelaunch"]["Parameters"]["Message.$"]
-    assert "$.groomPoll.Status" in msg
+    emitted = {
+        key[:-2]
+        for key in states["PrepRelaunch"]["Parameters"]
+        if key.endswith(".$")
+    } | {"fod"}
+    referenced = set(re.findall(r"(?<!\$)\$\.([A-Za-z_][A-Za-z0-9_]*)", msg))
+    assert referenced <= emitted, (
+        f"NotifyRelaunch reads {sorted(referenced - emitted)}, which PrepRelaunch "
+        f"does not emit (emits: {sorted(emitted)})"
+    )
     assert "States.JsonToString($.fod.force_on_demand)" in msg
+
+
+def test_lane_timeout_is_the_sole_bound_no_unemitted_heartbeat(states):
+    """groom-sweep-policy §2.1: a HeartbeatSeconds with no SendTaskHeartbeat
+    emitter silently becomes the lane's real timeout. On 2026-07-27 a 3600s
+    heartbeat sat beside a 21600s timeout with no emitter anywhere in the fleet,
+    and every lane died at 3606s."""
+    launch = states["LaunchGroomSpot"]
+    assert launch["TimeoutSeconds"] == 21600
+    assert "HeartbeatSeconds" not in launch, (
+        "no SendTaskHeartbeat emitter exists on the groom box — a heartbeat here "
+        "would become the real lane timeout"
+    )
+
+
+def test_every_lane_task_declares_a_timeout(states):
+    """groom-sweep-policy §2.1: no unbounded state."""
+    missing = [
+        name
+        for name, st in states.items()
+        if st.get("Type") == "Task" and "TimeoutSeconds" not in st
+    ]
+    assert not missing, f"Task states with no declared timeout: {missing}"
+
+
+def test_state_machine_declares_a_global_ceiling():
+    """A runaway backstop, not a budget — the per-lane timeout is the budget."""
+    doc = json.loads(_SF_PATH.read_text())
+    ceiling = doc.get("TimeoutSeconds")
+    assert ceiling, "the state machine must declare a top-level TimeoutSeconds"
+    lane = doc["States"]["MapLaunches"]["ItemProcessor"]["States"]["LaunchGroomSpot"]
+    max_attempts = doc["States"]["MapLaunches"]["ItemSelector"]["max_retries"] + 1
+    assert ceiling > lane["TimeoutSeconds"] * max_attempts, (
+        "the global ceiling must not preempt a legitimate full relaunch sequence"
+    )
+
+
+def test_top_level_tasks_declare_timeouts():
+    """Same rule, applied outside the Map."""
+    doc = json.loads(_SF_PATH.read_text())
+    missing = [
+        name
+        for name, st in doc["States"].items()
+        if st.get("Type") == "Task" and "TimeoutSeconds" not in st
+    ]
+    assert not missing, f"top-level Task states with no declared timeout: {missing}"


### PR DESCRIPTION
## Summary

**The groom has been down all day.** Every `alpha-engine-groom-dispatch` execution since the I4333 task-token definition went live has failed. This restores it and brings the definition into conformance with [`groom-sweep-policy`](https://github.com/nousergon/nous-ergon-ops/pull/82) §2.1 (bounded) and §2.2 (recoverable).

Merging is sufficient to deploy — `deploy-infrastructure.yml` fires on push to `main` and `deploy-infrastructure.sh` stamps and applies `step_function_groom.json` to the live state machine. No post-merge step.

## The four defects, in the order they fire

### 1. `MapLaunches.ItemSelector.retryState` — fatal on entry to the Map

```json
"retryState": { "retry_count.$": "$.retry_count", "max_retries.$": "$.max_retries" }
```

`ItemSelector` is evaluated against the Map's **input**, where neither field exists — they are created *by* `ItemSelector`, one scope down. Nothing anywhere reads `$.retryState`. Live failure, execution `c58a3177`:

> The JSONPath '$.retry_count' specified for the field 'retry_count.$' could not be found in the input '{"decideMarker":…,"schedInput":…,"decideResult":…}'

Removed.

> **Worth noting:** this was hand-patched out of the live definition during a firefight around 05:52 today (which is how the 05:57 run got past the Map), then silently restored by the next merge to `main`, because `deploy-infrastructure.sh` treats the repo as the sole writer. Exactly the scenario `weekly-sf-policy` §2.4 describes — "the fix is lost *and* the loss is undetectable."

### 2. A heartbeat with no emitter — every lane died at one hour

`LaunchGroomSpot` carried `TimeoutSeconds: 21600` **and** `HeartbeatSeconds: 3600`. On a `.waitForTaskToken` task the heartbeat is a contract with a producer, and there is no producer: `grep -rn "SendTaskHeartbeat|send_task_heartbeat"` across `nousergon-data` and `alpha-engine-config` returns zero hits. The box calls `send-task-success` exactly once, from its `finish()` trap.

So 3600s was the real lane budget, not 21600s. Execution `edb27a5b`:

```
17,19,21 TaskScheduled  05:57:49     <- three lanes
28       TaskTimedOut   06:57:55     States.Timeout
33       TaskTimedOut   06:57:57     States.Timeout
38       TaskTimedOut   06:57:57     States.Timeout
```

Removed the heartbeat rather than adding an emitter: a groom tier is *expected* to run for hours, so there is nothing a 1-hour liveness check buys that the 6h timeout does not, and adding an emitter would need a new `states:SendTaskHeartbeat` grant for no benefit. If sub-6h detection of a wedged box is wanted later, that is the emitter's design discussion — not a silent side effect of a config line.

### 3. The relaunch path referenced a producer I4333 deleted

Four states still read `$.groomPoll` / `$.groomLaunch`, both retired with the SSM poll loop: `PrepRelaunch`, `SetForceOnDemand`, `NotifyRelaunch`, `GroomRetriesExhausted`. The timeout path is `LaunchGroomSpot` → `CheckCompletionMarkerTaskToken` → `CheckRetryBudget` → `PrepRelaunch` → crash:

> An error occurred while executing the state 'PrepRelaunch' … The JSONPath '$.groomPoll' … could not be found

A `States.Runtime` raised while evaluating `Parameters` is **not catchable** — the definition's own comment on `NotifyRelaunch` says so. config#1645's bounded auto-relaunch was therefore entirely dead: a box that died mid-run hard-failed the execution instead of relaunching.

Rebuilt against the callback-era shape. `PrepRelaunch`/`SetForceOnDemand` now emit exactly what their successors read and nothing more. `GroomRetriesExhausted` was **split**: it had two callers (`CheckRetryBudget` and `CheckLaunchedCallback`) whose input shapes are disjoint, so no single Parameters block could resolve on both. The callback branch now terminates at a new `GroomLaunchStateUnknown` carrying its own real cause, per policy §2.4.

### 4. No unbounded state (policy §2.1)

Added `TimeoutSeconds` to five Tasks that had none, plus a top-level `TimeoutSeconds: 72000` — a runaway backstop, **not** a budget. Sized so it can never preempt a legitimate full relaunch sequence (3 attempts × 6h + decide + sweep dispatch + margin); the per-lane 21600 remains the budget.

## The lib-pin exemption, and why it hid a policy violation

`tests/test_lib_pin_lockstep.py` **did** cover this Lambda — via `_LAMBDA_PIN_EXEMPTIONS`, pinned at `v0.124.15`. Read the exemption's recorded reasons: every one is a **floor** ("bumped to vX for feature Y"). But exemptions are enforced as **equality**, so each floor became a ceiling and the Lambda froze at the version of its last feature need.

`nousergon-lib` v0.124.16 moved `TIER_MODELS["high"]` to `deepseek-v4-pro`. The exemption held the dispatcher at v0.124.15, so **every live `complexity:high` groom kept dispatching `claude-sonnet-5`** — violating groom-sweep-policy §5 (tier table) and §7 (no Claude for groom traffic) — while root sat at `v0.124.19` and CI was green throughout. Confirmed against the deployed artifact: the running Lambda bundles `nousergon_lib-0.124.15.dist-info` with `"high": "claude-sonnet-5"`.

Fixed by removing the exemption (a floor is not an exemption — root ≥ floor already satisfies it) and pinning the requirement explicitly instead: `test_groom_dispatcher_pin_can_express_the_policy_tier_table` fails if the pin ever regresses below the release carrying the assignment, however that happens.

The remaining exemptions have the same floor-as-equality shape (several sit at `v0.83.0`) and are **not** touched here — that is a separate sweep, filed as alpha-engine-config-I4802.

## Tests

**Removed the guard that was pinning defect 3 in place.** `test_prep_relaunch_preserves_poll_context_and_routes_to_force_on_demand_gate` asserted `groomPoll.$` **must** be present. It was a legitimate config#1645 guard; I4333 removed the field's producer and the assertion stayed, so **CI was green precisely because the crashing reference was still there**. Codified as a rule in groom-sweep-policy §9.

**Added `tests/test_sf_groom_field_reachability.py`** — a static dataflow analyzer, since no runtime guard for this class can exist. It walks each state graph from its entry point, propagates the set of available top-level fields, and asserts every field a state references is produced on **every** path that reaches it.

It is verified against itself: three negative tests reintroduce each historical defect into an in-memory copy and assert the analysis rejects it. A detector that only passes on healthy input is what we just had.

```
tests/test_sf_groom_field_reachability.py  6 passed
tests/test_sf_groom_relaunch_wiring.py    11 passed
tests/test_lib_pin_lockstep.py             4 passed
```

Full suite: `3735 passed, 5 failed` — all 5 failures reproduce identically on `origin/main` (`test_pipeline_status_registry_source_check`, `test_ssm_log_capture_wrapper_executes`) and CI is green on `main`, so they are local venv drift against a different `krepis`, not breakage from this change.

`aws stepfunctions validate-state-machine-definition` → `{"result": "OK", "diagnostics": []}`.

## Not fixed here

`MapLaunches` runs with the default `ToleratedFailurePercentage=0`, so one lane's terminal failure aborts its siblings mid-work (two `MapIterationAborted` events in today's 05:00 run). The EC2 boxes survive — the SSM command and the bootstrap's `EXIT` trap are independent — so the cost is lost SF observability and lost relaunch, not lost groom work. Correcting it means either relying on tolerated-failure output semantics or restructuring lane terminals to always succeed and aggregating outcomes after the Map. Both need a live exercise to verify, which is the wrong thing to bundle into a PR restoring a down system. Filed as alpha-engine-config-I4803 against policy §2.5.

Refs alpha-engine-config-I4333, alpha-engine-config-I4796

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
