### PR TITLE
[P1] feat(ci): make the IAM policy-change guard requireable — noop companion + pairing test (I1078)

### DIFF
--- a/.github/workflows/iam-policy-change-guard-noop.yml
+++ b/.github/workflows/iam-policy-change-guard-noop.yml
@@ -1,0 +1,47 @@
+name: IAM Policy Change Guard
+
+# Companion no-op to iam-policy-change-guard.yml (nousergon-data-I1078).
+#
+# Makes the guard's check context safely REQUIREABLE in branch protection.
+# GitHub blocks merge on a required check that never reports at all, and the
+# guard is path-filtered to `infrastructure/lambdas/*/iam-policy.json` — so
+# requiring it directly would permanently block every PR that does not touch
+# IAM, waiting for a status that can never arrive.
+#
+# This triggers on the exact complement (`paths-ignore` mirroring the guard's
+# `paths:`) and reports the SAME workflow name + job id, so exactly one of the
+# pair runs per PR and the shared context always reports.
+#
+# The `paths-ignore` list MUST stay identical to iam-policy-change-guard.yml's
+# `paths:` list. Mirrors the alpha-engine-config-I2529 pattern
+# (scripts-tests.yml / scripts-tests-noop.yml).
+#
+# WHY THIS MATTERS: the guard was advisory-only, so it could report FAIL and
+# the PR merged anyway — demonstrated live on nousergon-data-PR1077, where an
+# iam-policy.json change with no live-apply path merged despite the guard
+# failing. An unenforceable guard is worse than none: it reads as protection
+# that isn't there.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'infrastructure/lambdas/*/iam-policy.json'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  # Job id is the branch-protection CONTEXT. Deliberately specific rather
+  # than a generic `check`: a required context must be unambiguous, and a
+  # future workflow adding its own `check` job would otherwise collide with
+  # a REQUIRED status (nousergon-data-I1078).
+  iam-policy-change-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No iam-policy.json changed — guard not applicable
+        run: |
+          echo "This PR touches no infrastructure/lambdas/*/iam-policy.json."
+          echo "Reporting the shared 'check' context so the required-status gate"
+          echo "is satisfied without the real guard needing to run."

--- a/.github/workflows/iam-policy-change-guard.yml
+++ b/.github/workflows/iam-policy-change-guard.yml
@@ -28,7 +28,11 @@ permissions:
   pull-requests: read
 
 jobs:
