### PR TITLE
chore(deps): defer pandas 3.x majors to the tracked migration (config-I5213)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       interval: weekly
     cooldown:
       semver-major-days: 30
+    # Deferred to the tracked migration alpha-engine-config-I5213. Dependabot re-proposing
+    # this every week is pure queue noise while the migration is unscheduled, and
+    # it re-enters /backlog-triage each cycle. Narrow by dependency-name ON
+    # PURPOSE: a blanket "*" major ignore would also suppress future
+    # security-relevant majors. REMOVING THIS ENTRY IS PART OF alpha-engine-config-I5213's closes-when.
+    ignore:
+      - dependency-name: "pandas"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## What

Adds a **narrow, dependency-named** Dependabot `ignore` for major bumps that are now tracked as an explicit migration issue, so Dependabot stops re-proposing them weekly.

Defers `pandas` majors, superseding `nousergon-data-PR1017` (`>=2.0` -> `>=3.0.5`, failing `test`). Lockstep partner of the `crucible-backtester` change — tracked in **alpha-engine-config-I5213**.

## Why

All of these were opened as Dependabot PRs, went CI-red, and sat in the `triage:session` queue re-entering triage every cycle with nobody owning the underlying migration. Each repo's `main` is green, so the failures belonged to the bumps, not to a broken baseline.

Per Brian's batch ruling during `/backlog-triage` 2026-07-28: a semver-major bump that breaks CI is a **migration project, not a Dependabot PR**. The superseded PRs are closed against a tracked issue that carries the real scope, ordering constraints and gotchas; this PR stops the noise in the meantime.

## Why narrow rather than a blanket major ignore

A blanket `dependency-name: "*"` + `version-update:semver-major` ignore would have been a smaller diff and would have suppressed the noise just as well — and would ALSO have silently suppressed every future security-relevant major in these ecosystems, with nothing to signal it. Each entry here names one package and is explicitly tied to the issue whose completion removes it.

## The un-suppression is tracked, not remembered

Each tracked migration issue names removal of its `ignore` entries in its own `closes-when`. Without that, "temporarily deferred" quietly becomes "permanently pinned" — which is how a dependency ends up 38 minor versions stale with no one noticing.

Closes nothing on its own — see alpha-engine-config-I5213.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
