### PR TITLE
[P0] fix(deploy): stop reading IAM documents from a tree this repo no longer owns

### DIFF
--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -322,30 +322,61 @@ update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-dispatch" "Ba
 #
 # Ensuring the trust HERE — idempotently, before the CFN deploy, mirroring the
 # log-group prerequisites above and deploy_step_function.sh's own bootstrap —
-# makes this workflow self-sufficient: it no longer depends on a human having run
-# deploy_step_function.sh out-of-band, and it survives a role/DR rebuild. The role
-# is shared by BOTH the still-live SaturdayTrigger (events.amazonaws.com) and the
-# now-Scheduler weekday trigger (scheduler.amazonaws.com), so both principals must
-# be listed. update-assume-role-policy is idempotent (writes the full document);
-# the role always exists live (SaturdayTrigger depends on it), so no create-role
-# is attempted here — that keeps the GHA deploy role's IAM grant minimal
-# (iam:UpdateAssumeRolePolicy on this one role — see
-# infrastructure/iam/github-actions-lambda-deploy.json).
+# so both principals must be listed. The role is shared by BOTH the still-live
+# SaturdayTrigger (events.amazonaws.com) and the now-Scheduler weekday trigger
+# (scheduler.amazonaws.com).
 #
-# config#2826: the trust document itself lives in ONE place —
-# infrastructure/iam/alpha-engine-eventbridge-sfn-role.trust.json — the same
-# version-tracked snapshot deploy_step_function.sh's own bootstrap reads and
-# apply.sh/check-drift.py operate on. This step reads that file instead of
-# carrying its own inline copy, closing the exact class of drift that caused
-# this gap in the first place (two hand-maintained literals of the same
-# trust document, one of them missing a principal).
+# This step VERIFIES the trust; it no longer WRITES it (#1075 follow-up).
+#
+# It used to call update-assume-role-policy against
+# infrastructure/iam/alpha-engine-eventbridge-sfn-role.trust.json. Commit
+# 506be30 ("infra: remove the IAM tree — now owned by nous-ergon-ops", #1075)
+# deleted that tree and this line was missed, so every run from 15:34 UTC on
+# 2026-07-28 died here with "Unable to load paramfile … No such file or
+# directory" (9 consecutive Deploy Infrastructure failures; see
+# alpha-engine-config-I5271).
+#
+# Restoring the write is NOT the fix. Per nous-ergon-ops
+# policies/infrastructure-ownership-policy.md §35, IAM roles/policies/trust
+# documents were consolidated to nous-ergon-ops/infrastructure/iam/ on
+# 2026-07-27; this repo no longer owns them. That repo's own
+# iam-apply-on-merge.yml deliberately withholds iam:UpdateAssumeRolePolicy
+# from its CI identity — "a CI identity that can rewrite trust policies is a
+# privilege-escalation path" (alpha-engine-config#3150) — so trust is applied
+# as a one-time bootstrap and thereafter guarded by check-drift.py's daily
+# 09:35 UTC _check_trust. A deploy identity in THIS repo rewriting that
+# document on every run is the same escalation path, one repo over.
+#
+# What must be preserved is the #816 guarantee: EventBridge Scheduler
+# validates RoleArn assumability at CreateSchedule/UpdateSchedule time, and a
+# --no-execute-changeset dry run does not exercise it — so a missing principal
+# surfaces as an UPDATE_ROLLBACK_COMPLETE mid-apply. Failing loudly HERE, with
+# the remediation named, keeps that protection without the write.
+#
+# Principal.Service is a string for one principal and a list for several
+# (nousergon-data was bitten by exactly that shape change 2026-07-22, per
+# nous-ergon-ops check-drift.py). Matching against the raw JSON is correct for
+# both shapes and avoids a jq/python dependency this script does not otherwise
+# carry.
 EB_ROLE_NAME="alpha-engine-eventbridge-sfn-role"
