### PR TITLE
[P0/mid] feat(overseer): cut alert-drain over to the unified execution artifact (G16 step 2)

### DIFF
--- a/infrastructure/lambdas/alert-drain-dispatcher/index.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/index.py
@@ -140,8 +140,27 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str, str]:
 
 def _bootstrap_command(run_id: str, is_drill: str, model: str = "") -> str:
     """The async SSM RunShellScript body: fetch PAT, clone config, exec the
-    alert_drain_spot_bootstrap.sh entrypoint. Prelude failure shuts the box
-    down (mirrors the sibling dispatchers' prelude fail() trap exactly).
+    UNIFIED overseer_spot_bootstrap.sh with ``--playbook alert-drain``.
+    Prelude failure shuts the box down (mirrors the sibling dispatchers'
+    prelude fail() trap exactly).
+
+    Cutover, alpha-engine-config-I5284 / EPIC I4992 step 2. alert-drain is
+    first because it is the simplest agent playbook and runs 4x daily, which
+    is the fastest real evidence available — NOT because it is broken. The
+    EPIC's original rationale ("already at 100% failure, nothing to regress")
+    expired when config-I4996 restored it; it has since completed 12
+    consecutive runs. So this is a cutover of a WORKING component and carries
+    a revert lever accordingly: restoring the two lines below to
+    ``infrastructure/alert_drain_spot_bootstrap.sh --run-id … --is-drill …``
+    returns to the legacy path, which stays on disk until a real run proves
+    the unified one.
+
+    ``run_id`` and ``is_drill`` are EXPORTED rather than passed as flags: the
+    unified bootstrap reads ``DRAIN_RUN_ID`` / ``DRAIN_IS_DRILL`` from the
+    environment (per-playbook identity is registry data, not argv) and
+    forwards unrecognised argv to the run script. Passing them as flags would
+    leave both unset — the run script would invent a ``<ts>-adhoc`` run id and,
+    worse, read the drill flag as false and drain the real queue.
 
     ``model`` (config-I3293) is the registry-declared agent model injected by
     the overseer router; exported as DRAIN_MODEL for the bootstrap's runuser
@@ -165,8 +184,9 @@ git clone --depth 1 --branch {DRAIN_CONFIG_BRANCH} \
   "https://x-access-token:${{PAT}}@github.com/{DRAIN_CONFIG_REPO}.git" \
   /home/ec2-user/alpha-engine-config || fail "clone failed"
 cd /home/ec2-user/alpha-engine-config
-exec bash infrastructure/alert_drain_spot_bootstrap.sh \
-  --run-id "{run_id}" --is-drill "{is_drill}"
+export DRAIN_RUN_ID="{run_id}"
+export DRAIN_IS_DRILL="{is_drill}"
+exec bash infrastructure/overseer_spot_bootstrap.sh --playbook alert-drain
 """
 
 

--- a/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
@@ -115,13 +115,38 @@ class TestVerdicts:
 
 
 class TestBootstrapCommand:
-    def test_command_targets_alert_drain_bootstrap_with_run_id(self, index_mod):
+    def test_command_targets_the_unified_artifact_with_the_playbook_name(self, index_mod):
         index, sd = index_mod
         index.handler({"is_drill": "false"}, None)
         cmd = sd.send_async_command.call_args.args[1]
-        assert "infrastructure/alert_drain_spot_bootstrap.sh" in cmd
-        assert "--run-id" in cmd and "--is-drill" in cmd
+        assert "infrastructure/overseer_spot_bootstrap.sh" in cmd
+        assert "--playbook alert-drain" in cmd
         assert index.DRAIN_GH_PAT_SSM in cmd
