### PR TITLE
feat(rag): the weekly pipeline reads the corpus, it no longer fills it

### DIFF
--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -320,6 +320,69 @@ def collect(
             type(e).__name__, e,
         )
 
+    # ── RAG corpus ingest — ONE FETCH, TWO WRITE TARGETS ─────────────────────
+    #
+    # config-I5702 / rag-corpus-policy.md §2.3. These are the SAME articles the
+    # weekly RAGIngestion step used to re-fetch: this job already pulls them
+    # every weekday for the same decision set, and used to write them only to
+    # the analytics prefix above. The weekly sweep then paid Polygon a second
+    # time for an overlapping window.
+    #
+    # That split was by WRITE TARGET, not by fetch — "waste dressed as
+    # separation of concerns" (§2.3). Splitting the writes is right; splitting
+    # the fetch was not. Ingesting here is what makes the corpus WARM, which is
+    # what lets Saturday read instead of fetch.
+    #
+    # FAIL-SOFT, same acceptable category as the two writes above: (a) failure
+    # mode swallowed — the corpus ingest fails (pgvector down, Voyage
+    # throttled); (b) the primary deliverable, the daily aggregate, already
+    # landed and the morning brief is unaffected; (c) recording surface — a
+    # WARN here, ``rag_status`` on the returned dict, and — load-bearing — the
+    # watermarks are NOT advanced, so the gap stays outstanding and the next
+    # run (daily or weekly) picks it up rather than it becoming a silent hole.
+    rag_status = "ok"
+    rag_stats: dict[str, int] = {}
+    if dry_run:
+        rag_status = "skipped_dry_run"
+        logger.info("[daily_news] dry-run — skipping RAG corpus ingest")
+    else:
+        try:
+            from rag.pipelines._watermarks import WatermarkStore
+            from rag.pipelines.ingest_news import ingest_articles
+            from rag.pipelines.run_news_pipeline import (
+                NEWS_DOC_TYPE,
+                NEWS_SOURCE,
+                _load_ticker_sector_map,
+            )
+
+            rag_stats = ingest_articles(
+                articles=articles,
+                filed_date=agg_date,
+                ticker_to_sector=_load_ticker_sector_map(universe),
+            )
+            logger.info("[daily_news] RAG corpus ingest: %s", rag_stats)
+
+            if rag_stats.get("n_failures"):
+                rag_status = "partial"
+                logger.warning(
+                    "[daily_news] %d RAG ingest failure(s) — watermarks NOT "
+                    "advanced; the gap stays outstanding for the next run",
+                    rag_stats["n_failures"],
+                )
+            else:
+                wm = WatermarkStore(NEWS_SOURCE, bucket=bucket, s3_client=s3_client)
+                for t in universe:
+                    wm.advance(t, NEWS_DOC_TYPE)
+                wm.flush()
+        except Exception as e:  # noqa: BLE001 — fail-soft secondary (see above)
+            rag_status = "error"
+            logger.warning(
+                "[daily_news] RAG corpus ingest FAILED (%s: %s) — daily "
+                "aggregate already landed; watermarks NOT advanced so the "
+                "weekly path still sees the gap",
+                type(e).__name__, e,
+            )
+
     # ── Podcast-ready combined digest (portfolio + macro + tech) ─────────────
     # Combines the per-ticker article records ALREADY in memory (portfolio
     # section) with curated macro/tech RSS headlines (topic_news) into a single
@@ -418,6 +481,15 @@ def collect(
         "digest_key": digest_key,
         "digest_total": digest_total,
         "topic_status": topic_status,
+        # config-I5702: corpus-ingest outcome. `rag_status != "ok"` means the
+        # corpus did NOT warm this run, so Saturday's freshness assertion will
+        # see the gap — which is the intended, visible degradation rather than
+        # a silent one.
+        "rag_status": rag_status,
+        "rag_documents_ingested": int(rag_stats.get("n_documents_ingested", 0)),
+        "rag_documents_skipped_exists": int(
+            rag_stats.get("n_documents_skipped_exists", 0)
+        ),
     }
 
 

