### PR TITLE
[P1/mid] feat(groom): diversify the spot pool across arm64 families, record the type used, fix the SF deploy trigger

### DIFF
--- a/.github/workflows/deploy-scheduled-groom-dispatcher.yml
+++ b/.github/workflows/deploy-scheduled-groom-dispatcher.yml
@@ -32,6 +32,16 @@ on:
     paths:
       - 'infrastructure/lambdas/scheduled-groom-dispatcher/**'
       - '.github/workflows/deploy-scheduled-groom-dispatcher.yml'
+      # alpha-engine-config-I5512. deploy.sh deploys the STATE MACHINE as well
+      # as the Lambda, but this trigger only watched the Lambda directory — so
+      # a definition-only change reached production purely by luck, whenever a
+      # Lambda change happened to ride along in the same merge. Two changes hit
+      # that on 2026-07-30: the I5689 AllSkipped comment, and the I5229
+      # LaneDeath Catch, which merged and stayed un-deployed until it was
+      # pushed by hand. groom-sweep-policy §2.3: "config-only changes must
+      # reach production — either the trigger covers the path, or the file does
+      # not live outside it."
+      - 'infrastructure/step_function_groom.json'
   workflow_dispatch:
 
 concurrency:

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -207,9 +207,33 @@ _RESEARCH_BUCKET = "alpha-engine-research"
 # Savings Plan (instance-family-agnostic) already covers it — cost-I2864. CRITICAL:
 # every type here MUST be arm64 to match the arm64 AMI below — an arm64 AMI will
 # not boot on an x86 instance type (and vice-versa).
