### PR TITLE
fix(metron-intraday): dedicated venv + measured memory ceiling — the policy's own branch

### DIFF
--- a/infrastructure/install-metron-intraday.sh
+++ b/infrastructure/install-metron-intraday.sh
@@ -9,7 +9,36 @@ set -euo pipefail
 REPO_DIR="/home/ec2-user/alpha-engine-data"
 UNIT_DIR="${REPO_DIR}/infrastructure/systemd"
 
-# PREFLIGHT: prove the interpreter can actually run the job BEFORE enabling it.
+# ── Provision the interpreter the unit names ────────────────────────────────
+#
+# The venv is DERIVED FROM THE UNIT FILE, never hardcoded here. Two files naming
+# an interpreter independently is two places to be wrong, and the failure mode is
+# silent: the installer would happily verify a venv the unit does not use. Parse
+# ExecStart instead, so the thing tested is by construction the thing that runs.
+PY=$(sed -n 's|^ExecStart=\([^ ]*\).*|\1|p' "${UNIT_DIR}/metron-intraday.service")
+if [ -z "$PY" ]; then
+    echo "FATAL: could not read an ExecStart interpreter from ${UNIT_DIR}/metron-intraday.service" >&2
+    exit 1
+fi
+VENV_DIR="${PY%/bin/python}"
+
+# `.venv-intraday`, not the shared `.venv`: the shared one is Python 3.9,
+# provisioned for daily-news, and requirements.txt pins numpy>=2.4.6 (Python
+# 3.11+). Rebuilding the shared venv would change the interpreter daily-news runs
+# on; a dedicated one has no blast radius. See the unit file's header.
+if [ ! -x "$PY" ]; then
+    echo "provisioning ${VENV_DIR} (python3.12)…"
+    command -v python3.12 >/dev/null || {
+        echo "FATAL: python3.12 not found. requirements.txt pins numpy>=2.4.6," >&2
+        echo "which needs Python 3.11+. Install it before running this." >&2
+        exit 1
+    }
+    sudo -u ec2-user python3.12 -m venv "$VENV_DIR"
+fi
+sudo -u ec2-user "${VENV_DIR}/bin/pip" install -q --upgrade pip
+sudo -u ec2-user "${VENV_DIR}/bin/pip" install -q -r "${REPO_DIR}/requirements.txt"
+
+# ── PREFLIGHT: prove the interpreter can run the job BEFORE enabling it ──────
 #
 # This script used to copy units and `systemctl enable --now` without ever
 # checking that the venv named in the unit's ExecStart could import what the
@@ -23,13 +52,9 @@ UNIT_DIR="${REPO_DIR}/infrastructure/systemd"
 # without testing it moves the failure from install time -- where a human is
 # watching and the fix is obvious -- to run time, where it is a silent
 # background job. Fail here instead, loudly, with the remedy in the message.
-PY="${REPO_DIR}/.venv/bin/python"
-if [ ! -x "$PY" ]; then
-    echo "FATAL: ${PY} does not exist or is not executable." >&2
-    echo "The unit's ExecStart names this interpreter; installing the timer " >&2
-    echo "without it enables a job that cannot start." >&2
-    exit 1
-fi
+#
+# It runs AFTER the provisioning above rather than instead of it: the install is
+# what makes the claim true, this is what proves it.
 if ! "$PY" - <<'PREFLIGHT'
 import importlib.util, sys
 # The collector's HARD dependencies. Absent, it degrades to empty results
@@ -41,17 +66,17 @@ if missing:
     sys.exit(1)
 PREFLIGHT
 then
-    echo "FATAL: ${PY} cannot import the collector's required modules." >&2
+    echo "FATAL: ${PY} cannot import the collector's required modules even after" >&2
+    echo "installing requirements.txt into ${VENV_DIR}." >&2
     echo "" >&2
-    echo "Provision the venv from this repo's requirements.txt before installing" >&2
-    echo "the timer. NOTE that requirements.txt pins numpy>=2.4.6, which needs" >&2
-    echo "Python 3.11+ -- a 3.9 venv cannot satisfy it and must be rebuilt on a" >&2
-    echo "newer interpreter rather than patched with older wheels." >&2
+    echo "NOTE: requirements.txt pins numpy>=2.4.6, which needs Python 3.11+ --" >&2
+    echo "a 3.9 venv cannot satisfy it and must be rebuilt on a newer" >&2
+    echo "interpreter rather than patched with older wheels." >&2
     echo "" >&2
     echo "Refusing to enable a timer whose job provably cannot produce output." >&2
     exit 1
 fi
