### PR TITLE
fix(lib-pin): unfreeze the spot-dispatch lockstep group — it guarded a module that never changed

### DIFF
--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.5
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.5
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.5
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.5
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/ci-watch-dispatcher/test_handler.py
@@ -217,10 +217,14 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     # config#2292 root fix: the repo+sha discriminator tags ride the SAME
     # RunInstances call as the launch itself (extra_tags), not a separate
     # post-launch create_tags call.
-    assert calls["extra_tags"] == {
-        "ci-watch-repo": "nousergon/alpha-engine-config",
-        "ci-watch-sha": "abc1234def5678900000000000000000000abcd",
-    }
+    # I5751/I5727: launch_with_fallback tags every launch with
+    # LaunchMarket/LaunchReason, so assert the caller's own tags by key
+    # rather than exact-dict equality — the contract is "these tags ride
+    # RunInstances", never "nothing else may".
+    assert calls["extra_tags"]["ci-watch-repo"] == "nousergon/alpha-engine-config"
+    assert calls["extra_tags"]["ci-watch-sha"] == "abc1234def5678900000000000000000000abcd"
+    assert calls["extra_tags"]["LaunchMarket"] == "spot"
+    assert calls["extra_tags"]["LaunchReason"] == "spot_ok"
     assert idx._test_ec2.terminated == []
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
@@ -526,11 +530,15 @@ def test_drill_synthesizes_isolated_identity_and_launches(monkeypatch):
     assert out["is_drill"] is True
     assert out["repo"] == idx.DRILL_REPO == "nousergon/ci-watch-drill"
     assert out["sha"] == expected_sha
-    assert calls["extra_tags"] == {
-        "ci-watch-repo": idx.DRILL_REPO,
-        "ci-watch-sha": expected_sha,
-        "sf-watch-drill": "true",
-    }
+    # I5751/I5727: launch_with_fallback tags every launch with
+    # LaunchMarket/LaunchReason, so assert the caller's own tags by key
+    # rather than exact-dict equality — the contract is "these tags ride
+    # RunInstances", never "nothing else may".
+    assert calls["extra_tags"]["ci-watch-repo"] == idx.DRILL_REPO
+    assert calls["extra_tags"]["ci-watch-sha"] == expected_sha
+    assert calls["extra_tags"]["sf-watch-drill"] == "true"
+    assert calls["extra_tags"]["LaunchMarket"] == "spot"
+    assert calls["extra_tags"]["LaunchReason"] == "spot_ok"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     assert 'export CI_IS_DRILL="true"' in cmd
     assert f'export CI_REPO="{idx.DRILL_REPO}"' in cmd

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.5
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
 krepis>=0.14.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -241,11 +241,15 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     # ride the SAME RunInstances call as the launch itself (extra_tags), not
     # a separate post-launch create_tags call — used by both the concurrency
     # guard AND the fleet spot-orphan-reaper's completion check.
-    assert calls["extra_tags"] == {
-        "sf-watch-cadence": "saturday",
-        "sf-watch-pipeline": "ne-weekly-freshness-pipeline",
-        "sf-watch-run-date": "2026-07-11",
-    }
+    # I5751/I5727: launch_with_fallback tags every launch with
+    # LaunchMarket/LaunchReason, so assert the caller's own tags by key
+    # rather than exact-dict equality — the contract is "these tags ride
+    # RunInstances", never "nothing else may".
+    assert calls["extra_tags"]["sf-watch-cadence"] == "saturday"
+    assert calls["extra_tags"]["sf-watch-pipeline"] == "ne-weekly-freshness-pipeline"
+    assert calls["extra_tags"]["sf-watch-run-date"] == "2026-07-11"
+    assert calls["extra_tags"]["LaunchMarket"] == "spot"
+    assert calls["extra_tags"]["LaunchReason"] == "spot_ok"
     assert idx._test_ec2.terminated == []
     sent = idx._test_ssm.sent[0]
     cmd = sent["Parameters"]["commands"][0]