+# alpha-engine-config-I4989. The pool was `t4g.medium,t4g.large` — two types,
+# but ONE instance family, so effectively one spot capacity pool. Measured
+# 2026-07-30 20:00 UTC: all three lanes reclaimed
+# (`instance-terminated-no-capacity`) at the SAME SECOND, 6.5 minutes in,
+# taking out the whole cycle. Two types in one family is diversification in
+# name only.
+#
+# HARD CONSTRAINT: GROOM_AMI_ID is arm64 (Amazon Linux 2023 Graviton), and one
+# AMI serves one architecture — so x86 types CANNOT be added here without a
+# second AMI and an architecture-aware selection step. The widening therefore
+# stays arm64 and spans FAMILIES and GENERATIONS instead, which is what
+# actually separates capacity pools:
+#
+#   t4g  burstable      (current; CPU-credit throttling under sustained load)
+#   c6g/c7g  compute    2 vCPU / 4 GiB at .large — same shape as t4g.medium,
+#                       without the credit ceiling
+#   m6g/m7g  general    2 vCPU / 8 GiB at .large — headroom for agent runs
+#
+# All entries are >= 4 GiB, the floor a groom agent run needs. Override via
+# GROOM_INSTANCE_TYPES; anything added must be arm64 or the launch will fail
+# the AMI architecture check.
 INSTANCE_TYPES = [
     t.strip()
-    for t in os.environ.get("GROOM_INSTANCE_TYPES", "t4g.medium,t4g.large").split(",")
+    for t in os.environ.get(
+        "GROOM_INSTANCE_TYPES",
+        "t4g.medium,c6g.large,c7g.large,m6g.large,m7g.large,t4g.large",
+    ).split(",")
     if t.strip()
 ]
 SUBNETS = [
@@ -1149,9 +1173,37 @@ _COMPLETION_OUTCOMES = frozenset({
 })
 
 
+def _describe_instance_type(instance_id: str) -> str:
+    """The instance type actually launched, or "" if it cannot be read.
+
+    alpha-engine-config-I4989. `launch_with_fallback` returns only
+    (instance_id, market), so the TYPE that won the capacity race is not
+    otherwise recorded anywhere durable — and without it "how often is each
+    type used, and which ones get reclaimed" is unanswerable, which is exactly
+    the question a diversified pool creates. One extra DescribeInstances call
+    per launch is a fair price for that.
+
+    Best-effort by design: this feeds observability, and the ledger write it
+    contributes to is fail-loud for a DIFFERENT reason (the reconciler needs
+    the record to exist at all). Failing the launch because a describe hiccuped
+    would trade a real capability for a reporting nicety.
+    """
+    try:
+        resp = boto3.client("ec2", region_name=REGION).describe_instances(
+            InstanceIds=[instance_id])
+        for reservation in resp.get("Reservations", []):
+            for inst in reservation.get("Instances", []):
+                return str(inst.get("InstanceType", ""))
+    except Exception as exc:  # noqa: BLE001 — observability only; see docstring
+        logger.warning("instance-type lookup failed for %s (non-fatal): %s",
+                       instance_id, exc)
+    return ""
+
+
 def _write_dispatch_ledger_entry(run_token: str, tier_tag: str, schedule_label: str,
                                   instance_id: str = "", deadline_utc: str = "",
-                                  task_token: str = "") -> None:
+                                  task_token: str = "", instance_type: str = "",
+                                  market: str = "") -> None:
     """Record a launch ATTEMPT for the daily ceiling count (config#3173) AND
     an expectation record for the lane-death reconciler (config-I5229).
 
@@ -1177,6 +1229,15 @@ def _write_dispatch_ledger_entry(run_token: str, tier_tag: str, schedule_label: 
     }
     if task_token:
         fields["task_token"] = task_token
+    # I4989: which type/market actually won the capacity race. Recorded here
+    # rather than only as an EC2 tag because terminated instances age out of
+    # describe-instances in ~1h, while this ledger persists — so reclaim rate
+    # BY TYPE stays answerable after the fact, which is the whole point of
+    # widening the pool.
+    if instance_type:
+        fields["instance_type"] = instance_type
+    if market:
+        fields["market"] = market
     body = json.dumps(fields)
     boto3.client("s3", region_name=REGION).put_object(
         Bucket=_RESEARCH_BUCKET, Key=key, Body=body.encode(),
@@ -1480,6 +1541,7 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             run_token, tier_tag, schedule_label,
             instance_id=instance_id, deadline_utc=deadline_utc,
             task_token=task_token,
+            instance_type=_describe_instance_type(instance_id), market=market,
         )
     except Exception:
         logger.exception(_LEDGER_WRITE_FAILED_MSG)

--- a/tests/test_groom_dispatcher_engagement_iam_grants.py
+++ b/tests/test_groom_dispatcher_engagement_iam_grants.py
@@ -211,3 +211,79 @@ def test_send_task_failure_is_unscoped_because_iam_permits_nothing_narrower():
         "scoping evaluates implicitDeny and disables the reconciler's only "
         "means of reporting a dead lane."
     )
+
+
+# ── I4989 / I5512: capacity diversification and deploy-trigger coverage ──────
+
+
+def _dispatcher_source() -> str:
+    return (POLICY_FILE.parent / "index.py").read_text(encoding="utf-8")
+
+
+def test_instance_pool_spans_more_than_one_family():
+    """Two types in one family is one capacity pool, not a diversified one.
+
+    Measured 2026-07-30 20:00 UTC: the pool was t4g.medium + t4g.large and all
+    three lanes were reclaimed (`instance-terminated-no-capacity`) at the same
+    second, 6.5 minutes in, taking out the entire cycle.
+    """
+    import re
+    src = _dispatcher_source()
+    m = re.search(r'"GROOM_INSTANCE_TYPES",\s*\n?\s*"([^"]+)"', src)
+    assert m, "could not read the GROOM_INSTANCE_TYPES default"
+    types = [t.strip() for t in m.group(1).split(",") if t.strip()]
+    families = {t.split(".")[0] for t in types}
+    assert len(families) >= 3, (
+        f"instance pool spans only {sorted(families)} — spot capacity is pooled "
+        "per family, so a single-family list gives no real diversification"
+    )
+
+
+def test_instance_pool_is_all_arm64_families():
+    """One AMI serves one architecture; an x86 type here fails at launch.
+
+    GROOM_AMI_ID is Amazon Linux 2023 arm64/Graviton. Adding an x86 type would
+    not diversify anything — it would produce launch failures.
+    """
+    import re
+    src = _dispatcher_source()
+    m = re.search(r'"GROOM_INSTANCE_TYPES",\s*\n?\s*"([^"]+)"', src)
+    types = [t.strip() for t in m.group(1).split(",") if t.strip()]
+    # arm64 families in use are Graviton: t4g / c6g / c7g / m6g / m7g / r6g...
+    for t in types:
+        fam = t.split(".")[0]
+        assert fam.endswith("g"), (
+            f"{t!r} is not an arm64/Graviton type but GROOM_AMI_ID is arm64 — "
+            "this launch would fail the AMI architecture check"
+        )
+
+
+def test_launch_records_the_instance_type_it_actually_got():
+    """A diversified pool is only manageable if usage-by-type is countable."""
+    src = _dispatcher_source()
+    assert "_describe_instance_type" in src, (
+        "nothing records which instance type won the capacity race — reclaim "
+        "rate by type is then unanswerable, which is the question a "
+        "diversified pool creates"
+    )
+    assert '"instance_type"' in src and '"market"' in src, (
+        "the dispatch ledger does not carry instance_type/market — terminated "
+        "instances age out of describe-instances in ~1h, so the ledger is the "
+        "only durable record"
+    )
+
+
+def test_state_machine_definition_is_in_the_deploy_trigger():
+    """A merged definition change that never deploys is the I5512 class.
+
+    deploy.sh deploys the state machine as well as the Lambda, but the trigger
+    only watched the Lambda directory — so definition-only changes reached
+    production by luck. Two did so on 2026-07-30.
+    """
+    from pathlib import Path
+    wf = (Path(__file__).resolve().parents[1] / ".github" / "workflows"
+          / "deploy-scheduled-groom-dispatcher.yml").read_text(encoding="utf-8")
+    assert "infrastructure/step_function_groom.json" in wf, (
+        "the deploy workflow does not trigger on the state-machine definition "
+        "— a definition-only merge will not reach production"
+    )


### PR DESCRIPTION
## Three changes from the 2026-07-30 20:00 UTC cycle loss

### 1. Capacity diversification (I4989)

The pool was `t4g.medium,t4g.large` — two types but **one family**, so one spot capacity pool. All three lanes were reclaimed at the **same second**, 6.5 minutes in, taking out the whole cycle.

Brian was right that a mixed pool across AZs already existed — the mechanism is there and multi-subnet. A single family made it diversification in name only.

**Hard constraint confirmed before widening:** `GROOM_AMI_ID` is arm64 (AL2023 Graviton), and one AMI serves one architecture. x86 types cannot be added without a second AMI and architecture-aware selection. So the pool widens across arm64 **families and generations**, which is what actually separates capacity pools:

```
t4g.medium, c6g.large, c7g.large, m6g.large, m7g.large, t4g.large
```

Verified live against EC2 before committing:

| Type | Arch | vCPU | MiB | AZs |
|---|---|---|---|---|
| t4g.medium | arm64 | 2 | 4096 | 5 |
| c6g.large | arm64 | 2 | 4096 | 5 |
| c7g.large | arm64 | 2 | 4096 | 5 |
| m6g.large | arm64 | 2 | 8192 | 5 |
| m7g.large | arm64 | 2 | 8192 | 5 |

All >= 4 GiB, the agent-run floor. `c6g/c7g.large` match `t4g.medium`'s shape without the burstable CPU-credit ceiling.

### 2. Instance-type accounting

Brian: *"we would need to track how often each instance type is used (we should do this regardless)."*

`launch_with_fallback` returns only `(instance_id, market)`, so the type that won the capacity race was recorded nowhere durable — and a diversified pool is unmanageable without *which types get used, and which get reclaimed*. The dispatch ledger now carries `instance_type` + `market`.

Recorded in the **ledger** rather than only as an EC2 tag, deliberately: terminated instances age out of `describe-instances` in ~1h, while the ledger persists — so reclaim-rate-by-type stays answerable after the fact. The lookup is best-effort and never fails the launch; the ledger write is fail-loud for a *different* reason (the reconciler needs the record to exist).

### 3. Deploy-trigger gap (I5512 class)

`deploy.sh` deploys the **state machine** as well as the Lambda, but the workflow trigger only watched `infrastructure/lambdas/scheduled-groom-dispatcher/**`. A definition-only change reached production purely by luck, whenever a Lambda change happened to ride along.

**Two changes hit this today**: the I5689 `AllSkipped` comment, and the I5229 `LaneDeath` Catch — which merged and stayed un-deployed until I pushed it by hand. groom-sweep-policy §2.3: *"config-only changes must reach production."* `step_function_groom.json` is now in the trigger.

## Tests

Four new, all mutation-verified:
- pool spans >= 3 families (reverting to `t4g.*` fails)
- every type is arm64 (adding `t3.medium` fails — it would break launches, not diversify)
- the launch records its instance type
- the definition is in the deploy trigger

`pytest tests/` — **3953 passed**.

One PRE-EXISTING unrelated failure remains (`test_pipeline_status_registry_source_check` — `WaitForThinkTank` missing from `nousergon_lib` `WAIT_GROUPING`); identical on clean `main`, needs a cross-repo lib change.

## Note

On-demand last resort was already implemented (`launch_with_fallback(force_on_demand=…)` on the final relaunch attempt). It was unreachable while `LaneDeath` routed to the terminal path; `nousergon-data-PR1174` restored that, so it should now actually be reached. Worth confirming on the next reclaim rather than assuming.

## Related

- `nousergon-data-PR1174` — the routing fix that makes the on-demand escalation reachable
- `alpha-engine-config-I4989`, `I5512`, `I5229`, `I5727`

---
**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)