-echo "preflight ok: $("$PY" -V 2>&1) can import boto3, pandas, yfinance"
+echo "preflight ok: ${PY} ($("$PY" -V 2>&1)) can import boto3, pandas, yfinance"
 
 cp "${UNIT_DIR}/metron-intraday.service" /etc/systemd/system/metron-intraday.service
 cp "${UNIT_DIR}/metron-intraday.timer" /etc/systemd/system/metron-intraday.timer

--- a/infrastructure/systemd/metron-intraday.service
+++ b/infrastructure/systemd/metron-intraday.service
@@ -6,8 +6,32 @@
 # append --require-heartbeat below to stop fetching when no Metron app is open
 # (multi-tenant cost control; left OFF on this single-tenant owner build so the strip
 # stays warm and never freezes at the morning quote after the app has been idle).
-# Installed on the trading box by infrastructure/install-metron-intraday.sh;
-# S3 write rides the instance role (executor-role already has market_data/*).
+# Installed by infrastructure/install-metron-intraday.sh.
+#
+# INTERPRETER: `.venv-intraday`, NOT `.venv`. The shared `.venv` on the dashboard
+# box is Python 3.9 and was provisioned for daily-news — it has boto3 and
+# feedparser but no pandas and no yfinance. Pointing here at `.venv` produced a
+# timer that ran every 5 minutes for hours with zero successful runs: every
+# `_yfinance_*` helper took its `except ImportError -> return {}` branch and the
+# collector wrote an EMPTY artifact over a good one while reporting ok
+# (2026-07-29). requirements.txt pins numpy>=2.4.6, which needs Python 3.11+, so
+# that venv cannot be repaired by installing wheels into it — and rebuilding it
+# would change the interpreter daily-news runs on. A dedicated venv is the fix
+# with no blast radius: `python3.12 -m venv .venv-intraday` +
+# `pip install -r requirements.txt`, created by the installer.
+#
+# MEMORY: measured, not guessed — shared-application-host-policy.md §4.3 requires
+# a footprint measured BEFORE install. Three real in-session runs on 2026-07-29:
+# peak RSS 184 MB, wall clock 3.2-3.7s, 7 quotes + 4 indices + 2 fund proxies.
+# MemoryHigh=260M is ~1.4x that peak (reclaim window); MemoryMax=350M is ~1.9x
+# (hard stop). Against 1884 MB MemAvailable this is ~10% of the box's headroom,
+# which is why §4's stricter batch-job rule ("a peak larger than the box's
+# steady-state headroom does not belong here at all") does not send it to a spot
+# instance or Lambda. Re-measure before widening the universe it fetches.
+#
+# S3 write rides the instance role: alpha-engine-dashboard-role carries
+# market_data/intraday/* via alpha-engine-dashboard-metron-intraday-putobject
+# (nous-ergon-ops-PR185).
 [Unit]
 Description=Metron intraday quotes producer (alpha-engine-data)
 After=network-online.target
@@ -17,5 +41,7 @@ Wants=network-online.target
 Type=oneshot
 User=ec2-user
 WorkingDirectory=/home/ec2-user/alpha-engine-data
-ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python -m collectors.metron_market_data --only-intraday
+ExecStart=/home/ec2-user/alpha-engine-data/.venv-intraday/bin/python -m collectors.metron_market_data --only-intraday
 TimeoutStartSec=300
+MemoryHigh=260M
+MemoryMax=350M

--- a/tests/test_install_metron_intraday_preflight.py
+++ b/tests/test_install_metron_intraday_preflight.py
@@ -62,16 +62,51 @@ def test_preflight_failure_aborts_rather_than_warning():
     assert m, "a failed preflight must exit non-zero, not print and continue"
 
 
