### PR TITLE
[P1/mid] fix(ci): IAM guard accepts an already-live policy — breaks the guard deadlock (I5309)

### DIFF
--- a/.github/workflows/iam-policy-change-guard.yml
+++ b/.github/workflows/iam-policy-change-guard.yml
@@ -15,6 +15,29 @@ name: IAM Policy Change Guard
 # gated the change on a tracked operator issue. See infrastructure/iam/
 # README.md "Single-writer rule" and _shared/apply_iam_policy.sh.
 #
+# ── Third accepted branch: ALREADY LIVE (alpha-engine-config-I5309) ──────────
+#
+# The two original branches deadlocked against `gate-label-guard`, which fails
+# any PR carrying a `gate:*` label and was ALSO a required check on this repo.
+# Satisfying this guard via `gate:operator` therefore guaranteed the other guard
+# went red, so an IAM-only PR could not merge by any route. Hit live 2026-07-29
+# on nousergon-data-PR1132.
+#
+# The deeper problem is that both original branches accept an INTENTION — "an
+# operator will run --apply-iam later" — rather than a fact. The alpha-engine
+# standing rule actually PREFERS applying the policy in-session BEFORE opening
+# the PR, and that path had no way to satisfy this guard at all: the strictly
+# safer workflow was the one the guard rejected.
+#
+# So the third branch verifies the OUTCOME the other two only promise: read the
+# live inline policy and compare it to the PR's file. If they already match, the
+# change is not inert — it is deployed — and there is nothing left to gate on.
+# This is a fact about the account, not a label anyone can apply by hand.
+#
+# Read-only: the `github-actions-iam-drift-check` role holds iam:GetRolePolicy
+# and NOT iam:PutRolePolicy, so this guard cannot become the fourth IAM-clobber
+# incident. Verification stays strictly weaker than mutation.
+#
 # Usage: required status check on main branch protection.
 
 on:
@@ -26,6 +49,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  id-token: write   # OIDC -> github-actions-iam-drift-check (read-only IAM)
 
 jobs:
   # Job id is the branch-protection CONTEXT. Deliberately specific rather
@@ -40,6 +64,19 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+
+      # Read-only IAM identity — iam:GetRolePolicy without iam:PutRolePolicy.
+      # continue-on-error so an OIDC/STS hiccup degrades the ALREADY-LIVE branch
+      # to unavailable rather than failing the guard outright: the two original
+      # branches still work, so a credentials blip must not block a PR that
+      # satisfies them.
+      - name: Configure AWS credentials (read-only IAM drift-check role)
+        id: aws
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
+          aws-region: us-east-1
 
       - name: Check iam-policy.json changes have deploy.sh or gate:operator
         shell: bash
@@ -92,13 +129,52 @@ jobs:
               continue
             fi
 
-            echo "FAIL: ${POLICY} changed but ${DEPLOY_SCRIPT} was not touched"
-            echo "      and no gate:operator label is set on this PR."
+            # ── Branch 3: ALREADY LIVE (alpha-engine-config-I5309) ──────────
+            # Verify the OUTCOME the other two branches only promise. If the
+            # deployed inline policy already equals this PR's file, the change
+            # is not inert and there is nothing to gate on.
+            #
+            # Both documents are normalised through `jq -S` (recursively
+            # key-sorted, canonical whitespace) before comparison — IAM returns
+            # its own key order and URL-decodes the document, so a raw string
+            # compare would report drift on every PR and make this branch dead
+            # code that always falls through.
+            if [ "${{ steps.aws.outcome }}" = "success" ]; then
+              ROLE_NAME=$(grep -m1 '^ROLE_NAME=' "$DEPLOY_SCRIPT" 2>/dev/null | cut -d'"' -f2)
+              POLICY_NAME=$(grep -m1 '^POLICY_NAME=' "$DEPLOY_SCRIPT" 2>/dev/null | cut -d'"' -f2)
+              if [ -n "$ROLE_NAME" ] && [ -n "$POLICY_NAME" ]; then
+                if aws iam get-role-policy --role-name "$ROLE_NAME" \
+                     --policy-name "$POLICY_NAME" --query PolicyDocument \
+                     --output json > /tmp/live_policy.json 2>/dev/null; then
+                  if jq -S . /tmp/live_policy.json > /tmp/live_norm.json 2>/dev/null \
+                     && jq -S . "$POLICY" > /tmp/repo_norm.json 2>/dev/null \
+                     && diff -q /tmp/live_norm.json /tmp/repo_norm.json >/dev/null 2>&1; then
+                    echo "✓ ${POLICY}: ALREADY LIVE on ${ROLE_NAME}/${POLICY_NAME}"
+                    echo "  (applied in-session before merge — verified against the account,"
+                    echo "   not asserted by a label; nothing left to gate on)"
+                    continue
+                  fi
+                  echo "  ${POLICY}: live policy on ${ROLE_NAME}/${POLICY_NAME} DIFFERS from this PR"
+                else
+                  echo "  ${POLICY}: could not read live policy for ${ROLE_NAME}/${POLICY_NAME}"
+                fi
+              else
+                echo "  ${POLICY}: could not parse ROLE_NAME/POLICY_NAME from ${DEPLOY_SCRIPT}"
+              fi
+            else
+              echo "  ${POLICY}: AWS credentials unavailable — already-live check skipped"
+            fi
+
+            echo "FAIL: ${POLICY} changed but ${DEPLOY_SCRIPT} was not touched,"
+            echo "      no gate:operator label is set, and the policy is not already live."
             echo ""
             echo "      A changed iam-policy.json has NO LIVE EFFECT until an operator"
