### PR TITLE
fix(thinktank): rotate the alarms atomically with the cutover (config-I5208)

### DIFF
--- a/infrastructure/lambdas/thinktank-spot-dispatcher/README.md
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/README.md
@@ -68,12 +68,22 @@ Lambda until step 3.
 Roll back by re-running `put-targets` against the Lambda alias; the Lambda
 itself is left deployed and functional throughout.
 
-## Alarm follow-up (not yet done)
+## Alarm rotation (handled by `--cutover`)
 
-`alpha-engine-thinktank-daily-run-failed` currently watches the **Lambda's**
-`Errors` metric (`infrastructure/setup-thinktank-schedule.sh` in
-crucible-research). After step 4 that Lambda stops being invoked on a schedule,
-so the alarm goes **blind** — a green alarm would then mean "nothing ran", which
-is the same silence class this whole arc is about. The alarm has to move onto
-this dispatcher's `Errors` plus the freshness registry's
-`thinktank_challenger_selection` row before the cutover is complete.
+`alpha-engine-thinktank-daily-run-failed` and its `-timeout` sibling watch the
+**old Lambda's** metrics. The instant the rule stops targeting that function
+they stop seeing invocations — and because both were created with
+`--treat-missing-data notBreaching`, zero invocations evaluates to **OK**. They
+would go green *because nothing ran*, which is precisely the silence class
+config-I5208 is about.
+
+So `--cutover` rotates them atomically with the repoint:
+
+| Signal | Covers | Where |
+|---|---|---|
+| `alpha-engine-thinktank-spot-dispatch-failed` | **launch** — Errors >= 3/day means the invoke plus both async retries all raised, so no box exists | armed by `--cutover` |
+| `thinktank_challenger_selection` | **end-to-end** — the artifact itself going stale, i.e. a box that booted and produced nothing | ARTIFACT_REGISTRY, already live |
+
+Both are required. The dispatcher alarm cannot see a box that boots and then
+fails its run; the freshness row cannot distinguish "never launched" from
+"launched and failed". The two old alarms are deleted, not left green.

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -25,6 +25,9 @@ ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 FUNCTION_NAME="alpha-engine-thinktank-spot-dispatcher"
 ROLE_NAME="alpha-engine-thinktank-spot-dispatcher-role"
 RULE_NAME="alpha-research-thinktank-daily"
+# Same topic the alarms this cutover replaces already publish to, so the
+# rotation does not silently change where a Think Tank page lands.
+SNS_TOPIC_ARN="${SNS_TOPIC_ARN:-arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
@@ -95,8 +98,38 @@ if [ "$CUTOVER" -eq 1 ]; then
     aws events put-targets --rule "$RULE_NAME" \
         --targets "[{\"Id\":\"1\",\"Arn\":\"${TARGET_ARN}\"}]" --region "$REGION"
     echo "    $RULE_NAME now targets $FUNCTION_NAME."
