### PR TITLE
[P1] feat(groom): cycle-level STARTED/COMPLETE Telegram, and a liveness check that can actually fire

### DIFF
--- a/infrastructure/lambdas/flow_doctor_telegram.py
+++ b/infrastructure/lambdas/flow_doctor_telegram.py
@@ -37,14 +37,37 @@ def build_flow_doctor_config(
     *,
     db_basename: str,
     repo: str = "nousergon/nousergon-data",
+    notifier_overrides: Optional[Dict[str, Any]] = None,
 ) -> dict:
+    """Build a flow-doctor config for ``topics``.
+
+    ``notifier_overrides`` shallow-merges into EVERY notifier dict the fleet
+    spec produced — the escape hatch for a flow whose delivery posture differs
+    from its topic's canonical default. The one live use is the groom
+    CYCLE-level lifecycle flow: ``FleetTelegramTopic.GROOM``'s canonical spec is
+    ``notify_on=("info",)`` + ``disable_notification=True``, i.e. per-box
+    lifecycle pings land in ``#groom`` silently and anything above ``info`` is
+    dropped outright. That is the right default for ~18 per-box pings/day, and
+    the WRONG one for the 2 cycle-level pings/trigger the operator asked to
+    actually receive (2026-07-28 ruling).
+
+    This is a parameter rather than a second hand-written spec because
+    ``groom_flow_doctor_notify.py`` already open-codes exactly this override on
+    the box rail; two divergent copies of "how does groom traffic reach
+    Telegram" is the §2.3 one-owner-per-config-fact defect. Callers that pass
+    nothing are byte-identical to before.
+    """
     from nousergon_lib.flow_doctor_fleet import fleet_telegram_notifier_dicts