@@ -934,12 +938,16 @@ def test_drill_event_launches_with_drill_scoped_run_date_and_drill_tag(monkeypat
     # Tags: the normal discriminator triple (run_date drill-scoped) PLUS the
     # drill marker tag fleet consumers filter on — all riding the SAME
     # RunInstances call as the launch (config#2292 root fix).
-    assert calls["extra_tags"] == {
-        "sf-watch-cadence": "saturday",
-        "sf-watch-pipeline": "ne-weekly-freshness-pipeline",
-        "sf-watch-run-date": drill_date,
-        "sf-watch-drill": "true",
-    }
+    # I5751/I5727: launch_with_fallback tags every launch with
+    # LaunchMarket/LaunchReason, so assert the caller's own tags by key
+    # rather than exact-dict equality — the contract is "these tags ride
+    # RunInstances", never "nothing else may".
+    assert calls["extra_tags"]["sf-watch-cadence"] == "saturday"
+    assert calls["extra_tags"]["sf-watch-pipeline"] == "ne-weekly-freshness-pipeline"
+    assert calls["extra_tags"]["sf-watch-run-date"] == drill_date
+    assert calls["extra_tags"]["sf-watch-drill"] == "true"
+    assert calls["extra_tags"]["LaunchMarket"] == "spot"
+    assert calls["extra_tags"]["LaunchReason"] == "spot_ok"
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     assert 'export SF_IS_DRILL="true"' in cmd
     assert f'export SF_RUN_DATE="{drill_date}"' in cmd

--- a/tests/test_lib_pin_lockstep.py
+++ b/tests/test_lib_pin_lockstep.py
@@ -121,94 +121,32 @@ class _Exemption:
 # A floor is not an exemption: root >= floor already satisfies it.
 # scheduled-groom-dispatcher: see test_groom_dispatcher_is_not_exempted
 _LAMBDA_PIN_EXEMPTIONS: dict[str, _Exemption] = {
-    # ── Spot-dispatch lockstep group (alpha-engine-config-I3242) ────────
-    # These Lambdas share a common spot-dispatch chokepoint and must move
-    # together.  Re-evaluated against root quarterly.
-    "arctic-migration-dispatcher": _Exemption(
-        kind="group",
-        version="v0.124.5",
-        re_exam="2026-10-27",
-        reason=(
-            "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config-I3242): "
-            "same spot-launch/concurrency-lock primitives as the other spot-dispatch "
-            "Lambdas — stays in lockstep with them, not with root"
-        ),
-        members=(
-            "arctic-migration-dispatcher",
-            "canary-replay-dispatcher",
-            "alert-drain-dispatcher",
-            "ci-watch-dispatcher",
-            "sf-watch-spot-dispatcher",
-        ),
-    ),
-    "canary-replay-dispatcher": _Exemption(
-        kind="group",
-        version="v0.124.5",
-        re_exam="2026-10-27",
-        reason=(
-            "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config#2246): "
-            "same SpotProbeError handling as ci-watch-dispatcher; bumped for config#2698 "
-            "SpotQuotaExceededError on-demand fallback"
-        ),
-        members=(
-            "arctic-migration-dispatcher",
-            "canary-replay-dispatcher",
-            "alert-drain-dispatcher",
-            "ci-watch-dispatcher",
-            "sf-watch-spot-dispatcher",
-        ),
-    ),
-    "alert-drain-dispatcher": _Exemption(
-        kind="group",
-        version="v0.124.5",
-        re_exam="2026-10-27",
-        reason=(
-            "nousergon_lib.spot_dispatch chokepoint (alpha-engine-config-I2824): "
-            "same extra_tags atomic-launch-tagging floor as ci-watch-dispatcher; "
-            "bumped for config#2698 SpotQuotaExceededError on-demand fallback"
-        ),
-        members=(
-            "arctic-migration-dispatcher",
-            "canary-replay-dispatcher",
-            "alert-drain-dispatcher",
-            "ci-watch-dispatcher",
-            "sf-watch-spot-dispatcher",
-        ),
-    ),
-    "ci-watch-dispatcher": _Exemption(
-        kind="group",
-        version="v0.124.5",
-        re_exam="2026-10-27",
-        reason=(
-            "nousergon_lib.spot_dispatch chokepoint (config#2267): SpotProbeError handling; "
-            "bumped for extra_tags atomic-launch-tagging (config#2292) and config#2698 "
-            "SpotQuotaExceededError on-demand fallback"
-        ),
-        members=(
-            "arctic-migration-dispatcher",
-            "canary-replay-dispatcher",
-            "alert-drain-dispatcher",
-            "ci-watch-dispatcher",
-            "sf-watch-spot-dispatcher",
-        ),
-    ),
-    "sf-watch-spot-dispatcher": _Exemption(
-        kind="group",
-        version="v0.124.5",
-        re_exam="2026-10-27",
-        reason=(
-            "nousergon_lib.spot_dispatch chokepoint (config#2267): SpotProbeError handling; "
-            "bumped for extra_tags atomic-launch-tagging (config#2292) and config#2698 "
-            "SpotQuotaExceededError on-demand fallback"
-        ),
-        members=(
-            "arctic-migration-dispatcher",
-            "canary-replay-dispatcher",
-            "alert-drain-dispatcher",
-            "ci-watch-dispatcher",
-            "sf-watch-spot-dispatcher",
-        ),
-    ),
+    # EMPTY, and that is the target state (alpha-engine-config-I5751).
+    #
+    # The "Spot-dispatch lockstep group" that lived here — arctic-migration,
+    # canary-replay, alert-drain, ci-watch and sf-watch-spot — was removed
+    # 2026-07-30 after being frozen at v0.124.5 for nineteen lib versions.
+    #
+    # Its stated reason was that the five share the nousergon_lib.spot_dispatch
+    # chokepoint and so "stay in lockstep with them, not with root". That reason
+    # argues for bumping them AS A UNIT. It was enforced as not bumping them at
+    # all, and the difference cost something measurable: nousergon-lib#274 added
+    # launch-provenance tags to spot_dispatch itself, and the five Lambdas
+    # grouped around that module were the only five that would not have received
+    # it (alpha-engine-config-I5727).
+    #
+    # Measured before removing it, rather than assumed: across v0.124.5..v0.124.24
+    # the ONLY commit touching spot_dispatch.py or ec2_spot.py is #274, and all
+    # five Lambdas import spot_dispatch and nothing else from the library. The
+    # exemption therefore protected them from no change at all — the nineteen
+    # versions of drift were entirely in modules they do not import — while
+    # withholding the one change that was for them.
+    #
+    # A `group` kind still exists in _Exemption and is still legitimate: it means
+    # "these move together". If a future cluster genuinely cannot track root, it
+    # goes here WITH a contract reason naming what breaks — not "shares a
+    # chokepoint", which is an argument for coupling their bumps, not for
+    # freezing them.
 }
 
 


### PR DESCRIPTION
Closes `alpha-engine-config-I5751`.

## What was frozen

Five Lambdas pinned to `nousergon-lib` **v0.124.5** by a *"Spot-dispatch lockstep group"* exemption with `re_exam: 2026-10-27` — **nineteen versions** behind root: `arctic-migration-dispatcher`, `canary-replay-dispatcher`, `alert-drain-dispatcher`, `ci-watch-dispatcher`, `sf-watch-spot-dispatcher`.

## The exemption's reason argued for the opposite of what it did

Verbatim: *"nousergon_lib.spot_dispatch chokepoint — same spot-launch/concurrency-lock primitives as the other spot-dispatch Lambdas — stays in lockstep with them, not with root."*

That is an argument for bumping the five **as a unit**. It was enforced as **not bumping them at all**, and the difference cost something measurable: `nousergon-lib-PR274` added launch-provenance tags to `spot_dispatch` *itself*, so the five Lambdas grouped around that module were the only five that would not have received it — `alpha-engine-config-I5727` stalled at 6 of 11 lanes.

## Measured before removing it, not assumed

```
git log v0.124.5..v0.124.24 -- src/nousergon_lib/spot_dispatch.py \
                               src/nousergon_lib/ec2_spot.py
  → exactly one commit: #274, the change they were missing.
```

And every one of the five imports `spot_dispatch` and **nothing else** from the library (`alert-drain` additionally imports two exception classes from it).

**So the exemption protected them from no change at all** — nineteen versions of drift, entirely in modules they do not import — while withholding the single change that was for them. Pure cost, zero benefit.

## What changes

- Five pins `v0.124.5` → `v0.124.24` (root).
- `_LAMBDA_PIN_EXEMPTIONS` is now **empty**, and the file says why that is the target state rather than an accident.
- The `group` kind stays in `_Exemption` and stays legitimate — it means *"these move together"*. A future cluster that genuinely cannot track root goes there **with a contract reason naming what breaks**; "shares a chokepoint" is an argument for coupling bumps, not for freezing them.
- Four assertions in `ci-watch-dispatcher` and `sf-watch-spot-dispatcher` asserted exact-dict equality on `extra_tags` — correct at v0.124.5, wrong at v0.124.24, and wrong in kind: exact equality said *"nothing else may ride along"*, which was never the contract. Rewritten to assert each caller tag by key plus the two provenance keys, matching the shape `scheduled-groom-dispatcher` got in nousergon-data-PR1167.

## Testing

All **eleven** `launch_with_fallback` callers pass individually against v0.124.24 — run per-lambda, because one venv cannot hold two pins and a single-interpreter glob run cannot reproduce CI:

```
alert-drain 13 · arctic-migration 24 · canary-replay 18 · ci-watch 32 · data-spot 4
spot-orphan-reaper 22 · sf-watch-reclaim-sweep 23 · scheduled-groom 147
sf-watch-spot 43 · thinktank-spot 17 · weekly-freshness 13     — 0 failures
```

`tests/` → **3945 passed, 8 skipped**. `test_lib_pin_lockstep.py` green with an empty exemption table.

`alpha-engine-config-I5727` reaches 11 of 11 lanes once this deploys.

Follows nousergon-lib-PR274 and nousergon-data-PR1167, both merged.

---

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)