-    echo "    NOTE: alpha-engine-thinktank-daily-run-failed still watches the OLD"
-    echo "    Lambda's Errors metric and is now BLIND — move it before calling this done."
+
+    # ── Alarm rotation — ATOMIC with the repoint, deliberately ───────────────
+    # The instant the rule stops targeting alpha-engine-research-thinktank, that
+    # function's Errors/Duration alarms stop seeing invocations. Both were
+    # created with `--treat-missing-data notBreaching`, so zero invocations
+    # evaluates to OK: they go GREEN because nothing ran. That is the exact
+    # silence class this whole migration exists to close (config-I5208 — the
+    # Think Tank ran dead for 12 days while every surface read healthy), so
+    # leaving them behind "temporarily" would reintroduce it at the moment of
+    # cutover. They are deleted here, in the same action that blinds them.
+    OLD_FUNCTION="alpha-engine-research-thinktank"
+    DISPATCH_ALARM="alpha-engine-thinktank-spot-dispatch-failed"
+
+    echo "==> arming $DISPATCH_ALARM on the dispatcher"
+    aws cloudwatch put-metric-alarm \
+        --alarm-name "$DISPATCH_ALARM" \
+        --alarm-description "The daily Think Tank DISPATCH failed: >= 3 Lambda Errors in a day = the initial EventBridge invoke plus both async retries all raised, so no spot box was launched and the day has no Think Tank run. NOTE this alarm covers the LAUNCH only. A box that boots and then fails its run is NOT visible here -- that is covered end-to-end by the ARTIFACT_REGISTRY row thinktank_challenger_selection (continuous, 1440min interval, 720min SLA), which pages when the artifact itself goes stale. Both are required: this one catches 'never launched', the freshness row catches 'launched and produced nothing'." \
+        --namespace "AWS/Lambda" \
+        --metric-name Errors \
+        --dimensions "Name=FunctionName,Value=${FUNCTION_NAME}" \
+        --statistic Sum --period 86400 --evaluation-periods 1 \
+        --threshold 3 --comparison-operator GreaterThanOrEqualToThreshold \
+        --treat-missing-data notBreaching \
+        --alarm-actions "$SNS_TOPIC_ARN" --region "$REGION"
+
+    echo "==> deleting the now-blind $OLD_FUNCTION alarms"
+    aws cloudwatch delete-alarms --alarm-names \
+        "alpha-engine-thinktank-daily-run-failed" \
+        "alpha-engine-thinktank-daily-run-failed-timeout" \
+        --region "$REGION"
+    echo "    deleted. Coverage is now: $DISPATCH_ALARM (launch) +"
+    echo "    ARTIFACT_REGISTRY thinktank_challenger_selection (end-to-end)."
 fi
 
 echo "==> done"


### PR DESCRIPTION
## What

`deploy.sh --cutover` now rotates the Think Tank alarms in the **same action** that repoints the EventBridge rule. Follow-up to nousergon-data-PR1133 / PR1137, under alpha-engine-config-I5208.

## The gap this closes

The moment `--cutover` repoints `alpha-research-thinktank-daily` away from `alpha-engine-research-thinktank`, that function's two alarms stop seeing invocations:

- `alpha-engine-thinktank-daily-run-failed` (Errors >= 3/day)
- `alpha-engine-thinktank-daily-run-failed-timeout` (Duration >= 899000ms)

Both were created with `--treat-missing-data notBreaching`. **Zero invocations evaluates to OK.** They would sit green *because nothing ran* — which is exactly the silence class config-I5208 is about: the Think Tank ran dead for twelve days while every surface read healthy. Leaving them behind "until we get to it" would reintroduce that failure at the precise moment of cutover, on the artifact set the cutover exists to protect.

They are deleted here, in the same action that blinds them. A green alarm on a function nothing invokes is worse than no alarm, because it implies coverage.

## Replacement coverage is two signals, and both are needed

| Signal | Covers | Blind to |
|---|---|---|
| `alpha-engine-thinktank-spot-dispatch-failed` (new) | **launch** — Errors >= 3/day means the EventBridge invoke plus both async retries all raised, so no box was ever created | a box that boots and then fails its run |
| `thinktank_challenger_selection` (ARTIFACT_REGISTRY, already live) | **end-to-end** — the artifact going stale, i.e. launched-but-produced-nothing | cannot distinguish "never launched" from "launched and failed" |

Neither alone is sufficient, so the alarm description names the other explicitly rather than leaving the next reader to work out what it does not cover.

## Also fixes a latent `set -u` abort

`SNS_TOPIC_ARN` was referenced by the new alarm call but never defined in this script. Under `set -euo pipefail` that is an unbound-variable abort — and it would have fired **after** `put-targets` had already repointed the rule, leaving the cutover half-applied: schedule moved, alarms untouched. Now defined, defaulting to the same `alpha-engine-alerts` topic the alarms it replaces already publish to, so the rotation does not silently change where a Think Tank page lands. Topic ARN verified live.

## Testing

- `bash -n` and `shellcheck` clean.
- SNS topic `arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts` confirmed to exist via `sns get-topic-attributes`.
- No unit tests: this is deploy-script wiring whose behaviour is CloudWatch API calls. It is exercised by running `--cutover`, which is gated on `--smoke` passing first.

## Sequencing

Merging this changes nothing live — `--cutover` is an explicit operator flag, never triggered by a merge or a code deploy. It must be merged **before** `--cutover` is run, so the cutover and the alarm rotation stay atomic.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