+        # The legacy path must be gone, not merely unreferenced — a command
+        # that execs both, or the old one, is the cutover silently not
+        # happening.
+        assert "alert_drain_spot_bootstrap.sh" not in cmd
+
+    def test_run_identity_is_exported_not_passed_as_flags(self, index_mod):
+        """The unified bootstrap reads DRAIN_RUN_ID / DRAIN_IS_DRILL from the
+        ENVIRONMENT and forwards unrecognised argv to the run script. Passing
+        them as flags leaves both unset: the run script invents a `<ts>-adhoc`
+        run id (breaking dispatch-ledger correlation) and reads the drill flag
+        as false — so a drill would drain the real queue."""
+        index, sd = index_mod
+        index.handler({"is_drill": "true"}, None)
+        cmd = sd.send_async_command.call_args.args[1]
+        assert 'export DRAIN_IS_DRILL="true"' in cmd
+        assert "export DRAIN_RUN_ID=" in cmd
+        assert "--run-id" not in cmd and "--is-drill" not in cmd
+
+    def test_drill_run_id_keeps_its_prefix_through_the_export(self, index_mod):
+        """Drill isolation rides on the run id prefix (completion-marker and
+        ledger keys derive from it), so it must survive the argv -> env move."""
+        index, sd = index_mod
+        index.handler({"is_drill": "true"}, None)
+        cmd = sd.send_async_command.call_args.args[1]
+        assert 'export DRAIN_RUN_ID="drill-' in cmd
 
 
 def test_model_threaded_into_bootstrap_export():


### PR DESCRIPTION
## What

EPIC `alpha-engine-config-I4992` step 2, on Brian's 2026-07-29 approval. The `alert-drain` dispatcher now execs `infrastructure/overseer_spot_bootstrap.sh --playbook alert-drain` instead of `alert_drain_spot_bootstrap.sh`.

## Merge order — this is second

**`alpha-engine-config-PR5522` merges first.** The dispatcher clones `alpha-engine-config`'s `main` at run time, so the unified artifact has to be correct *there* before anything points at it. PR5522 fixes the defect that no per-playbook env crossed the `runuser` boundary — without it this cutover produces a drain that runs with an empty environment.

## Two corrections to the EPIC's plan

**1. The rationale expired.** *"Cut alert-drain first — it is already at 100% failure, so there is no working behavior to regress"* stopped being true when `config-I4996` restored the drain. It has since completed **12 consecutive runs, mean 8.1 min**. The four apparently-missed runs that suggested otherwise were false findings from the liveness probe reading the wrong timestamp field (`nousergon-data-PR1131`).

alert-drain is still the right first cutover — simplest agent playbook, 4×/day, the fastest real evidence available — but on that basis, not on "nothing to regress". This is a cutover of a **working** component and carries a revert lever accordingly: restoring two lines returns to the legacy path, which stays on disk until a real run proves the unified one.

**2. Run identity is exported, not passed as flags.** The unified bootstrap reads `DRAIN_RUN_ID` / `DRAIN_IS_DRILL` from the **environment** — per-playbook identity is registry data, not argv — and forwards unrecognised argv straight to the run script. Passing them as flags would leave both unset:

- the run script invents a `<ts>-adhoc` run id, so the drain ledger stops correlating with the dispatch ledger;
- the drill flag reads as `false`, so **a drill would drain the real queue**.

Rendered command for a drill, from the actual function:

```
export DRAIN_RUN_ID="drill-2026-07-29T1800Z"
export DRAIN_IS_DRILL="true"
exec bash infrastructure/overseer_spot_bootstrap.sh --playbook alert-drain
```

## Verification plan — overseer-policy invariant 14

> *"A plane change is not shipped until it has been observed working live … verified against a real (non-drill) run, or an explicitly-scheduled next run is named as its verification with an owner and a deadline."*

1. **On-demand drill** immediately after deploy — `{"is_drill": "true"}`. `alert-drain` carries `supports_drill: true`, drill-prefixed run ids, drill-vs-real isolation on the completion marker, and `drill_concurrent_skip` as a declared benign reason. A drill exercises the whole real path without touching the queue.
2. **Next scheduled real run — 22:00 UTC 2026-07-29** — is the non-drill verification. Owner: this session's follow-up; deadline: that run.
3. **Revert trigger:** the first missed or crashed run reverts to the legacy bootstrap rather than starting a debugging session. At-least-once means a failed run loses nothing — messages stay queued for the next drain — so the cost of a bad cycle is one missed drain, not data.

## Test plan

- `python3 -m pytest infrastructure/lambdas/alert-drain-dispatcher/test_handler.py -q` — **13 passed**.
- Three new tests: the command targets the unified artifact and the legacy path is *absent* (not merely unreferenced); run identity is exported rather than flagged; the `drill-` prefix survives the argv→env move.

Refs #4992

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