-EB_TRUST_FILE="$SCRIPT_DIR/iam/${EB_ROLE_NAME}.trust.json"
-echo "  Ensuring $EB_ROLE_NAME trusts events.amazonaws.com + scheduler.amazonaws.com (idempotent)..."
-aws iam update-assume-role-policy \
-    --role-name "$EB_ROLE_NAME" \
-    --policy-document "file://$EB_TRUST_FILE" \
-    --region "$REGION"
+echo "  Verifying $EB_ROLE_NAME trusts events.amazonaws.com + scheduler.amazonaws.com..."
+EB_TRUST_DOC="$(aws iam get-role --role-name "$EB_ROLE_NAME" \
+    --query 'Role.AssumeRolePolicyDocument' --output json --region "$REGION")"
+EB_TRUST_MISSING=()
+for principal in events.amazonaws.com scheduler.amazonaws.com; do
+    printf '%s' "$EB_TRUST_DOC" | grep -q "\"$principal\"" || EB_TRUST_MISSING+=("$principal")
+done
+if [ ${#EB_TRUST_MISSING[@]} -gt 0 ]; then
+    echo "  ERROR: $EB_ROLE_NAME trust policy is missing: ${EB_TRUST_MISSING[*]}"
+    echo "         CloudFormation would fail mid-apply (UPDATE_ROLLBACK_COMPLETE) when it"
+    echo "         creates/updates WeekdayPipelineSchedule against a role that does not"
+    echo "         trust the scheduler — see #816."
+    echo "         This repo does NOT own IAM (nous-ergon-ops infrastructure-ownership-policy.md §35)."
+    echo "         Remediate in nous-ergon-ops:"
+    echo "           infrastructure/iam/apply.sh trust-policy $EB_ROLE_NAME"
+    exit 1
+fi
+echo "  OK"
 
 # ── 4. Deploy/update CloudFormation stack ────────────────────────────────────
 echo ""

--- a/infrastructure/deploy_step_function.sh
+++ b/infrastructure/deploy_step_function.sh
@@ -95,23 +95,30 @@ fi
 # downstream pipelines (4 incidents in 2 months). Codified IAM is now
 # the single writer.
 
-echo "Ensuring IAM role exists: $ROLE_NAME..."
+echo "Checking IAM role exists: $ROLE_NAME..."
 
-# Trust policy (one-time bootstrap; safe to re-run). config#2826: read from
-# the version-tracked snapshot in infrastructure/iam/ rather than keeping an
-# inline copy here, so this script and deploy-infrastructure.sh's own trust
-# assertion can never drift apart from each other or from the codified SoT.
-TRUST_POLICY_FILE="$SCRIPT_DIR/iam/${ROLE_NAME}.trust.json"
-
-aws iam create-role \
-  --role-name "$ROLE_NAME" \
-  --assume-role-policy-document "file://$TRUST_POLICY_FILE" \
-  --region "$REGION" 2>/dev/null || echo "  Role already exists"
+# This script no longer CREATES the role (#1075 follow-up, alpha-engine-config-I5271).
+# IAM roles/policies/trust documents were consolidated into
+# nous-ergon-ops/infrastructure/iam/ on 2026-07-27
+# (infrastructure-ownership-policy.md §35); the trust snapshot this block used to
+# read out of $SCRIPT_DIR/iam/ was deleted from this repo by 506be30 and the
+# reference was missed, so the create-role call could only ever fail here.
+#
+# Role bootstrap belongs to that repo's apply.sh (which has its own create-or-skip
+# path). This script's job is the Step Function definition; it asserts its IAM
+# precondition and fails loud with the remediation rather than trying to satisfy it.
+if ! aws iam get-role --role-name "$ROLE_NAME" --region "$REGION" >/dev/null 2>&1; then
+  echo "  ERROR: role $ROLE_NAME does not exist."
+  echo "         IAM is owned by nous-ergon-ops (infrastructure-ownership-policy.md §35)."
+  echo "         Bootstrap it there first:"
+  echo "           infrastructure/iam/apply.sh $ROLE_NAME"
+  exit 1
+fi
 
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
 echo "  Role ARN: $ROLE_ARN"
-echo "  Inline policy is codified in infrastructure/iam/${ROLE_NAME}.json"
-echo "  Apply via: ./infrastructure/iam/apply.sh $ROLE_NAME"
+echo "  Role + inline policy + trust are codified in nous-ergon-ops/infrastructure/iam/${ROLE_NAME}/"
+echo "  Apply via (in nous-ergon-ops): infrastructure/iam/apply.sh $ROLE_NAME"
 
 # ── 3. State Machine — SINGLE-WRITER CONTRACT (config#2273) ────────────────
 #
@@ -275,19 +282,28 @@ echo "  State machine ARN: $SM_ARN"
 # document and can never drift apart.
 
 EB_ROLE_NAME="alpha-engine-eventbridge-sfn-role"
-EB_TRUST_FILE="$SCRIPT_DIR/iam/${EB_ROLE_NAME}.trust.json"
 
-aws iam create-role \
-  --role-name "$EB_ROLE_NAME" \
-  --assume-role-policy-document "file://$EB_TRUST_FILE" \
-  --region "$REGION" 2>/dev/null || \
-aws iam update-assume-role-policy \
-  --role-name "$EB_ROLE_NAME" \
-  --policy-document "file://$EB_TRUST_FILE" \
-  --region "$REGION"
+# Same ownership change as the $ROLE_NAME block above: verify, never create or
+# rewrite. Both principals must be present — EventBridge Scheduler validates
+# RoleArn assumability at CreateSchedule time (#816), and a trust document
+# missing scheduler.amazonaws.com surfaces only as a mid-apply CFN rollback.
+# Principal.Service is a string for one principal and a list for several, so the
+# raw JSON is matched rather than a fixed shape.
+EB_TRUST_DOC="$(aws iam get-role --role-name "$EB_ROLE_NAME" \
+  --query 'Role.AssumeRolePolicyDocument' --output json --region "$REGION" 2>/dev/null || true)"
+EB_TRUST_MISSING=()
+for principal in events.amazonaws.com scheduler.amazonaws.com; do
+  printf '%s' "$EB_TRUST_DOC" | grep -q "\"$principal\"" || EB_TRUST_MISSING+=("$principal")
+done
+if [ ${#EB_TRUST_MISSING[@]} -gt 0 ]; then
+  echo "  ERROR: $EB_ROLE_NAME trust policy missing (or role absent): ${EB_TRUST_MISSING[*]}"
+  echo "         IAM is owned by nous-ergon-ops (infrastructure-ownership-policy.md §35)."
+  echo "         Remediate there: infrastructure/iam/apply.sh trust-policy $EB_ROLE_NAME"
+  exit 1
+fi
 
 echo "  EventBridge rule + targets: managed by CFN orchestration template"
-echo "  EventBridge IAM role bootstrap: $EB_ROLE_NAME (idempotent; trusts events.amazonaws.com + scheduler.amazonaws.com)"
+echo "  EventBridge IAM role: $EB_ROLE_NAME verified (trusts events.amazonaws.com + scheduler.amazonaws.com)"
 
 # ── 5. Disable old crons (optional) ────────────────────────────────────────
 

--- a/tests/test_no_local_iam_tree_references.py
+++ b/tests/test_no_local_iam_tree_references.py
@@ -1,0 +1,146 @@
+"""This repo must not READ files from `infrastructure/iam/` — it no longer owns IAM.
+
+alpha-engine-config-I5271 · nous-ergon-ops `policies/infrastructure-ownership-policy.md` §35.
+
+WHY. IAM roles, policies and trust documents were consolidated into
+`nous-ergon-ops/infrastructure/iam/` on 2026-07-27. Commit `506be30`
+("[P2/high] infra: remove the IAM tree — now owned by nous-ergon-ops", #1075)
+deleted the tree from this repo, but `infrastructure/deploy-infrastructure.sh`
+still read one file out of it:
+
+    EB_TRUST_FILE="$SCRIPT_DIR/iam/${EB_ROLE_NAME}.trust.json"
+    aws iam update-assume-role-policy --policy-document "file://$EB_TRUST_FILE"
+
+That PR passed CI — nothing asserted the script's file references resolve — and
+`Deploy Infrastructure` then failed 9 consecutive times from 15:34 UTC on
+2026-07-28 with:
+
+    ParamValidation: Unable to load paramfile
+      .../infrastructure/iam/alpha-engine-eventbridge-sfn-role.trust.json
+    [Errno 2] No such file or directory
+
+Roughly six hours in which no orchestration/CFN change actually deployed, while
+every other check on those merges reported green. Each failure dispatched a
+ci-watch repair agent; all of them died at boot on an unrelated bug that landed
+one minute after this one (alpha-engine-config-PR5261), so nothing said a word.
+
+THE INVARIANT. A missing-file check would be too narrow: restoring the file
+would satisfy it while still violating the ownership policy. The real invariant
+is the ownership boundary itself — **this repo reads no file under an
+`iam/` tree**. That is stable under someone re-adding the directory, and it is
+what the policy actually says.
+
+Prose is exempt: comments here still cite `iam/github-actions-lambda-deploy.json`
+as the historical rationale for a grant, and citing a path is not depending on
+one. Only executable references count.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+INFRA = REPO / "infrastructure"
+
+# Shell scripts that run in deploy/CI. Bootstraps under infrastructure/ are
+# included: they run on boxes with a clone of this repo and would hit the same
+# missing-path failure.
+SHELL_SCRIPTS = sorted(INFRA.rglob("*.sh"))
+
+# An executable reference to a path inside an `iam/` directory. Matches the
+# `$SCRIPT_DIR/iam/x.json`, `infrastructure/iam/x.json` and `./iam/x.json`
+# forms; deliberately anchored on the `iam/` path segment followed by a
+# filename, so a bare mention of the word "iam" (e.g. `aws iam get-role`) is
+# not a hit.
+_IAM_PATH_RE = re.compile(r"[\w${}./\"-]*\biam/[\w.${}-]+\.(?:json|yaml|yml)")
+
+# Reading the OPS repo's iam tree through an explicit external-checkout variable
+# is the sanctioned post-consolidation pattern, not a violation — e.g.
+# `infrastructure/lambdas/sf-watch-market-hours-toggler/deploy.sh` reads
+# "${IAM_REPO}/infrastructure/iam/sf-watch-executor-role-policy.json". What this
+# test forbids is a path resolving INSIDE this repo ($SCRIPT_DIR/iam/…,
+# infrastructure/iam/…), not any mention of an iam tree anywhere.
+_EXTERNAL_REPO_MARKERS = ("IAM_REPO",)
+
+
+def _is_external_checkout(path_ref: str) -> bool:
+    return any(marker in path_ref for marker in _EXTERNAL_REPO_MARKERS)
+
+
+def _strip_comment(line: str) -> str:
+    """Drop a `#` comment, honouring quotes so a `#` inside a string survives."""
+    out, quote = [], None
+    for i, ch in enumerate(line):
+        if quote:
+            if ch == quote and line[i - 1 : i] != "\\":
+                quote = None
+            out.append(ch)
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            continue
+        if ch == "#":
+            if i and line[i - 1] in "${":
+                out.append(ch)
+                continue
+            break
+        out.append(ch)
+    return "".join(out)
+
+
+def test_scripts_are_discovered():
+    """Guard against the suite passing vacuously on an empty glob."""
+    assert SHELL_SCRIPTS, f"no *.sh found under {INFRA}"
+
+
+def test_local_iam_tree_does_not_exist():
+    """The tree is owned by nous-ergon-ops; re-adding it here re-forks it."""
+    assert not (INFRA / "iam").exists(), (
+        "infrastructure/iam/ is back in this repo. IAM was consolidated into "
+        "nous-ergon-ops/infrastructure/iam/ on 2026-07-27 "
+        "(infrastructure-ownership-policy.md §35). Re-adding it recreates the "
+        "per-repo mirrored trees that consolidation removed."
+    )
+
+
+@pytest.mark.parametrize("script", SHELL_SCRIPTS, ids=lambda p: p.name)
+def test_no_executable_reference_to_an_iam_file(script: Path):
+    offenders = []
+    for lineno, raw in enumerate(script.read_text().splitlines(), start=1):
+        code = _strip_comment(raw)
+        if not code.strip():
+            continue
+        for hit in _IAM_PATH_RE.findall(code):
+            if _is_external_checkout(hit):
+                continue
+            offenders.append((lineno, hit, raw.strip()))
+
+    assert not offenders, (
+        f"{script.relative_to(REPO)} reads {len(offenders)} file(s) from an iam/ tree "
+        f"this repo no longer owns — the exact shape that broke Deploy Infrastructure "
+        f"for ~6h on 2026-07-28 (alpha-engine-config-I5271). IAM lives in "
+        f"nous-ergon-ops/infrastructure/iam/; verify state with a read-only AWS call "
+        f"and fail loud pointing at that repo's apply.sh, rather than reading or "
+        f"writing the document from here. Offenders: "
+        + "; ".join(f"line {ln}: {hit}" for ln, hit, _ in offenders)
+    )
+
+
+def test_detector_catches_the_i5271_regression():
+    """Pin the detector against the exact line that broke, so a later refactor
+    of the regex cannot quietly neuter it."""
+    broken = 'EB_TRUST_FILE="$SCRIPT_DIR/iam/${EB_ROLE_NAME}.trust.json"'
+    assert _IAM_PATH_RE.findall(_strip_comment(broken))
+
+    # A comment citing the path is prose, not a dependency.
+    assert not _IAM_PATH_RE.findall(
+        _strip_comment("# see infrastructure/iam/github-actions-lambda-deploy.json).")
+    )
+    # An ordinary IAM API call is not a file reference.
+    assert not _IAM_PATH_RE.findall(
+        _strip_comment('aws iam get-role --role-name "$EB_ROLE_NAME" --output json')
+    )


### PR DESCRIPTION
Fixes the P0 in nousergon/alpha-engine-config#5271.

## `Deploy Infrastructure` has been red for ~6 hours

9 consecutive failures since 15:34 UTC today; last success 00:45 UTC.

```
ParamValidation: Unable to load paramfile
  infrastructure/iam/alpha-engine-eventbridge-sfn-role.trust.json
[Errno 2] No such file or directory
```

`506be30` (*"infra: remove the IAM tree — now owned by nous-ergon-ops"*, #1075) deleted `infrastructure/iam/`. **Three** executable references to it were missed. Nothing checked that the deploy scripts' file references resolve, so that PR merged green and the breakage surfaced only on the next deploy — meaning no orchestration/CFN change has actually shipped since, while every other check on those merges reported green.

## Restoring the files is not the fix

Per `nous-ergon-ops/policies/infrastructure-ownership-policy.md` §35, IAM was consolidated to `nous-ergon-ops/infrastructure/iam/` on 2026-07-27. That repo's `iam-apply-on-merge.yml` **deliberately withholds** `iam:UpdateAssumeRolePolicy` from its CI identity — *"a CI identity that can rewrite trust policies is a privilege-escalation path"* (alpha-engine-config#3150) — applying trust as a one-time bootstrap, guarded thereafter by `check-drift.py`'s daily 09:35 UTC `_check_trust`.

A deploy identity in **this** repo rewriting that same document on every run is that identical escalation path, one repo over. So each site becomes **verify**, not **write**:

| Site | Was | Now |
|---|---|---|
| `deploy-infrastructure.sh` | `update-assume-role-policy` from the deleted file | read-only `get-role`, assert both principals present |
| `deploy_step_function.sh` | `create-role` + `update-assume-role-policy`, two roles | `get-role` preconditions |

Every failure path *names* the remediation (`nous-ergon-ops … apply.sh`) rather than attempting it.

## What is deliberately preserved

The original write existed for a real reason (#816): EventBridge Scheduler validates `RoleArn` assumability at `CreateSchedule` time, and `--no-execute-changeset` does not exercise it — so a missing principal surfaces only as a mid-apply `UPDATE_ROLLBACK_COMPLETE`. **That protection is kept**: the check still fails loudly before the CFN step. It just no longer tries to repair IAM from a repo that doesn't own it.

`Principal.Service` is a string for one principal and a list for several — nousergon-data was bitten by that exact shape change on 2026-07-22, per ops's own `check-drift.py` — so the raw JSON is matched rather than a fixed shape, and no `jq`/`python` dependency is added that these scripts don't already carry.

No coverage is lost: ops codifies the document and detects drift daily; only the *write* moves, which is the documented posture for all 11 consolidated roles.

## The guard

`tests/test_no_local_iam_tree_references.py`. The invariant is **the ownership boundary, not file existence** — a missing-file check would be fully satisfied by re-adding the file while still violating the policy.

It found a third broken site the incident had not surfaced: `deploy_step_function.sh` is manual-only, so its breakage was latent rather than firing in CI. Fixed here too.

Reading the **ops** tree through an explicit external-checkout variable (`${IAM_REPO}/infrastructure/iam/...`) stays legal — that is the sanctioned post-consolidation pattern, and distinguishing it is what separates `sf-watch-market-hours-toggler/deploy.sh` (correct) from the two broken sites. Comments citing an `iam/` path are prose, not a dependency, and are exempt; the detector has unit tests pinning both distinctions.

## Verification

- Guard **fails against unmodified `origin/main`**, naming both broken scripts.
- Guard passes on this branch — 62 tests.
- `bash -n` clean on both modified scripts.
- Suite vs an `origin/main` baseline run in a detached worktree: **identical 125 failed / 48 errors** (pre-existing local dependency gaps — `ModuleNotFoundError: yfinance` etc., reproduced on the unmodified base), **3471 passed vs 3409** — exactly the 62 new tests, and **no new failures**.

## Deploy

Merging is sufficient. The next `Deploy Infrastructure` run picks this up; no post-merge step.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