-            echo "      runs 'deploy.sh --apply-iam' or 'deploy.sh --bootstrap'. Either:"
-            echo "        1) Also modify ${DEPLOY_SCRIPT} (so the operator knows to apply IAM)"
-            echo "        2) Add the 'gate:operator' label with a tracked operator issue"
+            echo "      runs 'deploy.sh --apply-iam' or 'deploy.sh --bootstrap'. Any of:"
+            echo "        1) Apply it now, BEFORE merging (preferred — the standing rule's"
+            echo "           own preference, and this guard then passes on its own):"
+            echo "             bash ${DEPLOY_SCRIPT} --apply-iam"
+            echo "        2) Also modify ${DEPLOY_SCRIPT} (so the operator knows to apply IAM)"
+            echo "        3) Add the 'gate:operator' label with a tracked operator issue"
             FAILED="true"
           done
 

--- a/tests/test_iam_guard_requireable_pair.py
+++ b/tests/test_iam_guard_requireable_pair.py
@@ -92,3 +92,79 @@ def test_both_react_to_label_events():
             f"{path.name} must trigger on labeled/unlabeled so the gate:operator "
             f"escape hatch can actually clear the check"
         )
+
+
+# ── Branch 3: ALREADY LIVE (alpha-engine-config-I5309) ──────────────────────
+#
+# The two original branches deadlocked against `gate-label-guard`, which fails
+# any PR carrying `gate:*` and was also a required check here: satisfying this
+# guard via `gate:operator` guaranteed the other went red, so an IAM-only PR
+# could not merge by any route (hit live on nousergon-data-PR1132).
+#
+# Both original branches also accept an INTENTION ("an operator will apply it
+# later") rather than a fact, and the standing rule's PREFERRED path — apply
+# in-session before opening the PR — could not satisfy the guard at all. The
+# third branch verifies the outcome directly against the account.
+
+_GUARD = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "iam-policy-change-guard.yml"
+
+
+def test_guard_accepts_an_already_live_policy():
+    """Without this branch, the strictly safer workflow (apply first, then open
+    the PR) is the one the guard rejects."""
+    body = _GUARD.read_text()
+    assert "get-role-policy" in body, (
+        "the guard must be able to read the live policy to verify it is applied")
+    assert "ALREADY LIVE" in body
+
+
+def test_already_live_comparison_is_normalised_not_a_raw_string_compare():
+    """IAM returns its own key order and URL-decodes the document, so a raw
+    compare reports drift on every PR — the branch would be dead code that
+    always falls through, which looks identical to working."""
+    body = _GUARD.read_text()
+    assert "jq -S" in body, "both documents must be key-sorted before diffing"
+
+
+def test_guard_uses_a_read_only_iam_identity():
+    """Verification must stay strictly weaker than mutation. The drift-check
+    role holds iam:GetRolePolicy and NOT iam:PutRolePolicy, so this guard
+    cannot become the fifth IAM-clobber incident."""
+    body = _GUARD.read_text()
+    assert "github-actions-iam-drift-check" in body
+    # Assert on INVOCATIONS, not on the presence of a word anywhere in the file.
+    # Three naive versions of this assertion failed while writing it, all the
+    # same way: the header comment mentions `PutRolePolicy` while explaining the
+    # role LACKS it, references `_shared/apply_iam_policy.sh` as documentation,
+    # and the failure message echoes `--apply-iam` as guidance for the operator.
+    # A substring test flags all three — text that says the opposite of the
+    # thing being guarded against.
+    #
+    # So: a mutating token is allowed on a comment or an echo line, and nowhere
+    # else. That is the real invariant — the guard may *talk about* applying IAM,
+    # it may not *do* it.
+    mutating = ("aws iam put-role-policy", "aws iam attach-role-policy",
+                "aws iam delete-role-policy", "apply_iam_policy.sh", "--apply-iam")
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith("echo "):
+            continue
+        for token in mutating:
+            assert token not in stripped, (
+                f"guard must not mutate IAM — {token!r} appears on an executable "
+                f"line: {stripped!r}")
+
+
+def test_aws_credential_step_is_non_fatal():
+    """An OIDC/STS hiccup must degrade the already-live branch to unavailable,
+    never fail a PR that satisfies one of the two original branches."""
+    body = _GUARD.read_text()
+    aws_step = body.split("Configure AWS credentials", 1)[1].split("- name:", 1)[0]
+    assert "continue-on-error: true" in aws_step
+
+
+def test_failure_message_names_the_apply_command():
+    """A guard that blocks without naming the unblocking step makes every hit
+    start with archaeology."""
+    body = _GUARD.read_text()
+    assert "--apply-iam" in body