--- a/rag/pipelines/assert_corpus_freshness.py
+++ b/rag/pipelines/assert_corpus_freshness.py
@@ -1,0 +1,205 @@
+"""Corpus freshness assertion — the weekly pipeline READS, it does not FILL.
+
+``rag-corpus-policy.md`` §2.3: *ingestion runs on its own cadence, in its own
+process, off every decision pipeline's critical path. A decision pipeline may
+VERIFY corpus freshness; it may never FILL the corpus.*
+
+WHAT THIS REPLACES
+------------------
+``run_weekly_ingestion.sh`` step 5 used to run the full news fetch inline —
+the ~3.1h Polygon sweep that dominated ``RAGIngestion``'s 6h budget and was
+the stage in flight when the 2026-07-29 weekly pipeline died
+(``alpha-engine-config-I5695``). ``collectors/daily_news.py`` now ingests the
+same articles into the corpus at the point it already fetches them every
+weekday (config-I5702), so by Saturday the corpus is warm and this step only
+has to answer one question:
+
+    is the corpus current enough for this run?
+
+THE NON-NEGOTIABLE
+------------------
+**This never fetches.** A stale corpus sets a visible degraded flag and the
+run proceeds on what is held. It does not stop to fill. §2.3's own warning:
+*"an assertion that blocks or backfills inline reintroduces the exact coupling
+this removes."* If the assertion fails, something OFF the critical path
+repairs the corpus — that is the whole point.
+
+Exit code is ALWAYS 0. Staleness is a degraded flag, not a pipeline failure:
+a retrieval-time miss degrades one answer, while failing the weekly pipeline
+over stale news degrades the belief set the whole trading week depends on.
+The degraded state is reported by the artifact and the log, never by a
+non-zero exit — which is exactly the honest-degradation shape
+``weekly-sf-policy.md`` §2.3 requires.
+
+THE SOURCE OF TRUTH
+-------------------
+The watermark store (config-I5701) already records the last CONFIRMED ingest
+per ``(ticker, doc_type)``. Freshness is therefore *derived from what actually
+landed*, not from an artifact's mtime — an artifact can be rewritten by a run
+that ingested nothing, but a watermark only advances on a confirmed store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+FRESHNESS_KEY = "rag/corpus_freshness/latest.json"
+
+# Weekdays only, so a Saturday run legitimately sees Friday-close data. The
+# weekly SF fires one day after the week's last trading session, so ~2 days of
+# slack covers the normal case; anything beyond that means the daily job has
+# actually stopped.
+DEFAULT_MAX_AGE_HOURS = 60
+
+# Below this share of the scope covered, the corpus is not merely stale, it is
+# patchy — a distinct condition worth naming separately in the flag.
+DEFAULT_MIN_COVERAGE = 0.80
+
+
+def assess(
+    *,
+    bucket: str,
+    run_date: str | None = None,
+    max_age_hours: int = DEFAULT_MAX_AGE_HOURS,
+    min_coverage: float = DEFAULT_MIN_COVERAGE,
+    s3_client=None,
+    now: datetime | None = None,
+) -> dict:
+    """Return the freshness verdict for the current decision set.
+
+    Never raises on a stale or patchy corpus — that is the reported outcome,
+    not an error. Only an unresolvable SCOPE raises, because without a scope
+    there is no question to answer.
+    """
+    from rag.pipelines._rag_scope import load_rag_scope
+    from rag.pipelines._watermarks import (
+        WatermarkStore,
+        _utcnow,
+    )
+    from rag.pipelines.run_news_pipeline import NEWS_DOC_TYPE, NEWS_SOURCE
+
+    now = now or _utcnow()
+    scope = load_rag_scope(bucket=bucket, s3_client=s3_client, run_date=run_date)
+    tickers = scope["tickers"]
+
+    store = WatermarkStore(NEWS_SOURCE, bucket=bucket, s3_client=s3_client)
+    fresh, stale, missing = [], [], []
+    oldest_age_h = 0.0
+    for t in tickers:
+        mark = store.get(t, NEWS_DOC_TYPE)
+        if mark is None:
+            missing.append(t)
+            continue
+        age_h = (now - mark).total_seconds() / 3600.0
+        oldest_age_h = max(oldest_age_h, age_h)
+        (fresh if age_h <= max_age_hours else stale).append(t)
+
+    covered = len(fresh)
+    coverage = (covered / len(tickers)) if tickers else 0.0
+
+    reasons = []
+    if missing:
+        reasons.append(f"{len(missing)} ticker(s) never ingested")
+    if stale:
+        reasons.append(
+            f"{len(stale)} ticker(s) older than {max_age_hours}h "
+            f"(oldest {oldest_age_h:.1f}h)"
+        )
+    if coverage < min_coverage:
+        reasons.append(
+            f"coverage {coverage:.0%} below the {min_coverage:.0%} floor"
+        )
+
+    return {
+        "schema_version": 1,
+        "checked_at": now.isoformat().replace("+00:00", "Z"),
+        "run_date": scope.get("run_date"),
+        "source": NEWS_SOURCE,
+        "doc_type": NEWS_DOC_TYPE,
+        "scope": len(tickers),
+        "fresh": covered,
+        "stale": len(stale),
+        "missing": len(missing),
+        "coverage": round(coverage, 4),
+        "oldest_age_hours": round(oldest_age_h, 2),
+        "max_age_hours": max_age_hours,
+        "min_coverage": min_coverage,
+        "degraded": bool(reasons),
+        "degraded_reasons": reasons,
+    }
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--bucket", default="alpha-engine-research")
+    p.add_argument("--run-date", default=None)
+    p.add_argument("--max-age-hours", type=int, default=DEFAULT_MAX_AGE_HOURS)
+    p.add_argument("--min-coverage", type=float, default=DEFAULT_MIN_COVERAGE)
+    p.add_argument(
+        "--no-write", action="store_true",
+        help="Assess and log without publishing the freshness artifact.",
+    )
+    args = p.parse_args()
+
+    try:
+        verdict = assess(
+            bucket=args.bucket,
+            run_date=args.run_date,
+            max_age_hours=args.max_age_hours,
+            min_coverage=args.min_coverage,
+        )
+    except Exception as e:
+        # An unresolvable scope is a real upstream failure, but it must still
+        # not take the weekly pipeline down over NEWS. Report maximally
+        # degraded and exit 0 — the scope failure itself is already loud in
+        # every other stage that needs it.
+        logger.error("[corpus_freshness] assessment FAILED (%s: %s) — "
+                     "reporting DEGRADED and continuing", type(e).__name__, e)
+        print(json.dumps({"degraded": True, "degraded_reasons": [str(e)],
+                          "schema_version": 1}))
+        return 0
+
+    if verdict["degraded"]:
+        logger.warning(
+            "[corpus_freshness] DEGRADED — %s | scope=%d fresh=%d stale=%d "
+            "missing=%d coverage=%.0f%%",
+            "; ".join(verdict["degraded_reasons"]), verdict["scope"],
+            verdict["fresh"], verdict["stale"], verdict["missing"],
+            verdict["coverage"] * 100,
+        )
+    else:
+        logger.info(
+            "[corpus_freshness] OK — scope=%d fresh=%d coverage=%.0f%% "
+            "oldest=%.1fh",
+            verdict["scope"], verdict["fresh"], verdict["coverage"] * 100,
+            verdict["oldest_age_hours"],
+        )
+
+    if not args.no_write:
+        try:
+            import boto3
+            boto3.client("s3").put_object(
+                Bucket=args.bucket, Key=FRESHNESS_KEY,
+                Body=json.dumps(verdict).encode(),
+                ContentType="application/json",
+            )
+            logger.info("[corpus_freshness] published s3://%s/%s",
+                        args.bucket, FRESHNESS_KEY)
+        except Exception as e:
+            logger.warning("[corpus_freshness] publish failed (%s) — the "
+                           "verdict is still on stdout and in this log", e)
+
+    # ALWAYS 0. See the module docstring: staleness is a degraded flag, never a
+    # pipeline failure.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rag/pipelines/run_weekly_ingestion.sh
+++ b/rag/pipelines/run_weekly_ingestion.sh
@@ -7,8 +7,9 @@
 #   2.  8-K material events — from signals universe, 1y lookback
 #   3.  Earnings transcripts (Finnhub) — from signals universe, latest 8
 #   4.  Thesis history — from research.db (incremental)
-#   5.  News pipeline (Wave 1 Gate A) — fetch via aggregator → NLP →
-#       news_aggregates parquet + RAG corpus ingest
+#   5.  News corpus freshness ASSERTION (config-I5702) — verifies the
+#       corpus is warm; NEVER fetches. The daily job ingests news at fetch
+#       time now, so Saturday reads instead of fetching.
 #   6.  Form 4 insider transactions (Wave 1 Gate A) — EDGAR → parquet
 #   7.  13F institutional ownership (config#2428) — reads the
 #       inst_ownership derived table (produced separately by
@@ -145,13 +146,28 @@ else
     echo "==> LM dict bootstrap: $LM_DICT_PATH already present, skipping download"
 fi
 
-# ── Step 5: News pipeline (Wave 1 Gate A) ────────────────────────────────────
-# Fetch news via NewsAggregator (Polygon + GDELT + Yahoo RSS) → NLP pipeline
-# (Loughran-McDonald sentiment + Anthropic-Haiku event extraction) → write
-# structured aggregates parquet → ingest article narrative to RAG corpus.
+# ── Step 5: News corpus freshness ASSERTION (config-I5702) ───────────────────
+# This step used to run the full news fetch inline — the ~3.1h Polygon sweep
+# that dominated RAGIngestion's 6h budget and was the stage in flight when the
+# 2026-07-29 weekly pipeline died (alpha-engine-config-I5695).
+#
+# collectors/daily_news.py now ingests the SAME articles into the corpus at the
+# point it already fetches them every weekday, so by Saturday the corpus is
+# warm and this step only VERIFIES it. rag-corpus-policy.md §2.3: a decision
+# pipeline may verify corpus freshness; it may never fill the corpus.
+#
+# NEVER FETCHES, ALWAYS EXITS 0. A stale corpus sets a visible degraded flag
+# and the run proceeds on what is held — an assertion that blocked or
+# backfilled inline would reintroduce the exact coupling this removes. Failing
+# the weekly pipeline over stale news would degrade the belief set the whole
+# trading week depends on, which is strictly worse than one stale answer.
+#
+# The verdict is derived from the WATERMARK store (config-I5701) — what
+# actually landed — not from an artifact's mtime, which a run that ingested
+# nothing can still refresh.
 echo ""
-echo "==> Step 5/10: News pipeline..."
-$PYTHON_BIN -m rag.pipelines.run_news_pipeline --from-signals --hours 168 $DRY_RUN
+echo "==> Step 5/10: News corpus freshness assertion (no fetch)..."
+$PYTHON_BIN -m rag.pipelines.assert_corpus_freshness ${DRY_RUN:+--no-write}
 
 # ── Step 6: Form 4 insider transactions (Wave 1 Gate A) ──────────────────────
 # EDGAR Form 4 → structured per-(filed_date) parquet at

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -126,6 +126,14 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # Health for this mechanism is skipped_at_watermark in
     # run_news_pipeline's RUN STATS line (policy §5), not artifact age.
     "rag/pipelines/_watermarks.py": 1,
+    # rag/corpus_freshness/latest.json — the freshness verdict published by
+    # the assertion that REPLACED the inline weekly news fetch
+    # (alpha-engine-config-I5702). Registered with a real SLA row in
+    # ARTIFACT_REGISTRY.yaml (artifact_id: rag_corpus_freshness), NOT
+    # grandfathered like its sibling rag/watermarks/ prefix: a stale verdict
+    # means the assertion itself stopped running — nobody is checking whether
+    # the corpus is warm — and nothing else surfaces that.
+    "rag/pipelines/assert_corpus_freshness.py": 1,
     "builders/migrate_universe_vwap.py": 1,
     "builders/prune_delisted_tickers.py": 1,
     # builders/backfill_delisted_audit/{date}-{HHMMSSZ}.json — per-run audit record for

--- a/tests/test_corpus_freshness_assertion.py
+++ b/tests/test_corpus_freshness_assertion.py
@@ -1,0 +1,147 @@
+"""Corpus freshness assertion (config-I5702).
+
+``rag-corpus-policy.md`` §2.3: a decision pipeline may VERIFY corpus freshness;
+it may never FILL the corpus. The two assertions that matter most here are the
+negative ones — that this module **never fetches** and **never exits non-zero**
+— because either would reintroduce the coupling that let a corpus-filling step
+take the weekly pipeline down (`alpha-engine-config-I5695`).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from rag.pipelines import assert_corpus_freshness as acf
+
+NOW = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+SCOPE = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+
+
+def _s3(marks: dict):
+    s3 = MagicMock()
+    payloads = {
+        "universe_membership/latest.json": {
+            "run_date": "2026-07-31",
+            "cuts": {"scanner_candidates": {"size": len(SCOPE), "tickers": SCOPE}},
+        },
+        "metron/holdings_universe.json": {"as_of": "2026-07-31", "tickers": []},
+        "rag/watermarks/v1/news.json": {"marks": marks},
+    }
+
+    def _get(Bucket, Key):
+        if Key not in payloads:
+            raise RuntimeError(f"NoSuchKey {Key}")
+        return {"Body": BytesIO(json.dumps(payloads[Key]).encode())}
+
+    s3.get_object.side_effect = _get
+    return s3
+
+
+def _marks(**ages_h) -> dict:
+    return {
+        f"{t}|news_article": (NOW - timedelta(hours=h)).isoformat().replace("+00:00", "Z")
+        for t, h in ages_h.items()
+    }
+
+
+# ── the two non-negotiables ──────────────────────────────────────────────
+
+
+def test_assess_never_issues_a_vendor_fetch():
+    # The whole point: verification reads state, it does not fill. If this
+    # module ever grows a fetch, the coupling that killed the 2026-07-29 run
+    # is back.
+    with patch("collectors.news_aggregator_async.AsyncNewsAggregator") as agg, \
+         patch("collectors.news_sources.polygon.PolygonNewsAdapter") as poly:
+        acf.assess(bucket="b", s3_client=_s3(_marks(**{t: 1 for t in SCOPE})), now=NOW)
+    agg.assert_not_called()
+    poly.assert_not_called()
+
+
+def test_main_exits_zero_even_when_maximally_degraded(monkeypatch, capsys):
+    # Staleness is a degraded FLAG, never a pipeline failure. Failing the
+    # weekly SF over stale news degrades the belief set the whole trading week
+    # depends on — strictly worse than one stale answer.
+    monkeypatch.setattr(
+        acf, "assess",
+        lambda **kw: {"degraded": True, "degraded_reasons": ["everything is stale"],
+                      "scope": 5, "fresh": 0, "stale": 5, "missing": 0,
+                      "coverage": 0.0, "oldest_age_hours": 999.0},
+    )
+    monkeypatch.setattr("sys.argv", ["assert_corpus_freshness", "--no-write"])
+    assert acf.main() == 0
+
+
+def test_main_exits_zero_when_the_assessment_itself_raises(monkeypatch, capsys):
+    # An unresolvable scope is a real upstream failure, but every other stage
+    # that needs the scope is already loud about it. This step must not be the
+    # one that takes the pipeline down over NEWS.
+    def _boom(**kw):
+        raise RuntimeError("membership artifact missing")
+
+    monkeypatch.setattr(acf, "assess", _boom)
+    monkeypatch.setattr("sys.argv", ["assert_corpus_freshness", "--no-write"])
+    assert acf.main() == 0
+    assert json.loads(capsys.readouterr().out)["degraded"] is True
+
+
+# ── verdict semantics ────────────────────────────────────────────────────
+
+
+def test_warm_corpus_is_not_degraded():
+    v = acf.assess(
+        bucket="b", s3_client=_s3(_marks(**{t: 6 for t in SCOPE})), now=NOW,
+    )
+    assert v["degraded"] is False
+    assert v["fresh"] == 5 and v["coverage"] == 1.0
+
+
+def test_saturday_tolerates_friday_close_data():
+    # The weekly SF fires one day after the week's last trading session, and
+    # the daily job is weekdays-only — so a ~2-day-old corpus on a Saturday is
+    # the NORMAL state, not a degradation. Written as a test so the tolerance
+    # is explicit rather than an accident of the default.
+    v = acf.assess(
+        bucket="b", s3_client=_s3(_marks(**{t: 48 for t in SCOPE})), now=NOW,
+    )
+    assert v["degraded"] is False
+
+
+def test_stale_beyond_the_window_is_degraded_and_says_why():
+    v = acf.assess(
+        bucket="b", s3_client=_s3(_marks(**{t: 200 for t in SCOPE})), now=NOW,
+    )
+    assert v["degraded"] is True
+    assert v["stale"] == 5
+    assert any("older than" in r for r in v["degraded_reasons"])
+
+
+def test_never_ingested_tickers_are_reported_separately_from_stale():
+    # "Missing" and "stale" are different conditions with different causes —
+    # a new ticker the daily job has not reached yet vs a daily job that has
+    # stopped. Collapsing them would hide which one is happening.
+    marks = _marks(AAA=1, BBB=1)
+    v = acf.assess(bucket="b", s3_client=_s3(marks), now=NOW)
+    assert v["missing"] == 3 and v["stale"] == 0
+    assert any("never ingested" in r for r in v["degraded_reasons"])
+
+
+def test_patchy_coverage_is_flagged_even_when_what_exists_is_fresh():
+    # 2 of 5 fresh, 3 never ingested: everything present is current, but the
+    # corpus is patchy — a distinct condition worth naming.
+    v = acf.assess(bucket="b", s3_client=_s3(_marks(AAA=1, BBB=1)), now=NOW)
+    assert v["coverage"] == 0.4
+    assert any("below the" in r for r in v["degraded_reasons"])
+
+
+def test_verdict_carries_the_thresholds_it_was_judged_against():
+    # A verdict a reader cannot re-derive is not auditable.
+    v = acf.assess(
+        bucket="b", s3_client=_s3(_marks(**{t: 1 for t in SCOPE})), now=NOW,
+        max_age_hours=12, min_coverage=0.5,
+    )
+    assert v["max_age_hours"] == 12 and v["min_coverage"] == 0.5
+    assert v["scope"] == 5 and "checked_at" in v


