### PR TITLE
[P0] feat(sf-watch): codify M2_DISPATCH_TARGET=overseer — the flip must survive its own deploy (I2830)

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -159,7 +159,7 @@ if $BOOTSTRAP; then
       --zip-file "fileb://${ZIP}" \
       --timeout 60 \
       --memory-size 256 \
-      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,M2_DISPATCH_TARGET=repository_dispatch,FAST_PATH_ENABLED=false,SF_WATCH_DISPATCH_AFTER_ESCALATION=true,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=true,SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
+      --environment 'Variables={LOG_LEVEL=INFO,AGENT_DISPATCH_ENABLED=false,M2_DISPATCH_TARGET=overseer,FAST_PATH_ENABLED=false,SF_WATCH_DISPATCH_AFTER_ESCALATION=true,EOD_SF_WATCH_DISPATCH_AFTER_ESCALATION=true,SF_WATCH_MAX_DISPATCHES_SATURDAY=8,SF_WATCH_MAX_DISPATCHES_WEEKDAY=2,SF_WATCH_MAX_DISPATCHES_EOD=2,FLOW_DOCTOR_ENABLED=1,ALPHA_ENGINE_DEPLOYED=1}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
   else
@@ -241,9 +241,25 @@ echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 # was open. Bootstrap (create-function above) still defaults false — safe
 # rollout posture for a NEW deployment only.
 CURRENT_DISPATCH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" AGENT_DISPATCH_ENABLED false)
-# M2_DISPATCH_TARGET (alpha-engine-config-I2823) — operator-owned routing flag:
+# M2_DISPATCH_TARGET (alpha-engine-config-I2823) — routing flag:
 # repository_dispatch (legacy GitHub round-trip) vs overseer (direct router).
-CURRENT_M2_TARGET=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" M2_DISPATCH_TARGET repository_dispatch)
+#
+# DEFAULT FLIPPED repository_dispatch -> overseer (alpha-engine-config-I2830,
+# actually applied 2026-07-27). I2830 was closed 2026-07-21 but the live flag
+# still read repository_dispatch six days later, because it was operator-owned:
+# set by hand, never codified. Flipping it live on 2026-07-27 was then CLOBBERED
+# within minutes by a redeploy — preserve_env_flag read the env before the
+# manual change and wrote its stale map after (LastModified 18:42Z). The very
+# next EOD failure recorded action=observe.
+#
+# So the fallback here is the DURABLE state, not a safe-rollout placeholder: it
+# is what a redeploy lands on whenever the live read races or returns empty.
+# Codifying `overseer` is what makes the routing survive its own deploy.
+#
+# Routing consequence: the router dispatches by PLAYBOOK, not by event type, so
+# it is a live listener for all three pipelines — this default is what enables
+# weekday/EOD SF coverage, with no .github/workflows/sf-watch.yml gate edit.
+CURRENT_M2_TARGET=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" M2_DISPATCH_TARGET overseer)
 # FAST_PATH_ENABLED (config#1900) is operator-owned exactly like
 # AGENT_DISPATCH_ENABLED — preserve the live value across redeploys.
 CURRENT_FAST_PATH=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" FAST_PATH_ENABLED false)

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -174,7 +174,12 @@ DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/alpha-engine-config")
 # OPERATOR-OWNED runtime flag like AGENT_DISPATCH_ENABLED (deploy.sh preserves
 # it across redeploys). Flip gated on the reshaped weekly SF's first live run
 # (gate:weekly-sf) — see alpha-engine-config-I2823.
-M2_DISPATCH_TARGET = os.environ.get("M2_DISPATCH_TARGET", "repository_dispatch")
+# alpha-engine-config-I2830 (applied 2026-07-27): default is `overseer`.
+# The router dispatches by PLAYBOOK rather than event type, so it listens for
+# all three pipelines — this default is what gives weekday/EOD SF coverage,
+# with no sf-watch.yml gate edit. Kept in lockstep with deploy.sh's two
+# defaults (pinned by test_m2_default_is_overseer_in_code_and_deploy).
+M2_DISPATCH_TARGET = os.environ.get("M2_DISPATCH_TARGET", "overseer")
 OVERSEER_FUNCTION = os.environ.get("OVERSEER_FUNCTION", "alpha-engine-overseer-dispatcher")
 # Dedicated fine-grained PAT (SecureString) scoped to the SF-path repos, shared
 # across pipelines. Read at dispatch time only — never logged.

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1569,28 +1569,20 @@ def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
 
 
 @pytest.mark.listener_semantics
