### PR TITLE
chore(gitignore): never track AGENTS.md in a public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ Thumbs.db
 # landing-spot only; NOUSERGON_PRIVATE_FEATURE_PACK may point anywhere on
 # disk (see features/private_pack.py). Never remove this entry.
 private_features/
+
+# Agent instruction file — local-only, same rule as CLAUDE.md above.
+# Symlinked in from the private nous-ergon-ops/agent-instructions/; its very
+# path reveals private repo structure, so it must never be tracked here.
+AGENTS.md


### PR DESCRIPTION
`CLAUDE.md` is already gitignored in this repo; `AGENTS.md` was not — despite serving the same purpose and carrying the same exposure.

This repo is **PUBLIC**, and `AGENTS.md` is a symlink into the private `nous-ergon-ops/agent-instructions/` tree. Even committing the link publishes private repo structure.

**Verified 2026-07-27** across the 9 public fleet repos: 4 were missing this line (`crucible-research`, `crucible-predictor`, `nousergon-data`, `nousergon-lib`), and in two of them the file was present on disk and untracked — one `git add -A` from being published. The other 5 already ignore it, so this closes the inconsistency rather than introducing a new rule.

Same class as the 2026-07-14 near-incident where module docs were briefly pushed to public repos.

Just the ignore line, no content, per the standing rule that a missing gitignore entry lands in its own tiny PR.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)