### PR DESCRIPTION
## What

Step 5 of `run_weekly_ingestion.sh` stops fetching news and becomes a **freshness assertion**. `collectors/daily_news.py` ingests the same articles into the corpus at the point it already fetches them. Closes `alpha-engine-config-I5702` — last of the four RAG defects.

## Why

Step 5 was the ~3.1h Polygon sweep that dominated `RAGIngestion`'s 6h budget and was the stage in flight when the 2026-07-29 weekly pipeline died (`alpha-engine-config-I5695`).

`daily_news` already pulled these exact articles every weekday, for the same decision set, and wrote them only to the analytics prefix. The weekly sweep then paid Polygon a second time for an overlapping window. That split was by **write target**, not by fetch — `rag-corpus-policy.md` §2.3's "waste dressed as separation of concerns." Splitting the writes is right; splitting the fetch was not.

## The two non-negotiables, both pinned by tests

| | |
|---|---|
| **Never fetches** | `test_assess_never_issues_a_vendor_fetch`. §2.3: *"an assertion that blocks or backfills inline reintroduces the exact coupling this removes."* |
| **Always exits 0** | Staleness is a visible degraded flag, not a pipeline failure. A retrieval-time miss degrades one answer; failing the weekly SF over stale news degrades the belief set the whole trading week depends on. This is `weekly-sf-policy.md` §2.3's honest-degradation shape. |