+
+    notify = fleet_telegram_notifier_dicts(topics)
+    if notifier_overrides:
+        notify = [{**spec, **notifier_overrides} for spec in notify]
 
     return {
         "flow_name": flow_name,
         "repo": repo,
         "owner": "@brianmcmahon",
-        "notify": fleet_telegram_notifier_dicts(topics),
+        "notify": notify,
         # DynamoDB, not local SQLite — dedup cooldowns must survive across
         # separate Lambda invocations (a fresh cold start gets an empty /tmp
         # every time, so SQLite there can never dedup cross-invocation;
@@ -64,7 +87,13 @@ def get_flow_doctor(
     topics: Sequence[Any],
     *,
     db_basename: str,
+    notifier_overrides: Optional[Dict[str, Any]] = None,
 ) -> Any | None:
+    # NOTE: the cache is keyed on flow_name alone, so a caller applying
+    # notifier_overrides MUST use a distinct flow_name (the groom cycle flow
+    # uses "backlog-groom-cycle" against the per-box rail's
+    # "backlog-groom-lifecycle"). Sharing a flow_name across differing
+    # overrides would silently serve whichever posture initialized first.
     if flow_name in _FLOW_DOCTOR_BY_NAME:
         return _FLOW_DOCTOR_BY_NAME[flow_name]
     if flow_name in _INIT_ATTEMPTED:
@@ -77,7 +106,10 @@ def get_flow_doctor(
         import yaml
         from nousergon_lib.logging import get_flow_doctor, setup_logging
 
-        cfg = build_flow_doctor_config(flow_name, topics, db_basename=db_basename)
+        cfg = build_flow_doctor_config(
+            flow_name, topics, db_basename=db_basename,
+            notifier_overrides=notifier_overrides,
+        )
         path = Path(f"/tmp/flow_doctor_{db_basename}.yaml")
         path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
         setup_logging(flow_name, flow_doctor_yaml=str(path))
@@ -154,6 +186,7 @@ def notify_via_flow_doctor(
     source: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
     silent_topic: Any | None = None,
+    notifier_overrides: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """Route ``text`` through flow-doctor forum topics; fallback to ``send_message``.
     Args:
@@ -171,6 +204,9 @@ def notify_via_flow_doctor(
             krepis behavior).
         context: Arbitrary key-value metadata.
         silent_topic: Optional topic for silent notifications when ``silent`` is True.
+        notifier_overrides: Per-flow delivery-posture override merged into every
+            notifier dict — see ``build_flow_doctor_config``. Requires a
+            flow_name unique to that posture (the config cache is keyed on it).
     """
     owner_repo = (context or {}).get("owner_repo")
     if owner_repo in TEST_NAMESPACE_OWNER_REPOS:
@@ -181,7 +217,10 @@ def notify_via_flow_doctor(
         )
         return False
     with _event_source_override(source):
-        fd = get_flow_doctor(flow_name, topics, db_basename=db_basename)
+        fd = get_flow_doctor(
+            flow_name, topics, db_basename=db_basename,
+            notifier_overrides=notifier_overrides,
+        )
         if fd is None:
             return send_message(text, disable_notification=silent)
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -115,6 +115,41 @@ REGION = os.environ.get("AWS_REGION", "us-east-1")
 _FLOW_NAME = "scheduled-groom-dispatcher"
 _DB_BASENAME = "flow_doctor_scheduled_groom_dispatcher"
 _GROOM_LIFECYCLE_TOPICS = (FleetTelegramTopic.GROOM,)
+
+# ── Cycle-level lifecycle rail (2026-07-28 operator ruling) ───────────────────
+# The groom's terminal reporting used to live exclusively on the BOX: groom_run.sh
+# emits ONLINE/FINISHED/WOUND-DOWN pings at severity=info, which
+# FleetTelegramTopic.GROOM's canonical spec delivers to #groom with
+# disable_notification=True. Two consequences, both confirmed live 2026-07-28:
+#
+#   1. A completion ping is delivered but never BUZZES, so the operator
+#      experiences "start + errors only" even though a FINISHED message exists.
+#   2. More seriously, a per-box trap structurally cannot report a box that
+#      never reached it. On the 12:00Z cycle all three lanes' spot boxes were
+#      reclaimed instance-terminated-no-capacity at 12:02Z; ZERO notifications
+#      fired on any rail and the SF sat in TaskSubmitted for four hours
+#      (config-I4987/I4989). GroomDispatchComplete is a bare Succeed — cycle
+#      completion had no notifier anywhere.
+#
+# The fix is to report from the ORCHESTRATOR, which survives the box's death:
+# one buzzing STARTED per trigger and one buzzing COMPLETE roll-up naming every
+# lane's terminal state. Deliberately CYCLE-level, not per-lane — un-silencing
+# the ~18 per-box pings/day is how the 11-day alert-fatigue outage happened.
+# Per-box pings keep their existing silent-in-topic posture untouched.
+#
+# Distinct flow_name is REQUIRED, not cosmetic: flow_doctor_telegram caches the
+# built config by flow_name, so sharing one with the silent rail would serve
+# whichever posture initialized first.
+_CYCLE_FLOW_NAME = "backlog-groom-cycle"
+_CYCLE_DB_BASENAME = "flow_doctor_backlog_groom_cycle"
+# Mirrors the override groom_flow_doctor_notify.py:96-98 open-codes on the box
+# rail — the canonical GROOM spec is info-only/silent, and a severity above
+# `info` sent against it is DROPPED rather than merely silenced.
+_CYCLE_NOTIFIER_OVERRIDES = {
+    "notify_on": ["info", "warning", "error", "critical"],
+    "disable_notification": False,
+}
+
 # Kill-switch: GROOM_DISPATCH_ENABLED=false disables the trigger without deleting
 # the EventBridge Scheduler rules. Default ON.
 DISPATCH_ENABLED = os.environ.get("GROOM_DISPATCH_ENABLED", "true").lower() == "true"
@@ -596,6 +631,224 @@ def _running_tier_instance_ids(tier_tag: str) -> list[str]:
             "correctness gate): %s", tier_tag, exc,
         )
         return []
+
+
+def _utc_today() -> str:
+    """UTC calendar date — the dedup/ledger partition key used throughout."""
+    return datetime.now(ZoneInfo("UTC")).strftime("%Y-%m-%d")
+
+
+def _notify_cycle(text: str, *, severity: str, dedup_key: str, context: dict) -> None:
+    """Send one CYCLE-level lifecycle ping (buzzing) — never raises.
+
+    Best-effort per groom-sweep-policy §8 ("a notify hiccup must never block a
+    relaunch or a status check"): the dispatch decision and the SF's terminal
+    routing are the primary deliverables, and a Telegram failure must not take
+    either down. The failure is still recorded in this Lambda's CW logs.
+    """
+    try:
+        notify_via_flow_doctor(
+            text, silent=False, severity=severity, dedup_key=dedup_key,
+            flow_name=_CYCLE_FLOW_NAME, topics=_GROOM_LIFECYCLE_TOPICS,
+            db_basename=_CYCLE_DB_BASENAME,
+            context=context,
+            notifier_overrides=_CYCLE_NOTIFIER_OVERRIDES,
+            # Matches playbooks.yaml's registered `groom_dispatch_telegram_only`
+            # class source exactly (config-I3513).
+            source="flow-doctor:scheduled-groom-dispatcher",
+        )
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("cycle lifecycle Telegram failed (non-fatal): %s", exc)
+
+
+def _notify_cycle_started(decide_payload: dict, schedule_label: str) -> None:
+    """Buzzing STARTED ping naming exactly which lanes this trigger launches.
+
+    Emitted from the decide phase — the single chokepoint every `decide_only`
+    response passes through — so the ping reflects what was actually decided,
+    derived from the same values the SF is about to fan out (policy §2.7: the
+    record is a receipt written by the dispatching code, never a second
+    declaration that can drift).
+
+    A ZERO-lane decision is announced too, not skipped. "No pings today" must
+    never be readable as either "nothing was due" or "the trigger never fired"
+    — that ambiguity is §2.4's absence-of-signal defect and it is exactly what
+    cost an operator session on 2026-07-27.
+    """
+    launches = decide_payload.get("launches") or []
+    lanes = [str(e.get("issue_filter") or "?") for e in launches]
+    counts = decide_payload.get("counts") or {}
+    counts_line = (
+        "\nbacklog: " + ", ".join(f"{t}={counts[t]}" for t in sorted(counts))
+        if counts else ""
+    )
+    if lanes:
+        head = f"🟢 Groom cycle {schedule_label} STARTED"
+        body = f"\nlanes: {', '.join(lanes)} · sweep queued{counts_line}"
+    else:
+        # Not an error — a legitimately quiet backlog. Still announced.
+        head = f"⚪ Groom cycle {schedule_label} STARTED — 0 lanes"
+        reason = str(decide_payload.get("reason") or "below demand floor")
+        body = f"\nno tier cleared the demand floor ({reason}); sweep still runs{counts_line}"
+    _notify_cycle(
+        head + body,
+        severity="info",
+        # Per-trigger-per-day key: a relaunch inside the same cycle must not
+        # re-announce, but tomorrow's same-labelled trigger must.
+        dedup_key=f"{_CYCLE_FLOW_NAME}:started:{_utc_today()}:{schedule_label}",
+        context={"schedule": schedule_label, "lanes": lanes, "counts": counts},
+    )
+
+
+# Terminal-state vocabulary (policy §2.4: "degraded exits are named exits").
+# Maps the completion-marker / lane-outcome tokens the box and the SF produce
+# onto the glyph the roll-up shows. An UNKNOWN token is never silently
+# dropped — _lane_glyph renders it verbatim with a ❔ so a new terminal state
+# invented downstream shows up as itself rather than disappearing.
+_LANE_GLYPHS = {
+    "success": "✅", "clean": "✅",
+    "interrupted": "🟠", "quota_stop": "🟠", "spot_stop": "🟠",
+    "skipped": "⚪", "not_launched": "⚪",
+    "timeout": "🔴", "failure": "🔴", "crash_cascade": "🔴",
+    "no_artifact": "🔴", "floor_fail": "🔴",
+    "turn_budget_exceeded": "🟡", "floor_near_miss": "🟡",
+    "lane_failed": "🔴",
+}
+
+
+def _lane_glyph(state: str) -> str:
+    return _LANE_GLYPHS.get(state, "❔")
+
+
+def _lane_rows(map_outcome: list) -> tuple[list[str], bool]:
+    """Render one row per lane; return (rows, any_degraded).
+
+    Totality matters more than prettiness here: every element of map_outcome
+    produces a row, including one whose shape this code did not anticipate.
+    A lane that produced no recognizable outcome renders as `no outcome
+    reported` rather than being filtered out of the roll-up — a lane silently
+    missing from the summary is precisely the failure this ping exists to
+    surface (config-I4987).
+    """
+    rows: list[str] = []
+    degraded = False
+    for i, item in enumerate(map_outcome or []):
+        if not isinstance(item, dict):
+            rows.append(f"  lane{i}  ❔ malformed outcome")
+            degraded = True
+            continue
+        lane_outcome = item.get("laneOutcome") or {}
+        launch = item.get("groomLaunch") or item.get("groom") or {}
+        tier = str(
+            item.get("issue_filter")
+            or launch.get("issue_filter")
+            or lane_outcome.get("issue_filter")
+            or f"lane{i}"
+        )
+        if lane_outcome.get("laneFailed"):
+            state = str(lane_outcome.get("reason") or "lane_failed")
+        else:
+            state = str(
+                lane_outcome.get("completion")
+                or launch.get("completion")
+                or launch.get("reason")
+                or ("success" if launch.get("launched") else "")
+            )
+        if not state:
+            state = "no outcome reported"
+            degraded = True
+        elif _lane_glyph(state) in ("🔴", "🟠", "❔"):
+            degraded = True
+        rows.append(f"  {tier:<6} {_lane_glyph(state)} {state}")
+    return rows, degraded
+
+
+def _notify_cycle_complete(cycle: dict) -> dict:
+    """Buzzing COMPLETE roll-up — one ping per trigger, every lane named.
+
+    Invoked by the dispatch SF immediately before its terminal Succeed/Fail
+    routing, so it fires on BOTH outcomes: a cycle that ends FAILED is exactly
+    the one whose roll-up the operator most needs. Returns a small record the
+    SF stores under $.cycleNotify for post-hoc verification (§2.8).
+    """
+    # The SF hands us its whole state object (`"cycle.$": "$"`) rather than
+    # cherry-picked fields. That is deliberate and load-bearing: `$.mapFailure`
+    # is ABSENT on the two healthy paths, and a `Parameters` reference to an
+    # absent field raises States.Runtime, which no Catch can intercept
+    # (policy §2.2 — "uncatchable failure classes are eliminated by
+    # construction, never caught"). Passing the root and reading with .get()
+    # here moves that from an SF-runtime concern to ordinary Python.
+    sched_input = cycle.get("schedInput") or {}
+    schedule_label = str(
+        cycle.get("schedule") or sched_input.get("schedule") or "unknown"
+    )
+    map_outcome = cycle.get("mapOutcome") or []
+    sweep = cycle.get("sweep") or {}
+    map_failure = cycle.get("mapFailure")
+
+    rows, degraded = _lane_rows(map_outcome)
+
+    # The sweep is dispatched fire-and-forget (DispatchEndOfSfSweep is a plain
+    # lambda:invoke, not .waitForTaskToken), so at this point we can honestly
+    # report only whether its BOX was launched — never that it finished. Say
+    # exactly that rather than implying a completion we did not observe; the
+    # sweep box files its own terminal ping on the per-box rail.
+    if sweep.get("dispatched") is False or sweep.get("launched") is False:
+        sweep_line = f"  sweep  🔴 not dispatched ({sweep.get('reason', 'unknown')})"
+        degraded = True
+    elif sweep:
+        sweep_line = "  sweep  ✅ box launched (runs to quiescence; reports separately)"
+    else:
+        sweep_line = "  sweep  ❔ no dispatch record"
+        degraded = True
+
+    if map_failure or degraded:
+        head = f"🟡 Groom cycle {schedule_label} COMPLETE — degraded"
+        severity = "warning"
+    else:
+        head = f"✅ Groom cycle {schedule_label} COMPLETE"
+        severity = "info"
+
+    lane_block = "\n".join(rows) if rows else "  (no lanes launched)"
+    text = f"{head}\n{lane_block}\n{sweep_line}"
+    if map_failure:
+        text += f"\nmap failure: {map_failure}"
+
+    _notify_cycle(
+        text, severity=severity,
+        dedup_key=f"{_CYCLE_FLOW_NAME}:complete:{_utc_today()}:{schedule_label}",
+        context={"schedule": schedule_label, "degraded": degraded,
+                 "lane_count": len(rows)},
+    )
+    return {"notified": True, "degraded": degraded, "lanes": len(rows)}
+
+
+def _decide_result(decide_payload: dict, schedule_label: str) -> dict:
+    """SINGLE chokepoint for every ``decide_only`` response.
+
+    Every early return in the decide phase routes through here so the STARTED
+    ping cannot be missed on one branch and present on another — including the
+    two zero-lane branches (enumeration failure, demand-gate skip), which are
+    the ones a per-branch notify would most likely have been forgotten on.
+    """
+    _notify_cycle_started(decide_payload, schedule_label)
+    return {"decide": decide_payload}
+
+
+def _handle_cycle_complete(event: dict) -> dict:
+    """``{"mode": "cycle_complete", "cycle": {...}}`` — SF terminal roll-up.
+
+    A FOURTH invocation shape alongside fallback / decide_only / launch_decided,
+    checked early and returned immediately. Deliberately total: any exception
+    is caught and reported in-band, because this state sits on the SF's path to
+    BOTH terminal states and must never convert a completed cycle into a
+    States.TaskFailed.
+    """
+    try:
+        return {"cycleNotify": _notify_cycle_complete(event.get("cycle") or {})}
+    except Exception as exc:  # noqa: BLE001 — never fail the terminal routing
+        logger.warning("cycle-complete notification failed (non-fatal): %s", exc)
+        return {"cycleNotify": {"notified": False, "error": str(exc)}}
 
 
 def _notify_concurrent_skip(tier_tag: str, existing_ids: list[str], schedule_label: str) -> None:
@@ -1533,6 +1786,11 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     event = event or {}
     if event.get("mode") == "fallback":
         return _handle_fallback_dispatch(event)
+    if event.get("mode") == "cycle_complete":
+        # 2026-07-28: SF terminal roll-up. Checked here, alongside `fallback`,
+        # for the same reason — no live schedule or other caller sets a
+        # top-level `mode`, so this cannot collide with any shape below.
+        return _handle_cycle_complete(event)
     run_mode = _resolve_run_mode(event)
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)
@@ -1637,7 +1895,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             _write_skip_record(schedule_label, "demand_all_failed", error=str(exc))
             err = {"launched": False, "reason": "demand_all_failed", "error": str(exc)}
             if event.get("decide_only"):
-                return {"decide": {"launches": [], **err}}
+                return _decide_result({"launches": [], **err}, schedule_label)
             return {"groom": err}
         if launches is not None:
             manifest_keys = _write_queue_manifests(schedule_label, launches, tier_issues)
@@ -1678,10 +1936,10 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 # optional "backend" key (I3479) rides the SF Map's wholesale
                 # per-item merge straight into the matching launch_decided
                 # invocation — see the module docstring.
-                return {"decide": {"trigger": "demand-all", "counts": counts,
-                                   "decisions": decisions_record,
-                                   "queue_manifests": manifest_keys,
-                                   "launches": entries}}
+                return _decide_result({"trigger": "demand-all", "counts": counts,
+                                       "decisions": decisions_record,
+                                       "queue_manifests": manifest_keys,
+                                       "launches": entries}, schedule_label)
             results = [
                 _launch_groom_spot(
                     run_mode, schedule_label, e["model"], e["issue_filter"], soft_limit_min,
@@ -1712,7 +1970,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 skip = {"launched": False, "reason": "demand_gate_skip",
                         "decision": decision.as_record(), "counts": counts}
                 if event.get("decide_only"):
-                    return {"decide": {"launches": [], **skip}}
+                    return _decide_result({"launches": [], **skip}, schedule_label)
                 return {"groom": skip}
             # Launch with the DECIDED bundle + cheapest adequate model — the
             # schedule's model is only the slot default; high never runs
@@ -1729,7 +1987,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             entry["pr_budget"] = pr_budget
         if backend:
             entry["backend"] = backend
-        return {"decide": {"launches": [entry]}}
+        return _decide_result({"launches": [entry]}, schedule_label)
 
     result = _launch_groom_spot(
         run_mode, schedule_label, model, issue_filter, soft_limit_min, pr_budget, force_on_demand,

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -199,6 +199,60 @@ run aws lambda add-permission \
   --source-arn "${RULE_ARN}" \
   --region "${REGION}" 2>/dev/null || true
 
+# ----- 2c. Groom dispatch SF — FAILURE statuses only (2026-07-28) -----------
+#
+# A SECOND rule rather than three more ARNs on the one above, because the
+# groom SF needs a DIFFERENT status set. The rule above fans RUNNING and
+# SUCCEEDED as well, which is right for the three pipeline SFs but wrong here:
+# the groom dispatch SF now emits its own cycle-level STARTED/COMPLETE pings
+# from NotifyCycleComplete + the decide phase, carrying the per-lane roll-up
+# this generic notifier cannot produce. Adding the groom ARN to the rule above
+# would double-report every cycle with a strictly less informative message.
+#
+# What was genuinely missing is the FAILURE half. The groom SF's own SNS
+# publishes (per-lane FailExecution, sweep-dispatch failure, top-level failure)
+# all go to `alpha-engine-alerts`, which has NO Telegram subscriber — its
+# subscribers are the alerts-forwarder and the changelog mirror. So a groom SF
+# that failed outright reached email and the Overseer intake bus but never
+# Telegram, which is why four consecutive failed cycles (2026-07-27..28)
+# produced no page. FAILED/TIMED_OUT/ABORTED here closes that, and cannot
+# collide with the cycle pings: those two are emitted from INSIDE a running
+# execution, this fires on its terminal transition.
+GROOM_RULE_NAME="alpha-engine-groom-sf-failure"
+echo "Reconciling EventBridge rule: ${GROOM_RULE_NAME}"
+GROOM_EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.states"],
+  "detail-type": ["Step Functions Execution Status Change"],
+  "detail": {
+    "stateMachineArn": [
+      "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
+    ],
+    "status": ["FAILED", "TIMED_OUT", "ABORTED"]
+  }
+}
+EOF
+)
+run aws events put-rule \
+  --name "${GROOM_RULE_NAME}" \
+  --event-pattern "${GROOM_EVENT_PATTERN}" \
+  --description "Fan groom-dispatch SF FAILURE transitions to alpha-engine-sf-telegram-notifier (successes are reported by the SF's own cycle roll-up)" \
+  --region "${REGION}" \
+  --query 'RuleArn' --output text
+
+run aws events put-targets \
+  --rule "${GROOM_RULE_NAME}" \
+  --targets "Id=1,Arn=${FN_ARN}" \
+  --region "${REGION}"
+
+run aws lambda add-permission \
+  --function-name "${FUNCTION_NAME}" \
+  --statement-id "eventbridge-${GROOM_RULE_NAME}" \
+  --action lambda:InvokeFunction \
+  --principal events.amazonaws.com \
+  --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${GROOM_RULE_NAME}" \
+  --region "${REGION}" 2>/dev/null || true
+
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 
 echo "Updating Lambda function code: ${FUNCTION_NAME}"

--- a/infrastructure/lambdas/sf-telegram-notifier/index.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/index.py
@@ -38,6 +38,13 @@ _SF_LABELS: dict[str, str] = {
     "ne-weekly-freshness-pipeline": "Weekly Freshness SF",
     "ne-preopen-trading-pipeline": "Pre-open Trading SF",
     "ne-postclose-trading-pipeline": "Post-close Trading SF",
+    # 2026-07-28: wired for FAILURE transitions only, via its own
+    # `alpha-engine-groom-sf-failure` rule (see deploy.sh §2c). Successes are
+    # reported by the SF's own NotifyCycleComplete roll-up, which names each
+    # lane's terminal state — strictly more informative than this generic
+    # notifier could be. Without this entry the label falls back to the raw
+    # state-machine name, which is legible but not consistent with the others.
+    "alpha-engine-groom-dispatch": "Backlog Groom Dispatch SF",
 }
 
 _PREFLIGHT_LABEL_OVERRIDE: dict[str, str] = {

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -234,9 +234,9 @@ playbooks:
     # per-run by groom_driver — deliberately NOT the router-injected `model:`
     # field, which only applies to routed playbooks (config-I3293).
     wake:
-      - "eventbridge: three daily fixed crons 01:00/07:00/19:00 UTC (demand-driven tier launches)"
+      - "eventbridge: three daily fixed crons 04:00/12:00/20:00 UTC + Sun 09:00 UTC (demand-driven tier launches)"
       - "demand: end-of-SF Haiku PR-sweep leg (groom_run.sh --mode pr_sweep)"
-    cadence: "3x daily fixed crons + end-of-SF sweep leg"
+    cadence: "3x daily fixed crons (+ a weekly Sunday slot) + end-of-SF sweep leg"
     executor_lambda_dir: scheduled-groom-dispatcher
     charter: alpha-engine-config/scripts/groom_run.sh
     concurrency_domain: EC2 tag lock on groom-issue-filter (tier lane; sweep has its own lane).
@@ -249,6 +249,22 @@ playbooks:
     # A trigger with no covering artifact = a silent groom death → problem line.
     # `schedule` MIRRORS scheduled-groom-dispatcher/deploy.sh SCHED_CRONS — the
     # registry is now the SSoT (was GROOM_SCHEDULE env / _DEFAULT_SCHEDULE const).
+    #
+    # config-I4988 (corrected 2026-07-28): these hours sat at 01:00/07:00/19:00,
+    # the RETIRED tier-per-slot schedule, three retirements behind the live
+    # crons. Because _rw_expected_triggers enumerates from this list, the check
+    # was accounting for triggers that no longer fire and blind to the ones that
+    # do — so on 2026-07-27/28, when four consecutive cycles failed and one lost
+    # all three lanes to a capacity event, the check that exists precisely to
+    # page on a silent groom death could not fire. A mirrored schedule with
+    # nothing enforcing the mirror is the §2.7 derive-once defect; the lockstep
+    # test added alongside this fix (tests/test_groom_schedule_lockstep.py) now
+    # fails CI the moment deploy.sh's SCHED_CRONS and this list disagree.
+    #
+    # NOTE this remains a SLOW backstop, not a fast pager: maturity is
+    # ceiling+margin = 405 min, so a lane that dies at bootstrap is still
+    # invisible here for ~7h. The fast instance-death signal is tracked
+    # separately — see the epic (config-I5194 Phase 1).
     liveness:
       checks:
         - type: run_window
@@ -259,9 +275,10 @@ playbooks:
           margin_min: 45     # box boot + report latency slack
           lookback_hours: 30
           schedule:
-            - {hour: 1, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "01:00 daily (Sonnet high-only)"}
-            - {hour: 7, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "07:00 daily (Sonnet mid-only)"}
-            - {hour: 19, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "19:00 daily (Haiku low-only)"}
+            - {hour: 4, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "04:00 UTC daily (demand-all)"}
+            - {hour: 12, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "12:00 UTC daily (demand-all)"}
+            - {hour: 20, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "20:00 UTC daily (demand-all)"}
+            - {hour: 9, minute: 0, dows: [0], label: "Sun 09:00 UTC (weekly extra slot)"}
 
   gate-sweeps:
     description: >-

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -462,7 +462,7 @@
         }
       ],
       "ResultPath": "$.sweep",
-      "Next": "CheckMapLaunchOutcome"
+      "Next": "NotifyCycleComplete"
     },
     "RecordSweepDispatchFailure": {
       "Type": "Pass",
@@ -490,12 +490,48 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "CheckMapLaunchOutcome",
+          "Next": "NotifyCycleComplete",
           "ResultPath": "$.sweep_notify_error"
         }
       ],
