### PR TITLE
[P1] fix(liveness): a run artifact proves a boot, not a run

### DIFF
--- a/infrastructure/lambdas/overseer-liveness-probe/index.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/index.py
@@ -524,13 +524,13 @@ def _rw_all_expected_triggers(spec: dict, s3, now: datetime) -> list[dict]:
     return sorted(merged.values(), key=lambda d: d["at"])
 
 
-def _rw_fetch_run_artifact_timestamps(spec: dict, s3, now: datetime) -> list[datetime]:
-    """``run_start`` timestamps of recent S3 run artifacts
-    (``{artifact_prefix}{date}/{run_id}.json``). PRIMARY input — RAISES on error
-    (fail-loud); a malformed individual artifact also raises (skipping it
-    silently would let a genuinely-missed trigger hide behind a corrupt one)."""
+def _rw_fetch_run_artifacts(spec: dict, s3, now: datetime) -> list[tuple[datetime, str, dict]]:
+    """Recent S3 run artifacts (``{artifact_prefix}{date}/{run_id}.json``) as
+    (run_start, key, artifact). PRIMARY input — RAISES on error (fail-loud); a
+    malformed individual artifact also raises (skipping it silently would let a
+    genuinely-missed trigger hide behind a corrupt one)."""
     artifact_prefix = spec["artifact_prefix"]
-    stamps: list[datetime] = []
+    found: list[tuple[datetime, str, dict]] = []
     for date in _rw_lookback_dates(spec, now):
         prefix = f"{artifact_prefix}{date}/"
         token = None
