### PR TITLE
feat(weekly-sf): start the weekly pipeline after EVERY post-close, not a weekly cron

### DIFF
--- a/.github/workflows/deploy-eod-success-friday-shell-trigger.yml
+++ b/.github/workflows/deploy-eod-success-friday-shell-trigger.yml
@@ -1,0 +1,89 @@
+name: Deploy eod-success-friday-shell-trigger
+
+# Auto-deploy the alpha-engine-eod-success-friday-shell-trigger Lambda CODE on
+# merge to main. Mirrors deploy-data-spot-dispatcher.yml — same gap, same fix:
+# a merged code change must not sit inert until someone remembers to run
+# deploy.sh by hand.
+#
+# This workflow exists because of exactly that failure mode, twice over:
+#   * 2026-07-08: an invoking SF def auto-deployed while its Lambda did not.
+#   * 2026-07-28: crucible-research-PR529 added a CloudWatch alarm to a shell
+#     script, merged, and was recorded as shipping the alarm. The script was
+#     never run, so the alarm never existed — verified absent 2026-07-29.
+# This Lambda now starts the FULL weekly pipeline after every post-close SF
+# (Brian ruling 2026-07-29), so a merged-but-undeployed change here means the
+# daily cadence silently does not happen.
+#
+# Separation of concerns: CODE only (deploy.sh with NO flag — the flagless run
+# is code-only). --bootstrap ADDS IAM-role creation and stays operator-only:
+# the github-actions-lambda-deploy OIDC role deliberately has no
+# iam:CreateRole / iam:PutRolePolicy, a fleet-wide policy after 4 IAM-clobber
+# incidents in 2 months.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-*.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/eod-success-friday-shell-trigger/**'
+      - '.github/workflows/deploy-eod-success-friday-shell-trigger.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-eod-success-friday-shell-trigger-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy eod-success-friday-shell-trigger Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy eod-success-friday-shell-trigger (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-eod-success-friday-shell-trigger \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-eod-success-friday-shell-trigger.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -225,9 +225,22 @@ Resources:
       # self-selects the single correct firing and Succeed-skips the rest.
       # Replaces the hand-built one-shot shift used for the 2026-07-03
       # holiday week.
