### PR TITLE
feat(thinktank): EC2 spot dispatcher for the daily run (config-I5208, ARCHITECTURE §47)

### DIFF
--- a/infrastructure/lambdas/_shared/test_terminate_coverage.py
+++ b/infrastructure/lambdas/_shared/test_terminate_coverage.py
@@ -35,6 +35,12 @@ _EXPECTED_LAUNCHERS = frozenset(
         # terminate-on-failure coverage plus a 13h InstanceInitiatedShutdown
         # watchdog sized past the SF's own 12h TimeoutSeconds.
         "weekly-freshness-spot-dispatcher",
+        # alpha-engine-config-I5208 / ARCHITECTURE §47 — daily Think Tank off
+        # the 900s Lambda ceiling onto spot. Terminates on failure in the
+        # launch→bootstrap window (the box has no watchdog or trap until the
+        # bootstrap command lands), plus a 2.5h watchdog sized above the SSM
+        # execution timeout.
+        "thinktank-spot-dispatcher",
     }
 )
 

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/README.md
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/README.md
@@ -1,0 +1,79 @@
+# alpha-engine-thinktank-spot-dispatcher
+
+Runs the daily Think Tank on a self-terminating EC2 spot box instead of a Lambda.
+
+**Why:** alpha-engine-config-I5208 / nous-ergon-ops-I162 / ARCHITECTURE §47. The
+daily run hit the 900s Lambda hard ceiling every day from 2026-07-17 and died
+mid-loop before its terminal writes — `thinktank/ratings/`,
+`thinktank/challenger_selection/`, `thinktank/events/` and the coverage shadow
+view all froze for twelve days while the run looked busy in logs.
+
+§47 has required since 2026-06-30 that a long-running agent/batch job runs on
+owned compute behind a dispatcher. This is at least the fourth site of the
+universe-growth timeout class (config-I3095 logged the evaluator as the third);
+the earlier ones were closed with guards rather than the placement fix.
+
+## Sizing is measured, not guessed
+
+| Run | Work done | Wall clock |
+|---|---|---|
+| 2026-07-16 (pre-#464) | 8 theses + 70-name sweep | **443s** |
+| 2026-07-29 (post-#464) | 5 theses, **sweep skipped** | 801s, truncated |
+
+crucible-research#464's pillar/moat call roughly tripled per-thesis wall-clock
+(~55s → ~160s). That, not the sweep, crossed the ceiling — the sweep chunks at
+`sweep_chunk_size=25`, so 135 covered names is 6 LLM calls costing well under a
+cent. Steady state is ~25 min, a shade over 2x the Lambda maximum.
+
+Defaults: **budget 5400s (90 min)**, SSM timeout 7200s, watchdog 9000s.
+
+## The coupling you must not break
+
+```
+RUN_BUDGET_SECONDS + 120s reserve  <  RUN_TIMEOUT_SECONDS  <  WATCHDOG_SECONDS
+```
+
+The box derives its deadline from the budget; SSM kills the command at the
+timeout. If the budget ever meets or exceeds the timeout, SSM guillotines the
+run mid-loop and every terminal write is lost again. `handler()` refuses to
+launch in that state and `test_handler.py` asserts it.
+
+**If runs start truncating, raise the timeout first, then the budget** —
+never the budget alone. Re-derive from `thinktank/runs/{date}/manifest_*.json`
+rather than guessing; `deadline_skipped_sweep` / `deadline_skipped_new` /
+`deadline_skipped_refresh` tell you exactly what did not fit.
+
+## Rollout order (staged — §47 sub-rule (b))
+
+Merging this PR has **zero live effect**. The Think Tank keeps running on
+Lambda until step 3.
+
+1. **crucible-research-PR544 must merge first.** The SSM prelude execs
+   `infrastructure/thinktank_spot_bootstrap.sh` from a shallow clone of
+   `main` — the script has to exist there before any box can run.
+2. `./deploy.sh --bootstrap` — creates the Lambda + IAM role. Still nothing
+   scheduled against it.
+3. `./deploy.sh --smoke` — **fires a REAL run on a REAL spot box.** This is the
+   validation gate, not a formality: §47 sub-rule (b) exists because stock
+   AMIs ship no git, SSM shells run as root with no `$HOME`, and a `$`-bearing
+   string expands as positional params under `set -u`. Three rounds of exactly
+   these were found on the 2026-06-30 groom cutover only by launching a box and
+   reading its output. Confirm the run wrote `thinktank/challenger_selection/`,
+   `thinktank/ratings/` **and** `thinktank/events/` for the trading day, and
+   that the box terminated itself.
+4. `./deploy.sh --cutover` — repoints `alpha-research-thinktank-daily` from
+   `alpha-engine-research-thinktank:live` to this dispatcher. Deliberately a
+   separate flag so no merge and no code deploy can repoint the live schedule.
+
+Roll back by re-running `put-targets` against the Lambda alias; the Lambda
+itself is left deployed and functional throughout.
+
+## Alarm follow-up (not yet done)
+
+`alpha-engine-thinktank-daily-run-failed` currently watches the **Lambda's**
+`Errors` metric (`infrastructure/setup-thinktank-schedule.sh` in
+crucible-research). After step 4 that Lambda stops being invoked on a schedule,
+so the alarm goes **blind** — a green alarm would then mean "nothing ran", which
+is the same silence class this whole arc is about. The alarm has to move onto
+this dispatcher's `Errors` plus the freshness registry's
+`thinktank_challenger_selection` row before the cutover is complete.

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# deploy.sh — alpha-engine-thinktank-spot-dispatcher (config-I5208, §47).
+#
+# Managed OUTSIDE CloudFormation, same as every sibling dispatcher (keeps the
+# github-actions-lambda-deploy OIDC role's blast radius narrow: it deliberately
+# lacks iam:CreateRole/iam:PutRolePolicy after 4 IAM-clobber incidents in 2
+# months — see infrastructure/iam/README.md).
+#
+# Flags are STAGED on purpose. A flagless run is code-only, so merging and
+# auto-deploy can never repoint the live schedule:
+#
+#   (no flags)    update the Lambda's code only
+#   --bootstrap   create the IAM role + Lambda (idempotent)
+#   --smoke       fire ONE real run on a REAL spot box (the §47 validation gate)
+#   --cutover     repoint alpha-research-thinktank-daily at this dispatcher
+#
+# See README.md for the full rollout order. crucible-research-PR544 must be
+# merged to main BEFORE --smoke: the SSM prelude execs
+# infrastructure/thinktank_spot_bootstrap.sh out of a shallow clone of main.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+FUNCTION_NAME="alpha-engine-thinktank-spot-dispatcher"
+ROLE_NAME="alpha-engine-thinktank-spot-dispatcher-role"
+RULE_NAME="alpha-research-thinktank-daily"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+BOOTSTRAP=0; SMOKE=0; CUTOVER=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --bootstrap) BOOTSTRAP=1; shift ;;
+        --smoke) SMOKE=1; shift ;;
+        --cutover) CUTOVER=1; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+echo "==> building package"
+cp "$SCRIPT_DIR/index.py" "$BUILD_DIR/"
+python3.12 -m pip install --quiet --target "$BUILD_DIR" -r "$SCRIPT_DIR/requirements.txt"
+(cd "$BUILD_DIR" && zip -qr /tmp/thinktank-spot-dispatcher.zip .)
+
+if [ "$BOOTSTRAP" -eq 1 ]; then
+    echo "==> creating IAM role $ROLE_NAME (idempotent)"
+    aws iam create-role --role-name "$ROLE_NAME" \
+        --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+        --region "$REGION" >/dev/null 2>&1 || echo "    (role exists)"
+    aws iam put-role-policy --role-name "$ROLE_NAME" \
+        --policy-name "${ROLE_NAME}-policy" \
+        --policy-document "file://$SCRIPT_DIR/iam-policy.json" \
+        --region "$REGION"
+    echo "    waiting for IAM propagation..."
+    sleep 10
+
+    echo "==> creating Lambda $FUNCTION_NAME (idempotent)"
+    aws lambda create-function --function-name "$FUNCTION_NAME" \
+        --runtime python3.12 --handler index.handler \
+        --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
+        --zip-file fileb:///tmp/thinktank-spot-dispatcher.zip \
+        --timeout 300 --memory-size 512 \
+        --region "$REGION" >/dev/null 2>&1 || echo "    (function exists — updating code below)"
+fi
+
+echo "==> updating function code"
+aws lambda update-function-code --function-name "$FUNCTION_NAME" \
+    --zip-file fileb:///tmp/thinktank-spot-dispatcher.zip \
+    --region "$REGION" --query 'LastModified' --output text
+aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION"
+
+if [ "$SMOKE" -eq 1 ]; then
+    echo "==> SMOKE: firing ONE real Think Tank run on a REAL spot box"
+    echo "    (this spends a spot instance and a real LLM pass — ~25 min expected)"
+    aws lambda invoke --function-name "$FUNCTION_NAME" \
+        --payload '{}' --cli-binary-format raw-in-base64-out \
+        --region "$REGION" /tmp/thinktank-smoke-out.json --query 'StatusCode' --output text
+    echo "    dispatcher returned:"
+    cat /tmp/thinktank-smoke-out.json; echo
+    echo "    Watch: aws logs tail /alpha-engine/thinktank-spot --follow"
+    echo "    Gate:  thinktank/challenger_selection/, thinktank/ratings/ AND"
+    echo "           thinktank/events/ written for the trading day, box self-terminated."
+fi
+
+if [ "$CUTOVER" -eq 1 ]; then
+    echo "==> CUTOVER: repointing $RULE_NAME at $FUNCTION_NAME"
+    TARGET_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+    aws lambda add-permission --function-name "$FUNCTION_NAME" \
+        --statement-id "${RULE_NAME}-invoke" --action lambda:InvokeFunction \
+        --principal events.amazonaws.com \
+        --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}" \
+        --region "$REGION" >/dev/null 2>&1 || echo "    (permission exists)"
+    aws events put-targets --rule "$RULE_NAME" \
+        --targets "[{\"Id\":\"1\",\"Arn\":\"${TARGET_ARN}\"}]" --region "$REGION"
+    echo "    $RULE_NAME now targets $FUNCTION_NAME."
+    echo "    NOTE: alpha-engine-thinktank-daily-run-failed still watches the OLD"
+    echo "    Lambda's Errors metric and is now BLIND — move it before calling this done."
+fi
+
+echo "==> done"

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/iam-policy.json
@@ -1,0 +1,59 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-thinktank-spot-dispatcher:*"
+    },
+    {
+      "Sid": "LaunchThinktankSpot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:CreateTags",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassExecutorProfileRoleToEc2",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::711398986525:role/alpha-engine-executor-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "SsmRunThinktankBootstrap",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:SendCommand",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "TerminateThinktankSpotOnError",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-thinktank-spot"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
@@ -1,0 +1,286 @@
+"""alpha-engine-thinktank-spot-dispatcher — run the daily Think Tank on EC2 spot.
+
+WHY (alpha-engine-config-I5208, nous-ergon-ops-I162, ARCHITECTURE §47): the
+daily Think Tank ran as a Lambda and hit the 900s hard ceiling every day from
+2026-07-17, dying mid-loop before any of its terminal writes. §47 has required
+since 2026-06-30 that a long-running agent/batch job runs on owned compute
+behind a dispatcher, never on a metered/ceilinged runtime. This is that
+dispatcher. The workload is a multi-tier LLM agent loop over a growing coverage
+universe — exactly the §47 shape.
+
+Measured, so the sizing is not a guess (see RUN_BUDGET_SECONDS): the
+2026-07-16 run did 8 theses AND a 70-name events sweep in 443s; the 2026-07-29
+run did 5 theses and NO sweep in 801s, truncated. crucible-research PR#464's
+pillar/moat call roughly tripled per-thesis wall-clock (~55s -> ~160s), which
+is what crossed the ceiling. Steady state is ~25 min — a shade over 2x the
+Lambda maximum, not hours.
+
+Mechanism (mirrors scheduled-groom-dispatcher / data-spot-dispatcher via the
+shared `nousergon_lib.spot_dispatch` chokepoint — no lib change):
+  1. `spot_dispatch.launch_with_fallback()` rotates instance_type x subnet on
+     capacity error, then falls back to on-demand so a capacity dip never
+     costs a day's Think Tank coverage.
+  2. Wait for the instance to run + its SSM agent to register Online.
+  3. Fire an ASYNC, detached `ssm send-command` carrying a minimal prelude:
+     install runtime, clone the (public) research repo, exec
+     `infrastructure/thinktank_spot_bootstrap.sh`. The box self-terminates.
+     This Lambda returns immediately — it does not babysit the run.
+
+THE BUDGET/TIMEOUT COUPLING IS LOAD-BEARING. `RUN_BUDGET_SECONDS` must stay
+below `RUN_TIMEOUT_SECONDS` by at least the run module's terminal-write
+reserve (`thinktank.run._TERMINAL_WRITE_RESERVE_S`, 120s). The box derives its
+deadline from the budget; SSM kills the command at the timeout. If the budget
+ever meets or exceeds the timeout, SSM guillotines the run mid-loop and every
+terminal write is lost again — i.e. the exact failure this dispatcher exists
+to fix, reintroduced through a config drift. `handler` refuses to launch in
+that state and `test_handler.py` asserts the inequality; do not "fix" a
+truncating run by raising the budget without raising the timeout first.
+
+Fail-loud (the daily Think Tank IS the deliverable, and it is one of three
+count-matched champion/challenger arms per config-I4983): a launch/SSM failure
+RAISES so EventBridge's async retries, the Lambda Errors metric, and the alarm
+watching it all surface the miss, rather than silently dropping a day.
+
+Managed OUTSIDE CloudFormation (same as every sibling dispatcher): operator-
+deployed via `deploy.sh --bootstrap`. Merging the PR has ZERO live effect until
+the Lambda + IAM are deployed AND the `alpha-research-thinktank-daily`
+EventBridge rule is repointed off the Lambda alias — see README.md for the
+staged-cutover order (§47 sub-rule (b): keep the old path live until the new
+one is validated by a REAL run).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+from nousergon_lib import spot_dispatch
+from nousergon_lib.spot_dispatch import SpotLaunchError, SpotProbeError
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Kill-switch. Unlike the weekly launcher there is no operator-supplied
+# alternative path here, so disabling this genuinely means "no Think Tank
+# today" — it RAISES rather than returning a quiet {"launched": false}, so a
+# disabled dispatcher is never indistinguishable from a healthy no-op.
+DISPATCH_ENABLED = (
+    os.environ.get("THINKTANK_SPOT_DISPATCH_ENABLED", "true").lower() == "true"
+)
+
+# ── Spot launch config ──────────────────────────────────────────────────────
+# Instance family mirrors the sibling launchers. The workload is LLM/network-
+# bound, not CPU-bound (the Lambda peaked at 394MB of 1024MB), so the smallest
+# standard tier is right; the multi-type list exists for capacity resilience,
+# not performance.
+INSTANCE_TYPES = [
+    t.strip()
+    for t in os.environ.get(
+        "THINKTANK_SPOT_INSTANCE_TYPES", "c5.large,m5.large,c6i.large,c5a.large"
+    ).split(",")
+    if t.strip()
+]
+SUBNETS = [
+    s.strip()
+    for s in os.environ.get(
+        "THINKTANK_SPOT_SUBNETS",
+        "subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,"
+        "subnet-c670118d,subnet-7cff7c43,subnet-e07166ec",
+    ).split(",")
+    if s.strip()
+]
+AMI_ID = os.environ.get("THINKTANK_SPOT_AMI_ID", "ami-0c421724a94bba6d6")  # AL2023 x86_64
+KEY_NAME = os.environ.get("THINKTANK_SPOT_KEY_NAME", "alpha-engine-key")
+SECURITY_GROUP = os.environ.get("THINKTANK_SPOT_SECURITY_GROUP", "sg-03cd3c4bd91e610b0")
+# Same profile every sibling spot box uses: ssm:GetParameter on /alpha-engine/*
+# (the config PAT + the provider key the run needs) and read/write on
+# s3://alpha-engine-research. This Lambda passes none of those itself.
+IAM_PROFILE = os.environ.get("THINKTANK_SPOT_IAM_PROFILE", "alpha-engine-executor-profile")
+# One shallow public clone + one private config clone + a venv carrying the
+# research stack. 40GB matches the weekly launcher's sizing for the same
+# reason (the venv, not the data).
+VOLUME_SIZE_GB = int(os.environ.get("THINKTANK_SPOT_VOLUME_SIZE_GB", "40"))
+
+RESEARCH_REPO = os.environ.get("THINKTANK_SPOT_RESEARCH_REPO", "nousergon/crucible-research")
+RESEARCH_BRANCH = os.environ.get("THINKTANK_SPOT_RESEARCH_BRANCH", "main")
+
+# ── Timing (see the module docstring: this coupling is load-bearing) ────────
+# Budget the box runs its deadline against. Derived from measured manifests,
+# with headroom for coverage growth to rank_ceiling=150 and the
+# stale_after_days=30 refresh wave starting early August.
+RUN_BUDGET_SECONDS = int(os.environ.get("THINKTANK_RUN_BUDGET_SECONDS", "5400"))  # 90 min
+# SSM's own ceiling on the command. Must exceed RUN_BUDGET_SECONDS by more
+# than the run module's 120s terminal-write reserve, PLUS bootstrap time
+# (clone + venv build, low single-digit minutes on a warm mirror).
+RUN_TIMEOUT_SECONDS = int(os.environ.get("THINKTANK_SPOT_RUN_TIMEOUT_SECONDS", "7200"))  # 2h
+# Orphan-prevention backstop only — never fires on a healthy run. Sized above
+# the SSM timeout so SSM's own kill (which the bootstrap trap converts into a
+# clean self-terminate) always wins first. spot-orphan-reaper is a 6.5h AGE
+# CAP, not a health check, so it is not a substitute for this.
+WATCHDOG_SECONDS = int(os.environ.get("THINKTANK_SPOT_WATCHDOG_SECONDS", "9000"))  # 2.5h
+SSM_ONLINE_BUDGET_SEC = int(os.environ.get("THINKTANK_SPOT_SSM_ONLINE_BUDGET_SEC", "300"))
+CW_LOG_GROUP = os.environ.get("THINKTANK_SPOT_CW_LOG_GROUP", "/alpha-engine/thinktank-spot")
+
+INSTANCE_TAG_NAME = "alpha-engine-thinktank-spot"
+
+
+def _bootstrap_command(run_token: str) -> str:
+    """The async SSM RunShellScript body: install runtime, clone the research
+    repo, exec the repo's bootstrap.
+
+    Deliberately minimal. The heavy, version-controlled logic lives in
+    crucible-research's ``infrastructure/thinktank_spot_bootstrap.sh`` so a
+    change to the run shape is a PR in that repo rather than a Lambda
+    redeploy (§47 sub-rule (a): one shared entrypoint, not two drifting
+    copies). This prelude is only the clone glue.
+
+    Runs as root under SSM with no $HOME — both are set explicitly below.
+    Stock AL2023 ships neither git nor python3.12, so both are installed
+    before the clone. Any prelude failure shuts the box down so a botched
+    launch never idles (§47 sub-rule (b): these are the exact classes that
+    only a real launch surfaces).
+    """
+    log = f"/var/log/thinktank-spot-bootstrap-{run_token}.log"
+    s3_log = (
+        f"s3://alpha-engine-research/_ssm_logs/thinktank-spot/"
+        f"$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%S)-{run_token}.log"
+    )
+    return f"""set -uo pipefail
+export HOME=/home/ec2-user
+export XDG_CACHE_HOME=/home/ec2-user/.cache
+export AWS_REGION={REGION}
+export AWS_DEFAULT_REGION={REGION}
+fail() {{ echo "[thinktank-spot-prelude] FATAL: $1"; aws s3 cp {log} "{s3_log}" --region {REGION} --quiet || true; shutdown -h now; exit 1; }}
+mkdir -p "$(dirname {log})"
+exec > >(tee -a {log}) 2>&1
+systemd-run --on-active={WATCHDOG_SECONDS} --unit=alpha-engine-thinktank-spot-watchdog \\
+  --description='alpha-engine thinktank-spot orphan-prevention watchdog' /sbin/shutdown -h now || true
+dnf install -y -q git python3.12 python3.12-pip python3.12-devel gcc >/dev/null 2>&1 \\
+  || fail "runtime install (git/python3.12) failed"
+git config --global --add safe.directory '*' || true
+rm -rf /home/ec2-user/crucible-research
+git clone --depth 1 --branch {RESEARCH_BRANCH} \\
+  https://github.com/{RESEARCH_REPO}.git /home/ec2-user/crucible-research \\
+  || fail "crucible-research clone failed"
+cd /home/ec2-user/crucible-research
+export THINKTANK_RUN_BUDGET_SECONDS={RUN_BUDGET_SECONDS}
+export THINKTANK_SPOT_RUN_TOKEN={run_token}
+exec bash infrastructure/thinktank_spot_bootstrap.sh
+"""
+
+
+def _launch_instance(force_on_demand: bool = False) -> tuple[str, str]:
+    return spot_dispatch.launch_with_fallback(
+        INSTANCE_TYPES,
+        SUBNETS,
+        image_id=AMI_ID,
+        key_name=KEY_NAME,
+        security_group_ids=[SECURITY_GROUP],
+        iam_instance_profile=IAM_PROFILE,
+        volume_size_gb=VOLUME_SIZE_GB,
+        tag_name=INSTANCE_TAG_NAME,
+        region=REGION,
+        force_on_demand=force_on_demand,
+    )
+
+
+def _already_running() -> list[str]:
+    """Duplicate-launch guard.
+
+    A degraded EC2 API must never read as "no duplicate running" — that is the
+    config#2267 fail-open class. ``running_instance_ids`` raises SpotProbeError
+    rather than returning a clean empty list, and the caller below chooses
+    coverage over dedupe explicitly and records the choice.
+    """
+    return spot_dispatch.running_instance_ids(tag_name=INSTANCE_TAG_NAME, region=REGION)
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    """EventBridge handler — launch the daily Think Tank box.
+
+    ``event`` may carry ``{"force_on_demand": bool}``. Returns
+    ``{"launched", "instance_id", "command_id", "market", "run_token",
+    "dedupe_degraded"}``.
+
+    Fail-loud: a launch/SSM error RAISES so EventBridge's two async retries
+    engage and the Lambda Errors metric drives the alarm.
+    """
+    event = event or {}
+    force_on_demand = bool(event.get("force_on_demand", False))
+
+    if not DISPATCH_ENABLED:
+        raise RuntimeError(
+            "THINKTANK_SPOT_DISPATCH_ENABLED=false — the daily Think Tank will "
+            "not run today. There is no alternative path; re-enable the "
+            "dispatcher or invoke the run manually."
+        )
+
+    if RUN_BUDGET_SECONDS >= RUN_TIMEOUT_SECONDS:
+        # Refuse to launch rather than run a box whose deadline SSM will
+        # preempt — that silently reintroduces the lost-terminal-writes bug.
+        raise ValueError(
+            f"THINKTANK_RUN_BUDGET_SECONDS={RUN_BUDGET_SECONDS} must be strictly "
+            f"below THINKTANK_SPOT_RUN_TIMEOUT_SECONDS={RUN_TIMEOUT_SECONDS}; "
+            "otherwise SSM guillotines the run before its terminal writes "
+            "(alpha-engine-config-I5208)"
+        )
+
+    dedupe_degraded = False
+    try:
+        running = _already_running()
+    except SpotProbeError:
+        # Coverage beats dedupe for a once-daily arm: a duplicate box costs
+        # cents and both runs converge on the same checkpointed ledger, while
+        # a skipped day costs a day of challenger evidence. Recorded, never
+        # silent.
+        logger.warning(
+            "thinktank-spot dedupe probe DEGRADED (DescribeInstances failed) — "
+            "launching anyway; a duplicate box is cheaper than a missed day"
+        )
+        dedupe_degraded = True
+        running = []
+    if running:
+        logger.warning(
+            "thinktank-spot box already running (%s) — skipping this launch", running
+        )
+        return {"launched": False, "reason": "already_running", "instance_ids": running}
+
+    run_token = uuid.uuid4().hex
+    try:
+        instance_id, market = _launch_instance(force_on_demand=force_on_demand)
+    except SpotLaunchError:
+        logger.error("thinktank-spot launch failed (spot + on-demand exhausted)")
+        raise
+    logger.info("launched thinktank-spot box %s (%s)", instance_id, market)
+
+    # Between launch and the bootstrap command landing there is no watchdog or
+    # trap on the box yet — anything failing in here would orphan it.
+    try:
+        spot_dispatch.wait_ssm_online(
+            instance_id, region=REGION, ssm_online_budget_sec=SSM_ONLINE_BUDGET_SEC
+        )
+        command_id = spot_dispatch.send_async_command(
+            instance_id,
+            _bootstrap_command(run_token),
+            comment=f"daily Think Tank run (config-I5208 §47) — {run_token}",
+            region=REGION,
+            cw_log_group=CW_LOG_GROUP,
+            execution_timeout_seconds=RUN_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        spot_dispatch.terminate_on_failure(
+            instance_id, region=REGION, label="thinktank-spot"
+        )
+        raise
+
+    return {
+        "launched": True,
+        "instance_id": instance_id,
+        "command_id": command_id,
+        "market": market,
+        "run_token": run_token,
+        "dedupe_degraded": dedupe_degraded,
+    }

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -1,0 +1,9 @@
+# boto3 is provided by the Lambda python3.12 runtime; pinned for reproducible builds.
+boto3>=1.34.0
+# Tracks the ROOT requirements.txt pin, per tests/test_lib_pin_lockstep.py.
+# This dispatcher uses only the shared spot_dispatch chokepoint
+# (launch_with_fallback / wait_ssm_online / send_async_command /
+# running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
+# which have been present since v0.106.0 — so there is no feature floor above
+# root here and no reason to carve an exemption. Bump in lockstep with root.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.21

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
@@ -1,0 +1,165 @@
+"""Tests for alpha-engine-thinktank-spot-dispatcher (config-I5208 §47).
+
+The load-bearing assertions here are about the budget/timeout coupling and the
+fail-loud posture. A dispatcher that launches a box whose deadline SSM will
+preempt reintroduces the exact lost-terminal-writes bug this migration exists
+to fix, so that inequality is asserted rather than left to a comment.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(monkeypatch_env: dict | None = None):
+    """Import index.py fresh so module-level env-derived constants re-evaluate."""
+    for k, v in (monkeypatch_env or {}).items():
+        os.environ[k] = v
+    spec = importlib.util.spec_from_file_location(
+        "thinktank_spot_dispatcher_index", os.path.join(_HERE, "index.py")
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["thinktank_spot_dispatcher_index"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    keys = [
+        "THINKTANK_RUN_BUDGET_SECONDS",
+        "THINKTANK_SPOT_RUN_TIMEOUT_SECONDS",
+        "THINKTANK_SPOT_WATCHDOG_SECONDS",
+        "THINKTANK_SPOT_DISPATCH_ENABLED",
+    ]
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class TestTimingCoupling:
+    def test_default_budget_is_below_the_ssm_timeout_by_more_than_the_reserve(self):
+        """The box's deadline must land before SSM's kill, with room for the
+        terminal writes. thinktank.run._TERMINAL_WRITE_RESERVE_S is 120s."""
+        mod = _load()
+        reserve = 120
+        assert mod.RUN_BUDGET_SECONDS + reserve < mod.RUN_TIMEOUT_SECONDS
+
+    def test_watchdog_sits_above_the_ssm_timeout(self):
+        """SSM's own kill (which the bootstrap trap turns into a clean
+        self-terminate) must always win before the orphan watchdog fires."""
+        mod = _load()
+        assert mod.WATCHDOG_SECONDS > mod.RUN_TIMEOUT_SECONDS
+
+    def test_handler_refuses_to_launch_when_the_coupling_is_violated(self):
+        """A config drift that inverts the inequality must fail loud at
+        dispatch, not produce a box that gets guillotined mid-run."""
+        mod = _load(
+            {
+                "THINKTANK_RUN_BUDGET_SECONDS": "7200",
+                "THINKTANK_SPOT_RUN_TIMEOUT_SECONDS": "7200",
+            }
+        )
+        with pytest.raises(ValueError, match="must be strictly below"):
+            mod.handler({}, None)
+
+    def test_budget_reaches_the_box_as_an_env_export(self):
+        """The bootstrap command is the only channel carrying the budget to
+        the box; if it is dropped the runner falls back to its own default and
+        the dispatcher's timeout coupling becomes a fiction."""
+        mod = _load()
+        cmd = mod._bootstrap_command("tok123")
+        assert f"export THINKTANK_RUN_BUDGET_SECONDS={mod.RUN_BUDGET_SECONDS}" in cmd
+
+
+class TestBootstrapCommand:
+    def test_execs_the_repo_owned_bootstrap_not_an_inline_copy(self):
+        """§47 sub-rule (a): one shared entrypoint. The prelude must hand off
+        to the version-controlled script rather than inline the run steps."""
+        cmd = _load()._bootstrap_command("tok")
+        assert "exec bash infrastructure/thinktank_spot_bootstrap.sh" in cmd
+
+    def test_sets_home_because_ssm_runs_as_root_without_one(self):
+        cmd = _load()._bootstrap_command("tok")
+        assert "export HOME=/home/ec2-user" in cmd
+
+    def test_installs_git_and_python_before_cloning(self):
+        """Stock AL2023 ships neither; the clone is the first thing that needs
+        git, so the install must precede it in the command text."""
+        cmd = _load()._bootstrap_command("tok")
+        assert cmd.index("dnf install") < cmd.index("git clone")
+
+    def test_arms_the_orphan_watchdog(self):
+        cmd = _load()._bootstrap_command("tok")
+        assert "alpha-engine-thinktank-spot-watchdog" in cmd
+
+    def test_prelude_failure_shuts_the_box_down(self):
+        """A botched launch must never idle — spot-orphan-reaper is a 6.5h age
+        cap, not a health check."""
+        cmd = _load()._bootstrap_command("tok")
+        assert "shutdown -h now" in cmd
+
+
+class TestDispatchPosture:
+    def test_disabled_dispatcher_raises_rather_than_returning_a_quiet_noop(self):
+        """A disabled dispatcher must never be indistinguishable from a healthy
+        run that had nothing to do."""
+        mod = _load({"THINKTANK_SPOT_DISPATCH_ENABLED": "false"})
+        with pytest.raises(RuntimeError, match="will not run today"):
+            mod.handler({}, None)
+
+    def test_degraded_dedupe_probe_launches_anyway_and_records_it(self, monkeypatch):
+        """config#2267: a degraded EC2 API must not read as 'no duplicate'.
+        For a once-daily arm, coverage beats dedupe — but the choice is
+        recorded, never silent."""
+        mod = _load()
+        monkeypatch.setattr(
+            mod, "_already_running", lambda: (_ for _ in ()).throw(mod.SpotProbeError("boom"))
+        )
+        monkeypatch.setattr(mod, "_launch_instance", lambda force_on_demand=False: ("i-abc", "spot"))
+        monkeypatch.setattr(mod.spot_dispatch, "wait_ssm_online", lambda *a, **k: None)
+        monkeypatch.setattr(mod.spot_dispatch, "send_async_command", lambda *a, **k: "cmd-1")
+        out = mod.handler({}, None)
+        assert out["launched"] is True
+        assert out["dedupe_degraded"] is True
+
+    def test_existing_box_short_circuits_the_launch(self, monkeypatch):
+        mod = _load()
+        monkeypatch.setattr(mod, "_already_running", lambda: ["i-live"])
+        out = mod.handler({}, None)
+        assert out["launched"] is False
+        assert out["reason"] == "already_running"
+
+    def test_ssm_failure_terminates_the_box_before_raising(self, monkeypatch):
+        """Between launch and the bootstrap landing there is no watchdog on the
+        box yet, so this window must tear the box down itself."""
+        mod = _load()
+        terminated: list[str] = []
+        monkeypatch.setattr(mod, "_already_running", lambda: [])
+        monkeypatch.setattr(mod, "_launch_instance", lambda force_on_demand=False: ("i-xyz", "spot"))
+        monkeypatch.setattr(
+            mod.spot_dispatch,
+            "wait_ssm_online",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ssm never came online")),
+        )
+        monkeypatch.setattr(
+            mod.spot_dispatch,
+            "terminate_on_failure",
+            lambda iid, **k: terminated.append(iid),
+        )
+        with pytest.raises(RuntimeError, match="ssm never came online"):
+            mod.handler({}, None)
+        assert terminated == ["i-xyz"]


### PR DESCRIPTION
## What

The dispatcher half of moving the daily Think Tank off Lambda onto self-terminating EC2 spot. Closes the **nous-ergon-ops-I162** dependency under **alpha-engine-config-I5208**, per **ARCHITECTURE §47**.

Companion: **crucible-research-PR544** (box-side runner + bootstrap). **Merge order: crucible-research-PR544 first** — this dispatcher's SSM prelude execs `infrastructure/thinktank_spot_bootstrap.sh` out of a shallow clone of that repo's `main`, so the script has to exist there before any box can run.

## Why this keeps happening

The daily run hit the 900s Lambda ceiling every day from 2026-07-17, dying mid-loop before its terminal writes — `ratings/`, `challenger_selection/`, `events/` and the coverage shadow view all froze for twelve days while the run looked busy in logs.

§47 has required owned compute for long-running agent jobs since 2026-06-30. This is at least the **fourth** site of the universe-growth timeout class — config-I3095 logged the evaluator as the third, and config-I3072 hit this very ceiling on 2026-07-20 and closed with a resumable-checkpoint guard. Each pass fixed the symptom the alert showed and left the placement. That is what this PR changes.

## Sizing is measured

| Run | Work | Wall clock |
|---|---|---|
| 2026-07-16 (pre-#464) | 8 theses + 70-name sweep | **443s** |
| 2026-07-29 (post-#464) | 5 theses, sweep skipped | 801s, truncated |

crucible-research#464's pillar/moat call roughly tripled per-thesis wall-clock (~55s → ~160s) — that, not the sweep, crossed the ceiling. The sweep chunks at 25, so 135 covered names is 6 LLM calls costing under a cent. Steady state ~25 min, a shade over 2x the Lambda max.

Defaults: budget **5400s**, SSM timeout 7200s, watchdog 9000s.

## The coupling is enforced, not documented

```
RUN_BUDGET_SECONDS + 120s reserve  <  RUN_TIMEOUT_SECONDS  <  WATCHDOG_SECONDS
```

`handler()` **refuses to launch** if that inverts, and a test asserts it. Without this, a later "runs are truncating, raise the budget" edit silently recreates the guillotine at 2h instead of 900s — the same bug, quieter. The README says to raise the timeout first and to re-derive from `deadline_skipped_*` on the run manifests rather than guessing.

## Design notes

- **Thin, on the shared chokepoint.** `nousergon_lib.spot_dispatch` only — no lib change, no fifth private copy of the launch/SSM/terminate primitives.
- **Prelude is clone glue only** and execs the repo-owned bootstrap (§47 sub-rule (a): one entrypoint, not two drifting copies).
- **Degraded dedupe probe launches anyway, and records it.** For a once-daily arm a duplicate box costs cents and both runs converge on the same checkpointed ledger, while a skipped day costs a day of challenger evidence. `SpotProbeError` is caught explicitly and surfaces as `dedupe_degraded: true` — never a silent fail-open (config#2267).
- **Disabled dispatcher raises** rather than returning a quiet `{"launched": false}` — there is no alternative path here, so "disabled" must not look like "nothing to do".
- **Launch→bootstrap window terminates on error**, since the box has no watchdog or trap until the bootstrap lands.

## Rollout is staged, and merging does nothing

`deploy.sh` flagless is code-only. `--bootstrap` creates IAM+Lambda. `--smoke` fires one real box. `--cutover` repoints `alpha-research-thinktank-daily`. **No merge and no auto-deploy can move the live schedule.** Rollback is one `put-targets` back at the Lambda alias.

`--smoke` is a real gate, not a formality: §47 sub-rule (b) exists because stock AMIs ship no git, SSM shells run as root with no `$HOME`, and `$`-bearing strings expand as positional params under `set -u`. Three rounds of exactly those were found on the 2026-06-30 groom cutover only by launching a box and reading its output.

## Known gap, called out rather than left

`alpha-engine-thinktank-daily-run-failed` watches the **old Lambda's** `Errors` metric. After cutover that Lambda stops being invoked on a schedule, so the alarm goes green-because-nothing-ran — the same silence class as the original bug. Documented in README and echoed by `--cutover` at runtime. It must move onto this dispatcher's `Errors` plus the freshness registry's `thinktank_challenger_selection` row before the cutover counts as finished.

## Testing

- `pytest infrastructure/lambdas/thinktank-spot-dispatcher/` → **13 passed**. Covers the timing coupling (including the handler's refusal), budget reaching the box as an env export, prelude ordering (install before clone), watchdog arming, shutdown-on-prelude-failure, the degraded-probe path, the already-running short-circuit, and terminate-on-SSM-failure.
- `pytest tests/test_lib_pin_lockstep.py tests/test_artifact_registry_coverage.py` → 7 passed. The new `requirements.txt` tracks the root pin (v0.124.21) with no exemption — this dispatcher uses only long-stable `spot_dispatch` surface, so it has no feature floor above root.
- Full suite: **3856 passed, 5 failed**; all 5 verified to fail identically on the unmodified base checkout (`test_pipeline_status_registry_source_check`, `test_ssm_log_capture_wrapper_executes`). Untouched by this change, which adds only new files in a new directory.
- `bash -n` and `shellcheck` clean on `deploy.sh`.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
