### PR TITLE
fix(metron-intraday): an empty fetch is a failed run, not an ok one that wipes latest.json

### DIFF
--- a/collectors/metron_market_data.py
+++ b/collectors/metron_market_data.py
@@ -2217,6 +2217,40 @@ def collect_intraday(
         "indices": dict(sorted(indices.items())),
         "fund_proxies": dict(sorted(fund_proxies.items())),
     }
+    # An EMPTY fetch is a failed run, and writing it destroys the last good one.
+    #
+    # `indices` and `fund_proxies` come from fixed non-empty constants and are
+    # fetched unconditionally, so zero of them is never a legitimate state --
+    # unlike `quotes`, which is legitimately empty for an account holding
+    # nothing. That asymmetry is what makes this a precise assertion rather than
+    # a heuristic on volume.
+    #
+    # Observed live 2026-07-29: `yfinance` was absent from the box's venv, so
+    # every `_yfinance_*` helper took its `except ImportError -> return {}`
+    # branch, logged a warning, and the run reported
+    # `{'status': 'ok', 'quotes': 0, 'indices': 0, 'fund_proxies': 0}` while
+    # OVERWRITING latest.json with a 126-byte artifact containing no quotes at
+    # all. The producer replaced good data with nothing and called it success.
+    # Every ImportError branch is marked `# pragma: no cover - yfinance/pandas
+    # are prod deps`, which is exactly the assumption that broke; this is the
+    # assertion the pragma was standing in for.
+    #
+    # Refuse before the write, not after: a consumer reading a stale as_of_utc
+    # can tell the feed is old, but one reading a fresh timestamp over an empty
+    # body cannot tell anything is wrong.
+    if not indices or not fund_proxies:
+        missing = [n for n, v in (("indices", indices), ("fund_proxies", fund_proxies)) if not v]
+        logger.error(
+            "[metron_market_data] intraday fetch returned NOTHING for %s -- these come "
+            "from fixed symbol lists and can never be legitimately empty. Refusing to "
+            "overwrite %slatest.json with an empty artifact. Check that yfinance and "
+            "pandas are importable in this interpreter.",
+            " and ".join(missing), INTRADAY_PREFIX,
+        )
+        return {"status": "error", "error": f"empty intraday fetch for {','.join(missing)}",
+                "quotes": len(quotes), "indices": len(indices),
+                "fund_proxies": len(fund_proxies)}
+
     if dry_run:
         logger.info("[metron_market_data] DRY-RUN intraday: %d quotes, %d indices, %d fund-proxies (not written)",
                     len(quotes), len(indices), len(fund_proxies))

--- a/infrastructure/install-metron-intraday.sh
+++ b/infrastructure/install-metron-intraday.sh
@@ -9,6 +9,50 @@ set -euo pipefail
 REPO_DIR="/home/ec2-user/alpha-engine-data"
 UNIT_DIR="${REPO_DIR}/infrastructure/systemd"
 
+# PREFLIGHT: prove the interpreter can actually run the job BEFORE enabling it.
+#
+# This script used to copy units and `systemctl enable --now` without ever
+# checking that the venv named in the unit's ExecStart could import what the
+# collector needs. On 2026-07-29 that produced a timer that fired every five
+# minutes for hours with zero successful runs: the box's venv had boto3 and
+# feedparser (it was built for daily-news) but no yfinance and no pandas, so
+# every fetch helper took its `except ImportError -> return {}` branch and the
+# collector wrote an EMPTY artifact over a good one while reporting success.
+#
+# Enabling a unit is a claim that it works. An installer that makes that claim
+# without testing it moves the failure from install time -- where a human is
+# watching and the fix is obvious -- to run time, where it is a silent
+# background job. Fail here instead, loudly, with the remedy in the message.
+PY="${REPO_DIR}/.venv/bin/python"
+if [ ! -x "$PY" ]; then
+    echo "FATAL: ${PY} does not exist or is not executable." >&2
+    echo "The unit's ExecStart names this interpreter; installing the timer " >&2
+    echo "without it enables a job that cannot start." >&2
+    exit 1
+fi
+if ! "$PY" - <<'PREFLIGHT'
+import importlib.util, sys
+# The collector's HARD dependencies. Absent, it degrades to empty results
+# rather than crashing, which is why their absence has to be caught here.
+required = ("boto3", "pandas", "yfinance")
+missing = [m for m in required if importlib.util.find_spec(m) is None]
+if missing:
+    print("missing modules: " + ", ".join(missing), file=sys.stderr)
+    sys.exit(1)
+PREFLIGHT
+then
+    echo "FATAL: ${PY} cannot import the collector's required modules." >&2
+    echo "" >&2
+    echo "Provision the venv from this repo's requirements.txt before installing" >&2
+    echo "the timer. NOTE that requirements.txt pins numpy>=2.4.6, which needs" >&2
+    echo "Python 3.11+ -- a 3.9 venv cannot satisfy it and must be rebuilt on a" >&2
+    echo "newer interpreter rather than patched with older wheels." >&2
+    echo "" >&2
+    echo "Refusing to enable a timer whose job provably cannot produce output." >&2
+    exit 1
+fi
+echo "preflight ok: $("$PY" -V 2>&1) can import boto3, pandas, yfinance"
+
 cp "${UNIT_DIR}/metron-intraday.service" /etc/systemd/system/metron-intraday.service
 cp "${UNIT_DIR}/metron-intraday.timer" /etc/systemd/system/metron-intraday.timer
 systemctl daemon-reload