-      Description: Thu-Sat 09:00 UTC — weekly pipeline fires day after last trading session (WeeklyRunDayGate self-selects; config#1824)
+      #
+      # DISABLED 2026-07-29 (Brian ruling): the weekly pipeline is now started
+      # by alpha-engine-eod-success-friday-shell-trigger on EVERY successful
+      # post-close SF, not by this cron. Leaving it ENABLED would double-run:
+      # Friday's post-close starts a full weekly Friday evening, then this
+      # cron starts a second full weekly Saturday 09:00 UTC against the same
+      # data. The mutex does not collapse them — its key is
+      # {state-machine}#{pipeline_role}#{run_date} and the two firings carry
+      # different run_dates (Fri vs Sat).
+      #
+      # Kept as a DISABLED resource rather than deleted so the schedule, its
+      # rationale and the config#1824 gate history stay one edit away if the
+      # event-driven trigger is ever reverted.
+      Description: 'RETIRED 2026-07-29 — superseded by the post-close-SF event trigger (see eod-success-friday-shell-trigger). Kept disabled for fast revert.'
       ScheduleExpression: 'cron(0 9 ? * THU-SAT *)'
-      State: ENABLED
+      State: DISABLED
       Targets:
         # SINGLE TARGET PER RULE. EventBridge dispatches the cron event
         # to every target on a rule; a duplicate target ID fans the

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
@@ -1,43 +1,58 @@
-"""alpha-engine-eod-success-friday-shell-trigger — kick the weekly shell-run.
+"""alpha-engine-eod-success-friday-shell-trigger — start the weekly SF after EOD.
 
-Subscribes to EventBridge ``Step Functions Execution Status Change`` events,
-filtered to ``ne-postclose-trading-pipeline`` + ``SUCCEEDED``. On every EOD-SF
-success the handler computes the trading_day this execution closed against
-and, if that trading_day is a Friday, starts the Saturday Step Function in
-shell-run mode (``shell_run: true``) so the spot instances boot for real
-while the workload paths short-circuit.
+NAME IS HISTORICAL. This Lambda no longer fires a Friday-only shell run; it
+starts a FULL weekly-freshness execution after EVERY successful post-close SF.
+The physical function/rule names are kept because the CloudFormation template
+references them and a rename is a separate, reversible change (tracked
+separately) — not because the name is right.
 
-Replaces the prior fixed-time EventBridge cron (``alpha-engine-friday-shell-run``,
-cron(45 20 ? * FRI *) = 13:45 PT Friday), which fired unconditionally and
-raced the EOD SF's ``StopTradingInstance`` state when EOD ran long. The
-event-driven design has three guarantees the cron lacked:
+WHY DAILY (Brian ruling 2026-07-29): the weekly pipeline was failing, and every
+failure waited a week to resurface. Defects were deferred to "next Saturday",
+Saturday failed, and the cycle restarted — 15+ hand-driven reruns across
+2026-07-26/27 to nurse one weekly through. Running the full pipeline after
+every trading day converts a weekly guessing game into a daily signal: it
+breaks today, it gets fixed today. This is the same reasoning weekly-sf-policy
+already states about rehearsal paths ("a change that would make Saturday robust
+waits for a Saturday to validate, while every Saturday runs on the un-hardened
+path") — applied to the pipeline itself rather than to changes against it.
 
-  1. **No fire on Friday-EOD failure.** If Friday's EOD never reaches
-     SUCCEEDED, this Lambda never invokes, so the shell-run does not chase
-     a broken upstream.
-  2. **Late re-runs work for free.** If Friday's EOD is fixed and re-run
-     later that day (or Saturday morning processing Friday's data), the
-     handler still sees a SUCCEEDED transition and trading_day is still
-     Friday — the shell-run starts at the fix-time, not on a stale clock.
-  3. **trading_day-bound, not wall-clock.** trading_day is derived via
-     ``nousergon_lib.trading_calendar.last_closed_trading_day`` from
-     ``detail.stopDate`` (epoch ms UTC), so a Friday EOD re-run that
-     succeeds at 02:00 UTC Saturday (= Friday evening PT) correctly stamps
-     trading_day=Fri and fires. Pure ``datetime.now()`` would have read
-     Saturday and skipped.
+Mechanism: subscribes to EventBridge ``Step Functions Execution Status Change``
+filtered to ``ne-postclose-trading-pipeline`` + ``SUCCEEDED``, derives the
+trading_day the execution closed against, and starts
+``ne-weekly-freshness-pipeline``. Three properties carried over from the
+Friday-shell design, all still load-bearing:
 
-Fail-loud semantics (per the ``feedback_wire_orphaned_producer_must_fail_loud``
-discipline — this Lambda is a new producer of shell-run starts):
+  1. **No fire on EOD failure.** If EOD never reaches SUCCEEDED this never
+     invokes, so the weekly does not chase a broken upstream.
+  2. **Late re-runs work for free.** A fixed-and-rerun EOD still produces a
+     SUCCEEDED transition with the same trading_day.
+  3. **trading_day-bound, not wall-clock.** Derived via
+     ``last_closed_trading_day`` from ``detail.stopDate``, so an EOD that
+     succeeds at 02:00 UTC (= previous evening ET) stamps the right day.
 
-  * Missing ``detail.stopDate`` → raises. SUCCEEDED events without a stop
-    timestamp are an upstream contract violation, not a silent skip.
-  * trading_calendar lookup failure → raises (lib bug surfaces fast).
-  * boto3 ``states:StartExecution`` failure → raises (do not silently
-    fail to launch the shell run; the EventBridge → Lambda retry policy
-    will retry, and CW alarms on Lambda errors will page).
+Run shape — three deliberate input choices:
 
-Non-Friday trading_day is the intended skip path and returns ``{"fired": False}``
-with a structured log line; this is NOT a swallow.
+  * ``shell_run`` is NOT set. The 2026-07-26/27 failures were WORKLOAD
+    failures (skip-parity, skip-backtester, bt-eval), which a shell run
+    short-circuits past and would never have caught. A dry pass that cannot
+    see the breakage is not a signal.
+  * ``skip_weekly_run_day_gate: true`` — the sanctioned operator bypass
+    (config#1617 skip-flag charter). Without it ``CheckWeeklyRunDayGate``
+    routes to ``WeeklyRunDayGate``, which is true only when yesterday was the
+    week's LAST trading session, so Mon-Thu firings would be rejected at
+    state one and this whole change would be a no-op.
+  * ``pipeline_role: "weekly"`` — keeps the existing mutex semantics. The
+    mutex key is ``{state-machine}#{pipeline_role}#{run_date}``, so two
+    firings for the same trading day (an EOD rerun, an EventBridge retry)
+    collapse to one execution instead of racing.
+
+Fail-loud (this is a producer of weekly-SF starts):
+
+  * Missing ``detail.stopDate`` → raises (upstream contract violation).
+  * trading_calendar lookup failure → raises.
+  * ``states:StartExecution`` failure → raises, so the EventBridge retry
+    policy engages and the Lambda Errors alarm pages. A silent failure here
+    means no weekly ran and nothing said so.
 """
 
 from __future__ import annotations
@@ -67,9 +82,6 @@ SNS_TOPIC_ARN = os.environ.get(
     f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts",
 )
 
-FRIDAY_WEEKDAY = 4  # date.weekday(): Mon=0, Fri=4
-
-
 def _derive_trading_day_utc_ms(stop_date_ms: int):
     """trading_day = NYSE last-closed session at the EventBridge stopDate moment.
 
@@ -82,39 +94,31 @@ def _derive_trading_day_utc_ms(stop_date_ms: int):
     return last_closed_trading_day(dt_utc)
 
 
-def _build_shell_run_input() -> str:
-    # NO ec2_instance_id (config#2248, root-cause SPOF fix): this used to
-    # hardcode the always-on dashboard box id (despite the misleading
-    # TRADING_EC2_INSTANCE_ID name — it was never the trading box) into the
-    # SAME field all 14 of the weekly SF's downstream sendCommand/Lambda
-    # states key off. The SF's own CheckSpotDispatchNeeded/
-    # DispatchWeeklyFreshnessSpot states (step_function.json, right after
-    # AcquireMutex) now populate $.ec2_instance_id from a fresh ephemeral
-    # spot on every execution this Lambda starts — omitting the field here
-    # lets that dispatch path engage for the Friday shell-run exactly like
-    # it does for the real Saturday cron.
+def _build_run_input() -> str:
+    """Full weekly-freshness run input.
+
+    NO ec2_instance_id (config#2248): the SF's own CheckSpotDispatchNeeded/
+    DispatchWeeklyFreshnessSpot states populate $.ec2_instance_id from a fresh
+    ephemeral spot per execution. Hardcoding it here reintroduced a SPOF.
+
+    NO shell_run: this is a real run. See the module docstring — the failures
+    this exists to surface are workload failures a shell run skips past.
+    """
     return json.dumps(
         {
             "sns_topic_arn": SNS_TOPIC_ARN,
-            "shell_run": True,
-            # pipeline_role="shell-run" (Option-D taxonomy): tags this
-            # execution so the dashboard page-25 / Slack / CLI role filters
-            # distinguish the Friday-PM dry-pass from the canonical weekly
-            # run. The retired cron rule (alpha-engine-friday-shell-run,
-            # ROADMAP L4055) carried this tag; restored here so the
-            # event-driven path is a faithful replacement, not a surface
-            # regression. shell_run=true stays the load-bearing input.
-            "pipeline_role": "shell-run",
+            "pipeline_role": "weekly",
+            "skip_weekly_run_day_gate": True,
         }
     )
 
 
-def _start_saturday_shell_run(execution_name: str) -> str:
+def _start_weekly_run(execution_name: str) -> str:
     client = boto3.client("stepfunctions", region_name=REGION)
     resp = client.start_execution(
         stateMachineArn=SATURDAY_SF_ARN,
         name=execution_name,
-        input=_build_shell_run_input(),
+        input=_build_run_input(),
     )
     return resp["executionArn"]
 
@@ -144,29 +148,21 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         )
 
     trading_day = _derive_trading_day_utc_ms(stop_date_ms)
-    if trading_day.weekday() != FRIDAY_WEEKDAY:
-        logger.info(
-            "EOD SUCCEEDED trading_day=%s (weekday=%d) — not Friday, no shell run",
-            trading_day.isoformat(),
-            trading_day.weekday(),
-        )
-        return {
-            "fired": False,
-            "reason": "not_friday",
-            "trading_day": trading_day.isoformat(),
-        }
 
+    # No weekday filter. Every successful post-close starts a full weekly run
+    # (Brian ruling 2026-07-29) — see the module docstring for why the old
+    # Friday-only shell-run shape was the problem rather than the design.
     eod_name = detail.get("name", "unknown")
-    sat_name = f"friday-shell-{trading_day.isoformat()}-{eod_name}"[:80]
-    sat_arn = _start_saturday_shell_run(sat_name)
+    run_name = f"eod-daily-{trading_day.isoformat()}-{eod_name}"[:80]
+    run_arn = _start_weekly_run(run_name)
     logger.info(
-        "Friday EOD SUCCEEDED (trading_day=%s) → started saturday shell run: %s",
+        "EOD SUCCEEDED (trading_day=%s) -> started weekly-freshness run: %s",
         trading_day.isoformat(),
-        sat_arn,
+        run_arn,
     )
     return {
         "fired": True,
         "trading_day": trading_day.isoformat(),
-        "saturday_execution_arn": sat_arn,
-        "saturday_execution_name": sat_name,
+        "weekly_execution_arn": run_arn,
+        "weekly_execution_name": run_name,
     }

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/test_handler.py
@@ -88,9 +88,15 @@ def _patch_sfn(start_execution_return: dict | None = None, side_effect=None):
     return patch("index.boto3.client", return_value=fake_client), fake_client
 
 
-def test_friday_eod_success_fires_saturday_sf_with_shell_run_input():
-    """Friday EOD SUCCEEDED → StartExecution on saturday SF with shell_run:true."""
-    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)  # Friday
+def test_eod_success_fires_full_weekly_run_not_a_shell_run():
+    """EOD SUCCEEDED -> StartExecution on the weekly SF as a REAL run.
+
+    shell_run must NOT be set. The 2026-07-26/27 failures this daily cadence
+    exists to surface were workload failures (skip-parity, skip-backtester,
+    bt-eval); a shell run short-circuits past exactly those, so a dry pass
+    would run green while the pipeline stayed broken.
+    """
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)
     sfn_patch, fake_client = _patch_sfn()
     with sfn_patch:
         result = index.handler(_event(), None)
@@ -98,25 +104,53 @@ def test_friday_eod_success_fires_saturday_sf_with_shell_run_input():
     fake_client.start_execution.assert_called_once()
     call_kwargs = fake_client.start_execution.call_args.kwargs
     assert call_kwargs["stateMachineArn"] == SATURDAY_ARN
-    assert call_kwargs["name"].startswith("friday-shell-2026-05-22-")
+    assert call_kwargs["name"].startswith("eod-daily-2026-05-22-")
 
     import json as _json
 
     input_dict = _json.loads(call_kwargs["input"])
-    assert input_dict["shell_run"] is True
-    # config#2248: ec2_instance_id is intentionally ABSENT — the weekly SF's
-    # own CheckSpotDispatchNeeded/DispatchWeeklyFreshnessSpot states populate
-    # it from a fresh ephemeral spot; this Lambda no longer hardcodes the
-    # always-on dashboard box id.
+    assert "shell_run" not in input_dict
+    # config#2248: ec2_instance_id intentionally ABSENT — the SF dispatches a
+    # fresh ephemeral spot per execution.
     assert "ec2_instance_id" not in input_dict
     assert input_dict["sns_topic_arn"] == index.SNS_TOPIC_ARN
-    # pipeline_role="shell-run" surface-contract tag (parity with the retired
-    # cron rule per ROADMAP L4055) so page-25 role filters bucket the dry-pass.
-    assert input_dict["pipeline_role"] == "shell-run"
-
     assert result["fired"] is True
     assert result["trading_day"] == "2026-05-22"
-    assert result["saturday_execution_arn"].endswith(":friday-shell-test")
+
+
+def test_run_day_gate_is_explicitly_bypassed():
+    """Without skip_weekly_run_day_gate the whole change is inert.
+
+    CheckWeeklyRunDayGate routes to WeeklyRunDayGate whenever
+    pipeline_role == 'weekly' AND skip_weekly_run_day_gate is false, and that
+    gate is true only when yesterday was the week's LAST trading session. So a
+    Mon-Thu firing without this flag is rejected at state one and no weekly
+    runs -- silently, since the skip path is a clean Succeed.
+    """
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 20)  # a Wednesday
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch:
+        index.handler(_event(), None)
+
+    import json as _json
+
+    input_dict = _json.loads(fake_client.start_execution.call_args.kwargs["input"])
+    assert input_dict["skip_weekly_run_day_gate"] is True
+
+
+def test_pipeline_role_weekly_preserves_mutex_dedupe():
+    """mutex key is {state-machine}#{pipeline_role}#{run_date}, so keeping
+    pipeline_role='weekly' collapses two firings for the same trading day (an
+    EOD rerun, an EventBridge retry) into one execution instead of racing."""
+    _tc_mod.last_closed_trading_day.return_value = date(2026, 5, 22)
+    sfn_patch, fake_client = _patch_sfn()
+    with sfn_patch:
+        index.handler(_event(), None)
+
+    import json as _json
+
+    input_dict = _json.loads(fake_client.start_execution.call_args.kwargs["input"])
+    assert input_dict["pipeline_role"] == "weekly"
 
 
 @pytest.mark.parametrize(
@@ -128,15 +162,15 @@ def test_friday_eod_success_fires_saturday_sf_with_shell_run_input():
         (date(2026, 5, 21), "Thu"),
     ],
 )
