### PR TITLE
fix(sf): ThinkTankCoverage dispatches to spot instead of a 900s lambda:invoke

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -55,4 +55,4 @@ boto3>=1.34.0
 # The exemption is removed and the tier-model floor is asserted explicitly in
 # tests/test_lib_pin_lockstep.py::test_groom_dispatcher_pin_can_express_the_policy_tier_table.
 # Bump this in lockstep with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 krepis>=0.14.0

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1324,35 +1324,26 @@
             },
             "ThinkTankCoverage": {
               "Type": "Task",
-              "Comment": "Think Tank observe-mode coverage top-up (alpha-engine-config-I2467). config-I2515 Phase B: MOVED to run AFTER the RAG ingestion chain (was between Scanner and RAG) so Think Tank's theses read the FRESH corpus instead of the week-old one — this also resolves alpha-engine-config-I2511. The daily EventBridge cadence (alpha-research-thinktank-daily) is the primary coverage-growth mechanism (5/day toward the full rank_ceiling=150 universe, handling staleness refresh gradually) and stays unchanged. This state's job is a narrower, reactive top-up — mode=gap_fill shores up whatever of the CURRENT top-60 the daily cadence hasn't caught up to yet by the time the fresh weekly scan lands, sized to the EXACT measured coverage_gap.uncovered_count (never a fixed constant, never padded with stale-refill — see crucible-research thinktank/run.py's gap_fill_only). Small and bounded by construction, so no sf_cover_target/sf_cover_ceiling numbers to keep in sync across repos. Observe-only: writes to thinktank/ S3 prefix for validation tracking; does NOT gate the Predictor. Non-blocking Catch routes forward on any failure so the pipeline continues exactly as it would without this step. The Retry below (States.Timeout/Lambda.Unknown) stays as cheap defense-in-depth even though the gap-fill workload is small.",
+              "Comment": "Think Tank observe-mode coverage top-up, dispatched to EC2 SPOT (alpha-engine-config-I5758). PREVIOUSLY a direct lambda:invoke against alpha-engine-research-thinktank with TimeoutSeconds 900 — the AWS Lambda MAXIMUM, which this workload cannot fit in: measured 2026-07-30 on watch-rerun-2026-07-29-1, both attempts hit States.Timeout at 900s (11:24:47 and 11:40:48) for 30 min of wall-clock and zero output. alpha-engine-config-I5208 established the same failure on the DAILY cadence and ARCHITECTURE §47 ruled the fix: a long-running agent loop runs on owned compute behind a dispatcher. That fix shipped for the daily path (crucible-research infrastructure/thinktank_box_runner.py + thinktank_spot_bootstrap.sh + this dispatcher) and THIS state was never repointed — the weekly SF kept re-entering the failure the migration already fixed, on the one path inside a decision pipeline. The dispatcher fires an ASYNC detached SSM command and returns immediately, so this state only LAUNCHES; the poll quartet below waits for the box, mirroring the RAGIngestion / WaitForRAGIngestion / CheckRAGIngestionStatus / RAGIngestionWait shape. Budget chain (load-bearing, asserted by the dispatcher's own handler and test_handler.py): THINKTANK_RUN_BUDGET_SECONDS (5400) < THINKTANK_SPOT_RUN_TIMEOUT_SECONDS (7200) < this state's poll bound. If the budget ever meets the SSM timeout, SSM guillotines the run mid-loop and every terminal write is lost — the exact I5208 failure, reintroduced by config drift. config-I2515 Phase B ordering is preserved: this runs AFTER the RAG chain so Think Tank's theses read the FRESH corpus. The daily EventBridge cadence stays the primary coverage-growth mechanism; this state remains the reactive gap_fill top-up.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
-                "FunctionName": "alpha-engine-research-thinktank:live",
+                "FunctionName": "alpha-engine-thinktank-spot-dispatcher",
                 "Payload": {
                   "mode": "gap_fill",
                   "run_date.$": "$.run_date"
                 }
               },