-def test_missing_interpreter_is_its_own_named_failure():
-    assert re.search(r'if \[ ! -x "\$PY" \]', SCRIPT), (
-        "an absent interpreter must be reported distinctly -- it is a different "
-        "remedy from an under-provisioned one"
-    )
-
-
 def test_the_message_names_the_interpreter_constraint():
     """Otherwise the next reader tries to pip-install into the 3.9 venv and fails."""
     assert "numpy>=2.4.6" in SCRIPT and "3.11+" in SCRIPT, (
         "the remedy text must say the venv needs rebuilding on a newer Python, "
         "not that packages need installing"
+    )
+
+
+def test_interpreter_is_derived_from_the_unit_not_hardcoded():
+    """Two files naming an interpreter independently is two places to be wrong.
+
+    If the installer hardcodes a venv path, it can verify one interpreter while
+    the unit runs another — and the mismatch is silent, because a passing
+    preflight looks identical either way. Parsing ExecStart makes the thing
+    tested the thing that runs, by construction.
+    """
+    assert re.search(r"PY=\$\(sed .*ExecStart.*metron-intraday\.service", SCRIPT), (
+        "the interpreter must be parsed out of the unit file's ExecStart"
+    )
+    assert '"${REPO_DIR}/.venv/bin/python"' not in SCRIPT, (
+        "a hardcoded interpreter path can drift from the unit's ExecStart"
+    )
+
+
+def test_the_venv_is_provisioned_before_the_preflight_runs():
+    """The install is what makes the claim true; the preflight proves it.
+
+    A preflight with no provisioning step turns every fresh box into a manual
+    remediation. A provisioning step with no preflight is the original defect.
+    Both, in that order.
+    """
+    install = SCRIPT.index("pip\" install -q -r")
+    check = SCRIPT.index("find_spec")
+    enable = SCRIPT.index("systemctl enable --now metron-intraday.timer")
+    assert install < check < enable, (
+        "order must be provision -> verify -> enable; "
+        f"got install={install} check={check} enable={enable}"
+    )
+
+
+def test_provisioning_requires_a_new_enough_interpreter():
+    """python3.12 explicitly: `python3 -m venv` on this box is 3.9 and cannot
+    satisfy requirements.txt, which is the whole defect."""
+    assert "python3.12 -m venv" in SCRIPT
+    assert re.search(r"command -v python3\.12", SCRIPT), (
+        "a missing python3.12 must be its own named failure, not a confusing "
+        "pip resolution error"
     )

--- a/tests/test_metron_intraday_unit_footprint.py
+++ b/tests/test_metron_intraday_unit_footprint.py
@@ -1,0 +1,89 @@
+"""metron-intraday.service must declare a measured memory ceiling.
+
+`shared-application-host-policy.md` §4.3: a service on the shared dashboard box
+needs a "bounded, declared resource footprint — a steady-state memory ceiling
+measured before install and enforced as a `MemoryMax=` in its unit", and "a
+service whose footprint is unknown is measured first, not installed first."
+
+This unit was installed on 2026-07-29 with no cap of any kind. Its peak was then
+measured across three real runs on the box: **184 MB RSS, 3.2-3.7s wall**. The
+caps here are sized from that (260M soft / 350M hard, ~1.4x / ~1.9x).
+
+The interpreter assertion belongs with the footprint one: both are properties of
+"this unit can actually run here", and the venv it names is the thing that made
+the footprint zero in the first place — an ImportError path returns empty
+results without allocating anything.
+"""
+
+import re
+from pathlib import Path
+
+UNIT = (
+    Path(__file__).parent.parent / "infrastructure" / "systemd" / "metron-intraday.service"
+).read_text()
+
+
+def _directive(name: str) -> str | None:
+    m = re.search(rf"^{name}=(.+)$", UNIT, re.M)
+    return m.group(1).strip() if m else None
+
+
+def test_declares_a_hard_memory_ceiling():
+    """Policy §4.3 — a service with no MemoryMax has an unbounded footprint."""
+    assert _directive("MemoryMax"), (
+        "no MemoryMax=. On the shared box an uncapped unit is exactly what T1-1 "
+        "exists to prevent: per-service caps are the only thing standing between "
+        "one runaway and the other thirteen services."
+    )
+
+
+def test_declares_a_reclaim_window_below_the_hard_cap():
+    """MemoryHigh throttles and reclaims; MemoryMax kills.
+
+    A unit with only a hard cap goes from unconstrained straight to a kill — the
+    same reasoning budget.yaml records for every long-running service here.
+    """
+    high, mx = _directive("MemoryHigh"), _directive("MemoryMax")
+    assert high, "no MemoryHigh= — no reclaim window before the hard cap"
+
+    def mb(v: str) -> int:
+        return int(v.rstrip("MG")) * (1024 if v.endswith("G") else 1)
+
+    assert mb(high) < mb(mx), f"MemoryHigh ({high}) must sit below MemoryMax ({mx})"
+
+
+def test_caps_are_clear_of_the_measured_peak():
+    """Sized ABOVE the measurement, not fitted to it.
+
+    A cap set just above an observed number re-pins the service the moment
+    anything moves — the mistake budget.yaml records twice on this box
+    (config-I5216, config-I5237), where a cap raised to just over a censored
+    reading was throttling again within a day.
+    """
+    measured_peak_mb = 184  # three runs, 2026-07-29, /usr/bin/time -v
+    high = int(_directive("MemoryHigh").rstrip("M"))
+    assert high >= measured_peak_mb * 1.25, (
+        f"MemoryHigh={high}M leaves under 25% over the measured {measured_peak_mb} MB peak"
+    )
+
+
+def test_the_measurement_is_recorded_in_the_unit():
+    """A bare number is unreviewable; the next person needs to know what it came from."""
+    assert "184" in UNIT and re.search(r"peak|RSS", UNIT), (
+        "the unit must record the measurement its caps derive from, so a future "
+        "change knows whether it is re-deriving or guessing"
+    )
+
+
+def test_runs_on_the_dedicated_venv_not_the_shared_one():
+    """The shared .venv is Python 3.9 without pandas/yfinance.
+
+    Pointed there, every fetch helper returns {} and the collector writes an
+    empty artifact over a good one while reporting success — the 2026-07-29
+    defect. This assertion is what stops a future edit "simplifying" the path
+    back to the shared venv.
+    """
+    exec_start = _directive("ExecStart")
+    assert ".venv-intraday/bin/python" in exec_start, (
+        f"ExecStart names {exec_start!r}; the shared .venv cannot run this job"
+    )


