### PR TITLE
fix(ci): SHA-pin third-party GitHub Actions (config-I2844)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: shellcheck (infrastructure/*.sh, error severity)
         run: shellcheck --severity=error infrastructure/*.sh
 
@@ -41,7 +41,7 @@ jobs:
   iam-getobject-listbucket-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - name: Check all iam-policy.json for GetObject-without-ListBucket
         run: python3 infrastructure/lambdas/_shared/check_iam_getobject_listbucket.py
 
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -58,7 +58,7 @@ jobs:
             --output text
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/flow-doctor-fix.yml
+++ b/.github/workflows/flow-doctor-fix.yml
@@ -23,9 +23,9 @@ jobs:
     if: github.event.label.name == 'flow-doctor:fix'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: "3.12"
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/live-fred-smoke.yml
+++ b/.github/workflows/live-fred-smoke.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/live-polygon-smoke.yml
+++ b/.github/workflows/live-polygon-smoke.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -44,7 +44,7 @@ jobs:
   drift-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3


### PR DESCRIPTION
## What & why

SHA-pins third-party GitHub Actions in this repo's workflows — one repo's share of **alpha-engine-config-I2844**.

Mutable tag refs are a supply-chain hole: whoever controls the action's repository can move the tag, and the new code runs inside our OIDC-credentialed deploy context. CodeQL's `unpinned-tag` query flagged this class on nousergon-data-PR908 (2026-07-17), which is what opened the issue.

```diff
- uses: actions/checkout@v7
+ uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
```

Tag kept as a trailing comment so the intent stays readable and Dependabot can still propose updates (it understands the sha+comment form).

## First-party carve-out

`nousergon/*` refs are deliberately **not** pinned, per the issue: they evolve in lockstep with the fleet, and an attacker with org write defeats a sha pin anyway. Enforced mechanically — the sweep asserts **zero** `+uses: nousergon/` lines in its own diff.

## The annotated-tag trap, and how it was avoided

`GET /git/ref/tags/{tag}` returns the **tag object's** sha for an annotated tag, not the commit's. Pinning that object sha makes the workflow fail at **startup** — zero jobs, no check-run produced — which for a required context means the PR is blocked permanently with nothing to click.

Every ref here was resolved through the dereference path (`object.type == "tag"` → `GET /git/tags/{sha}` → `object.sha`), then **verified reachable as a commit** via `GET /commits/{sha}` before being written. Two of the fourteen refs across the fleet sweep were annotated and needed it:

| ref | |
|---|---|
| `actions/github-script@v9` | dereferenced |
| `aws-actions/configure-aws-credentials@v6` | dereferenced |

## Test plan / verification (run before opening)

Per repo, all three checked mechanically:

| check | result |
|---|---|
| every workflow file still parses (`yaml.safe_load`) | ✅ |
| residual third-party `uses: owner/repo@vN` refs | **0** |
| first-party `nousergon/*` refs touched | **0** |

No test suite covers workflow YAML; the checks above are the verification. CI running green on this PR is itself the end-to-end proof the pins resolve — a bad sha would surface as a startup failure.

## Deploy-mechanism

`N/A` — CI configuration only.

## Cross-repo

One PR per repo, ten total, **no merge order between them** — each repo's workflows are independent. Companions (9 others, any order): `crucible-executor-PR448` · `alpha-engine-config-PR5295` · `crucible-research-PR527` · `crucible-predictor-PR432` · `crucible-dashboard-PR586` · `crucible-evaluator-PR147` · `nousergon-lib-PR266` · `metron-PR358` · `krepis-PR80`.

Closes the repo's share of alpha-engine-config-I2844; the issue closes when the last one lands.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