-              "TimeoutSeconds": 900,
+              "TimeoutSeconds": 330,
               "Retry": [
                 {
                   "ErrorEquals": [
                     "Lambda.ServiceException",
                     "Lambda.TooManyRequestsException",
-                    "States.TaskFailed"
+                    "Lambda.SdkClientException"
                   ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                },
-                {
-                  "ErrorEquals": [
-                    "States.Timeout",
-                    "Lambda.Unknown"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0
                 }
               ],
               "Catch": [
@@ -1360,12 +1351,146 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Observe-mode non-blocking: think tank failure must NOT halt the pipeline. Routes forward to CheckSkipRegimeRetrospectiveEval (ThinkTankCoverage's new post-RAG successor, config-I2515 Phase B).",
-                  "Next": "CheckSkipRegimeRetrospectiveEval",
+                  "Comment": "Observe-mode non-blocking: a Think Tank failure must NOT halt the pipeline (config-I2515 Phase B). Routes to ThinkTankDegraded, which SETS A VISIBLE FLAG before converging — weekly-sf-policy.md §2.3 permits fail-open ONLY with a flag that propagates to the terminal notification, and champion-challenger-policy.md §3 requires a cycle with no arm output to be recorded as a MISS, never omitted. The flagless fail-open this replaces is why 13 days of silent Lambda timeouts went unnoticed.",
+                  "Next": "ThinkTankDegraded",
                   "ResultPath": "$.thinktank_error"
                 }
               ],
-              "ResultPath": "$.thinktank_result",
+              "ResultSelector": {
+                "launched.$": "$.Payload.launched",
+                "instance_id.$": "$.Payload.instance_id",
+                "command_id.$": "$.Payload.command_id"
+              },
+              "ResultPath": "$.thinktank_dispatch",
+              "Next": "CheckThinkTankLaunched"
+            },
+            "CheckThinkTankLaunched": {
+              "Type": "Choice",
+              "Comment": "The dispatcher returns launched=false with reason=already_running when a Think Tank box is already up — normally the DAILY cadence's box. That box writes the same terminal artifacts this state wants, so waiting for a command_id we do not have would be wrong; converge with a degraded flag naming the reason instead. Skipping silently would render identically to a genuine zero, which champion-challenger-policy.md §3 forbids.",
+              "Choices": [
+                {
+                  "Variable": "$.thinktank_dispatch.launched",
+                  "BooleanEquals": true,
+                  "Next": "InitThinkTankPollCount"
+                }
+              ],
+              "Default": "ThinkTankDegraded"
+            },
+            "InitThinkTankPollCount": {
+              "Type": "Pass",
+              "Comment": "Poll-iteration budget seed (alpha-engine-config-I5687). Every other poll loop in this pipeline is unbounded and instance-liveness-blind, which cost 5h11m of blind polling on 2026-07-29; this new loop ships bounded rather than adding a 16th instance of that defect. Bound is derived: THINKTANK_SPOT_RUN_TIMEOUT_SECONDS (7200) / Wait 60s = 120 polls, +20% slack = 144.",
+              "Result": 0,
+              "ResultPath": "$.thinktank_polls",
+              "Next": "WaitForThinkTank"
+            },
+            "WaitForThinkTank": {
+              "Type": "Task",
+              "Comment": "Poll the detached SSM command until it reaches a terminal status.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.thinktank_dispatch.command_id",
+                "InstanceId.$": "$.thinktank_dispatch.instance_id"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "Comment": "The dispatcher sends the command asynchronously, so the invocation can lag the returned command_id by a beat.",
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "ThinkTankDegraded",
+                  "ResultPath": "$.thinktank_error"
+                }
+              ],
+              "ResultSelector": {
+                "Status.$": "$.Status",
+                "ResponseCode.$": "$.ResponseCode",
+                "StatusDetails.$": "$.StatusDetails",
+                "StandardErrorContent.$": "$.StandardErrorContent"
+              },
+              "ResultPath": "$.thinktank_poll",
+              "Next": "CheckThinkTankStatus"
+            },
+            "CheckThinkTankStatus": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.thinktank_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "CheckSkipRegimeRetrospectiveEval"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.thinktank_polls",
+                      "IsPresent": true
+                    },
+                    {
+                      "Or": [
+                        {
+                          "Variable": "$.thinktank_poll.Status",
+                          "StringEquals": "InProgress"
+                        },
+                        {
+                          "Variable": "$.thinktank_poll.Status",
+                          "StringEquals": "Pending"
+                        }
+                      ]
+                    },
+                    {
+                      "Variable": "$.thinktank_polls",
+                      "NumericLessThan": 144
+                    }
+                  ],
+                  "Next": "ThinkTankWait"
+                }
+              ],
+              "Default": "ThinkTankDegraded"
+            },
+            "ThinkTankWait": {
+              "Type": "Pass",
+              "Comment": "Increment the poll counter, then wait. A Pass+Wait pair rather than a bare Wait so the budget in CheckThinkTankStatus actually advances — a counter that never increments is an unbounded loop wearing a bound.",
+              "Parameters": {
+                "polls.$": "States.MathAdd($.thinktank_polls, 1)"
+              },
+              "ResultPath": "$.thinktank_poll_count",
+              "Next": "ThinkTankPollWait"
+            },
+            "ThinkTankPollWait": {
+              "Type": "Wait",
+              "Seconds": 60,
+              "Next": "MergeThinkTankPollCount"
+            },
+            "MergeThinkTankPollCount": {
+              "Type": "Pass",
+              "InputPath": "$.thinktank_poll_count.polls",
+              "ResultPath": "$.thinktank_polls",
+              "Next": "WaitForThinkTank"
+            },
+            "ThinkTankDegraded": {
+              "Type": "Pass",
+              "Comment": "THE VISIBLE DEGRADED FLAG (alpha-engine-config-I5758). Every non-Success path converges here — dispatch failure, already_running, poll failure, poll-budget exhaustion, a non-Success SSM status. weekly-sf-policy.md §2.3: a stage may fail-open ONLY if the fail-open sets a visible degraded flag that propagates to the terminal notification, and a pipeline reaching NotifyComplete having degraded a stage must say so BY NAME. champion-challenger-policy.md §3: a cycle where an arm produces no output is recorded as a MISS, not omitted — silent absence and a genuine zero must never render identically. The predecessor of this state had no flag at all, which is exactly why 13 consecutive days of 900s Lambda timeouts (2026-07-17 onward) passed unnoticed while the thinktank_coverage challenger arm was absent from the champion/challenger loop.",
+              "Result": true,
+              "ResultPath": "$.thinktank_degraded",
               "Next": "CheckSkipRegimeRetrospectiveEval"
             },
             "CheckSkipRegimeRetrospectiveEval": {

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0.12
 anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.24
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.25
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -694,25 +694,90 @@ class TestPerBranchErrorIsolation:
         ]
 
     def test_thinktank_coverage_is_non_blocking(self, branch_a):
