### PR TITLE
fix(ci): deploy pipeline-watchdog on merge — PR#1148's fix never went live (config-I5606)

### DIFF
--- a/.github/workflows/deploy-pipeline-watchdog.yml
+++ b/.github/workflows/deploy-pipeline-watchdog.yml
@@ -1,0 +1,96 @@
+name: Deploy pipeline-watchdog
+
+# Auto-deploy the alpha-engine-pipeline-watchdog Lambda CODE on merge to main.
+#
+# Why this exists (alpha-engine-config#5606): nousergon-data#1148 fixed a
+# DISARMED watchdog — its Saturday check counted executions on
+# ne-weekly-freshness-pipeline with no pipeline_role filter, so the ~5 daily
+# exercise runs (alpha-engine-config#5489) satisfied its 7-day window
+# unconditionally and it could never alert again. That fix merged and did NOT
+# go live: this Lambda had no deploy workflow, `deploy.yml` covers only the
+# Phase-2 image paths, and its own deploy.sh header says "operator-deployed
+# only". A merged fix to a detector that never reaches production leaves the
+# detector broken while the tracker says it is fixed — the exact shape
+# deploy-freshness-monitor.yml was created to close on 2026-06-26 ("a
+# registry/lib fix sat inert").
+#
+# Mirrors deploy-freshness-monitor.yml deliberately rather than inventing a
+# second shape. Code only: deploy.sh with no flags is its update-code path.
+# --bootstrap (SNS topic, EventBridge rule, IAM) stays operator-run, so this
+# workflow cannot create or rewire infrastructure — only ship code to a
+# function that already exists.
+#
+# IAM: no change needed. github-actions-lambda-deploy's LambdaUpdate statement
+# already grants GetFunction / GetFunctionConfiguration / UpdateFunctionCode /
+# UpdateFunctionConfiguration on arn:aws:lambda:us-east-1:711398986525:
+# function:alpha-engine-*, which covers alpha-engine-pipeline-watchdog. Those
+# four are every AWS call the no-flag deploy.sh path makes (verified against
+# nous-ergon-ops/infrastructure/iam/github-actions-lambda-deploy/ on
+# 2026-07-29).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/pipeline-watchdog/**'
+      - '.github/workflows/deploy-pipeline-watchdog.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-pipeline-watchdog-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy pipeline-watchdog Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy pipeline-watchdog (code-only)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/pipeline-watchdog/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-pipeline-watchdog \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-pipeline-watchdog.yml
+
+  # Alert (Telegram) on genuine post-merge failure on the default branch.
+  # Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit


### PR DESCRIPTION
## nousergon-data#1148 merged green and never went live

#1148 fixed a **disarmed** watchdog: the Saturday check counted executions on
`ne-weekly-freshness-pipeline` with no `pipeline_role` filter, so the ~5 daily
exercise runs (alpha-engine-config-I5489) satisfied its 7-day window
unconditionally — it could never alert again, no matter how dead the Saturday
cron was.

That PR merged. **The running Lambda did not change.** `pipeline-watchdog` has
no deploy workflow, `deploy.yml`'s `paths:` filter covers only the Phase-2
image, and its own `deploy.sh` header says "operator-deployed only".

A merged fix to a detector that never reaches production is worse than no fix:
the tracker records the gap as closed while the detector stays broken.

`deploy-freshness-monitor.yml` was created 2026-06-26 for this exact shape —
its header records that "a registry/lib fix sat inert." This mirrors it rather
than inventing a second form.

## Scope of what this workflow can do

**Code only.** `deploy.sh` with no flags is its update-code path.
`--bootstrap` (SNS topic, EventBridge rule, IAM) stays operator-run, so this
workflow cannot create or rewire infrastructure — only ship code to a function
that already exists. That keeps the OIDC blast radius narrow, which is the
stated reason several of these Lambdas were operator-only to begin with.

**No IAM change needed.** `github-actions-lambda-deploy`'s `LambdaUpdate`
statement already grants `GetFunction` / `GetFunctionConfiguration` /
`UpdateFunctionCode` / `UpdateFunctionConfiguration` on
`arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*`, which covers
`alpha-engine-pipeline-watchdog`. Those four are **every** AWS call the no-flag
`deploy.sh` path makes — verified line by line against
`nous-ergon-ops/infrastructure/iam/github-actions-lambda-deploy/`.

## The class, measured — not fixed here

```
lambda directories                       37
auto-deployed on merge to main           20
NOT auto-deployed (operator-run only)    17   ← all have a deploy.sh
```

At least seven are detectors or alert transports:
`alert-drain-liveness-probe`, `ci-watch-liveness-probe`, `eod-backstop`,
`saturday-integrity-sentinel`, `substrate-health-gate`,
`sweep-artifact-monitor`, `sf-telegram-notifier`.

Filed as **alpha-engine-config-I5606**, with the deliverable: classify all 17
(auto-deploy, or explicitly operator-deployed with the reason recorded), then
pin the split with a test so a new lambda is a conscious decision rather than
silence. Classify first — a pin over an unreviewed split just freezes the
current accident.

This PR deliberately fixes the **one** instance whose fix is sitting inert
right now.

## SOTA alignment

This is the SOTA form for the instance — mirroring the existing in-repo
pattern rather than adding a parallel mechanism (`policy-shared-code`). **Delta
on the class:** the remaining 17 stay operator-deployed until
alpha-engine-config-I5606 is worked, so "merged ≠ deployed" is still true for
them tonight.

## Testing

`3912 passed, 8 skipped` (full `tests/` suite). Workflow YAML parses; the
`paths:`, action SHA pins, OIDC role and `notify-main-failure` wiring are
copied verbatim from `deploy-freshness-monitor.yml`.

Verification after merge is automatic and visible: the workflow's own "Report
deployed version" step prints the function's `LastModified` + `CodeSha256`.

Closes #5606 partially — the instance; the class stays open on that issue.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