### PR DESCRIPTION
## The deadlock

`iam-policy-change-guard` requires either a `deploy.sh` touch **or** a `gate:operator` label. `gate-label-guard` fails any PR carrying `gate:*` — and is **also** a required check on this repo.

So satisfying this guard via the label guaranteed the other went red. **An IAM-only PR could not merge by any route.** Hit live 2026-07-29 on `nousergon-data-PR1132`; I only got that PR through by updating a `deploy.sh` header comment that happened to be genuinely stale.

## The deeper problem

Both original branches accept an **intention** — "an operator will run `--apply-iam` later" — rather than a fact. Neither verifies anything.

Meanwhile the alpha-engine standing rule *prefers* applying the policy in-session **before** opening the PR. That path could not satisfy the guard at all. **The strictly safer workflow was the one the guard rejected**, which is backwards.

## The fix

A third accepted branch that verifies the outcome the other two only promise: read the live inline policy, compare it to the PR's file. Equal means the change is not inert — it is deployed — and there is nothing left to gate on. That's a fact about the account, not a label anyone can apply by hand.

- **Normalised comparison.** Both documents go through `jq -S` before diffing. IAM returns its own key order and URL-decodes the document, so a raw string compare reports drift on every PR — the branch would be dead code that always falls through, which is indistinguishable from working.
- **Read-only identity.** `github-actions-iam-drift-check` holds `iam:GetRolePolicy` and **not** `iam:PutRolePolicy`. Verification stays strictly weaker than mutation, so this guard cannot become the fifth IAM-clobber incident.
- **Credential step is `continue-on-error`.** An OIDC/STS hiccup degrades the already-live branch to *unavailable*, never fails a PR that satisfies one of the two original branches.
- **The failure message now names the apply command**, so a hit doesn't start with archaeology.

## Test plan

Verified against the real account before opening, not just in CI:

- `alpha-engine-scheduled-groom-dispatcher-role` / `...-policy`, whose policy I applied in-session earlier today: **matching policy → branch PASSES.**
- Same policy with one added statement: **correctly DIFFERS → falls through to FAIL.** The branch is not a rubber stamp.
- `tests/test_iam_guard_requireable_pair.py` — **10 passed** (5 pre-existing pair-invariant cases, 5 new).
- `test_groom_sf_iam_lambda_grants.py`, `test_groom_dispatcher_engagement_iam_grants.py` — 15 passed together.

The read-only assertion is deliberately **line-aware** rather than a substring test. Three naive versions failed on the guard's own documentation: it mentions `PutRolePolicy` while explaining the role lacks it, references `apply_iam_policy.sh` as a doc pointer, and echoes `--apply-iam` as operator guidance. The invariant is that the guard may *talk about* applying IAM, not *do* it.

Unrelated `tests/` collection errors (`ModuleNotFoundError: yfinance`) are pre-existing and reproduce on unmodified `main`.

## What this does NOT close

`alpha-engine-config-I5309` stays open. `gate-label-guard` is still a **required** check on `crucible-backtester`, `crucible-research` and `nousergon-data`, contradicting the 2026-07-24 ruling that made it advisory fleet-wide. That half is a branch-protection change needing an operator.

This removes the deadlock's bite regardless: an IAM PR whose policy is already applied now merges with **no gate label at all**, so the two guards no longer have to be satisfied simultaneously.

Refs nousergon/alpha-engine-config#5309

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