-  check:
+  # Job id is the branch-protection CONTEXT. Deliberately specific rather
+  # than a generic `check`: a required context must be unambiguous, and a
+  # future workflow adding its own `check` job would otherwise collide with
+  # a REQUIRED status (nousergon-data-I1078).
+  iam-policy-change-guard:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tests/test_iam_guard_requireable_pair.py
+++ b/tests/test_iam_guard_requireable_pair.py
@@ -1,0 +1,94 @@
+"""The IAM guard and its no-op companion must stay a matched pair.
+
+nousergon-data-I1078. `iam-policy-change-guard.yml` is path-filtered to
+`infrastructure/lambdas/*/iam-policy.json`, so making it a REQUIRED status
+check directly would block every PR that does not touch IAM — GitHub waits
+forever for a status that never reports.
+
+The fix is a companion workflow triggering on the exact complement
+(`paths-ignore`) with the SAME workflow name and job id, so exactly one of the
+pair runs per PR and the shared context always reports.
+
+That only holds while the two lists stay in lockstep. If they drift:
+
+  - guard `paths` ⊄ noop `paths-ignore`  ->  BOTH run on some PRs (duplicate
+    context, ambiguous required status)
+  - noop `paths-ignore` ⊄ guard `paths`  ->  NEITHER runs on some PRs, and a
+    required context that never reports blocks the merge permanently
+
+Either way the required check becomes unreliable, which is worse than not
+requiring it — an unenforceable guard reads as protection that is not there.
+That is exactly what happened before: the guard was advisory-only, reported
+FAIL on nousergon-data-PR1077, and the PR merged anyway.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+GUARD = WORKFLOWS / "iam-policy-change-guard.yml"
+NOOP = WORKFLOWS / "iam-policy-change-guard-noop.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(doc: dict) -> dict:
+    # PyYAML parses the bare key `on:` as the boolean True (YAML 1.1).
+    return doc.get("on", doc.get(True)) or {}
+
+
+def test_both_workflows_exist():
+    assert GUARD.is_file(), "the IAM policy-change guard is missing"
+    assert NOOP.is_file(), (
+        "the guard's no-op companion is missing — without it the guard's context "
+        "cannot be required without deadlocking non-IAM PRs"
+    )
+
+
+def test_workflow_names_match():
+    """Branch protection keys off the reported context, which derives from the
+    workflow name + job id. Divergent names produce two distinct contexts."""
+    assert _load(GUARD)["name"] == _load(NOOP)["name"]
+
+
+def test_job_ids_match_and_are_specific():
+    guard_jobs = list(_load(GUARD)["jobs"])
+    noop_jobs = list(_load(NOOP)["jobs"])
+    assert guard_jobs == noop_jobs, (
+        f"job ids diverged: guard={guard_jobs} noop={noop_jobs} — the pair would "
+        f"report two different check contexts"
+    )
+    assert guard_jobs == ["iam-policy-change-guard"], (
+        "the job id IS the required branch-protection context; keep it specific "
+        "so a future workflow's generic job name cannot collide with a required "
+        "status"
+    )
+
+
+def test_path_filters_are_exact_complements():
+    guard_paths = _triggers(_load(GUARD))["pull_request"]["paths"]
+    noop_ignores = _triggers(_load(NOOP))["pull_request"]["paths-ignore"]
+    assert guard_paths == noop_ignores, (
+        f"guard paths {guard_paths} and noop paths-ignore {noop_ignores} must be "
+        f"identical. Drift means some PR gets BOTH checks (ambiguous) or NEITHER "
+        f"(required context never reports -> permanent merge block)."
+    )
+
+
+def test_both_react_to_label_events():
+    """The guard's escape hatch is a `gate:operator` label, so both halves must
+    re-run on label changes — otherwise adding the label after the initial run
+    leaves the failing status in place with no way to clear it."""
+    for path in (GUARD, NOOP):
+        types = _triggers(_load(path))["pull_request"].get("types") or []
+        assert "labeled" in types and "unlabeled" in types, (
+            f"{path.name} must trigger on labeled/unlabeled so the gate:operator "
+            f"escape hatch can actually clear the check"
+        )


### PR DESCRIPTION
Closes #1078
Refs #1077, alpha-engine-config-I4472, alpha-engine-config-I4825

## Problem

The guard exists to stop an `iam-policy.json` change merging with **no live-apply path**. It is **advisory only** — `main` requires just:

```
["test", "gate-label-guard / gate-label-guard"]
```

So the guard reports FAIL and the merge proceeds. Demonstrated live on #1077: the guard failed, the PR merged anyway.

An unenforceable guard is worse than none — it reads as protection that isn't there. Same shape as alpha-engine-config-I3496, where a gate everyone believed was blocking turned out to be advisory and 6 CI-red PRs auto-merged.

## Why it can't just be added to the required list

The guard is path-filtered to `infrastructure/lambdas/*/iam-policy.json`. GitHub blocks merge on a required check that **never reports at all**, so requiring it directly would permanently block every PR that doesn't touch IAM — waiting for a status that can never arrive.

## Fix

A companion no-op on the exact complement (`paths-ignore` mirroring the guard's `paths`), same workflow name and job id, so **exactly one of the pair runs per PR** and the shared context always reports. Mirrors the alpha-engine-config-I2529 pattern (`scripts-tests.yml` / `scripts-tests-noop.yml`).

Also renames the job id `check` → `iam-policy-change-guard` in **both** halves. The job id becomes the branch-protection context, and a required context must be unambiguous — a future workflow adding its own generic `check` job would otherwise collide with a *required* status. No collision exists today (verified across all workflows), but the rename costs nothing now and the failure mode later is silent.

## The test is the load-bearing part

`tests/test_iam_guard_requireable_pair.py` pins the invariant the whole scheme rests on. If the two path lists drift:

- guard `paths` ⊄ noop `paths-ignore` → **both** run on some PRs (duplicate, ambiguous context)
- noop `paths-ignore` ⊄ guard `paths` → **neither** runs → required context never reports → permanent merge block

It also asserts both halves react to `labeled`/`unlabeled`, since the guard's escape hatch is a `gate:operator` label and a stale failing status has to be clearable.

Verified it actually bites: widening the noop's `paths-ignore` to `infrastructure/lambdas/**` makes it go red.

## Follow-up (needs admin, deliberately not here)

Once this merges, add `iam-policy-change-guard` to `main`'s `required_status_checks` contexts. Doing that **before** this merges would deadlock every open PR.

## Testing

`tests/test_iam_guard_requireable_pair.py` → **5 passed**.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)