-        """config#3218 (§119 rule 3): CLAUDE.md asserts ThinkTankCoverage's
-        gap_fill top-up is observe-only and must never halt the pipeline —
-        this pins that claim against the live SF wiring instead of leaving
-        it a doc-only assumption. The Catch must route to the SAME state as
-        the success path's Next (CheckSkipRegimeRetrospectiveEval), so a
-        thesis-generation failure is silently absorbed rather than
-        detouring the run onto a different, untested path."""
+        """config#3218 (§119 rule 3): the gap_fill top-up is observe-only and
+        must never halt the pipeline.
+
+        alpha-engine-config-I5758 changed HOW that holds. It used to be
+        "absorbed silently" — the Catch pointed straight at the success path's
+        Next. That silence is precisely why 13 consecutive days of 900s Lambda
+        timeouts (2026-07-17 onward) went unnoticed while the
+        thinktank_coverage challenger arm was absent from the loop.
+
+        Non-blocking is now reached VIA ThinkTankDegraded, which sets a visible
+        flag first. weekly-sf-policy.md §2.3 permits fail-open only with a flag
+        that propagates to the terminal notification; champion-challenger-policy
+        §3 requires a cycle with no arm output to be recorded as a MISS rather
+        than omitted. So this asserts the PROPERTY (converges to the shared
+        successor without failing the branch) plus the flag, not a literal
+        target."""
         state = branch_a["ThinkTankCoverage"]
         catch_targets = [c["Next"] for c in state["Catch"]]
-        assert catch_targets == ["CheckSkipRegimeRetrospectiveEval"]
-        assert catch_targets == [state["Next"]]
+        assert catch_targets == ["ThinkTankDegraded"]
         assert "BranchAFailed" not in catch_targets
-        # Failure output must be quarantined off the success ResultPath so a
-        # caught error can never masquerade as a real thinktank_result.
+
+        degraded = branch_a["ThinkTankDegraded"]
+        # The flag itself — a fail-open without one is what this replaced.
+        assert degraded["Result"] is True
+        assert degraded["ResultPath"] == "$.thinktank_degraded"
+        # ...and it converges on the same successor the success path reaches,
+        # so the branch is never detoured onto an untested path.
+        assert degraded["Next"] == "CheckSkipRegimeRetrospectiveEval"
+        assert (
+            branch_a["CheckThinkTankStatus"]["Choices"][0]["Next"]
+            == "CheckSkipRegimeRetrospectiveEval"
+        )
+
+        # Failure output must be quarantined off the dispatch ResultPath so a
+        # caught error can never masquerade as a real dispatch result.
         assert [c["ErrorEquals"] for c in state["Catch"]] == [["States.ALL"]]