-def test_m2_default_target_is_overseer(monkeypatch):
-    """alpha-engine-config-I2830, applied 2026-07-27. Was pinned to
-    `repository_dispatch` as a safe-rollout default. That default outlived its
-    purpose and became the bug: the flag was flipped live, a redeploy raced
-    preserve_env_flag and wrote its stale map back, and routing silently
-    reverted — the next EOD failure recorded action=observe."""
-    monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    assert index.M2_DISPATCH_TARGET == "overseer"
-    factory, sf, s3, lam, lambda_configs = _make_clients_with_lambda()
-    monkeypatch.setattr(index, "_get_github_pat", MagicMock(return_value="pat"))
-    resp_cm = MagicMock()
-    resp_cm.__enter__ = MagicMock(return_value=MagicMock(status=204))
-    resp_cm.__exit__ = MagicMock(return_value=False)
-    with patch("index.boto3.client", side_effect=factory), patch(
-        "index.urllib.request.urlopen", return_value=resp_cm
-    ) as urlopen:
-        result = index.handler(_event("FAILED"), None)
+def test_m2_default_target_is_overseer():
+    """alpha-engine-config-I2830, applied 2026-07-27.
 
-    assert result["agent_dispatch"]["dispatched"] is True
-    assert result["agent_dispatch"].get("target") != "overseer"
-    urlopen.assert_called_once()
-    lam.invoke.assert_not_called()
+    Was `test_m2_default_target_still_uses_repository_dispatch`, which asserted
+    the constant AND that the default produced a GitHub POST. That composite
+    intent no longer holds, and the routing half is already covered by
+    `test_dispatch_enabled_fires_repository_dispatch` (which pins the mode
+    explicitly). This asserts only the constant.
+
+    The old default outlived its purpose and became the bug: the flag was
+    flipped live, a redeploy raced preserve_env_flag and wrote its stale map
+    back, and routing silently reverted — the very next EOD failure recorded
+    action=observe."""
+    assert index.M2_DISPATCH_TARGET == "overseer"
 
 
 # ── I4510: mode-aware listener semantics ─────────────────────────────────────

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -124,6 +124,14 @@ def _legacy_weekday_listener(request, monkeypatch):
     """
     if request.node.get_closest_marker("listener_semantics"):
         return
+    # Routing mode: the CODE default is now `overseer` (I2830, applied
+    # 2026-07-27), but the great majority of this suite was written against the
+    # legacy repository_dispatch path — it asserts the urlopen POST, the
+    # `no_listener` decline, the weekday event_type, and so on. Pin the legacy
+    # mode by default so those keep testing what they were written to test;
+    # tests that assert the NEW default or the overseer path opt out with
+    # @pytest.mark.listener_semantics (or set the mode explicitly themselves).
+    monkeypatch.setattr(index, "M2_DISPATCH_TARGET", "repository_dispatch", raising=False)
     for pipeline in ("ne-preopen-trading-pipeline", "ne-postclose-trading-pipeline"):
         monkeypatch.setitem(index.PIPELINES[pipeline], "has_listener", True)
 
@@ -1560,6 +1568,7 @@ def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
     assert "router down" in result["agent_dispatch"]["error"]
 
 
+@pytest.mark.listener_semantics
 def test_m2_default_target_is_overseer(monkeypatch):
     """alpha-engine-config-I2830, applied 2026-07-27. Was pinned to
     `repository_dispatch` as a safe-rollout default. That default outlived its

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -1560,9 +1560,14 @@ def test_m2_overseer_invoke_failure_is_nonfatal(monkeypatch):
     assert "router down" in result["agent_dispatch"]["error"]
 
 
-def test_m2_default_target_still_uses_repository_dispatch(monkeypatch):
+def test_m2_default_target_is_overseer(monkeypatch):
+    """alpha-engine-config-I2830, applied 2026-07-27. Was pinned to
+    `repository_dispatch` as a safe-rollout default. That default outlived its
+    purpose and became the bug: the flag was flipped live, a redeploy raced
+    preserve_env_flag and wrote its stale map back, and routing silently
+    reverted — the next EOD failure recorded action=observe."""
     monkeypatch.setattr(index, "AGENT_DISPATCH_ENABLED", True)