--- a/tests/test_install_metron_intraday_preflight.py
+++ b/tests/test_install_metron_intraday_preflight.py
@@ -1,0 +1,77 @@
+"""install-metron-intraday.sh must prove the venv works BEFORE enabling the timer.
+
+WHY
+---
+The installer copied units and ran `systemctl enable --now` without checking
+that the interpreter named in the unit's ExecStart could import what the
+collector needs.
+
+On 2026-07-29 that shipped a timer firing every five minutes with zero
+successful runs. The box's venv was built for daily-news -- boto3, feedparser,
+anthropic -- and had neither pandas nor yfinance. Every `_yfinance_*` helper in
+`collectors/metron_market_data.py` carries an `except ImportError: return {}`
+branch marked `# pragma: no cover - yfinance/pandas are prod deps`, so the run
+did not crash: it logged a warning, produced nothing, and wrote an empty
+artifact over the previous good one while reporting `status: ok`.
+
+Enabling a unit is a claim that it works. The claim now has to be tested at
+install time, where a human is watching, rather than discovered at run time in
+a background job.
+
+The interpreter is the real constraint and the message must say so:
+requirements.txt pins `numpy>=2.4.6`, which needs Python 3.11+, so the box's
+3.9 venv cannot be repaired by installing older wheels -- it has to be rebuilt.
+An error message that says "install pandas" would send the next reader down a
+path that cannot work.
+
+Source-text assertions: the script runs as root on an EC2 box via SSM, so
+executing it in CI is not meaningful. What these pin is that the preflight
+exists, covers the deps whose absence is silent, and runs before the enable.
+"""
+
+import re
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parent.parent / "infrastructure" / "install-metron-intraday.sh"
+).read_text()
+
+
+def test_preflight_checks_the_silently_degrading_deps():
+    """boto3 crashes loudly if missing; pandas and yfinance do not."""
+    for module in ("pandas", "yfinance"):
+        assert module in SCRIPT, (
+            f"the preflight does not check {module}. Its absence does not raise -- "
+            "the collector returns empty results and reports success."
+        )
+
+
+def test_preflight_runs_before_the_timer_is_enabled():
+    """Order is the whole point: a passing check after `enable --now` proves nothing."""
+    enable = SCRIPT.index("systemctl enable --now metron-intraday.timer")
+    check = SCRIPT.index("find_spec")
+    assert check < enable, (
+        "the dependency check runs AFTER the timer is enabled, so a broken venv "
+        "still gets a live timer"
+    )
+
+
+def test_preflight_failure_aborts_rather_than_warning():
+    """A warning here is the same defect one layer up: a claim without a test."""
+    m = re.search(r"cannot import the collector's required modules.*?exit 1", SCRIPT, re.S)
+    assert m, "a failed preflight must exit non-zero, not print and continue"
+
+
+def test_missing_interpreter_is_its_own_named_failure():
+    assert re.search(r'if \[ ! -x "\$PY" \]', SCRIPT), (
+        "an absent interpreter must be reported distinctly -- it is a different "
+        "remedy from an under-provisioned one"
+    )
+
+
+def test_the_message_names_the_interpreter_constraint():
+    """Otherwise the next reader tries to pip-install into the 3.9 venv and fails."""
+    assert "numpy>=2.4.6" in SCRIPT and "3.11+" in SCRIPT, (
+        "the remedy text must say the venv needs rebuilding on a newer Python, "
+        "not that packages need installing"
+    )