-        assert state["ResultPath"] == "$.thinktank_result"
+        assert state["ResultPath"] == "$.thinktank_dispatch"
         assert all(
             c["ResultPath"] != state["ResultPath"] for c in state["Catch"]
         )
+
+    def test_thinktank_runs_on_spot_not_a_ceilinged_lambda(self, branch_a):
+        """alpha-engine-config-I5758 / I5208, ARCHITECTURE §47: a long-running
+        agent loop runs on owned compute behind a dispatcher, never on a
+        metered/ceilinged runtime.
+
+        The regression this pins is specific and already happened: the spot
+        migration shipped for the DAILY cadence while this state kept invoking
+        alpha-engine-research-thinktank directly at TimeoutSeconds 900 — the
+        AWS Lambda maximum — so the weekly SF re-entered the exact failure the
+        migration had fixed. Measured 2026-07-30 on watch-rerun-2026-07-29-1:
+        two States.Timeouts, 30 min of wall-clock, zero output."""
+        state = branch_a["ThinkTankCoverage"]
+        fn = state["Parameters"]["FunctionName"]
+        assert fn == "alpha-engine-thinktank-spot-dispatcher", (
+            f"ThinkTankCoverage must dispatch to spot, not invoke {fn!r} "
+            "directly — 900s is the AWS Lambda maximum and this workload does "
+            "not fit in it"
+        )
+        assert "alpha-engine-research-thinktank" not in fn
+        # The dispatcher launches and returns; it never babysits the run, so
+        # this Task's timeout bounds a LAUNCH, not the agent loop.
+        assert state["TimeoutSeconds"] <= 600
+
+    def test_thinktank_poll_loop_is_bounded(self, branch_a):
+        """alpha-engine-config-I5687: the other 15 poll loops in this pipeline
+        are unbounded and instance-liveness-blind, which cost 5h11m of blind
+        polling on 2026-07-29. A new loop ships bounded rather than adding a
+        16th instance of that defect.
+
+        Also pins that the counter actually ADVANCES — a bound whose counter
+        never increments is an unbounded loop wearing a bound."""
+        choice = branch_a["CheckThinkTankStatus"]
+        in_progress = choice["Choices"][1]["And"]
+        # config#2275: the IsPresent guard must PRECEDE the dereference.
+        assert in_progress[0]["Variable"] == "$.thinktank_polls"
+        assert in_progress[0]["IsPresent"] is True
+        bound = [c for c in in_progress if "NumericLessThan" in c]
+        assert bound and bound[0]["NumericLessThan"] > 0
+        # Exhausting the budget must degrade, never spin.
+        assert choice["Default"] == "ThinkTankDegraded"
+        # The increment exists and feeds back into the same variable.
+        assert "States.MathAdd" in branch_a["ThinkTankWait"]["Parameters"]["polls.$"]
+        assert branch_a["MergeThinkTankPollCount"]["ResultPath"] == "$.thinktank_polls"
 
     def test_predictor_failure_routes_to_branch_b_failed(self, branch_b):
         """PredictorTraining failures (Task Catch + WaitForPredictorTraining


### PR DESCRIPTION
## What

`ThinkTankCoverage` in the weekly SF stops calling `alpha-engine-research-thinktank` directly (`TimeoutSeconds: 900` — the **AWS Lambda maximum**) and dispatches to `alpha-engine-thinktank-spot-dispatcher` via the standard dispatch → poll → status → wait quartet. Closes `alpha-engine-config-I5758`.

## Why

**The spot migration already shipped.** `crucible-research:infrastructure/thinktank_box_runner.py` and `thinktank_spot_bootstrap.sh` exist, both naming `alpha-engine-config-I5208` / `ARCHITECTURE §47`, and the dispatcher Lambda is live. The **daily** cadence uses it.

The weekly SF was never repointed, so it kept re-entering the failure the migration had already fixed — on the one path inside a decision pipeline. Same fork shape as the sync/async news aggregator found earlier the same day: fixed on the daily path, left on the critical one.

```
alpha-engine-thinktank-spot-dispatcher   Timeout 300   <- daily path
alpha-engine-research-thinktank          Timeout 900   <- what this state called
```

**Measured**, execution `watch-rerun-2026-07-29-1`:

```
11:09:47  ENTER ThinkTankCoverage
11:24:47  TaskTimedOut  States.Timeout          <- 900s, attempt 1
11:40:48  TaskTimedOut  States.Timeout          <- 900s, attempt 2
11:40:48  ENTER CheckSkipRegimeRetrospectiveEval  <- failed OPEN, silently
```

30 minutes of wall-clock, zero output, and the pipeline continued as though the challenger arm had run.

## The flag is the other half of the fix

The old fail-open carried **no degraded flag**. That silence is why 13 consecutive days of 900s timeouts (2026-07-17 onward) went unnoticed while the `thinktank_coverage` challenger arm was absent from the champion/challenger loop.

Every non-Success path — dispatch failure, `already_running`, poll failure, budget exhaustion, non-Success SSM status — now converges on `ThinkTankDegraded`, which sets `$.thinktank_degraded` before rejoining.

- `weekly-sf-policy.md` §2.3: fail-open is permitted **only** with a visible flag that propagates to the terminal notification.
- `champion-challenger-policy.md` §3: a cycle where an arm produces no output is recorded as a **miss**, not omitted — silent absence and a genuine zero must never render identically.

Non-blocking is preserved; it is now reached via a flagged intermediary rather than silently.

## Design notes

- **`CheckThinkTankLaunched`** — the dispatcher returns `launched: false, reason: already_running` when the daily box is up. That box writes the same terminal artifacts, so waiting on a `command_id` we do not have would be wrong; converge with a flag naming the reason.
- **The poll loop ships bounded.** The other 15 poll loops here are unbounded and liveness-blind (`alpha-engine-config-I5687` — 5h11m of blind polling on 2026-07-29). Bound derived: SSM `RUN_TIMEOUT` 7200s / 60s wait = 120, +20% slack = 144. The counter increments via `States.MathAdd` and feeds back into `$.thinktank_polls` — a bound whose counter never advances is an unbounded loop wearing a bound, and a test pins that.
- **Budget chain, load-bearing:** `THINKTANK_RUN_BUDGET_SECONDS` (5400) < `THINKTANK_SPOT_RUN_TIMEOUT_SECONDS` (7200) < the 144-poll bound. If the budget ever meets the SSM timeout, SSM guillotines the run mid-loop and every terminal write is lost — the exact I5208 failure via config drift. The dispatcher's own handler refuses to launch in that state.

## Two existing guards caught real defects here

Both kept, neither weakened:

- `test_sf_choice_guards` forced the `IsPresent` guard to **precede** the `NumericLessThan` on `$.thinktank_polls` (config#2275) — otherwise an absent field is a `States.Runtime`.
- `test_pipeline_status_registry_source_check` forced the `WaitForThinkTank` rollup row, which is the cross-repo half below.

## Cross-repo — merge order

1. **`nousergon-lib-PR275`** — adds `"WaitForThinkTank": "ThinkTankCoverage"` to `WAIT_GROUPING`.
2. Lib auto-version-bump releases.
3. **This PR** — bump the lib pin (currently `v0.124.24`) to the released version, then merge.

**Draft until step 2**, because the registry test fails on `main` until the lib version exists. This is why it is not ready — not because the change is incomplete.

`Rehearsal-path:` `run_weekly_offcycle.sh` — exercises this exact definition path (dispatch, poll, degraded convergence) without waiting for a Saturday, per `weekly-sf-policy.md` §7.

## Test plan

- Full suite: **3947 passed, 8 skipped**.
- 3 new structural tests: `test_thinktank_runs_on_spot_not_a_ceilinged_lambda`, `test_thinktank_poll_loop_is_bounded`, and a rewritten `test_thinktank_coverage_is_non_blocking` that asserts the property plus the flag rather than a literal Catch target.
- Dangling-transition check across all 203 states: none.

## Related, not fixed here

`alpha-engine-config-I5752` — thinktank is the only spot-box class missing a `spot-orphan-reaper` `WatchKind` row, so a weekly thinktank box that boots and dies is detected 720 min late. And `alpha-engine-config-I5695` — adding a spot stage to Branch A brings the run closer to the reaper's 6.5h cap on the launcher box. Both should land alongside this.

Closes #5758

---

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)