### PR TITLE
fix(thinktank): running_instance_ids takes discriminator_tags positionally (config-I5208)

### DIFF
--- a/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
@@ -195,7 +195,11 @@ def _already_running() -> list[str]:
     rather than returning a clean empty list, and the caller below chooses
     coverage over dedupe explicitly and records the choice.
     """
-    return spot_dispatch.running_instance_ids(tag_name=INSTANCE_TAG_NAME, region=REGION)
+    # discriminator_tags is REQUIRED positional. Empty is correct here: this
+    # dispatcher has exactly one lane (one daily run), so the Name tag alone
+    # identifies a duplicate — same shape as alert-drain-dispatcher. Lanes
+    # that DO partition (groom tiers, arctic migrations) pass a discriminator.
+    return spot_dispatch.running_instance_ids(INSTANCE_TAG_NAME, {}, region=REGION)
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
@@ -113,6 +113,76 @@ class TestBootstrapCommand:
         assert "shutdown -h now" in cmd
 
 
+class TestLibCallSignatures:
+    """Bind every spot_dispatch call against the REAL library signature.
+
+    The 2026-07-29 smoke run died on
+    ``running_instance_ids() missing 1 required positional argument:
+    'discriminator_tags'`` — an error every unit test above missed, because
+    they monkeypatch ``_already_running`` and the ``spot_dispatch`` functions
+    themselves, so no test ever touched the real signature. Mocks make a
+    call site untestable exactly where it talks to someone else's contract.
+    ``inspect.signature().bind()`` closes that without needing AWS.
+    """
+
+    def test_running_instance_ids_call_binds(self):
+        import inspect
+
+        from nousergon_lib import spot_dispatch as real
+
+        mod = _load()
+        inspect.signature(real.running_instance_ids).bind(
+            mod.INSTANCE_TAG_NAME, {}, region=mod.REGION
+        )
+
+    def test_launch_with_fallback_call_binds(self):
+        import inspect
+
+        from nousergon_lib import spot_dispatch as real
+
+        mod = _load()
+        inspect.signature(real.launch_with_fallback).bind(
+            mod.INSTANCE_TYPES,
+            mod.SUBNETS,
+            image_id=mod.AMI_ID,
+            key_name=mod.KEY_NAME,
+            security_group_ids=[mod.SECURITY_GROUP],
+            iam_instance_profile=mod.IAM_PROFILE,
+            volume_size_gb=mod.VOLUME_SIZE_GB,
+            tag_name=mod.INSTANCE_TAG_NAME,
+            region=mod.REGION,
+            force_on_demand=False,
+        )
+
+    def test_send_async_command_call_binds(self):
+        import inspect
+
+        from nousergon_lib import spot_dispatch as real
+
+        mod = _load()
+        inspect.signature(real.send_async_command).bind(
+            "i-abc",
+            mod._bootstrap_command("tok"),
+            comment="x",
+            region=mod.REGION,
+            cw_log_group=mod.CW_LOG_GROUP,
+            execution_timeout_seconds=mod.RUN_TIMEOUT_SECONDS,
+        )
+
+    def test_wait_ssm_online_and_terminate_calls_bind(self):
+        import inspect
+
+        from nousergon_lib import spot_dispatch as real
+
+        mod = _load()
+        inspect.signature(real.wait_ssm_online).bind(
+            "i-abc", region=mod.REGION, ssm_online_budget_sec=mod.SSM_ONLINE_BUDGET_SEC
+        )
+        inspect.signature(real.terminate_on_failure).bind(
+            "i-abc", region=mod.REGION, label="thinktank-spot"
+        )
+
+
 class TestDispatchPosture:
     def test_disabled_dispatcher_raises_rather_than_returning_a_quiet_noop(self):
         """A disabled dispatcher must never be indistinguishable from a healthy


### PR DESCRIPTION
## What

The 2026-07-29 `--smoke` run of nousergon-data-PR1133's dispatcher failed at dispatch:

```
running_instance_ids() missing 1 required positional argument: 'discriminator_tags'
```

`discriminator_tags` is a required **positional** parameter. No box was launched — the concurrency probe runs before the launch — so nothing was orphaned and no spend occurred. But the dispatcher could not have run at all.

Follow-up to nousergon-data-PR1133, under alpha-engine-config-I5208 / nous-ergon-ops-I162.

## Fix

Empty discriminator is the correct value here: this dispatcher has exactly one lane (one daily run), so the `Name` tag alone identifies a duplicate. Same shape as `alert-drain-dispatcher`. Lanes that genuinely partition — groom tiers, arctic migrations — pass a real discriminator.

## Why no test caught it

Every existing test monkeypatches either `_already_running` or the `spot_dispatch` functions themselves, so **nothing ever touched the real signature**. That is the general trap: mocks make a call site untestable precisely where it talks to someone else's contract, and this is a cross-repo contract (nousergon-lib → this Lambda) that moves independently.

Adds `inspect.signature().bind()` assertions for all five `spot_dispatch` call sites — `running_instance_ids`, `launch_with_fallback`, `send_async_command`, `wait_ssm_online`, `terminate_on_failure`. These catch signature drift with no AWS and no mocking, and they will fail on the next lib bump that changes any of those shapes rather than at the next live launch.

**Verified the new test actually catches this bug**, rather than assuming:

```
$ python -c "inspect.signature(real.running_instance_ids).bind(tag_name='x', region='us-east-1')"
TypeError: missing a required argument: 'discriminator_tags'
```

## This is what the §47 validation gate is for

ARCHITECTURE §47 sub-rule (b) requires validating environment-dependent infra by RUNNING it, never by text tests, and lists the classes it catches — stock AMIs with no git, root SSM shells with no `$HOME`, `$`-expansion under `set -u`. This is another member of that family: a cross-repo signature mismatch that no amount of local unit testing surfaced. The gate worked exactly as designed, and it worked *before* the EventBridge cutover, which is why the staged rollout is ordered `--bootstrap` → `--smoke` → `--cutover` rather than merging straight into a live schedule.

## Testing

- `pytest infrastructure/lambdas/thinktank-spot-dispatcher/` → **17 passed** (13 existing + 4 new binding tests).
- Re-run of `deploy.sh --smoke` follows this merge; the cutover stays gated on that run writing `thinktank/challenger_selection/`, `thinktank/ratings/` **and** `thinktank/events/` for the trading day with the box self-terminating.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