-    assert index.M2_DISPATCH_TARGET == "repository_dispatch"
+    assert index.M2_DISPATCH_TARGET == "overseer"
     factory, sf, s3, lam, lambda_configs = _make_clients_with_lambda()
     monkeypatch.setattr(index, "_get_github_pat", MagicMock(return_value="pat"))
     resp_cm = MagicMock()
@@ -1641,3 +1646,31 @@ def test_has_listener_helper_modes():
     with patch.object(index, "M2_DISPATCH_TARGET", "overseer"):
         assert index._has_listener(saturday) is True
         assert index._has_listener(weekday) is True
+
+
+def test_m2_default_is_overseer_in_code_and_deploy():
+    """LOCKSTEP: index.py's fallback and BOTH deploy.sh defaults (create-function
+    and preserve_env_flag) must agree.
+
+    Three independent places encode this routing mode. The 2026-07-27 incident
+    was exactly a disagreement between them — the live env said `overseer`,
+    deploy.sh's preserve fallback said `repository_dispatch`, and the deploy
+    won. Pinning all three together is what makes the routing survive its own
+    deploy."""
+    import re
+    from pathlib import Path
+
+    here = Path(__file__).resolve().parent
+    src = (here / "index.py").read_text(encoding="utf-8")
+    m = re.search(r'M2_DISPATCH_TARGET = os\.environ\.get\(\s*"M2_DISPATCH_TARGET",\s*"([a-z_]+)"', src)
+    assert m and m.group(1) == "overseer", "index.py fallback must default to overseer"
+
+    deploy = (here / "deploy.sh").read_text(encoding="utf-8")
+    assert "M2_DISPATCH_TARGET=overseer," in deploy, (
+        "deploy.sh create-function default must be overseer"
+    )
+    assert re.search(r'preserve_env_flag[^\n]*M2_DISPATCH_TARGET overseer', deploy), (
+        "deploy.sh preserve_env_flag fallback must be overseer — this is the value "
+        "a redeploy lands on when the live read races or returns empty, i.e. the "
+        "one that actually clobbered the manual flip"
+    )


### PR DESCRIPTION
Refs alpha-engine-config-I2830, alpha-engine-config-I4510, alpha-engine-config-I4472

## What happened

alpha-engine-config-I2830 was closed 2026-07-21 as *"flip M2_DISPATCH_TARGET to overseer"*. **Six days later the live flag still read `repository_dispatch`** — it was operator-owned: set by hand, never codified.

Flipping it live on 2026-07-27 was then **clobbered within minutes**. The #1071 merge triggered a redeploy; `preserve_env_flag` read the env *before* the manual change and wrote its stale map *after* (Lambda `LastModified` 18:42:29Z). Classic TOCTOU.

The very next EOD pipeline failure recorded `action: observe, has_listener: False` — the new #1071 code behaving **correctly**, on routing that had silently reverted underneath it.

## Why the fix isn't "re-apply more carefully"

This is the third instance this week of one disease — manually-applied state doesn't stick:

- **I3508** — probe IAM merged, never applied → watch plane blind four days
- **I2830** — closed-as-done while the live flag disagreed for six days
- **I4825** — same thing today

Three in a week is a design problem. The value has to stop living only in live state.

## Change

Three places encode this routing mode, and the incident was exactly a disagreement between them. All three now say `overseer`:

| Location | Was | Now |
|---|---|---|
| `index.py` `os.environ.get` fallback | `repository_dispatch` | `overseer` |
| `deploy.sh` create-function default | `repository_dispatch` | `overseer` |
| `deploy.sh` `preserve_env_flag` fallback | `repository_dispatch` | `overseer` |

That third one did the clobbering, and its meaning changes here: it is no longer a safe-rollout placeholder but the **durable state** — what a redeploy lands on whenever the live read races or returns empty.

## Routing consequence

The router dispatches by **playbook**, not by event type, so it is a live listener for all three pipelines. This default is what gives **weekday/EOD SF coverage**, with no `.github/workflows/sf-watch.yml` gate edit — matching the standing direction to cede sf-watch dispatch to the Overseer rather than patch the legacy GHA path.

Paired with #1071, which made `has_listener` mode-aware, the notification and watch-log now tell the truth in both modes.

## Testing

- `test_m2_default_target_still_uses_repository_dispatch` → inverted to `test_m2_default_target_is_overseer`
- **New lockstep test** pinning all three defaults together, so they cannot drift apart again. Verified all three regexes match live.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)