### PR DESCRIPTION
Supersedes disabling the timer, which was not a solution the box policy offers.

`shared-application-host-policy.md` §4.3 does not present a fork here. A service
whose footprint is unknown "is measured first, not installed first", and the
measurement then decides mechanically: within the box's steady-state headroom it
stays with a declared MemoryMax; larger than that headroom and §4's batch-job
rule sends it to a spot instance or Lambda. The remedy for an unmeasured job is
to measure it.

MEASURED, on the box, three real runs 2026-07-29:

  peak RSS 184 MB · wall clock 3.2-3.7s · 7 quotes + 4 indices + 2 fund proxies

Against 1884 MB MemAvailable that is ~10% of the box's headroom, so §4's batch
rule does not fire and the job belongs here. Caps sized from the measurement and
recorded in the unit: MemoryHigh=260M (~1.4x, reclaim window), MemoryMax=350M
(~1.9x, hard stop) — clear of the peak rather than fitted to it, which is the
mistake budget.yaml already records twice on this box (config-I5216, I5237),
where a cap raised to just above an observed number re-pinned within a day.

INTERPRETER. ExecStart moves to `.venv-intraday`, a dedicated Python 3.12 venv,
because the shared `.venv` is Python 3.9 provisioned for daily-news and
requirements.txt pins numpy>=2.4.6 (needs 3.11+). Rebuilding the shared venv
would change the interpreter a live product runs on; a dedicated one has no
blast radius. Built and verified in-session: yfinance 1.5.2, pandas 2.3.3,
numpy 2.5.1, 706 MB against 16 GB free.

INSTALLER. Now provisions that venv from requirements.txt, then preflights it,
then enables — in that order. A preflight with no provisioning step turns every
fresh box into a manual remediation; a provisioning step with no preflight is
the original defect. The interpreter is PARSED OUT OF THE UNIT'S ExecStart
rather than hardcoded: two files naming an interpreter independently is two
places to be wrong, and the mismatch is silent because a passing preflight looks
identical either way.

Guards: `tests/test_metron_intraday_unit_footprint.py` pins the cap, the reclaim
window, the clearance over the measured peak, the recorded provenance of the
number, and the venv path. `test_install_metron_intraday_preflight.py` gains the
derived-interpreter and provision-then-verify-then-enable ordering assertions.

Follow-on in crucible-dashboard: budget.yaml gains a `timer_jobs:` section so a
timer's declared cap is drift-checked like a service's instead of living only in
its unit file. Not required for this to be correct; it closes the surrounding
hole (morning-signal.service is currently SUPPRESSED from the budget's orphan
check rather than declared).

Test plan: `pytest tests/` — 3879 passed, 5 failed; all five fail identically on
the unmodified base (3 pipeline-status-registry, 2 ssm-log-capture) and are
untouched by this diff. `bash -n` clean on the installer.

Refs alpha-engine-config-I5503.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)