-def test_non_friday_eod_success_does_not_fire(trading_day, weekday_label):
+def test_every_weekday_fires_now(trading_day, weekday_label):
+    """The Friday-only filter is gone: every trading day starts a weekly run."""
     _tc_mod.last_closed_trading_day.return_value = trading_day
     sfn_patch, fake_client = _patch_sfn()
     with sfn_patch:
         result = index.handler(_event(), None)
 
-    fake_client.start_execution.assert_not_called()
-    assert result["fired"] is False
-    assert result["reason"] == "not_friday"
+    fake_client.start_execution.assert_called_once()
+    assert result["fired"] is True
     assert result["trading_day"] == trading_day.isoformat()
 
 

--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -251,30 +251,27 @@ do_shell() {
 
 do_full() {
   echo "== OFF-CYCLE FULL WEEKLY RUN =="
-  local sat_date
-  sat_date=$(next_saturday_utc)
-  echo "Upcoming Saturday cron fire to SUPPRESS: ${sat_date} 09:00 UTC"
-  echo "Auto re-enable scheduled for:           ${sat_date} 09:30 UTC"
+  # Saturday-cron suppression REMOVED 2026-07-29 (Brian ruling). The
+  # alpha-engine-saturday cron is retired -- the weekly pipeline is now started
+  # by the post-close-SF event trigger on every trading day, and the cron is
+  # State: DISABLED in CloudFormation.
+  #
+  # This block used to: schedule a re-enable, disable the cron, run, then
+  # re-enable. Left in place it would RE-ENABLE A RETIRED CRON as a side effect
+  # of an unrelated off-cycle run -- silently restoring the double-run this
+  # migration removed (post-close starts a full weekly Friday evening, cron
+  # starts a second one Saturday 09:00 against the same data, and the mutex
+  # does not collapse them because the run_dates differ).
+  #
+  # There is nothing left to suppress: an off-cycle run and the event-driven
+  # trigger are deduped by the SF's own mutex
+  # ({state-machine}#{pipeline_role}#{run_date}).
+  echo "Saturday cron is retired — nothing to suppress."
   echo ""
-  echo "[1/3] ensure re-enable infra + schedule (BEFORE disabling cron)"
-  ensure_reenable_role
-  schedule_reenable "${sat_date}"
-  echo ""
-  echo "[2/3] disable Saturday cron"
-  run aws events disable-rule --name "${SATURDAY_RULE}" --region "${REGION}"
-  if ! $DRY_RUN; then
-    local st
-    st=$(rule_state)
-    [[ "$st" == "DISABLED" ]] \
-      || { echo "ERROR: ${SATURDAY_RULE} state is '${st}', expected DISABLED — aborting BEFORE starting run" >&2; exit 1; }
-    echo "  ✓ ${SATURDAY_RULE} is DISABLED"
-  fi
-  echo ""
-  echo "[3/3] start full weekly execution"
+  echo "[1/1] start full weekly execution"
   start_execution "offcycle-full-$(utc_stamp)" "$(full_input)"
   echo ""
-  echo "Done. Saturday cron will auto re-enable at ${sat_date} 09:30 UTC."
-  echo "To restore manually at any time: bash $0 restore"
+  echo "Done."
 }
 
 do_restore() {

--- a/tests/test_run_weekly_offcycle.py
+++ b/tests/test_run_weekly_offcycle.py
@@ -113,39 +113,50 @@ def test_full_input_matches_live_cron_target() -> None:
     assert _dry_run_input("full")["pipeline_role"] == "weekly"
 
 
-def test_shell_input_matches_lambda() -> None:
-    """The ``shell`` builder must reproduce the friday-shell Lambda input."""
-    lam = _LAMBDA.read_text()
-    assert '"shell_run": True' in lam or '"shell_run": true' in lam.lower()
-    assert '"pipeline_role"' in lam and "shell-run" in lam
+def test_shell_builder_still_produces_a_shell_run() -> None:
+    """The ``shell`` builder remains the shell-run producer.
+
+    It used to be pinned against the eod-success Lambda, which sent the same
+    input. That coupling is GONE as of 2026-07-29: the Lambda now starts a FULL
+    weekly run after every post-close (Brian ruling), so it sends neither
+    shell_run nor pipeline_role="shell-run". This script is now the only
+    shell-run producer, so the assertion is on the script alone.
+    """
     obj = _dry_run_input("shell")
     assert obj["shell_run"] is True
     assert obj["pipeline_role"] == "shell-run"
+
+
+def test_eod_lambda_no_longer_starts_shell_runs() -> None:
+    """Guards the divergence above rather than leaving it implicit.
+
+    If the Lambda is reverted to shell_run mode, the daily cadence silently
+    becomes a daily DRY pass -- green executions skipping the very workload
+    stages whose failures the daily cadence exists to surface.
+    """
+    lam = _LAMBDA.read_text()
+    assert '"shell_run": True' not in lam
+    assert '"shell-run"' not in lam
+    assert '"skip_weekly_run_day_gate": True' in lam
+
+
+def test_full_run_does_not_touch_the_retired_saturday_cron(runner_text: str) -> None:
+    """do_full must NOT disable/re-enable alpha-engine-saturday.
+
+    The cron is retired (State: DISABLED in CloudFormation) now that the
+    post-close-SF event trigger starts the weekly every trading day. The old
+    suppress-then-restore dance would RE-ENABLE it as a side effect of an
+    unrelated off-cycle run, silently restoring the double-run this migration
+    removed -- and the SF mutex would not catch it, because the two firings
+    carry different run_dates.
+    """
+    body = _builder_body(runner_text, "do_full")
+    assert "disable-rule" not in body
+    assert "enable-rule" not in body
+    assert "schedule_reenable" not in body
 
 
 def test_full_targets_correct_state_machine(runner_text: str) -> None:
     assert "ne-weekly-freshness-pipeline" in runner_text
 
 
-def test_full_suppresses_then_starts_safely(runner_text: str) -> None:
-    """Fail-loud ordering: schedule re-enable, THEN disable cron, THEN start."""
-    body = _builder_body(runner_text, "do_full")
-    i_schedule = body.index("schedule_reenable")
-    i_disable = body.index("disable-rule")
-    i_start = body.index("start_execution")
-    assert i_schedule < i_disable < i_start, (
-        "do_full must schedule the auto re-enable before disabling the cron, "
-        "and disable the cron before starting the execution"
-    )
-
-
-def test_reenable_role_scoped_to_saturday_rule(runner_text: str) -> None:
-    """The scheduler role grants events:EnableRule on the Saturday rule ONLY."""
-    assert "events:EnableRule" in runner_text
-    assert "scheduler.amazonaws.com" in runner_text
-    # The inline policy Resource is the single Saturday rule ARN.
-    assert "rule/${SATURDAY_RULE}" in runner_text or "SATURDAY_RULE_ARN" in runner_text
-
-
-def test_reenable_schedule_self_deletes(runner_text: str) -> None:
-    assert "--action-after-completion DELETE" in runner_text


### PR DESCRIPTION
## What

The weekly pipeline now starts after **every** successful post-close SF, instead of a Thu–Sat cron. Brian ruling, 2026-07-29:

> *"we are not fixing problems, deferring until the weekly sf runs, the weekly sf fails miserably, and then we are back where we started. no more. we fix it when it breaks."*

## Why

Every weekly failure waited a week to resurface. The evidence is the execution history: the last 20 executions of `ne-weekly-freshness-pipeline` contain **zero scheduled runs** — they are all `rerun-2026-07-25-*` and `offcycle-shell-*`, 15+ hand-driven attempts across 07-26 and 07-27 nursing a single weekly through, most `FAILED` or `ABORTED`.

Running the full pipeline after every trading day converts that into a daily signal. It is the same argument `weekly-sf-policy.md` already makes about rehearsal paths — *"a change that would make Saturday robust waits for a Saturday to validate, while every Saturday runs on the un-hardened path"* — applied to the pipeline itself rather than to changes against it.

## No Step Function change required

`CheckWeeklyRunDayGate` applies the run-day gate **only** when `pipeline_role == "weekly"` AND `skip_weekly_run_day_gate == false`. The bypass is an existing, documented input (config#1617 skip-flag charter), so this is a one-Lambda change rather than a pipeline edit.

## Three input choices, each load-bearing

| Input | Why |
|---|---|
| `shell_run` **not set** | The 07-26/27 failures were WORKLOAD failures (`skip-parity`, `skip-backtester`, `bt-eval`) — precisely what a shell run short-circuits past. A dry pass would run green while the pipeline stayed broken. |
| `skip_weekly_run_day_gate: true` | Without it, Mon–Thu firings hit `WeeklyRunDayGate` (true only when yesterday was the week's LAST trading session) and Succeed-skip at state one. The change would be **silently inert** — a clean green execution that did nothing. |
| `pipeline_role: "weekly"` | Mutex key is `{state-machine}#{pipeline_role}#{run_date}`, so an EOD rerun or an EventBridge retry for the same trading day collapses to one execution instead of racing. |

## The Saturday cron is disabled in the same change

Left enabled it would **double-run**: Friday's post-close starts a full weekly Friday evening, then `alpha-engine-saturday` starts a second full weekly at Saturday 09:00 UTC against the same data. The mutex does **not** collapse these — the two firings carry different `run_date`s (Fri vs Sat), so the key differs.

Kept as `State: DISABLED` rather than deleted, so the schedule and its config#1824 THU-SAT gate rationale are one edit away if the event-driven trigger is ever reverted.

## Properties carried over from the Friday-shell design

All three still hold and are worth not losing:

1. **No fire on EOD failure** — if EOD never reaches SUCCEEDED, this never invokes, so the weekly does not chase a broken upstream.
2. **Late reruns work for free** — a fixed-and-rerun EOD still produces a SUCCEEDED transition with the same `trading_day`.
3. **trading_day-bound, not wall-clock** — derived via `last_closed_trading_day` from `detail.stopDate`, so an EOD succeeding at 02:00 UTC (= previous evening ET) stamps the right day.

## Known misnomer, stated rather than hidden

The physical function and rule names still say `eod-success-friday-shell-trigger`. It is now neither Friday-only nor a shell run. Renaming means renaming a resource the CloudFormation template references, which is a separate reversible change — so the module docstring says the name is historical **explicitly**, rather than letting it quietly mislead the next reader.

## Testing

- `pytest infrastructure/lambdas/eod-success-friday-shell-trigger/` → **15 passed**.
- New tests pin the three things that would silently break this: `shell_run` absent, `skip_weekly_run_day_gate` present (without it the whole change is a no-op), `pipeline_role` preserved for mutex dedupe. Plus a parametrised Mon–Thu case asserting every weekday now fires, replacing the old "does not fire" assertions.
- `infrastructure/lambdas/_shared/test_terminate_coverage.py` → OK.
- CloudFormation template parses.

## Consequence you should know about

Champion promotion has **no hysteresis and no cooldown** — I2518 retired both on 2026-07-14 in favour of winner-take-all. This is inert today because config-I5195 means the leaderboard scores nothing (`n_dates: 0` for four straight weeks), so there is no promotion signal at all. But once I5195 is fixed, daily runs plus winner-take-all plus no cooldown means the champion can flip daily on a 21-day metric that barely moves day to day. Filed separately rather than left to surface as a surprise.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