@@ -548,11 +548,13 @@ def _rw_fetch_run_artifact_timestamps(spec: dict, s3, now: datetime) -> list[dat
                 run_start = art.get("run_start")
                 if not run_start:
                     continue
-                stamps.append(datetime.fromisoformat(run_start.replace("Z", "+00:00")))
+                found.append(
+                    (datetime.fromisoformat(run_start.replace("Z", "+00:00")), key, art)
+                )
             if not resp.get("IsTruncated"):
                 break
             token = resp.get("NextContinuationToken")
-    return stamps
+    return found
 
 
 def _rw_missed(spec: dict, triggers: list[dict], stamps: list[datetime]) -> list[dict]:
@@ -560,6 +562,76 @@ def _rw_missed(spec: dict, triggers: list[dict], stamps: list[datetime]) -> list
     window [T, T + ceiling + margin]."""
     window = timedelta(minutes=spec["ceiling_min"] + spec["margin_min"])
     return [trig for trig in triggers if not any(trig["at"] <= s <= trig["at"] + window for s in stamps)]
+
+
+def _rw_clause_holds(clause: dict, art: dict) -> bool:
+    """Evaluate ONE declarative ``productive_when`` clause against an artifact.
+
+    Supported: ``{field: <name>, gt|ge|lt|le|eq: <number-or-value>}``. An
+    unknown operator RAISES — a registry that outran the evaluator is a
+    packaging bug, and silently treating the clause as unsatisfied would make
+    every run look dead (or, worse, alive) for the wrong reason.
+    """
+    value = art.get(clause["field"])
+    for op, expected in clause.items():
+        if op == "field":
+            continue
+        if op == "eq":
+            if value != expected:
+                return False
+        elif op in ("gt", "ge", "lt", "le"):
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return False
+            if not {
+                "gt": value > expected,
+                "ge": value >= expected,
+                "lt": value < expected,
+                "le": value <= expected,
+            }[op]:
+                return False
+        else:
+            raise _RegistryError(f"run_window: unknown productive_when operator {op!r}")
+    return True
+
+
+def _rw_dead_runs(spec: dict, artifacts: list[tuple[datetime, str, dict]]) -> list[str]:
+    """Run artifacts that prove a box BOOTED but not that the run did anything.
+
+    A pure existence check answers "was an artifact written?", which is not the
+    question the probe exists to answer. On 2026-07-28 all three groom lanes
+    crash-cascaded two minutes after boot — every chunk agent refused to start
+    because a truncated `runuser` left the run as root — and each lane still
+    wrote a well-formed artifact (`engaged: 0`, `floor_fail: true`,
+    `artifact_ok: true`). 378 issues went un-dispositioned and this check saw
+    full coverage, because it only ever read `run_start`.
+
+    ``productive_when`` is an OR of declarative clauses; an artifact matching
+    NONE of them is a dead run. Specs without the key keep the old
+    existence-only semantics, so this is additive per registry entry.
+    """
+    clauses = spec.get("productive_when")
+    if not clauses:
+        return []
+    label = spec["label"]
+    problems: list[str] = []
+    for run_start, key, art in sorted(artifacts, key=lambda t: t[0]):
+        if any(_rw_clause_holds(c, art) for c in clauses):
+            continue
+        detail = ", ".join(
+            f"{f}={art[f]!r}"
+            for f in ("engaged", "total_issues", "undispositioned", "floor_fail",
+                      "spot_interrupted", "elapsed_min")
+            if f in art
+        )
+        stop = str(art.get("stop_reason") or "").strip()
+        problems.append(
+            f"scheduled {label} run @ {run_start.strftime('%Y-%m-%d %H:%M')}Z RAN BUT "
+            f"DID NO WORK — the artifact exists, so run-window coverage looks green, "
+            f"but the run engaged nothing it was dispatched to engage ({detail}). "
+            f"artifact=s3://{WATCH_BUCKET}/{key}"
+            + (f" stop_reason={stop[:200]!r}" if stop else "")
+        )
+    return problems
 
 
 def _check_run_window(spec: dict, now: datetime) -> tuple[list[str], dict]:
@@ -572,14 +644,18 @@ def _check_run_window(spec: dict, now: datetime) -> tuple[list[str], dict]:
     if not triggers:
         logger.info("run_window[%s]: no mature triggers in window", label)
         return [], {}
-    stamps = _rw_fetch_run_artifact_timestamps(spec, s3, now)  # PRIMARY — fail-loud
-    misses = _rw_missed(spec, triggers, stamps)
+    artifacts = _rw_fetch_run_artifacts(spec, s3, now)  # PRIMARY — fail-loud
+    misses = _rw_missed(spec, triggers, [a[0] for a in artifacts])
     problems = [
         f"scheduled {label} run '{m['label']}' @ {m['at'].strftime('%Y-%m-%d %H:%M')}Z filed NO "
         f"terminal report (no S3 run artifact under '{spec['artifact_prefix']}' in-window) — box "
         "likely died silently (spot reclaim / OOM / pre-trap crash) or was never dispatched"
         for m in misses
     ]
+    # Second failure mode, same check: the artifact EXISTS but the run did
+    # nothing. Reported per-artifact rather than per-trigger, so one dead lane
+    # is visible even when its sibling lanes covered the same trigger.
+    problems += _rw_dead_runs(spec, artifacts)
     return problems, {}
 
 

--- a/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/overseer-liveness-probe/test_handler.py
@@ -920,3 +920,128 @@ def test_real_registry_watch_plane_covers_dispatcher_and_intake():
     queues = {c.get("queue_name") for c in checks if c["type"] == "sqs_queue_exists"}
     assert "alpha-engine-overseer-dispatcher" in functions
     assert "nousergon-overseer-intake" in queues
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# run_window: productive_when — an artifact proves a BOOT, not a RUN
+# ══════════════════════════════════════════════════════════════════════════
+#
+# 2026-07-28: all three groom lanes crash-cascaded two minutes after boot (a
+# comment truncated the bootstrap's `runuser`, so groom_run.sh ran as root and
+# every chunk agent refused to start). Each lane still wrote a well-formed run
+# artifact, so the existence-only check reported full coverage while 378 issues
+# went un-dispositioned.
+
+_RW_SPEC_PRODUCTIVE = dict(
+    _RW_SPEC,
+    productive_when=[{"field": "engaged", "gt": 0}, {"field": "total_issues", "eq": 0}],
+)
+
+# Verbatim fields from s3://alpha-engine-research/groom/2026-07-28/
+# 9d2004971a8e4b39ad554a47cd80ae39.json (the high lane).
+_REAL_CRASH_CASCADE_ARTIFACT = {
+    "schema_version": 10,
+    "run_start": "2026-07-17T01:05:00+00:00",  # re-dated into this suite's window
+    "run_kind": "coverage",
+    "issue_filter": "high-only",
+    "stop_reason": "3 consecutive chunk-agent crashes — aborting the run loudly "
+                   "(18 issues un-dispositioned) instead of burning the queue's "
+                   "re-queue budget",
+    "floor_fail": True,
+    "spot_interrupted": False,
+    "engaged": 0,
+    "floor": 8,
+    "total_issues": 21,
+    "processed": 9,
+    "undispositioned": 21,
+    "elapsed_min": 3,
+}
+
+
+def test_crash_cascaded_run_is_flagged_despite_writing_an_artifact():
+    """The regression this check exists for, driven by the real artifact."""
+    s3 = _FakeRunWindowS3({"2026-07-17": [_REAL_CRASH_CASCADE_ARTIFACT]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC_PRODUCTIVE, NOW)
+    assert len(problems) == 1, problems
+    assert "RAN BUT DID NO WORK" in problems[0]
+    assert "engaged=0" in problems[0] and "total_issues=21" in problems[0]
+    assert "chunk-agent crashes" in problems[0]
+    # ...and it must NOT also be reported as a missing artifact: the trigger IS
+    # covered. Two different findings; only the productivity one applies.
+    assert "filed NO" not in problems[0]
+
+
+def test_same_artifact_without_the_predicate_is_still_silent():
+    """Existence-only semantics are preserved for specs that don't opt in —
+    so adding the key to one registry entry cannot change another's."""
+    s3 = _FakeRunWindowS3({"2026-07-17": [_REAL_CRASH_CASCADE_ARTIFACT]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC, NOW)
+    assert problems == []
+
+
+def test_productive_run_is_silent():
+    art = dict(_REAL_CRASH_CASCADE_ARTIFACT, engaged=7, floor_fail=False, stop_reason="")
+    s3 = _FakeRunWindowS3({"2026-07-17": [art]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC_PRODUCTIVE, NOW)
+    assert problems == []
+
+
+def test_empty_queue_is_a_legitimate_zero():
+    """engaged=0 with nothing to engage is a healthy run, not a dead one."""
+    art = dict(_REAL_CRASH_CASCADE_ARTIFACT, engaged=0, total_issues=0, floor_fail=False)
+    s3 = _FakeRunWindowS3({"2026-07-17": [art]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC_PRODUCTIVE, NOW)
+    assert problems == []
+
+
+def test_one_dead_lane_is_visible_even_when_a_sibling_lane_covered_the_trigger():
+    """Reported per-artifact, not per-trigger: the mid lane succeeding must not
+    mask the high lane doing nothing."""
+    good = dict(_REAL_CRASH_CASCADE_ARTIFACT, engaged=12, floor_fail=False)
+    s3 = _FakeRunWindowS3({"2026-07-17": [good, _REAL_CRASH_CASCADE_ARTIFACT]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC_PRODUCTIVE, NOW)
+    assert len(problems) == 1 and "RAN BUT DID NO WORK" in problems[0]
+
+
+def test_unknown_operator_raises_rather_than_silently_passing():
+    spec = dict(_RW_SPEC, productive_when=[{"field": "engaged", "roughly": 3}])
+    s3 = _FakeRunWindowS3({"2026-07-17": [_REAL_CRASH_CASCADE_ARTIFACT]})
+    with patch("index._s3_client", return_value=s3):
+        with pytest.raises(index._RegistryError):
+            index._check_run_window(spec, NOW)
+
+
+def test_bool_is_not_treated_as_a_number_by_gt():
+    """`engaged: True` must not satisfy `{engaged: {gt: 0}}` — Python would say
+    True > 0, which would make a malformed artifact look productive."""
+    art = dict(_REAL_CRASH_CASCADE_ARTIFACT, engaged=True)
+    s3 = _FakeRunWindowS3({"2026-07-17": [art]})
+    with patch("index._s3_client", return_value=s3):
+        problems, _ = index._check_run_window(_RW_SPEC_PRODUCTIVE, NOW)
+    assert len(problems) == 1
+
+
+def test_registry_declares_productive_when_for_groom():
+    """The live registry must actually opt groom in — the code path above is
+    inert otherwise, which is precisely how this failure stayed invisible."""
+    import yaml
+    reg = yaml.safe_load(
+        (Path(__file__).resolve().parents[2] / "overseer" / "playbooks.yaml").read_text()
+    )
+    checks = [
+        c
+        for pb in reg["playbooks"].values()
+        for c in ((pb.get("liveness") or {}).get("checks") or [])
+        if c.get("type") == "run_window" and c.get("label") == "groom"
+    ]
+    assert checks, "no run_window check labelled 'groom' in the registry"
+    for c in checks:
+        assert c.get("productive_when"), (
+            "the groom run_window check must declare productive_when — without it "
+            "a crash-cascaded run that writes an artifact reads as full coverage"
+        )

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -326,6 +326,22 @@
             "ceiling_min": { "type": "integer", "minimum": 1 },
             "margin_min": { "type": "integer", "minimum": 0 },
             "lookback_hours": { "type": "integer", "minimum": 1 },
+            "productive_when": {
+              "description": "OPTIONAL. An OR of clauses over the run artifact's own fields; an in-window artifact matching NONE of them is reported as a DEAD run (a box that booted and wrote an artifact while doing no work) — distinct from a MISSING artifact. Omit to keep existence-only semantics. Each clause is {field, <op>} with op in gt|ge|lt|le|eq; an operator outside that set RAISES in _rw_clause_holds rather than silently leaving the clause unsatisfied.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["field"],
+                "minProperties": 2,
+                "maxProperties": 2,
+                "properties": {
+                  "field": { "type": "string", "minLength": 1 },
+                  "gt": {}, "ge": {}, "lt": {}, "le": {}, "eq": {}
+                }
+              }
+            },
             "schedule": {
               "type": "array",
               "minItems": 1,

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -274,6 +274,16 @@ playbooks:
           ceiling_min: 360   # groom_spot_bootstrap.sh MAX_RUNTIME_SECONDS (360 min)
           margin_min: 45     # box boot + report latency slack
           lookback_hours: 30
+          # An artifact proves a box BOOTED, not that the run did anything.
+          # 2026-07-28: all three lanes crash-cascaded 2 min in (a truncated
+          # `runuser` left groom_run.sh as root, so every chunk agent refused
+          # to start), each still wrote a well-formed artifact, and this check
+          # reported full coverage while 378 issues went un-dispositioned.
+          # A run counts as coverage only if it engaged work — or there was no
+          # work to engage, which is the legitimate zero.
+          productive_when:
+            - {field: engaged, gt: 0}
+            - {field: total_issues, eq: 0}
           schedule:
             - {hour: 4, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "04:00 UTC daily (demand-all)"}
             - {hour: 12, minute: 0, dows: [0, 1, 2, 3, 4, 5, 6], label: "12:00 UTC daily (demand-all)"}


### PR DESCRIPTION
## The gap

The groom `run_window` check asked *"was an artifact written in-window?"* — which is not the question a liveness probe exists to answer.

On 2026-07-28 all three groom lanes crash-cascaded two minutes after boot (a comment inside `groom_spot_bootstrap.sh`'s `runuser ... \` continuation truncated the command, so `groom_run.sh` ran as root and every chunk agent refused to start — fixed in alpha-engine-config-PR5259). Each lane still wrote a well-formed run artifact:

```json
{"run_start": "2026-07-28T20:04:16Z", "engaged": 0, "total_issues": 21,
 "undispositioned": 21, "floor_fail": true, "elapsed_min": 3,
 "stop_reason": "3 consecutive chunk-agent crashes — aborting the run loudly ..."}
```

**378 issues went un-dispositioned across the three lanes and this check reported full coverage.** `_rw_fetch_run_artifact_timestamps` read the whole artifact and then used only `run_start` — the signal that would have caught it was already being fetched and discarded.

## The change

An **optional, declarative** `productive_when` on the `run_window` spec: an OR of `{field, gt|ge|lt|le|eq}` clauses. An in-window artifact matching none of them is reported as a **dead run**, a finding distinct from a missing one. The groom entry declares:

```yaml
productive_when:
  - {field: engaged, gt: 0}       # it engaged something
  - {field: total_issues, eq: 0}  # or there was nothing to engage
```

Design notes:

- **Per-artifact, not per-trigger.** One dead lane stays visible when a sibling lane covered the same trigger — the per-trigger framing would have masked a single-lane failure.
- **Additive per registry entry.** Specs without the key keep existence-only semantics, so this cannot change alert-drain's behaviour.
- **Unknown operator raises** (`_RegistryError`), consistent with the module's fail-loud posture for a registry that outran its evaluator. Silently treating an unparseable clause as unsatisfied would mark every run dead for the wrong reason.
- **`bool` is excluded from numeric comparison** — `True > 0` is true in Python, which would let a malformed artifact read as productive. Pinned by a test.

## Verification

- Evaluated against the **real** artifact still in S3 — `s3://alpha-engine-research/groom/2026-07-28/9d2004971a8e4b39ad554a47cd80ae39.json` → `productive=False` → **FLAGGED**. Its fields are pinned verbatim in the test rather than hand-written.
- `68 passed` — 60 existing unchanged, 8 new.
- One of the new tests asserts the **live registry** actually opts groom in. The code path is inert without it, which is precisely how this class stays invisible.

## Deploy

Merge-button complete: `deploy-overseer-liveness-probe.yml` fires on `main` for both changed paths (`infrastructure/lambdas/overseer-liveness-probe/**` and `infrastructure/overseer/playbooks.yaml`, which is bundled into the zip). No `--bootstrap`, no cadence change, no new IAM.

## Not in this PR

`alert-drain`'s `run_window` entry has the same latent gap but a different artifact schema (`overseer/drain_ledger/`). Filed separately rather than guessed at.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