--- a/tests/test_metron_market_data.py
+++ b/tests/test_metron_market_data.py
@@ -814,7 +814,8 @@ class TestIntraday:
         quotes = {"AAPL": {"last": 350.0, "open": 200.5, "prev_close": 201.5,
                            "session_date": "2026-06-12", "prev_session_date": "2026-06-11"}}
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=self._stub(quotes), now=self._RTH
+            bucket="b", s3_client=s3, intraday_source=self._stub(quotes, self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
+            now=self._RTH,
         )
         assert result["status"] == "ok"
         art = _puts(s3)["market_data/intraday/latest.json"]
@@ -836,7 +837,8 @@ class TestIntraday:
         quotes = {"AAPL": {"last": 202.1, "open": 200.5, "prev_close": 196.4,
                            "session_date": "2026-06-12", "prev_session_date": "2026-06-11"}}
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=self._stub(quotes), now=self._RTH
+            bucket="b", s3_client=s3, intraday_source=self._stub(quotes, self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
+            now=self._RTH,
         )
         assert result["status"] == "ok"
         q = _puts(s3)["market_data/intraday/latest.json"]["quotes"]["AAPL"]
@@ -856,7 +858,8 @@ class TestIntraday:
                         "session_date": "2026-06-12", "prev_session_date": "2026-06-11"},
         }
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=self._stub(quotes), now=self._RTH
+            bucket="b", s3_client=s3, intraday_source=self._stub(quotes, self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
+            now=self._RTH,
         )
         assert result["status"] == "ok"
         art_quotes = _puts(s3)["market_data/intraday/latest.json"]["quotes"]
@@ -870,7 +873,8 @@ class TestIntraday:
         quotes = {"AAPL": {"last": 202.1, "open": 200.5, "prev_close": 201.5,
                            "session_date": "2026-06-12", "prev_session_date": "2026-06-11"}}
         result = mmd.collect_intraday(
-            bucket="b", s3_client=s3, intraday_source=self._stub(quotes), now=self._RTH
+            bucket="b", s3_client=s3, intraday_source=self._stub(quotes, self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
+            now=self._RTH,
         )
         assert result["status"] == "ok"
         assert "suspect" not in _puts(s3)["market_data/intraday/latest.json"]["quotes"]["AAPL"]
@@ -965,6 +969,58 @@ class TestIntraday:
         )
         assert result["status"] == "ok_dry_run" and result["quotes"] == 2 and result["indices"] == 4
         assert not s3.put_object.called
+
+    def test_empty_fetch_refuses_to_overwrite_latest(self):
+        """The 2026-07-29 live defect: an empty run reported ok and wiped latest.json.
+
+        `yfinance` was absent from the box's venv, so every `_yfinance_*` helper
+        took its `except ImportError -> return {}` branch. The run reported
+        `{'status': 'ok', 'quotes': 0, 'indices': 0, 'fund_proxies': 0}` and
+        PUT a 126-byte artifact with no quotes over the previous good one.
+
+        `indices` comes from a fixed non-empty constant fetched unconditionally,
+        so zero of them can only mean the fetch failed.
+        """
+        s3 = self._s3()
+        result = mmd.collect_intraday(
+            bucket="b", s3_client=s3, intraday_source=lambda syms: {}, now=self._RTH,
+        )
+        assert result["status"] == "error", "an empty fetch must not report ok"
+        assert not s3.put_object.called, (
+            "the empty artifact must never be written -- a fresh as_of_utc over an "
+            "empty body is undetectable downstream, unlike a stale one"
+        )
+
+    def test_the_guard_names_which_fixed_set_came_back_empty(self):
+        """The message has to say what failed, not that something did.
+
+        Both fixed sets are asserted rather than just `indices`, though SPY is in
+        BOTH lists — so a fund-proxy fetch returning nothing implies the index
+        fetch lost SPY too. The second assertion is defence in depth against
+        FUND_PROXY_ETFS diverging from INDEX_PROXY_SYMBOLS later, not a case
+        reachable through a symbol-keyed source today.
+        """
+        s3 = self._s3()
+        result = mmd.collect_intraday(
+            bucket="b", s3_client=s3, intraday_source=lambda syms: {}, now=self._RTH,
+        )
+        assert "indices" in result["error"] and "fund_proxies" in result["error"]
+
+    def test_empty_held_universe_is_still_a_normal_run(self):
+        """`quotes` IS legitimately empty — a new account holds nothing.
+
+        The guard must not fire here, or it converts a supported state into a
+        permanent failure. This is the line between the assertion and a
+        heuristic on volume.
+        """
+        s3 = self._s3(universe={"holdings": []})
+        result = mmd.collect_intraday(
+            bucket="b", s3_client=s3,
+            intraday_source=self._stub(self._INDEX_QUOTES, self._FUND_PROXY_QUOTES),
+            now=self._RTH,
+        )
+        assert result["status"] == "ok" and result["quotes"] == 0
+        assert s3.put_object.called
 
 
 class TestEafeUniverse:


### PR DESCRIPTION
Found live 2026-07-29 on the dashboard box. metron-intraday.timer fires every
5 minutes; `yfinance` and `pandas` are absent from the venv its ExecStart
names, so every `_yfinance_*` helper took its
`except ImportError -> return {}` branch, logged a warning, and the run
reported:

  intraday done: {'status': 'ok', 'universe': 8, 'quotes': 0, 'indices': 0,
                  'fund_proxies': 0}

while PUTting a 126-byte artifact containing no quotes over the previous good
market_data/intraday/latest.json. A producer replaced live data with nothing
and called it success. Every one of those ImportError branches is marked
`# pragma: no cover - yfinance/pandas are prod deps` — precisely the
assumption that broke.

TWO FIXES, ONE CLASS.

1. collect_intraday refuses to write when a FIXED symbol set comes back
   empty. `indices` (INDEX_PROXY_SYMBOLS) and `fund_proxies`
   (FUND_PROXY_ETFS) are constants fetched unconditionally, so zero of them
   can only mean the fetch failed — unlike `quotes`, which is legitimately
   empty for an account holding nothing. That asymmetry makes this an
   assertion rather than a heuristic on volume, and a test pins the
   empty-universe case as a NORMAL run so the guard cannot creep into it.

   It refuses BEFORE the write. A consumer reading a stale `as_of_utc` can
   tell the feed is old; one reading a fresh timestamp over an empty body
   cannot tell anything is wrong.

2. install-metron-intraday.sh preflights the interpreter before
   `systemctl enable --now`. It previously copied units and enabled the timer
   without ever checking that the venv could import what the collector needs.
   Enabling a unit is a claim that it works; the claim is now tested at
   install time, where a human is watching, instead of discovered at run time
   in a background job.

   The remedy text names the real constraint: requirements.txt pins
   numpy>=2.4.6, which needs Python 3.11+, and the box venv is 3.9 — so it
   must be REBUILT, not patched with older wheels. A message saying "install
   pandas" would send the next reader down a path that cannot work.

Four existing intraday tests stubbed only held-symbol quotes, leaving both
fixed sets empty — a state production cannot reach, since the index proxies
are fetched unconditionally. They now stub the proxy sets too; their suspect-
flagging assertions are unchanged.

NOT fixed here, and deliberately: the box's venv itself. Rebuilding it on a
newer interpreter changes an environment daily-news also runs from, and adds
a pandas/numpy footprint to a 5-minute job on the shared host — that is a
shared-application-host §4 question, not a collector change. The timer is
disabled on the box in the meantime and the decision is tracked separately.
With this merged the same condition is loud instead of silent, which is what
made disabling it the safe interim.

Test plan: `pytest tests/test_metron_market_data.py
tests/test_install_metron_intraday_preflight.py` — 66 passed. Full
`pytest tests/` — 3851 passed, 5 failed; all five fail identically on the
unmodified base (3 pipeline-status-registry, 2 ssm-log-capture) and are
untouched by this diff.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)