-      "Next": "CheckMapLaunchOutcome",
+      "Next": "NotifyCycleComplete",
       "TimeoutSeconds": 60
+    },
+    "NotifyCycleComplete": {
+      "Type": "Task",
+      "Comment": "2026-07-28 operator ruling: emit ONE buzzing cycle-level COMPLETE roll-up naming every lane's terminal state and the sweep's dispatch outcome. Sits on the single convergence point ahead of CheckMapLaunchOutcome so it fires on BOTH terminal routings — a cycle that ends FAILED is the one whose roll-up matters most. Before this, GroomDispatchComplete was a bare Succeed and cycle completion had no notifier on ANY rail, so the three lanes reclaimed at bootstrap on the 12:00Z cycle (config-I4987/I4989) produced total Telegram silence. Payload passes the state ROOT (\"cycle.$\": \"$\") rather than named fields because $.mapFailure is ABSENT on the two healthy paths, and a Parameters reference to an absent field raises States.Runtime, which no Catch can intercept (groom-sweep-policy §2.2).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
+        "Payload": {
+          "mode": "cycle_complete",
+          "cycle.$": "$"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 5,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Best-effort per groom-sweep-policy §8 — a notify hiccup must never change this execution's terminal state. The Lambda handler is itself total (it catches and returns an in-band error record rather than raising), so reaching this Catch means the invoke itself failed.",
+          "Next": "CheckMapLaunchOutcome",
+          "ResultPath": "$.cycleNotifyError"
+        }
+      ],
+      "ResultPath": "$.cycleNotify",
+      "Next": "CheckMapLaunchOutcome"
     },
     "CheckMapLaunchOutcome": {
       "Type": "Choice",

--- a/tests/test_groom_cycle_notifications.py
+++ b/tests/test_groom_cycle_notifications.py
@@ -1,0 +1,374 @@
+"""tests/test_groom_cycle_notifications.py — cycle-level groom lifecycle pings.
+
+Guards the 2026-07-28 operator ruling: the groom must emit ONE buzzing STARTED
+ping and ONE buzzing COMPLETE roll-up per trigger cycle, from the ORCHESTRATOR
+rather than the box.
+
+Why it exists. Before this, terminal reporting lived exclusively in
+``groom_run.sh``'s §7, at ``severity=info`` — which ``FleetTelegramTopic.GROOM``
+delivers with ``disable_notification=True``. Two independent consequences, both
+observed live on 2026-07-28:
+
+  * a FINISHED message was delivered but never buzzed, so the operator's lived
+    experience was "start + errors only"; and
+  * a per-box trap structurally cannot report a box that never reached it. On
+    the 12:00Z cycle all three lanes were reclaimed
+    ``instance-terminated-no-capacity`` two minutes after launch. Zero
+    notifications fired on any rail and the SF sat in ``TaskSubmitted`` for four
+    hours (config-I4987/I4989). ``GroomDispatchComplete`` was a bare ``Succeed``.
+
+The tests below pin the three things that make the fix real rather than
+cosmetic: the SF actually routes through the notifier on BOTH terminal paths,
+the notifier is total (no lane silently omitted from the roll-up), and the
+buzz-vs-silent posture is explicit rather than inherited.
+
+The schedule-lockstep test is a separate concern riding the same PR: the
+Overseer's ``run_window`` liveness check enumerates expected triggers from
+``playbooks.yaml``, and that list had drifted three retirements behind the live
+crons (config-I4988), so the one check that should have paged on 2026-07-27/28
+structurally could not fire. A mirrored schedule with nothing enforcing the
+mirror is the §2.7 derive-once defect; this test is the enforcement.
+"""
+
+import importlib.util
+import json
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SF_FILE = REPO_ROOT / "infrastructure" / "step_function_groom.json"
+DISPATCHER_DIR = REPO_ROOT / "infrastructure" / "lambdas" / "scheduled-groom-dispatcher"
+DISPATCHER_DEPLOY = DISPATCHER_DIR / "deploy.sh"
+PLAYBOOKS = REPO_ROOT / "infrastructure" / "overseer" / "playbooks.yaml"
+NOTIFIER_DEPLOY = (
+    REPO_ROOT / "infrastructure" / "lambdas" / "sf-telegram-notifier" / "deploy.sh"
+)
+
+
+@pytest.fixture(scope="module")
+def states():
+    return json.loads(SF_FILE.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def dispatcher():
+    """Import the dispatcher Lambda with its AWS/lib imports stubbed.
+
+    The module is a Lambda entrypoint, not a package — it imports boto3 and
+    nousergon_lib at module scope. Only the pure notification-shaping helpers
+    are under test here, so the heavy imports are satisfied with stubs rather
+    than pulled in for real.
+    """
+    def stub(name, **attrs):
+        """Install a stub ONLY if the real module is genuinely unavailable."""
+        try:
+            importlib.import_module(name)
+            return
+        except ImportError:
+            pass
+        mod = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(mod, k, v)
+        sys.modules[name] = mod
+
+    stub("boto3", client=lambda *a, **k: None)  # noqa: ARG005
+    stub("flow_doctor_telegram", notify_via_flow_doctor=lambda *a, **k: True)  # noqa: ARG005
+    # nousergon_lib.spot_dispatch imports `from krepis import alerts` at module
+    # scope; krepis is a runtime dep of the Lambda bundle, not of this test
+    # suite's env.
+    stub("krepis")
+    stub("krepis.alerts", publish=lambda *a, **k: None)  # noqa: ARG005
+    if "krepis" in sys.modules and not hasattr(sys.modules["krepis"], "alerts"):
+        sys.modules["krepis"].alerts = sys.modules["krepis.alerts"]
+
+    sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "groom_dispatcher_under_test", DISPATCHER_DIR / "index.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Deliberately NOT wrapped in try/pytest.skip. An unimportable dispatcher
+    # must FAIL this suite, not quietly skip 9 assertions — a skipped guard is
+    # indistinguishable from a passing one in CI output, which is the same
+    # absence-of-signal defect these tests exist to prevent (policy §2.4).
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── SF wiring ────────────────────────────────────────────────────────────────
+
+
+def test_notify_cycle_complete_exists_and_invokes_the_dispatcher(states):
+    st = states["NotifyCycleComplete"]
+    assert st["Type"] == "Task"
+    assert st["Resource"] == "arn:aws:states:::lambda:invoke"
+    payload = st["Parameters"]["Payload"]
+    assert payload["mode"] == "cycle_complete"
+    assert (
+        st["Parameters"]["FunctionName"] == "alpha-engine-scheduled-groom-dispatcher"
+    )
+
+
+def test_cycle_notify_passes_the_state_root_not_named_fields(states):
+    """$.mapFailure is ABSENT on the two healthy paths.
+
+    A ``Parameters`` reference to an absent field raises ``States.Runtime``,
+    which no ``Catch`` can intercept — groom-sweep-policy §2.2 requires that
+    class be eliminated by construction. Passing the root and reading with
+    ``.get()`` in Python is that construction; a future edit that "helpfully"
+    cherry-picks $.mapFailure here would reintroduce an uncatchable failure on
+    the SUCCESS path only, which is exactly the shape that survives review.
+    """
+    payload = states["NotifyCycleComplete"]["Parameters"]["Payload"]
+    assert payload["cycle.$"] == "$"
+    flat = json.dumps(payload)
+    assert "$.mapFailure" not in flat
+    assert "$.sweep" not in flat
+
+
+def test_both_terminal_paths_route_through_the_cycle_notification(states):
+    """Success AND failure must both be reported.
+
+    A cycle ending FAILED is the one whose roll-up the operator most needs, so
+    the notifier sits ahead of CheckMapLaunchOutcome rather than on either
+    branch of it.
+    """
+    check = states["CheckMapLaunchOutcome"]
+    assert check["Choices"][0]["Next"] == "GroomMapLaunchFailed"
+    assert check["Default"] == "GroomDispatchComplete"
+
+    feeders = [
+        name for name, st in states.items()
+        if st.get("Next") == "CheckMapLaunchOutcome"
+        or any(c.get("Next") == "CheckMapLaunchOutcome" for c in st.get("Catch", []))
+    ]
+    # Only the notifier itself (success Next + best-effort Catch) may feed the
+    # outcome check. Anything else means a path bypasses the roll-up.
+    assert feeders == ["NotifyCycleComplete"], (
+        f"{feeders} reach CheckMapLaunchOutcome directly — every converging "
+        "path must pass through NotifyCycleComplete first, or that cycle "
+        "terminates with no operator notification (the 12:00Z silence)"
+    )
+
+
+def test_cycle_notification_is_best_effort_and_cannot_change_the_outcome(states):
+    """Policy §8 carve-out: a notify hiccup must never fail the execution."""
+    st = states["NotifyCycleComplete"]
+    catch = st["Catch"][0]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "CheckMapLaunchOutcome"
+    assert catch["ResultPath"] == "$.cycleNotifyError"
+    assert st["ResultPath"] == "$.cycleNotify"
+    # ResultPath must not clobber the state root — $.mapFailure has to survive
+    # this state or a failed cycle would report SUCCEEDED.
+    assert st["ResultPath"] not in ("$", None)
+    assert "TimeoutSeconds" in st, "no unbounded state (policy §2.1)"
+
+
+# ── Notification shaping ─────────────────────────────────────────────────────
+
+
+def test_every_lane_appears_in_the_rollup_including_unrecognized_shapes(dispatcher):
+    """Totality, not prettiness (policy §2.4 no-silent-default).
+
+    A lane whose outcome this code did not anticipate must still produce a row.
+    A lane silently missing from the summary is precisely the failure the ping
+    exists to surface.
+    """
+    rows, degraded = dispatcher._lane_rows([
+        {"issue_filter": "low-only", "groomLaunch": {"launched": True,
+                                                     "completion": "success"}},
+        {"issue_filter": "mid-only", "laneOutcome": {"laneFailed": True,
+                                                     "reason": "timeout"}},
+        {"issue_filter": "high-only"},                      # no outcome at all
+        {"issue_filter": "weird", "groomLaunch": {"completion": "invented_state"}},
+        "not-even-a-dict",                                  # malformed
+    ])
+    assert len(rows) == 5, "a lane was dropped from the roll-up"
+    assert degraded is True
+    joined = "\n".join(rows)
+    assert "low-only" in joined and "mid-only" in joined and "high-only" in joined
+    assert "no outcome reported" in joined
+    assert "invented_state" in joined, "an unknown terminal state must render as itself"
+    assert "malformed outcome" in joined
+
+
+def test_all_clean_lanes_report_not_degraded(dispatcher):
+    rows, degraded = dispatcher._lane_rows([
+        {"issue_filter": "low-only", "groomLaunch": {"completion": "success"}},
+        {"issue_filter": "mid-only", "groomLaunch": {"completion": "success"}},
+    ])
+    assert degraded is False
+    assert len(rows) == 2
+
+
+def test_unknown_terminal_state_is_never_silently_treated_as_healthy(dispatcher):
+    assert dispatcher._lane_glyph("success") == "✅"
+    assert dispatcher._lane_glyph("a-state-invented-next-month") == "❔"
+
+
+def test_cycle_pings_are_buzzing_not_silent(dispatcher):
+    """The whole point of the ruling.
+
+    The canonical GROOM topic spec is ``notify_on=("info",)`` +
+    ``disable_notification=True``. Cycle-level pings override BOTH: severities
+    above info are otherwise DROPPED, not merely silenced.
+    """
+    ov = dispatcher._CYCLE_NOTIFIER_OVERRIDES
+    assert ov["disable_notification"] is False
+    assert set(ov["notify_on"]) >= {"info", "warning", "error", "critical"}
+
+
+def test_cycle_flow_name_is_distinct_from_the_silent_per_box_rail(dispatcher):
+    """flow_doctor_telegram caches the built config by flow_name.
+
+    Sharing one with the silent rail would serve whichever posture initialized
+    first — a coin-flip between buzzing and silent, per cold start.
+    """
+    assert dispatcher._CYCLE_FLOW_NAME != dispatcher._FLOW_NAME
+    assert dispatcher._CYCLE_DB_BASENAME != dispatcher._DB_BASENAME
+
+
+def test_zero_lane_cycles_are_announced_not_skipped(dispatcher, monkeypatch):
+    """"No ping today" must never be readable as either "nothing was due" or
+    "the trigger never fired" — that ambiguity cost an operator session on
+    2026-07-27 (policy §2.4)."""
+    sent = []
+    monkeypatch.setattr(dispatcher, "_notify_cycle",
+                        lambda text, **kw: sent.append((text, kw)))
+    dispatcher._notify_cycle_started({"launches": [], "reason": "below floor"},
+                                     "0 12 * * *")
+    assert len(sent) == 1
+    assert "0 lanes" in sent[0][0]
+    assert "sweep still runs" in sent[0][0]
+
+
+def test_every_decide_response_flows_through_one_notification_chokepoint():
+    """A per-branch notify would be forgotten on exactly the quiet branches."""
+    src = (DISPATCHER_DIR / "index.py").read_text()
+    # The chokepoint's own return is the ONE legitimate construction of this
+    # shape; every other occurrence is a branch that skipped the ping.
+    bypasses = [
+        line for line in src.splitlines()
+        if 'return {"decide"' in line and "decide_payload" not in line
+    ]
+    assert not bypasses, (
+        f"decide_only response(s) bypass _decide_result: {bypasses} — their "
+        "cycle STARTED ping would never fire"
+    )
+    assert src.count("return _decide_result(") >= 4
+
+
+def test_cycle_complete_handler_is_total(dispatcher, monkeypatch):
+    """It sits on the SF's path to BOTH terminal states.
+
+    An exception here would convert a completed cycle into States.TaskFailed —
+    the notification is the least important thing in the execution and must
+    never be able to change its outcome.
+    """
+    def boom(*_a, **_k):
+        raise RuntimeError("telegram down")
+
+    monkeypatch.setattr(dispatcher, "_notify_cycle_complete", boom)
+    out = dispatcher._handle_cycle_complete({"cycle": {}})
+    assert out["cycleNotify"]["notified"] is False
+    assert "telegram down" in out["cycleNotify"]["error"]
+
+
+def test_cycle_complete_never_claims_the_sweep_finished(dispatcher, monkeypatch):
+    """DispatchEndOfSfSweep is a plain lambda:invoke, not .waitForTaskToken.
+
+    At roll-up time we can honestly report only that the sweep BOX launched.
+    Claiming completion we did not observe is the §2.8 defect — a record
+    asserting an action that never happened.
+    """
+    sent = []
+    monkeypatch.setattr(dispatcher, "_notify_cycle",
+                        lambda text, **kw: sent.append(text))
+    dispatcher._notify_cycle_complete({
+        "schedInput": {"schedule": "0 20 * * *"},
+        "mapOutcome": [{"issue_filter": "low-only",
+                        "groomLaunch": {"completion": "success"}}],
+        "sweep": {"launched": True},
+    })
+    body = sent[0]
+    assert "box launched" in body
+    assert "quiescent" not in body.lower()
+
+
+def test_a_failed_cycle_reports_degraded(dispatcher, monkeypatch):
+    sent = []
+    monkeypatch.setattr(dispatcher, "_notify_cycle",
+                        lambda text, **kw: sent.append((text, kw)))
+    dispatcher._notify_cycle_complete({
+        "schedInput": {"schedule": "0 12 * * *"},
+        "mapOutcome": [{"issue_filter": "low-only",
+                        "laneOutcome": {"laneFailed": True, "reason": "timeout"}}],
+        "sweep": {"dispatched": False, "reason": "sweep_dispatch_failed"},
+        "mapFailure": {"failed": True, "reason": "one_or_more_lanes_failed"},
+    })
+    text, kw = sent[0]
+    assert "degraded" in text
+    assert kw["severity"] == "warning", "a degraded cycle must not ping as routine info"
+    assert "not dispatched" in text
+
+
+# ── Schedule lockstep (config-I4988) ─────────────────────────────────────────
+
+
+def _deploy_sched_crons() -> list[tuple[int, int]]:
+    """(hour, minute) of every cron in the dispatcher's SCHED_CRONS array."""
+    src = DISPATCHER_DEPLOY.read_text()
+    block = re.search(r"SCHED_CRONS=\((.*?)\n\)", src, re.S)
+    assert block, "SCHED_CRONS array not found in scheduled-groom-dispatcher/deploy.sh"
+    out = []
+    for minute, hour in re.findall(r'"cron\((\d+)\s+(\d+)\s', block.group(1)):
+        out.append((int(hour), int(minute)))
+    assert out, "no cron expressions parsed from SCHED_CRONS"
+    return sorted(out)
+
+
+def _registry_run_window_schedule() -> list[tuple[int, int]]:
+    doc = yaml.safe_load(PLAYBOOKS.read_text())
+    groom = doc["playbooks"]["groom"] if "playbooks" in doc else doc["groom"]
+    checks = groom["liveness"]["checks"]
+    rw = [c for c in checks if c["type"] == "run_window"]
+    assert len(rw) == 1
+    return sorted((s["hour"], s["minute"]) for s in rw[0]["schedule"])
+
+
+def test_liveness_run_window_schedule_matches_the_deployed_crons():
+    """config-I4988: the mirror must be enforced, not merely asserted in a comment.
+
+    ``_rw_expected_triggers`` enumerates from the registry, so a stale list
+    means the check accounts for triggers that never fire and is blind to the
+    ones that do — which is why the groom's own liveness check could not fire
+    across four consecutive failed cycles.
+    """
+    assert _registry_run_window_schedule() == _deploy_sched_crons(), (
+        "playbooks.yaml groom run_window schedule has drifted from "
+        "scheduled-groom-dispatcher/deploy.sh SCHED_CRONS — the liveness check "
+        "is enumerating triggers that do not fire (config-I4988)"
+    )
+
+
+def test_groom_sf_failures_reach_telegram():
+    """The groom SF's own SNS publishes go to `alpha-engine-alerts`, which has
+    NO Telegram subscriber — so a failed groom SF reached email and the intake
+    bus but never Telegram. Successes are deliberately NOT in this rule: the SF
+    emits its own richer cycle roll-up, and adding them here would double-report.
+    """
+    src = NOTIFIER_DEPLOY.read_text()
+    assert "alpha-engine-groom-sf-failure" in src
+    block = src[src.index("GROOM_EVENT_PATTERN=") :]
+    pattern = json.loads(re.search(r"\{.*?\n\}\n", block, re.S).group(0))
+    assert pattern["detail"]["stateMachineArn"] == [
+        "arn:aws:states:${REGION}:${ACCOUNT_ID}:stateMachine:alpha-engine-groom-dispatch"
+    ]
+    assert set(pattern["detail"]["status"]) == {"FAILED", "TIMED_OUT", "ABORTED"}
+    assert "SUCCEEDED" not in pattern["detail"]["status"]
+    assert "RUNNING" not in pattern["detail"]["status"]

--- a/tests/test_sf_groom_end_of_sf_sweep_wiring.py
+++ b/tests/test_sf_groom_end_of_sf_sweep_wiring.py
@@ -104,6 +104,34 @@ def test_sweep_payload_is_the_launch_decided_sweep_contract(states):
     }
 
 
+def _reaches(states, start, target, *, follow_catch=True):
+    """Is `target` reachable from `start` by Next/Catch edges (top level only)?
+
+    2026-07-28: these assertions used to pin DIRECT edges to
+    CheckMapLaunchOutcome. Inserting NotifyCycleComplete on the shared
+    convergence broke them without touching the invariant they actually guard —
+    "every converging path still reaches the outcome check after the sweep has
+    been attempted". Reachability is the more faithful expression of that
+    invariant and does not re-break the next time a state is inserted on the
+    same run, so per groom-sweep-policy §9 the guards are rewritten here rather
+    than the change being bent to fit them.
+    """
+    seen, stack = set(), [start]
+    while stack:
+        name = stack.pop()
+        if name == target:
+            return True
+        if name in seen or name not in states:
+            continue
+        seen.add(name)
+        st = states[name]
+        if st.get("Next"):
+            stack.append(st["Next"])
+        if follow_catch:
+            stack.extend(c["Next"] for c in st.get("Catch", []) if c.get("Next"))
+    return False
+
+
 def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
     """Catch → record (Pass, dispatched:false into $.sweep) → best-effort SNS
     → CheckMapLaunchOutcome (config#2311: no longer directly to the terminal
@@ -129,8 +157,8 @@ def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
     notify = states["NotifySweepDispatchFailure"]
     assert notify["Resource"] == "arn:aws:states:::sns:publish"
     assert "$.sweepDispatchError" in notify["Parameters"]["Message.$"]
-    assert notify["Next"] == "CheckMapLaunchOutcome"
-    assert notify["Catch"][0]["Next"] == "CheckMapLaunchOutcome"
+    assert _reaches(states, notify["Next"], "CheckMapLaunchOutcome")
+    assert _reaches(states, notify["Catch"][0]["Next"], "CheckMapLaunchOutcome")
 
     assert states["GroomDispatchComplete"]["Type"] == "Succeed"
     # A sweep-dispatch failure alone (Catch -> Record -> Notify) must never
@@ -151,7 +179,7 @@ def test_sweep_launch_failure_is_nonfatal_recorded_and_notified(states):
 def test_sweep_success_path_records_result_and_succeeds(states):
     st = states["DispatchEndOfSfSweep"]
     assert st["ResultPath"] == "$.sweep"
-    assert st["Next"] == "CheckMapLaunchOutcome"
+    assert _reaches(states, st["Next"], "CheckMapLaunchOutcome")
 
 
 def test_sweep_is_fire_and_forget_no_polling_loop(states):
@@ -234,14 +262,15 @@ def test_map_launch_failure_still_terminates_execution_failed(states):
     # of the sweep-failure sub-path). DispatchEndOfSfSweep's Catch is exempt
     # here — that's the sweep's OWN failure path, which correctly detours
     # through RecordSweepDispatchFailure/NotifySweepDispatchFailure first.
-    assert states["DispatchEndOfSfSweep"]["Next"] == "CheckMapLaunchOutcome"
+    assert _reaches(states, states["DispatchEndOfSfSweep"]["Next"],
+                    "CheckMapLaunchOutcome")
     notify = states["NotifySweepDispatchFailure"]
     nexts = [notify.get("Next")] + [c.get("Next") for c in notify.get("Catch", [])]
     for nxt in nexts:
-        assert nxt == "CheckMapLaunchOutcome", (
-            f"NotifySweepDispatchFailure routes to {nxt} instead of "
-            "CheckMapLaunchOutcome — a Map-launch failure recorded in "
-            "$.mapFailure would be lost")
+        assert _reaches(states, nxt, "CheckMapLaunchOutcome"), (
+            f"NotifySweepDispatchFailure routes to {nxt}, from which "
+            "CheckMapLaunchOutcome is unreachable — a Map-launch failure "
+            "recorded in $.mapFailure would be lost")
 
     check = states["CheckMapLaunchOutcome"]
     assert check["Type"] == "Choice"


### PR DESCRIPTION
## Why

Operator ruling 2026-07-28: groom and sweep completions must actually be received, not merely delivered.

The groom's terminal reporting lived exclusively on the box. `groom_run.sh` emits ONLINE / FINISHED / WOUND-DOWN at `severity=info`, which `FleetTelegramTopic.GROOM` delivers with `disable_notification=True`. Two independent consequences, both confirmed live today:

1. A completion ping is delivered but **never buzzes**, so the lived experience is "start + errors only" even though a FINISHED message exists.
2. More seriously, **a per-box trap structurally cannot report a box that never reached it.** On the 12:00Z cycle all three lanes were reclaimed `instance-terminated-no-capacity` two minutes after launch. Zero notifications fired on any rail, and the SF sat in `TaskSubmitted` for four hours before being stopped by hand (config-I4987 / I4989). `GroomDispatchComplete` was a bare `Succeed` — cycle completion had no notifier anywhere.

Cycle completion rate over the rolling 7 days is **9 of 20 scheduled executions (45%)** against §10.1's 80% red line — and that is an upper bound, since the real unit (every demanded lane reaching a named terminal state *and* the sweep running) is not measured at all yet.

## What changes

Report from the **orchestrator**, which survives the box's death.

- **`NotifyCycleComplete`** sits on the single convergence ahead of `CheckMapLaunchOutcome`, so it fires on **both** terminal routings — a cycle ending FAILED is the one whose roll-up matters most. It names every lane's terminal state and the sweep's dispatch outcome.
- It passes the state **root** (`"cycle.$": "$"`) rather than named fields. `$.mapFailure` is absent on the two healthy paths, and a `Parameters` reference to an absent field raises `States.Runtime`, which no `Catch` can intercept — policy §2.2 requires that class be eliminated by construction, not caught.
- **One STARTED ping** from the decide phase, through a single chokepoint (`_decide_result`), so the zero-lane branches announce themselves too. "No ping today" must not be readable as either "nothing was due" or "the trigger never fired" (§2.4).
- **Cycle-level only.** Per-box posture is untouched: un-silencing ~18 pings/day is how the 11-day alert-fatigue outage happened.

Delivery posture is a **parameter on the shared helper**, not a second hand-written spec — `groom_flow_doctor_notify.py` already open-codes this exact override on the box rail, and two divergent copies of "how groom traffic reaches Telegram" is the §2.3 one-owner defect.

### Also in scope

- **SF failures now reach Telegram.** The groom SF's own SNS publishes go to `alpha-engine-alerts`, which has **no Telegram subscriber** — so four consecutive failed cycles (7/27–28) produced no page. A second EventBridge rule fans `FAILED`/`TIMED_OUT`/`ABORTED` only; successes stay with the richer cycle roll-up rather than double-reporting.
- **config-I4988.** The Overseer `run_window` schedule sat at the retired `01:00/07:00/19:00` crons, so the check that exists precisely to page on a silent groom death was enumerating triggers that never fire. Corrected to the live `04:00/12:00/20:00` + Sun `09:00`, and a **lockstep test** now fails CI the moment it drifts from `deploy.sh` `SCHED_CRONS` — a mirrored schedule with nothing enforcing the mirror is the §2.7 derive-once defect.

## Tests

`tests/test_groom_cycle_notifications.py` (16, no skips). The fixture deliberately does **not** `pytest.skip` on import failure — a skipped guard is indistinguishable from a passing one in CI output, which is the same absence-of-signal defect these tests exist to prevent.

Three existing sweep-wiring assertions pinned a **direct** edge to `CheckMapLaunchOutcome`. The invariant they guard — every converging path reaches the outcome check after the sweep — still holds transitively, so they are rewritten as reachability per policy §9 rather than the change being bent to fit them.

## Not closed by this

A lane that dies at bootstrap still pages only via the slow 405-min `run_window` backstop. A fast instance-death signal needs an out-of-band poller and is tracked under **config-I5194 Phase 1** — this PR does not deliver "pages within minutes".

## Verification

Local: 16/16 new, 70/70 SF+registry, 1393 passing across the groom/sf/overseer/iam selection. Three pre-existing failures in `test_sf_preflight.py` / `test_weekly_collector_heartbeat_wiring.py` are missing optional deps (`pyarrow`, `tenacity`) in the local 3.14 env — they fail identically on unmodified `main`.

Post-merge the SF definition and the two Lambdas need a deploy; the next 20:00Z / 04:00Z trigger is the live check.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)