The verdict derives from the **watermark store** (`I5701`) — what actually landed — not from an artifact's mtime, which a run that ingested nothing can still refresh. It separates `missing` (never ingested) from `stale` (daily job has stopped) because those have different causes, and carries the thresholds it was judged against so a reader can re-derive it.

Default tolerance 60h, so a Saturday run legitimately accepts Friday-close data from a weekdays-only producer — written as a test rather than left as an accident of the default.

## Failure direction

The corpus ingest in `daily_news` is fail-soft in the same acceptable category as its two sibling writes: (a) swallowed — pgvector down / Voyage throttled; (b) primary survives — the daily aggregate already landed, morning brief unaffected; (c) recorded — a WARN, `rag_status` on the returned dict, and, load-bearing, **the watermarks are not advanced**, so the gap stays outstanding and the next run picks it up instead of it becoming a silent hole.

## Deliberately not done here

The four lockstep RAG timeout constants (`WEEKLY_RAG_EXECUTION_TIMEOUT_SECONDS` + three mirrors) should fall dramatically now, but §2.4 says re-baseline from **measurement**, not from a guess. They stay put until a real run measures the new shape; the existing lockstep guard keeps them honest meanwhile.

## Measured on the live resume run

`watch-rerun-2026-07-29-1`, running the merged `I5700`+`I5703` code:

```
[rag_scope] resolved 67 ticker(s) — scanner cut 60 ∪ held 8, 1 non-equity dropped
weekly Polygon news budget = 1800s for 67 tickers   (was 11288s / 3.14h)
RAGIngestion 10:37 -> 11:09:47 PT  =  ~32 min       (budget was 6h; the 7/29 run died at 7h29m)
```

## Test plan

- Full suite: **3953 passed, 8 skipped**.
- New `tests/test_corpus_freshness_assertion.py` — 9 tests covering the two non-negotiables above plus verdict semantics (warm / Saturday tolerance / stale / missing-vs-stale separation / patchy coverage / threshold auditability).
- `bash -n` and `shellcheck` clean on the modified script (only pre-existing SC1091 venv-source infos).

## Related

Follows `nousergon-data-PR1164` (`ba177b35`) and `nousergon-data-PR1165` (`be71dd73`), both merged.

Closes #5702

---

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)