### PR TITLE
[P1/high] feat(groom): fault-injection harness — and the States.Runtime it found on its first successful run

### DIFF
--- a/.github/workflows/fault-injection-weekly.yml
+++ b/.github/workflows/fault-injection-weekly.yml
@@ -1,0 +1,74 @@
+name: Fault Injection (weekly)
+
+# groom-sweep-policy §10.2 — fault injection is a STANDING GATE, not a one-off.
+# §2.2 holds that "a recovery path that has never executed is presumed broken",
+# and this workflow is the thing that MAKES them execute. Before it existed the
+# only exerciser was production breakage, which is why every recovery path in
+# the 2026-07-27 arc was found broken at the moment it was first needed — and
+# why the first successful run of this harness immediately surfaced a
+# States.Runtime that made a fully-successful groom cycle impossible
+# (alpha-engine-config-I5718).
+#
+# Runs against the STAGING dispatch only: the Lambda is a scripted mock with no
+# EC2/SSM/GitHub grants, and the SNS target is a staging topic. An injection run
+# cannot launch a spot box, touch the backlog, or page the operator.
+#
+# Sunday 06:00 UTC — deliberately AFTER the Sun 09:00 UTC weekly groom slot's
+# preceding week and before the new week's Monday cycles, so a regression is
+# known before the week's grooming depends on it.
+
+on:
+  schedule:
+    - cron: "0 6 * * SUN"
+  workflow_dispatch: {}
+  # Also on any change to the definition under test or the harness itself —
+  # a topology change is exactly when the recovery paths need re-proving.
+  pull_request:
+    paths:
+      - "infrastructure/step_function_groom.json"
+      - "infrastructure/lambdas/groom-inject-mock/**"
+      - "scripts/fault_injection_run.py"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  inject:
+    name: fault-injection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install boto3
+        run: pip install --quiet boto3
+
+      # The pure derivation tests run WITHOUT credentials, so a PR from a fork
+      # or a credential outage still catches the dangerous-swap regressions
+      # rather than silently skipping the whole gate.
+      - name: Guard the staging derivation (no credentials needed)
+        run: pip install --quiet pytest && python -m pytest tests/test_fault_injection_staging.py -q
+
+      - name: Configure AWS credentials
+        id: creds
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-fault-injection
+          aws-region: us-east-1
+
+      # §2.4 no-silent-caps: if credentials are unavailable the gate reports
+      # UNVERIFIED and fails, rather than passing on a run that never happened.
+      - name: Run the injection programme
+        run: |
+          if [ "${{ steps.creds.outcome }}" != "success" ]; then
+            echo "::error::AWS credentials unavailable — the injection programme did NOT run."
+            echo "::error::Every failure mode is therefore UNVERIFIED. This gate fails rather"
+            echo "::error::than passing on an exercise that did not occur (groom-sweep-policy §10.2)."
+            exit 1
+          fi
+          python scripts/fault_injection_run.py

--- a/.github/workflows/fault-injection-weekly.yml
+++ b/.github/workflows/fault-injection-weekly.yml
@@ -53,17 +53,34 @@ jobs:
       - name: Guard the staging derivation (no credentials needed)
         run: pip install --quiet pytest && python -m pytest tests/test_fault_injection_staging.py -q
 
+      # The full programme needs AWS and therefore only runs on the SCHEDULE
+      # (and on demand) — not on pull_request. Two reasons, and the second is
+      # the load-bearing one:
+      #
+      #   1. A PR from a fork cannot hold OIDC credentials, so a credentialed
+      #      step there is unrunnable by construction.
+      #   2. §10.2's gate is the WEEKLY programme. Making every PR block on it
+      #      would mean the first missing role or expired credential turns a
+      #      standing gate into a thing people disable — which is precisely how
+      #      an exercise programme dies.
+      #
+      # The derivation tests above DO run on every PR without credentials, so
+      # the two dangerous swaps (production Lambda, production SNS topic) stay
+      # guarded on the path that actually changes them.
       - name: Configure AWS credentials
         id: creds
+        if: github.event_name != 'pull_request'
         continue-on-error: true
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::711398986525:role/github-actions-fault-injection
           aws-region: us-east-1
 
-      # §2.4 no-silent-caps: if credentials are unavailable the gate reports
-      # UNVERIFIED and fails, rather than passing on a run that never happened.
+      # §2.4 no-silent-caps: on the scheduled run, unavailable credentials mean
+      # every failure mode is UNVERIFIED, and the gate FAILS rather than passing
+      # on an exercise that did not happen.
       - name: Run the injection programme
+        if: github.event_name != 'pull_request'
         run: |
           if [ "${{ steps.creds.outcome }}" != "success" ]; then
             echo "::error::AWS credentials unavailable — the injection programme did NOT run."

--- a/infrastructure/lambdas/groom-inject-mock/deploy.sh
+++ b/infrastructure/lambdas/groom-inject-mock/deploy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# deploy.sh — the fault-injection mock Lambda + its role, and the staging
+# state machine's execution role (alpha-engine-config-I5718).
+#
+# This deploys NOTHING that production depends on. The mock exists only to
+# stand in for the groom dispatcher inside the staging dispatch, and its role
+# is deliberately the narrowest in the fleet: CloudWatch Logs, plus
+# states:SendTask* so it can complete or fail injected lanes. No EC2, no SSM,
+# no GitHub, no S3.
+#
+# The staging state machine itself is built by
+# `scripts/fault_injection_run.py --deploy`, which DERIVES it from the
+# production definition rather than carrying a copy. That script is the entry
+# point; this file exists so the mock's IAM is codified rather than applied by
+# hand (it was, once, on 2026-07-30 — this replaces that).
+#
+# Usage:
+#   bash infrastructure/lambdas/groom-inject-mock/deploy.sh            # code only
+#   bash infrastructure/lambdas/groom-inject-mock/deploy.sh --bootstrap  # + roles/topic
+#   bash infrastructure/lambdas/groom-inject-mock/deploy.sh --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FUNCTION_NAME="alpha-engine-groom-inject-mock"
+ROLE_NAME="alpha-engine-groom-inject-mock-role"
+POLICY_NAME="alpha-engine-groom-inject-mock-policy"
+SF_ROLE_NAME="alpha-engine-groom-inject-sf-role"
+SF_POLICY_NAME="alpha-engine-groom-inject-sf-policy"
+STAGING_TOPIC="alpha-engine-groom-inject-alerts"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+BOOTSTRAP=false
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --bootstrap) BOOTSTRAP=true ;;
+    --dry-run) DRY_RUN=true ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+run() { if $DRY_RUN; then echo "[dry-run] $*"; else "$@"; fi; }
+
+if $BOOTSTRAP; then
+  echo "== mock execution role =="
+  run aws iam create-role --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+    >/dev/null 2>&1 || echo "  (already exists)"
+  run aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  echo "== staging state-machine execution role =="
+  # Deliberately NOT the production groom SF role: that role is scoped to the
+  # production Lambda and the real alerts topic, so reusing it both fails (the
+  # first injection run did) and would let a staging machine reach production
+  # resources if the definition swap were ever incomplete. Isolation is
+  # enforced by IAM here, not by the swap being correct.
+  run aws iam create-role --role-name "${SF_ROLE_NAME}" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"states.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+    >/dev/null 2>&1 || echo "  (already exists)"
+  run aws iam put-role-policy --role-name "${SF_ROLE_NAME}" \
+    --policy-name "${SF_POLICY_NAME}" \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"InvokeOnlyTheMock\",\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"${FN_ARN}\"},{\"Sid\":\"PublishOnlyToStagingTopic\",\"Effect\":\"Allow\",\"Action\":\"sns:Publish\",\"Resource\":\"arn:aws:sns:${REGION}:${ACCOUNT_ID}:${STAGING_TOPIC}\"}]}"
+
+  echo "== staging alerts topic =="
+  run aws sns create-topic --name "${STAGING_TOPIC}" --region "${REGION}" \
+    --query TopicArn --output text
+fi
+
+echo "== mock code =="
+ZIP="$(mktemp -d)/mock.zip"
+(cd "${SCRIPT_DIR}" && zip -q "${ZIP}" index.py)
+if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" \
+    --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+  run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
+    --zip-file "fileb://${ZIP}" --region "${REGION}" \
+    --query LastUpdateStatus --output text
+else
+  run aws lambda create-function --function-name "${FUNCTION_NAME}" \
+    --runtime python3.12 \
+    --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
+    --handler index.handler --zip-file "fileb://${ZIP}" \
+    --timeout 60 --memory-size 256 --region "${REGION}" \
+    --query FunctionArn --output text
+fi
+
+echo "Done. Build/refresh the staging state machine with:"
+echo "  python3 scripts/fault_injection_run.py --deploy"

--- a/infrastructure/lambdas/groom-inject-mock/iam-policy.json
+++ b/infrastructure/lambdas/groom-inject-mock/iam-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-groom-inject-mock:*"
+    },
+    {
+      "Sid": "CompleteInjectedLanes",
+      "Effect": "Allow",
+      "Action": [
+        "states:SendTaskSuccess",
+        "states:SendTaskFailure"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/groom-inject-mock/index.py
+++ b/infrastructure/lambdas/groom-inject-mock/index.py
@@ -1,0 +1,205 @@
+"""groom-inject-mock — the scripted stand-in for the groom dispatcher, used
+ONLY by the fault-injection staging dispatch (alpha-engine-config-I5718).
+
+Why a separate function rather than a flag on the real dispatcher: a
+`GROOM_INJECT_MODE` branch inside the production Lambda is one bad conditional
+away from launching real spot boxes against the real backlog. Nothing here has
+EC2, SSM or GitHub permissions — see iam-policy.json, which grants only
+`states:SendTask*` and CloudWatch Logs.
+
+**What it is NOT.** This does not mock the groom's *judgment* — no issue
+selection, no model routing, no PR logic. It answers exactly the Task states
+the dispatch state machine invokes, with responses shaped like the real
+Lambda's, so the STATE MACHINE's recovery topology is what gets exercised:
+timeout -> CheckCompletionMarker -> relaunch -> retry budget -> HandleFailure.
+That topology is where every failure recorded in this system has actually
+lived (config-I4333, I4987, I5371, I5372), and it is the part unit tests
+cannot reach.
+
+**How a scenario is driven.** The staging execution's input carries
+`inject: {scenario}`. Scenarios are declared in SCENARIOS below; each names the
+failure mode from groom-sweep-policy §10.2's minimum standing set that it
+reproduces. The driver reads this map out of the DEPLOYED function rather than
+keeping its own copy, so driver and mock cannot drift (§2.7 derive-once,
+applied to the harness itself).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+SCENARIOS: dict[str, str] = {
+    "callback_never_arrives": "box killed after work, before callback",
+    "callback_rejected": "callback rejected",
+    "box_dies_mid_run": "box killed mid-run",
+    "box_dies_mid_bootstrap": "box killed mid-bootstrap",
+    "relaunch_guard_refuses": "a relaunch whose guard refuses it",
+    "empty_enumeration": "empty enumeration",
+    "malformed_decide_payload": "malformed classify payload",
+    "decide_raises": "GitHub search 500",
+    "ledger_write_fails": "expectation-record write failure",
+    "happy_path": "(control — not a failure mode; proves the harness can pass)",
+}
+
+
+def _scenario(event: dict) -> str:
+    """Read the scenario from wherever the SF hands it to us.
+
+    An unknown or absent scenario is NOT defaulted to happy_path — that would
+    let a driver bug read as a passing injection, which is the §2.4 failure
+    this whole programme exists to catch. It raises instead.
+    """
+    for candidate in (
+        event.get("inject"),
+        (event.get("schedInput") or {}).get("inject"),
+        (event.get("cycle") or {}).get("inject"),
+    ):
+        if isinstance(candidate, dict) and candidate.get("scenario"):
+            return str(candidate["scenario"])
+    raise ValueError(
+        f"no inject.scenario in event keys={sorted(event)!r} — the injection "
+        "driver did not thread the scenario through, and defaulting it would "
+        "make a harness bug look like a passing test"
+    )
+
+
+def _decide_response(scenario: str) -> dict:
+    """Answer for DecideLaunches."""
+    if scenario == "empty_enumeration":
+        # Zero actionable issues -> AllSkipped -> sweep. Post-I5689 this must
+        # report as a HEALTHY skip, not a degraded one.
+        return {"decide": {"launches": [], "reason": "demand_gate_skip"}}
+    if scenario == "malformed_decide_payload":
+        return {"decide": {"launches": "not-a-list", "reason": "malformed"}}
+    if scenario == "decide_raises":
+        raise RuntimeError("injected: GitHub search returned 500")
+    return {
+        "decide": {
+            "trigger": "demand-all",
+            "counts": {"low": 1, "mid": 1, "high": 0},
+            "launches": [{
+                "issue_filter": "mid-only",
+                "model": "inject-mock",
+                "tier_tag": "mid-only",
+                "launch_decided": True,
+            }],
+        }
+    }
+
+
+def _launch_response(scenario: str, task_token: str) -> dict:
+    """Answer for LaunchGroomSpot (invoke.waitForTaskToken).
+
+    Returning normally does NOT complete the state — the SF waits for the task
+    token. That is precisely what lets us reproduce a lost callback: answer,
+    and never send the token.
+    """
+    sfn = boto3.client("stepfunctions", region_name=REGION)
+
+    if scenario == "ledger_write_fails":
+        # The post-launch expectation write is fail-loud (§2.7): the real
+        # Lambda terminates the box and raises.
+        raise RuntimeError("injected: expectation-record write failed")
+
+    if scenario == "relaunch_guard_refuses":
+        # The I4987 defect: the relaunch fires, the concurrent-tier guard
+        # refuses because the PREVIOUS box is still alive, and the SF waits on
+        # a no-op until it times out. launched:false and NO token.
+        return {"groom": {
+            "launched": False, "reason": "concurrent_tier_skip",
+            "issue_filter": "mid-only",
+            "existing_instance_ids": ["i-injected-previous-attempt"],
+        }}
+
+    if scenario == "box_dies_mid_bootstrap":
+        return {"groom": {"launched": True, "instance_id": "i-injected-dead-boot",
+                          "market": "spot", "run_token": "inject-boot"}}
+
+    if scenario in ("callback_never_arrives", "box_dies_mid_run"):
+        return {"groom": {"launched": True, "instance_id": "i-injected-silent",
+                          "market": "spot", "run_token": "inject-silent"}}
+
+    if scenario == "callback_rejected":
+        if task_token:
+            sfn.send_task_failure(
+                taskToken=task_token,
+                error="InjectedCallbackRejected",
+                cause="injected: box reported failure via send-task-failure",
+            )
+        return {"groom": {"launched": True, "instance_id": "i-injected-rejected"}}
+
+    if task_token:
+        _r = sfn.send_task_success(
+            taskToken=task_token,
+            output=json.dumps({"groomLaunch": {"Payload": {"groom": {
+                "launched": True, "completion": "success",
+                "instance_id": "i-injected-ok", "run_token": "inject-ok",
+            }}}}),
+        )
+        logger.info('lane completed via task token (http=%s)',
+                    _r.get('ResponseMetadata', {}).get('HTTPStatusCode'))
+    return {"groom": {"launched": True, "instance_id": "i-injected-ok"}}
+
+
+def handler(event, _context):  # noqa: ANN001 — Lambda signature
+    """Total by construction: every shape either answers or raises loudly."""
+    if event.get("mode") == "list_scenarios":
+        return {"scenarios": SCENARIOS}
+
+    if event.get("mode") == "cycle_complete":
+        return {"cycleNotify": {"notified": True, "degraded": False,
+                                "lanes": 0, "injected": True}}
+
+    if event.get("run_mode") == "sweep":
+        return {"groom": {"launched": True, "instance_id": "i-injected-sweep",
+                          "run_mode": "sweep", "injected": True}}
+
+    scenario = _scenario(event)
+    if scenario not in SCENARIOS:
+        raise ValueError(f"unknown injection scenario {scenario!r}; "
+                         f"known: {sorted(SCENARIOS)}")
+
+    logger.info("inject scenario=%s keys=%s", scenario, sorted(event))
+
+    # Route by the field that UNIQUELY identifies each caller. Ordering matters
+    # and the discriminators are not interchangeable: LaunchGroomSpot's payload
+    # is JsonMerge(schedInput, launchDecision, fod, $$.Task), so it also carries
+    # `trigger`, `run_mode` and `schedule` from schedInput. Routing on `trigger`
+    # therefore sends the LANE to the decide branch, the token is never used,
+    # and every lane times out — which is exactly what happened on the first
+    # live run of this harness (2026-07-30) and cost three relaunch cycles
+    # before the log showed `Token` sitting unread in the payload.
+    #
+    # `Token` is present ONLY on the waitForTaskToken state, so it is checked
+    # FIRST and is the only safe discriminator for the lane.
+    if event.get("Token"):
+        return _launch_response(scenario, event["Token"])
+
+    # DecideLaunches is the only caller with decide_only.
+    if "decide_only" in event:
+        return _decide_response(scenario)
+
+    # CheckCompletionMarkerTaskToken — reached after a lane timeout, identified
+    # by the markers the SF threads through it. The real Lambda relaunches
+    # here; answering the same shape exercises the retry budget and
+    # HandleFailure path for real.
+    if "retryMarker" in event or "decideMarker" in event:
+        return {"groom": {"launched": True, "instance_id": "i-injected-relaunch",
+                          "run_token": "inject-relaunch"}}
+
+    # No silent fallthrough: an unrecognized caller means the production
+    # definition grew a state this mock does not answer, and guessing would
+    # make the harness report on a topology it is not actually driving.
+    raise ValueError(
+        f"unroutable invocation for scenario {scenario!r}; keys={sorted(event)!r} "
+        "— the dispatch state machine invoked a state this mock does not model"
+    )

--- a/infrastructure/lambdas/groom-inject-mock/staging_definition.py
+++ b/infrastructure/lambdas/groom-inject-mock/staging_definition.py
@@ -1,0 +1,110 @@
+"""Build the fault-injection staging state machine FROM the production
+definition (alpha-engine-config-I5718).
+
+The whole value of this harness rests on one property: **the topology under
+test is the production topology.** A hand-written staging definition would
+drift within a week and would then be testing a state machine that does not
+exist, which is worse than testing nothing because it reports green.
+
+So the staging machine is *derived*, not authored. Exactly three
+transformations are applied to `infrastructure/step_function_groom.json`, and
+each one is here because leaving it out would make the harness unusable or
+dangerous:
+
+1. **Lambda ARN -> the mock.** Otherwise an injection run launches real spot
+   boxes against the real backlog.
+2. **SNS topic -> a staging topic.** Otherwise every injection run pages Brian
+   on the real alerts topic. This is the transformation most likely to be
+   forgotten and the most obnoxious when it is.
+3. **Timeouts scaled down.** The lane timeout is 21600s; a harness that takes
+   six hours to observe one timeout path will never run. Scaling preserves the
+   ORDERING of budgets (which is what the recovery logic branches on) while
+   making the run take seconds.
+
+Everything else — state names, Choice conditions, Catch blocks, Retry policy,
+the relaunch budget, ResultPath wiring — is passed through untouched. If a
+transformation beyond these three is ever needed, that is a signal the
+production definition is not testable, and the fix belongs there.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+#: Applied to every TimeoutSeconds in the definition, including the top-level
+#: one. 720 turns the 21600s lane budget into 30s and the 72000s execution
+#: ceiling into 100s, so a full three-attempt relaunch exhaustion — the exact
+#: 18h shape observed in production on 2026-07-29 — completes in ~90 seconds.
+TIMEOUT_DIVISOR = 720
+
+#: Never scale below this. A 360s state at /720 would be 0.5s and would start
+#: failing on Lambda cold starts, turning the harness flaky — which is how an
+#: exercise programme gets switched off.
+MIN_TIMEOUT_SECONDS = 5
+
+PROD_LAMBDA = "alpha-engine-scheduled-groom-dispatcher"
+MOCK_LAMBDA = "alpha-engine-groom-inject-mock"
+PROD_SNS_PATTERN = re.compile(r"arn:aws:sns:[^\"]*:alpha-engine-alerts")
+STAGING_SNS_NAME = "alpha-engine-groom-inject-alerts"
+
+
+def _scale_timeouts(node: Any) -> Any:
+    """Recursively scale every TimeoutSeconds, preserving budget ORDER."""
+    if isinstance(node, dict):
+        out = {}
+        for key, value in node.items():
+            if key == "TimeoutSeconds" and isinstance(value, (int, float)):
+                out[key] = max(MIN_TIMEOUT_SECONDS, int(value) // TIMEOUT_DIVISOR)
+            else:
+                out[key] = _scale_timeouts(value)
+        return out
+    if isinstance(node, list):
+        return [_scale_timeouts(item) for item in node]
+    return node
+
+
+def build_staging_definition(prod_definition: dict, *, account_id: str,
+                             region: str) -> dict:
+    """Return the staging definition derived from ``prod_definition``.
+
+    Pure: no AWS calls, no file IO. That is what lets the unit tests assert the
+    transformation without credentials.
+    """
+    staging_topic = f"arn:aws:sns:{region}:{account_id}:{STAGING_SNS_NAME}"
+
+    raw = json.dumps(prod_definition)
+    if PROD_LAMBDA not in raw:
+        raise ValueError(
+            f"production definition names no {PROD_LAMBDA!r} — the Lambda was "
+            "renamed and this builder would have produced a staging machine "
+            "still pointing at production"
+        )
+    raw = raw.replace(PROD_LAMBDA, MOCK_LAMBDA)
+
+    raw, sns_swaps = PROD_SNS_PATTERN.subn(staging_topic, raw)
+    if sns_swaps == 0:
+        raise ValueError(
+            "production definition names no alpha-engine-alerts topic — either "
+            "alerting moved, or this builder is about to ship a staging machine "
+            "that publishes somewhere unaudited. Fix the pattern deliberately."
+        )
+
+    definition = _scale_timeouts(json.loads(raw))
+    definition["Comment"] = (
+        "FAULT-INJECTION STAGING — derived from step_function_groom.json by "
+        "staging_definition.py (alpha-engine-config-I5718). DO NOT EDIT: "
+        "regenerate instead. Lambda -> inject mock, SNS -> staging topic, "
+        f"timeouts /{TIMEOUT_DIVISOR}. Original comment: "
+        + str(prod_definition.get("Comment", ""))[:400]
+    )
+    return definition
+
+
+def load_prod_definition(repo_root: Path | None = None) -> dict:
+    root = repo_root or Path(__file__).resolve().parents[3]
+    return json.loads(
+        (root / "infrastructure" / "step_function_groom.json").read_text()
+    )

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1253,6 +1253,20 @@ def _write_dispatch_ledger_entry(run_token: str, tier_tag: str, schedule_label: 
 # the same verdict.
 
 _RECONCILE_COMPLETED_PREFIX = "groom/_control/completed"
+
+# Expectations this reconciler has already ACTIONED (paged + send-task-failure).
+# Without it the reconciler re-detects the same dead lane on every 5-minute
+# tick for as long as the ledger entry is in the scan window, and re-pages —
+# which is exactly what Brian saw on 2026-07-30 after the reconciler shipped.
+# The per-run_token dedup key on the notification did NOT hold across
+# invocations, so the fix belongs here, at the source: an actioned expectation
+# is a CLOSED expectation.
+#
+# Deliberately a SEPARATE prefix from `completed/`: that marker means "the box
+# finished its work and said so", and writing a death into it would make a
+# reclaimed lane indistinguishable from a successful one to every other
+# consumer of that prefix.
+_RECONCILE_ACTIONED_PREFIX = "groom/_control/reconciled"
 # describe-instances returns terminated instances for only ~1h (AWS docs).
 # An instance absent from the response is treated as lane_died — the
 # unmatched expectation IS the signal (§2.7).
@@ -1297,6 +1311,14 @@ def _reconcile_lane_death() -> dict:
                 run_token = run_token[:-5]  # strip ".json"
                 if run_token in seen_tokens:
                     continue  # same token filed under both days — count once
+                # Already actioned by a previous tick — closed, not open.
+                actioned_key = f"{_RECONCILE_ACTIONED_PREFIX}/{run_token}.json"
+                try:
+                    s3.head_object(Bucket=_RESEARCH_BUCKET, Key=actioned_key)
+                    seen_tokens.add(run_token)
+                    continue
+                except Exception:
+                    pass
                 completed_key = f"{_RECONCILE_COMPLETED_PREFIX}/{run_token}.json"
                 try:
                     s3.head_object(Bucket=_RESEARCH_BUCKET, Key=completed_key)
@@ -1382,6 +1404,29 @@ def _reconcile_lane_death() -> dict:
                                      if not k.startswith("_")},
                      "reason": reason, "instance_state": state},
         )
+
+        # Close the expectation BEFORE the send-task-failure below. Ordering is
+        # deliberate: if the marker write fails we must not have already paged
+        # AND actioned without a record, and if send-task-failure fails the
+        # expectation is still closed — the page has been delivered, and
+        # re-paging every 5 minutes forever is strictly worse than one missed
+        # SF collapse (which the 6h TimeoutSeconds still covers).
+        try:
+            boto3.client("s3", region_name=REGION).put_object(
+                Bucket=_RESEARCH_BUCKET,
+                Key=f"{_RECONCILE_ACTIONED_PREFIX}/{exp.get('run_token', '')}.json",
+                Body=json.dumps({
+                    "outcome": "lane_died" if state not in _ALIVE_STATES else "overdue",
+                    "reason": reason,
+                    "instance_id": instance_id,
+                    "instance_state": state,
+                    "actioned_at": now.isoformat(),
+                }).encode(),
+                ContentType="application/json")
+        except Exception as exc:  # noqa: BLE001 — see ordering note above
+            logger.warning(
+                "reconciler: could not close expectation %s (will re-page next "
+                "tick): %s", exp.get("run_token"), exc)
 
         # Collapse the SF execution immediately for a dead box — the task
         # token would otherwise sit outstanding for 6h (the TimeoutSeconds

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2619,3 +2619,59 @@ def test_reconciler_fixtures_are_not_date_pinned():
         f"date-pinned ledger partition(s) in test fixtures: {sorted(set(pinned))} — "
         "derive the partition from the clock via _ledger_key() instead"
     )
+
+
+def test_reconciler_pages_a_death_only_once(monkeypatch):
+    """An actioned expectation is a CLOSED expectation.
+
+    Brian, 2026-07-30: "why are the groom lane death error messages repeating?
+    they should be sent one time only." The reconciler paged and sent
+    send-task-failure but recorded nothing, so every 5-minute tick re-detected
+    the same dead lane and paged again. The per-run_token dedup key on the
+    notification did not hold across invocations.
+    """
+    ledger = {
+        _ledger_key("tok-dead"): json.dumps({
+            "run_token": "tok-dead", "tier_tag": "mid-only",
+            "schedule": "0 20 * * *", "instance_id": "i-dead",
+            "deadline_utc": _future_deadline(),
+        }).encode(),
+    }
+    idx = _load(monkeypatch, s3_objects=dict(ledger))
+
+    first = idx.handler({"mode": "reconcile"}, None)
+    assert first["deaths"] == 1, "the first tick must detect and page the death"
+
+    # The second tick runs against the SAME bucket the first one wrote to.
+    second = idx.handler({"mode": "reconcile"}, None)
+    assert second["deaths"] == 0, (
+        "the reconciler re-detected an already-actioned lane death — this is "
+        "the repeating-alert defect: it pages every 5 minutes until the ledger "
+        "entry ages out of the scan window"
+    )
+    assert second["open_expectations"] == 0
+
+
+def test_actioned_marker_is_not_written_to_the_completed_prefix(monkeypatch):
+    """A death must not be indistinguishable from a clean completion.
+
+    `completed/` means "the box finished its work and said so". Writing a
+    reclaimed lane into it would corrupt that meaning for every other consumer,
+    so the reconciler uses its own prefix.
+    """
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok-dead"): json.dumps({
+            "run_token": "tok-dead", "tier_tag": "mid-only",
+            "schedule": "0 20 * * *", "instance_id": "i-dead",
+            "deadline_utc": _future_deadline(),
+        }).encode(),
+    })
+    idx.handler({"mode": "reconcile"}, None)
+    written = getattr(idx._test_s3, "_objects", {})
+    completed = [k for k in written if "_control/completed/" in k]
+    actioned = [k for k in written if "_control/reconciled/" in k]
+    assert not completed, (
+        f"reconciler wrote into the completed/ prefix: {completed} — a dead "
+        "lane would read as a successful one"
+    )
+    assert actioned, "no reconciled/ marker written; the expectation stays open"

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -1,10 +1,10 @@
 {
-  "Comment": "Backlog groom dispatch (config#1472, restructured config#2129, end-of-SF sweep config#2201) \u2014 wraps the EventBridge Scheduler -> Lambda -> EC2-spot-via-SSM dispatch chain in a Step Function so the fleet's existing Fleet-SF Watch resilience/observability agent covers groom runs the SAME way it covers the Saturday/weekday/EOD pipelines. config#2129 TWO-PHASE REDESIGN: the OLD version invoked the scheduled-groom-dispatcher Lambda ONCE per trigger and tried to poll a SINGLE CommandId/InstanceId \u2014 that worked for a single-tier launch, but config#1933's 'demand-all' symmetric triggers made ALL 3 tiers co-launch on every recorded trigger (2026-07-08..10), and the Lambda's demand-all response is a `launches: [...]` ARRAY with no top-level launched/instance_id/command_id. CheckLaunched/PollGroomCommand's Choice/Task Parameters referenced that missing singular shape and failed with States.Runtime on ~83% of real triggers (5 of the last 6 executions checked 2026-07-10) \u2014 the SF reported FAILED (or never even reached PollGroomCommand) on runs where the real EC2 boxes launched and worked FINE; Fleet-SF-Watch had zero real visibility into them. This is now: DecideLaunches (Lambda op=decide_only \u2014 enumerate + decide WITHOUT launching, returns 0..3 launch decisions) -> CheckAnyLaunches -> a Map state, ONE ITERATION PER DECISION, each independently launching (Lambda op=launch_decided) and polling via the SAME per-box states the old single-launch design already had (LaunchGroomSpot/PollGroomCommand/CheckGroomStatus/.../GroomSucceeded/GroomSkipped/FailExecution, now scoped inside the Map's ItemProcessor instead of the top level). A Standard Map state's default semantics (ToleratedFailurePercentage=0) mean ANY iteration reaching its own FailExecution fails the whole Map \u2014 and hence the whole SF execution \u2014 which is the correct 'fail loud' extension of the old single-box behavior to N co-launched boxes. config#1645's bounded auto-relaunch (spot-interruption recovery via the S3 completion-marker check) is UNCHANGED, just now per-iteration instead of per-execution \u2014 each co-launched tier can independently die mid-run and independently relaunch up to max_retries times without affecting its siblings. config#2201 END-OF-SF SWEEP (Brian design 2026-07-10): after the Map fully winds down \u2014 and equally on the zero-launches path \u2014 a final DispatchEndOfSfSweep state launches ONE Haiku run_mode=sweep spot box covering the full org PR set. This replaces the config#2129 per-box partitioned sweeps (the partition machinery is retired in the dispatcher + config driver): sweeps now run unconditionally every trigger cycle (the drain-the-backlog end state can never starve them) and AFTER all groomers finish (catching the PRs they just opened). The sweep dispatch is fire-and-forget (no polling loop \u2014 Brian removed the wait): a sweep-launch failure is RECORDED in the execution output + SNS-notified but never fails the SF (the groom boxes are the primary deliverable; the next trigger's sweep covers the tail).",
+  "Comment": "Backlog groom dispatch (config#1472, restructured config#2129, end-of-SF sweep config#2201) — wraps the EventBridge Scheduler -> Lambda -> EC2-spot-via-SSM dispatch chain in a Step Function so the fleet's existing Fleet-SF Watch resilience/observability agent covers groom runs the SAME way it covers the Saturday/weekday/EOD pipelines. config#2129 TWO-PHASE REDESIGN: the OLD version invoked the scheduled-groom-dispatcher Lambda ONCE per trigger and tried to poll a SINGLE CommandId/InstanceId — that worked for a single-tier launch, but config#1933's 'demand-all' symmetric triggers made ALL 3 tiers co-launch on every recorded trigger (2026-07-08..10), and the Lambda's demand-all response is a `launches: [...]` ARRAY with no top-level launched/instance_id/command_id. CheckLaunched/PollGroomCommand's Choice/Task Parameters referenced that missing singular shape and failed with States.Runtime on ~83% of real triggers (5 of the last 6 executions checked 2026-07-10) — the SF reported FAILED (or never even reached PollGroomCommand) on runs where the real EC2 boxes launched and worked FINE; Fleet-SF-Watch had zero real visibility into them. This is now: DecideLaunches (Lambda op=decide_only — enumerate + decide WITHOUT launching, returns 0..3 launch decisions) -> CheckAnyLaunches -> a Map state, ONE ITERATION PER DECISION, each independently launching (Lambda op=launch_decided) and polling via the SAME per-box states the old single-launch design already had (LaunchGroomSpot/PollGroomCommand/CheckGroomStatus/.../GroomSucceeded/GroomSkipped/FailExecution, now scoped inside the Map's ItemProcessor instead of the top level). A Standard Map state's default semantics (ToleratedFailurePercentage=0) mean ANY iteration reaching its own FailExecution fails the whole Map — and hence the whole SF execution — which is the correct 'fail loud' extension of the old single-box behavior to N co-launched boxes. config#1645's bounded auto-relaunch (spot-interruption recovery via the S3 completion-marker check) is UNCHANGED, just now per-iteration instead of per-execution — each co-launched tier can independently die mid-run and independently relaunch up to max_retries times without affecting its siblings. config#2201 END-OF-SF SWEEP (Brian design 2026-07-10): after the Map fully winds down — and equally on the zero-launches path — a final DispatchEndOfSfSweep state launches ONE Haiku run_mode=sweep spot box covering the full org PR set. This replaces the config#2129 per-box partitioned sweeps (the partition machinery is retired in the dispatcher + config driver): sweeps now run unconditionally every trigger cycle (the drain-the-backlog end state can never starve them) and AFTER all groomers finish (catching the PRs they just opened). The sweep dispatch is fire-and-forget (no polling loop — Brian removed the wait): a sweep-launch failure is RECORDED in the execution output + SNS-notified but never fails the SF (the groom boxes are the primary deliverable; the next trigger's sweep covers the tail).",
   "StartAt": "InitRunState",
   "States": {
     "InitRunState": {
       "Type": "Pass",
-      "Comment": "Seed schedInput (the raw EventBridge Scheduler input, e.g. {run_mode, trigger, pr_budget, schedule} \u2014 unchanged contract) and a literal decide_only marker merged into DecideLaunches's Payload below (States.JsonMerge arguments must be real JSONPaths, so the literal lives here rather than inline in the merge call). alpha-engine-config-I5371: also seeds executionArn from the SF context object so the decide phase can enforce a CYCLE SINGLETON (skip when an earlier dispatch execution is still RUNNING). The context object is not reachable from inside States.JsonMerge, so it is seeded here like decide_only itself.",
+      "Comment": "Seed schedInput (the raw EventBridge Scheduler input, e.g. {run_mode, trigger, pr_budget, schedule} — unchanged contract) and a literal decide_only marker merged into DecideLaunches's Payload below (States.JsonMerge arguments must be real JSONPaths, so the literal lives here rather than inline in the merge call). alpha-engine-config-I5371: also seeds executionArn from the SF context object so the decide phase can enforce a CYCLE SINGLETON (skip when an earlier dispatch execution is still RUNNING). The context object is not reachable from inside States.JsonMerge, so it is seeded here like decide_only itself.",
       "Parameters": {
         "schedInput.$": "$",
         "decideMarker": {
@@ -16,7 +16,7 @@
     },
     "DecideLaunches": {
       "Type": "Task",
-      "Comment": "config#2129: invoke the Lambda's NEW decide_only operation \u2014 enumerates the backlog (or applies the pre-boot pace gate) and returns 0..3 launch DECISIONS without launching anything. Each decision carries model/issue_filter(+pr_budget when applicable) \u2014 the config#2129 per-decision sweep-partition fields are retired (config#2201: one end-of-SF sweep box replaces per-box partitioned sweeps). Payload is schedInput merged with the decide_only marker \u2014 same pass-through-wrapper contract the old LaunchGroomSpot had, just decide instead of decide-and-launch.",
+      "Comment": "config#2129: invoke the Lambda's NEW decide_only operation — enumerates the backlog (or applies the pre-boot pace gate) and returns 0..3 launch DECISIONS without launching anything. Each decision carries model/issue_filter(+pr_budget when applicable) — the config#2129 per-decision sweep-partition fields are retired (config#2201: one end-of-SF sweep box replaces per-box partitioned sweeps). Payload is schedInput merged with the decide_only marker — same pass-through-wrapper contract the old LaunchGroomSpot had, just decide instead of decide-and-launch.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
@@ -39,7 +39,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "A genuine invoke-level failure (throttle, IAM, unhandled exception) \u2014 distinct from a clean 'nothing to launch' decide response (pace-gate skip / demand-gate skip / fail-safe enumeration-error skip), which CheckAnyLaunches below routes to AllSkipped, not here.",
+          "Comment": "A genuine invoke-level failure (throttle, IAM, unhandled exception) — distinct from a clean 'nothing to launch' decide response (pace-gate skip / demand-gate skip / fail-safe enumeration-error skip), which CheckAnyLaunches below routes to AllSkipped, not here.",
           "Next": "HandleDecideFailure",
           "ResultPath": "$.error"
         }
@@ -49,7 +49,7 @@
     },
     "CheckAnyLaunches": {
       "Type": "Choice",
-      "Comment": "IsPresent on launches[0] is the standard ASL idiom for 'array non-empty' (no native length operator). Empty covers: pace-gate skip, demand-gate skip (light queue), and the fail-safe enumeration-error skip \u2014 all clean, zero-spend, non-failure outcomes.",
+      "Comment": "IsPresent on launches[0] is the standard ASL idiom for 'array non-empty' (no native length operator). Empty covers: pace-gate skip, demand-gate skip (light queue), and the fail-safe enumeration-error skip — all clean, zero-spend, non-failure outcomes.",
       "Choices": [
         {
           "Variable": "$.decideResult.Payload.decide.launches[0]",
@@ -61,7 +61,7 @@
     },
     "AllSkipped": {
       "Type": "Pass",
-      "Comment": "Zero groom spot/WET spend \u2014 but NOT automatically healthy. This state is reached by several distinct routes and only some are benign: a demand-gate skip (light backlog) is the system correctly declining to spend, while a concurrent_cycle_skip is a cycle the backlog needed and did not get. The route travels in $.decideResult.Payload.decide.reason and is CLASSIFIED by _SKIP_REASONS in the dispatcher Lambda (alpha-engine-config-I5689) \u2014 before that table both rendered as a clean '\u2705 COMPLETE'. Deliberately NOT branched on here via JSONPath: a plain light-backlog decide carries launches:[] with no reason field at all, and a Parameters reference to an absent field raises States.Runtime that no Catch can intercept (groom-sweep-policy \u00a72.2). The pre-boot pace gate named in the previous version of this comment was DISMANTLED by Brian's 2026-07-14 ruling and is no longer a route to this state. config#2201: no longer a terminal Succeed \u2014 the zero-launches path MUST still reach DispatchEndOfSfSweep (unconditional sweep coverage is the whole point of the end-of-SF design: the drain-the-backlog end state can never starve the PR sweep).",
+      "Comment": "Zero groom spot/WET spend — but NOT automatically healthy. This state is reached by several distinct routes and only some are benign: a demand-gate skip (light backlog) is the system correctly declining to spend, while a concurrent_cycle_skip is a cycle the backlog needed and did not get. The route travels in $.decideResult.Payload.decide.reason and is CLASSIFIED by _SKIP_REASONS in the dispatcher Lambda (alpha-engine-config-I5689) — before that table both rendered as a clean '✅ COMPLETE'. Deliberately NOT branched on here via JSONPath: a plain light-backlog decide carries launches:[] with no reason field at all, and a Parameters reference to an absent field raises States.Runtime that no Catch can intercept (groom-sweep-policy §2.2). The pre-boot pace gate named in the previous version of this comment was DISMANTLED by Brian's 2026-07-14 ruling and is no longer a route to this state. config#2201: no longer a terminal Succeed — the zero-launches path MUST still reach DispatchEndOfSfSweep (unconditional sweep coverage is the whole point of the end-of-SF design: the drain-the-backlog end state can never starve the PR sweep).",
       "Result": {
         "all_skipped": true
       },
@@ -70,7 +70,7 @@
     },
     "MapLaunches": {
       "Type": "Map",
-      "Comment": "config#2129: one iteration per launch decision \u2014 up to 3 (low/mid/high co-launch is the observed steady state). Each iteration independently launches (op=launch_decided, .waitForTaskToken) and waits for the box to call send-task-success on completion. Timeout (6h) routes to the existing CheckCompletionMarker / bounded-retry relaunch loop. config-I4333: replaces the old SSM poll loop (15s intervals x hours) with a sub-second task-token callback \u2014 the sweep dispatches immediately after the last tier completes. config#4803: per-lane FailExecution replaced with RecordLaneFailure (a recording Pass) \u2014 every iteration succeeds from the Map's perspective, so a single lane failure no longer aborts its siblings mid-work. Post-Map aggregation (CheckMapLaneOutcomes \u2192 SetMapFailureFromLanes) inspects $.mapOutcome[*].laneOutcome.laneFailed and routes to GroomMapLaunchFailed if any lane recorded a failure, preserving fail-loud at the execution level without sibling collateral.",
+      "Comment": "config#2129: one iteration per launch decision — up to 3 (low/mid/high co-launch is the observed steady state). Each iteration independently launches (op=launch_decided, .waitForTaskToken) and waits for the box to call send-task-success on completion. Timeout (6h) routes to the existing CheckCompletionMarker / bounded-retry relaunch loop. config-I4333: replaces the old SSM poll loop (15s intervals x hours) with a sub-second task-token callback — the sweep dispatches immediately after the last tier completes. config#4803: per-lane FailExecution replaced with RecordLaneFailure (a recording Pass) — every iteration succeeds from the Map's perspective, so a single lane failure no longer aborts its siblings mid-work. Post-Map aggregation (CheckMapLaneOutcomes → SetMapFailureFromLanes) inspects $.mapOutcome[*].laneOutcome.laneFailed and routes to GroomMapLaunchFailed if any lane recorded a failure, preserving fail-loud at the execution level without sibling collateral.",
       "ItemsPath": "$.decideResult.Payload.decide.launches",
       "MaxConcurrency": 3,
       "ItemSelector": {
@@ -88,7 +88,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2311 + config#4803: a Map-level Catch here now catches only genuine Map-level failures (States.Runtime from a malformed definition, etc.) \u2014 per-lane failures no longer fail the Map (RecordLaneFailure is a Pass, not a Fail). On a Map-level failure, route through RecordMapLaunchFailure so the sweep still fires, then re-assert FAILED via CheckMapLaunchOutcome/GroomMapLaunchFailed after the sweep dispatch completes. The healthy path (Map succeeds, all iterations complete, possibly with laneOutcome.laneFailed markers) goes through CheckMapLaneOutcomes \u2192 SetMapFailureFromLanes or DispatchEndOfSfSweep.",
+          "Comment": "config#2311 + config#4803: a Map-level Catch here now catches only genuine Map-level failures (States.Runtime from a malformed definition, etc.) — per-lane failures no longer fail the Map (RecordLaneFailure is a Pass, not a Fail). On a Map-level failure, route through RecordMapLaunchFailure so the sweep still fires, then re-assert FAILED via CheckMapLaunchOutcome/GroomMapLaunchFailed after the sweep dispatch completes. The healthy path (Map succeeds, all iterations complete, possibly with laneOutcome.laneFailed markers) goes through CheckMapLaneOutcomes → SetMapFailureFromLanes or DispatchEndOfSfSweep.",
           "Next": "RecordMapLaunchFailure",
           "ResultPath": "$.mapLaunchError"
         }
@@ -101,7 +101,7 @@
         "States": {
           "LaunchGroomSpot": {
             "Type": "Task",
-            "Comment": "config#2129 + alpha-engine-config-I4333 (task-token callback): invoke the Lambda's launch_decided operation with .waitForTaskToken so the SF pauses here until the box calls send-task-success (sub-second) instead of polling SSM every 15s for hours. The token is carried INSIDE the Payload by merging the context object's $$.Task ({Token: ...}) into the same wholesale merge \u2014 `TaskToken` is NOT a field of the Lambda Invoke API, and declaring it as a sibling of Payload is rejected at RUNTIME (not by validate-state-machine-definition), which is how the 2026-07-27 20:00 UTC run died 11s in. String-building the key with States.Format does not work either: Format cannot emit a literal brace. The Lambda reads event['Token']. The Lambda launches the box, embeds the token in the SSM command, and returns immediately \u2014 the SF ignores the return value; the callback payload IS the state output. TimeoutSeconds (6h, matching the box's own watchdog) is the SOLE authoritative bound on a lane \u2014 groom-sweep-policy \u00a72.1. A HeartbeatSeconds was declared here until 2026-07-27 with NO SendTaskHeartbeat emitter on the box, which silently made 3600s the real lane timeout and killed every run longer than an hour; do not re-add a liveness interval without a proven emitter and its states:SendTaskHeartbeat grant. Timeout routes to CheckCompletionMarkerTaskToken / the bounded relaunch loop.",
+            "Comment": "config#2129 + alpha-engine-config-I4333 (task-token callback): invoke the Lambda's launch_decided operation with .waitForTaskToken so the SF pauses here until the box calls send-task-success (sub-second) instead of polling SSM every 15s for hours. The token is carried INSIDE the Payload by merging the context object's $$.Task ({Token: ...}) into the same wholesale merge — `TaskToken` is NOT a field of the Lambda Invoke API, and declaring it as a sibling of Payload is rejected at RUNTIME (not by validate-state-machine-definition), which is how the 2026-07-27 20:00 UTC run died 11s in. String-building the key with States.Format does not work either: Format cannot emit a literal brace. The Lambda reads event['Token']. The Lambda launches the box, embeds the token in the SSM command, and returns immediately — the SF ignores the return value; the callback payload IS the state output. TimeoutSeconds (6h, matching the box's own watchdog) is the SOLE authoritative bound on a lane — groom-sweep-policy §2.1. A HeartbeatSeconds was declared here until 2026-07-27 with NO SendTaskHeartbeat emitter on the box, which silently made 3600s the real lane timeout and killed every run longer than an hour; do not re-add a liveness interval without a proven emitter and its states:SendTaskHeartbeat grant. Timeout routes to CheckCompletionMarkerTaskToken / the bounded relaunch loop.",
             "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
             "Parameters": {
               "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
@@ -132,7 +132,7 @@
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "Comment": "Launch failure (spot+on-demand exhaustion, SSM send failure, etc.) \u2014 the Lambda already terminates any partially-launched box before re-raising.",
+                "Comment": "Launch failure (spot+on-demand exhaustion, SSM send failure, etc.) — the Lambda already terminates any partially-launched box before re-raising.",
                 "Next": "HandleFailure",
                 "ResultPath": "$.error"
               }
@@ -142,7 +142,7 @@
           },
           "RelaunchNotifyGate": {
             "Type": "Choice",
-            "Comment": "Relaunch-first, notify-second (2026-07-06): only ping SNS after a successful re-launch (retry_count>0). First launch (retry_count==0) skips straight to polling. NotifyRelaunch failures must not block polling \u2014 its Catch routes to CheckLaunched.",
+            "Comment": "Relaunch-first, notify-second (2026-07-06): only ping SNS after a successful re-launch (retry_count>0). First launch (retry_count==0) skips straight to polling. NotifyRelaunch failures must not block polling — its Catch routes to CheckLaunched.",
             "Choices": [
               {
                 "Variable": "$.retry_count",
@@ -154,7 +154,7 @@
           },
           "CheckLaunchedCallback": {
             "Type": "Choice",
-            "Comment": "config-I4333: the callback output carries {groomLaunch} with the same shape the old Lambda return did. Route launched=true \u2192 GroomSucceeded (box already ran cleanly \u2014 the callback IS the completion signal), launched=false \u2192 GroomSkipped.",
+            "Comment": "config-I4333: the callback output carries {groomLaunch} with the same shape the old Lambda return did. Route launched=true → GroomSucceeded (box already ran cleanly — the callback IS the completion signal), launched=false → GroomSkipped.",
             "Choices": [
               {
                 "And": [
@@ -208,7 +208,7 @@
           },
           "CheckRetryBudget": {
             "Type": "Choice",
-            "Comment": "config#1645: marker is absent (box died mid-run) \u2014 relaunch if attempts remain, else give up and alert. Bounded to max_retries (2, i.e. up to 3 total launch attempts per iteration) so a genuinely bad AWS day can't spot-cycle indefinitely.",
+            "Comment": "config#1645: marker is absent (box died mid-run) — relaunch if attempts remain, else give up and alert. Bounded to max_retries (2, i.e. up to 3 total launch attempts per iteration) so a genuinely bad AWS day can't spot-cycle indefinitely.",
             "Choices": [
               {
                 "Variable": "$.retry_count",
@@ -220,7 +220,7 @@
           },
           "PrepRelaunch": {
             "Type": "Pass",
-            "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token \u2014 the old attempt's absent marker is never confused with the new attempt's). Emits EXACTLY the shape LaunchGroomSpot needs (schedInput/launchDecision/fod for its Payload merge, retry_count for RelaunchNotifyGate, max_retries for CheckRetryBudget) and nothing else. Until 2026-07-27 this also carried groomPoll/groomLaunch, retired with the SSM poll loop by I4333 \u2014 the dangling reference raised an UNCATCHABLE States.Runtime here and killed the entire bounded-relaunch loop (groom-sweep-policy \u00a72.2). Every field referenced below must be produced by a predecessor on the path that reaches this state.",
+            "Comment": "config#1645: bump the counter for the next attempt (each relaunch calls the Lambda fresh, which mints its own new run_token — the old attempt's absent marker is never confused with the new attempt's). Emits EXACTLY the shape LaunchGroomSpot needs (schedInput/launchDecision/fod for its Payload merge, retry_count for RelaunchNotifyGate, max_retries for CheckRetryBudget) and nothing else. Until 2026-07-27 this also carried groomPoll/groomLaunch, retired with the SSM poll loop by I4333 — the dangling reference raised an UNCATCHABLE States.Runtime here and killed the entire bounded-relaunch loop (groom-sweep-policy §2.2). Every field referenced below must be produced by a predecessor on the path that reaches this state.",
             "Parameters": {
               "schedInput.$": "$.schedInput",
               "launchDecision.$": "$.launchDecision",
@@ -244,7 +244,7 @@
           },
           "SetForceOnDemand": {
             "Type": "Pass",
-            "Comment": "Final relaunch attempt \u2014 escalate to on-demand so a bad spot-capacity window still guarantees completion. Same field discipline as PrepRelaunch: emits only what LaunchGroomSpot and its downstream Choices actually read.",
+            "Comment": "Final relaunch attempt — escalate to on-demand so a bad spot-capacity window still guarantees completion. Same field discipline as PrepRelaunch: emits only what LaunchGroomSpot and its downstream Choices actually read.",
             "Parameters": {
               "schedInput.$": "$.schedInput",
               "launchDecision.$": "$.launchDecision",
@@ -259,11 +259,11 @@
           },
           "NotifyRelaunch": {
             "Type": "Task",
-            "Comment": "config#1645: best-effort WARNING-level ping AFTER the relaunch box is already launching (LaunchGroomSpot -> RelaunchNotifyGate -> here). A States.Format intrinsic error in Parameters is NOT catchable (States.Runtime), so this message may reference ONLY fields PrepRelaunch/SetForceOnDemand emit \u2014 it referenced the retired $.groomPoll.Status until 2026-07-27. SNS publish failures ARE catchable and route to CheckLaunchedCallback so a notify hiccup never blocks the new run.",
+            "Comment": "config#1645: best-effort WARNING-level ping AFTER the relaunch box is already launching (LaunchGroomSpot -> RelaunchNotifyGate -> here). A States.Format intrinsic error in Parameters is NOT catchable (States.Runtime), so this message may reference ONLY fields PrepRelaunch/SetForceOnDemand emit — it referenced the retired $.groomPoll.Status until 2026-07-27. SNS publish failures ARE catchable and route to CheckLaunchedCallback so a notify hiccup never blocks the new run.",
             "Resource": "arn:aws:states:::sns:publish",
             "Parameters": {
               "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-              "Subject": "Alpha Engine Backlog Groom \u2014 spot interrupted, auto-relaunching",
+              "Subject": "Alpha Engine Backlog Groom — spot interrupted, auto-relaunching",
               "Message.$": "States.Format('Backlog groom box died mid-run (task token never fired; no completion marker). Tier: {}. Relaunched automatically: attempt {} of {} (force_on_demand={}).', $.launchDecision.issue_filter, $.retry_count, $.max_retries, States.JsonToString($.fod.force_on_demand))"
             },
             "ResultPath": "$.relaunch_notify",
@@ -284,11 +284,11 @@
           },
           "GroomSkipped": {
             "Type": "Succeed",
-            "Comment": "GROOM_DISPATCH_ENABLED=false kill-switch, or config#1979's concurrent-same-tier skip \u2014 intentional no-op, not a failure."
+            "Comment": "GROOM_DISPATCH_ENABLED=false kill-switch, or config#1979's concurrent-same-tier skip — intentional no-op, not a failure."
           },
           "RecordLaneFailure": {
             "Type": "Pass",
-            "Comment": "config#4803: record lane failure in the iteration output instead of failing the Map. A Map iteration FailExecution aborts every sibling iteration mid-work (ToleratedFailurePercentage=0) \u2014 the per-lane terminal is now a recording Pass, so every iteration 'succeeds' from the Map's perspective. Post-Map aggregation (CheckMapLaneOutcomes \u2192 SetMapFailureFromLanes) inspects $.mapOutcome[*].laneOutcome.laneFailed and routes to GroomMapLaunchFailed if any lane recorded a failure, preserving fail-loud at the execution level without sibling collateral.",
+            "Comment": "config#4803: record lane failure in the iteration output instead of failing the Map. A Map iteration FailExecution aborts every sibling iteration mid-work (ToleratedFailurePercentage=0) — the per-lane terminal is now a recording Pass, so every iteration 'succeeds' from the Map's perspective. Post-Map aggregation (CheckMapLaneOutcomes → SetMapFailureFromLanes) inspects $.mapOutcome[*].laneOutcome.laneFailed and routes to GroomMapLaunchFailed if any lane recorded a failure, preserving fail-loud at the execution level without sibling collateral.",
             "Parameters": {
               "laneFailed": true,
               "reason": "groom_lane_failure",
@@ -299,11 +299,11 @@
           },
           "LaneCompleted": {
             "Type": "Succeed",
-            "Comment": "Lane completed with failure recorded \u2014 this is a Map-iteration success, NOT a terminal lane failure. The post-Map aggregation (CheckMapLaneOutcomes \u2192 SetMapFailureFromLanes) determines the execution outcome from $.mapOutcome[*].laneOutcome.laneFailed."
+            "Comment": "Lane completed with failure recorded — this is a Map-iteration success, NOT a terminal lane failure. The post-Map aggregation (CheckMapLaneOutcomes → SetMapFailureFromLanes) determines the execution outcome from $.mapOutcome[*].laneOutcome.laneFailed."
           },
           "GroomRetriesExhausted": {
             "Type": "Pass",
-            "Comment": "config#1645: the task token never fired on any attempt (box died mid-run each time) and the bounded relaunch budget \u2014 including the forced-on-demand final attempt \u2014 is spent. A genuine escalation, not a routine spot hiccup. Reached ONLY from CheckRetryBudget, so $.timeoutError is always present; the CheckLaunchedCallback path has its own terminal (GroomLaunchStateUnknown) because its input shape is disjoint from this one.",
+            "Comment": "config#1645: the task token never fired on any attempt (box died mid-run each time) and the bounded relaunch budget — including the forced-on-demand final attempt — is spent. A genuine escalation, not a routine spot hiccup. Reached ONLY from CheckRetryBudget, so $.timeoutError is always present; the CheckLaunchedCallback path has its own terminal (GroomLaunchStateUnknown) because its input shape is disjoint from this one.",
             "Parameters": {
               "source": "groom_status",
               "reason": "spot_interruption_retries_exhausted",
@@ -317,11 +317,11 @@
           },
           "HandleFailure": {
             "Type": "Task",
-            "Comment": "Failure alert via SNS (same topic the fleet SFs already use). No force-stop step is needed here \u2014 unlike the persistent trading instance the EOD SF guards, the groom spot box tears itself down via groom_spot_bootstrap.sh's own EXIT trap regardless of what this SF observes; there is no idle-cost risk to guard against.",
+            "Comment": "Failure alert via SNS (same topic the fleet SFs already use). No force-stop step is needed here — unlike the persistent trading instance the EOD SF guards, the groom spot box tears itself down via groom_spot_bootstrap.sh's own EXIT trap regardless of what this SF observes; there is no idle-cost risk to guard against.",
             "Resource": "arn:aws:states:::sns:publish",
             "Parameters": {
               "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-              "Subject": "Alpha Engine Backlog Groom \u2014 FAILED",
+              "Subject": "Alpha Engine Backlog Groom — FAILED",
               "Message.$": "States.Format('Backlog groom dispatch failed. Error: {}', States.JsonToString($.error))"
             },
             "ResultPath": "$.failure_notify",
@@ -340,7 +340,7 @@
           },
           "GroomLaunchStateUnknown": {
             "Type": "Pass",
-            "Comment": "config-I4333: the task-token callback returned but its payload carries no groom.launched flag \u2014 the box called send-task-success with an unrecognised shape. Distinct from the retries-exhausted path above: this one has $.callbackOutput and no $.timeoutError, so it needs its own terminal rather than sharing one whose Parameters cannot resolve here (groom-sweep-policy \u00a72.2).",
+            "Comment": "config-I4333: the task-token callback returned but its payload carries no groom.launched flag — the box called send-task-success with an unrecognised shape. Distinct from the retries-exhausted path above: this one has $.callbackOutput and no $.timeoutError, so it needs its own terminal rather than sharing one whose Parameters cannot resolve here (groom-sweep-policy §2.2).",
             "Parameters": {
               "source": "groom_status",
               "reason": "callback_payload_missing_launch_flag",
@@ -358,12 +358,16 @@
     },
     "CheckMapLaneOutcomes": {
       "Type": "Choice",
-      "Comment": "config#4803: inspect every iteration's output for a laneOutcome.laneFailed marker. Because the per-lane FailExecution was replaced with RecordLaneFailure (a Pass, not a Fail), every iteration 'succeeds' from the Map's perspective \u2014 no sibling abort. Each index is guarded by IsPresent (fewer than 3 iterations is a valid path) and BooleanEquals on laneFailed \u2014 if any lane recorded a failure, SetMapFailureFromLanes shapes the same $.mapFailure marker that RecordMapLaunchFailure (the Map's Catch) produces, so CheckMapLaunchOutcome routes to GroomMapLaunchFailed without changes and the execution still terminates FAILED for Fleet-SF Watch.",
+      "Comment": "config#4803: inspect every iteration's output for a laneOutcome.laneFailed marker. Because the per-lane FailExecution was replaced with RecordLaneFailure (a Pass, not a Fail), every iteration 'succeeds' from the Map's perspective — no sibling abort. Each index is guarded by IsPresent (fewer than 3 iterations is a valid path) and BooleanEquals on laneFailed — if any lane recorded a failure, SetMapFailureFromLanes shapes the same $.mapFailure marker that RecordMapLaunchFailure (the Map's Catch) produces, so CheckMapLaunchOutcome routes to GroomMapLaunchFailed without changes and the execution still terminates FAILED for Fleet-SF Watch. NOTE 2026-07-30 (alpha-engine-config-I5718): each choice now carries an IsPresent on the laneOutcome.laneFailed PATH ITSELF, not only on the iteration that contains it. ASL's And does not short-circuit path validity, and laneOutcome is written ONLY by RecordLaneFailure — so a lane that SUCCEEDED left the path absent and BooleanEquals raised States.Runtime, which no Catch can intercept (groom-sweep-policy §2.2). A cycle in which every lane succeeded therefore could not complete. It went unnoticed because a fully-successful Map has never occurred under this definition: the lost-callback defect (I4987) meant lanes timed out instead, and the Map's Catch bypasses this state entirely. Found by the first successful run of the fault-injection harness.",
       "Choices": [
         {
           "And": [
             {
               "Variable": "$.mapOutcome[0]",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.mapOutcome[0].laneOutcome.laneFailed",
               "IsPresent": true
             },
             {
@@ -381,6 +385,10 @@
             },
             {
               "Variable": "$.mapOutcome[1].laneOutcome.laneFailed",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.mapOutcome[1].laneOutcome.laneFailed",
               "BooleanEquals": true
             }
           ],
@@ -390,6 +398,10 @@
           "And": [
             {
               "Variable": "$.mapOutcome[2]",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.mapOutcome[2].laneOutcome.laneFailed",
               "IsPresent": true
             },
             {
@@ -404,7 +416,7 @@
     },
     "SetMapFailureFromLanes": {
       "Type": "Pass",
-      "Comment": "config#4803: at least one lane recorded laneFailed \u2192 shape the same $.mapFailure marker that RecordMapLaunchFailure (the Map Catch) produces. CheckMapLaunchOutcome's existing Choice (IsPresent on $.mapFailure) routes to GroomMapLaunchFailed unchanged \u2014 the execution still terminates FAILED for Fleet-SF Watch after the sweep dispatch completes.",
+      "Comment": "config#4803: at least one lane recorded laneFailed → shape the same $.mapFailure marker that RecordMapLaunchFailure (the Map Catch) produces. CheckMapLaunchOutcome's existing Choice (IsPresent on $.mapFailure) routes to GroomMapLaunchFailed unchanged — the execution still terminates FAILED for Fleet-SF Watch after the sweep dispatch completes.",
       "Parameters": {
         "failed": true,
         "reason": "one_or_more_lanes_failed",
@@ -417,7 +429,7 @@
     },
     "RecordMapLaunchFailure": {
       "Type": "Pass",
-      "Comment": "config#2311 no-silent-caps: shape an explicit failed:true record into $.mapFailure (mirrors RecordSweepDispatchFailure's $.sweep shape) so a Map-iteration failure is visible in the execution output. The raw error stays alongside in $.mapLaunchError. Falls through to the SAME DispatchEndOfSfSweep the healthy paths use \u2014 the sweep is unconditional regardless of how this state was reached \u2014 then CheckMapLaunchOutcome re-asserts FAILED once the sweep dispatch is done.",
+      "Comment": "config#2311 no-silent-caps: shape an explicit failed:true record into $.mapFailure (mirrors RecordSweepDispatchFailure's $.sweep shape) so a Map-iteration failure is visible in the execution output. The raw error stays alongside in $.mapLaunchError. Falls through to the SAME DispatchEndOfSfSweep the healthy paths use — the sweep is unconditional regardless of how this state was reached — then CheckMapLaunchOutcome re-asserts FAILED once the sweep dispatch is done.",
       "Parameters": {
         "failed": true,
         "reason": "map_iteration_failed",
@@ -428,7 +440,7 @@
     },
     "DispatchEndOfSfSweep": {
       "Type": "Task",
-      "Comment": "config#2201: ONE Haiku run_mode=sweep spot box per trigger cycle, launched AFTER every groom box has fully wound down (this state is reached when every Map iteration hit its own GroomSucceeded/GroomSkipped/LaneCompleted \u2014 per-lane failures now record into $.mapOutcome[*].laneOutcome rather than failing the Map, so the Map always completes) \u2014 and equally via AllSkipped when zero groom boxes launched, or SetMapFailureFromLanes when lanes failed. Payload is a LITERAL launch_decided event (no pace/demand re-check \u2014 the sweep is unconditional by design; issue_filter is inert for run_mode=sweep but the launch path validates it, so the mid-only default is passed explicitly). The dispatcher tags sweep boxes groom-issue-filter=sweep \u2014 distinct from every groom tier tag \u2014 so its config#1979 concurrent guard skips ONLY when a prior cycle's sweep box is still live (launched:false, reason=concurrent_tier_skip, recorded in $.sweep), never colliding with a live mid-only groom box. Fire-and-forget: the Lambda returns as soon as the async SSM command is delivered; no polling loop here (Brian removed the wait \u2014 the sweep box self-terminates and writes its own S3 run artifact + completion marker). NON-FATAL: a sweep-launch failure must never fail the groom SF execution \u2014 Catch records it in the execution output (no-silent-caps) + SNS-notifies, then the SF still succeeds.",
+      "Comment": "config#2201: ONE Haiku run_mode=sweep spot box per trigger cycle, launched AFTER every groom box has fully wound down (this state is reached when every Map iteration hit its own GroomSucceeded/GroomSkipped/LaneCompleted — per-lane failures now record into $.mapOutcome[*].laneOutcome rather than failing the Map, so the Map always completes) — and equally via AllSkipped when zero groom boxes launched, or SetMapFailureFromLanes when lanes failed. Payload is a LITERAL launch_decided event (no pace/demand re-check — the sweep is unconditional by design; issue_filter is inert for run_mode=sweep but the launch path validates it, so the mid-only default is passed explicitly). The dispatcher tags sweep boxes groom-issue-filter=sweep — distinct from every groom tier tag — so its config#1979 concurrent guard skips ONLY when a prior cycle's sweep box is still live (launched:false, reason=concurrent_tier_skip, recorded in $.sweep), never colliding with a live mid-only groom box. Fire-and-forget: the Lambda returns as soon as the async SSM command is delivered; no polling loop here (Brian removed the wait — the sweep box self-terminates and writes its own S3 run artifact + completion marker). NON-FATAL: a sweep-launch failure must never fail the groom SF execution — Catch records it in the execution output (no-silent-caps) + SNS-notifies, then the SF still succeeds.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
@@ -457,7 +469,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Sweep-launch failure (spot+on-demand exhaustion, SSM send failure, Lambda error) \u2014 recorded + notified below, NEVER fatal to the groom SF: the groom boxes already ran/skipped cleanly by the time this state executes, and the next trigger cycle's sweep covers the tail. The Lambda itself already terminates any partially-launched box before re-raising.",
+          "Comment": "Sweep-launch failure (spot+on-demand exhaustion, SSM send failure, Lambda error) — recorded + notified below, NEVER fatal to the groom SF: the groom boxes already ran/skipped cleanly by the time this state executes, and the next trigger cycle's sweep covers the tail. The Lambda itself already terminates any partially-launched box before re-raising.",
           "Next": "RecordSweepDispatchFailure",
           "ResultPath": "$.sweepDispatchError"
         }
@@ -478,12 +490,12 @@
     },
     "NotifySweepDispatchFailure": {
       "Type": "Task",
-      "Comment": "Best-effort WARNING ping \u2014 the sweep miss must page (no-silent-caps) but must not fail the SF; an SNS publish failure routes straight to the terminal Succeed (the $.sweep record above already persisted into the execution output).",
+      "Comment": "Best-effort WARNING ping — the sweep miss must page (no-silent-caps) but must not fail the SF; an SNS publish failure routes straight to the terminal Succeed (the $.sweep record above already persisted into the execution output).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine Backlog Groom \u2014 end-of-SF PR sweep NOT dispatched",
-        "Message.$": "States.Format('End-of-SF PR-sweep box failed to launch (config#2201) \u2014 the groom boxes themselves completed/skipped cleanly and this execution still SUCCEEDS, but this cycle has NO PR merge-readiness sweep. Next trigger cycle covers the tail. Error: {}', States.JsonToString($.sweepDispatchError))"
+        "Subject": "Alpha Engine Backlog Groom — end-of-SF PR sweep NOT dispatched",
+        "Message.$": "States.Format('End-of-SF PR-sweep box failed to launch (config#2201) — the groom boxes themselves completed/skipped cleanly and this execution still SUCCEEDS, but this cycle has NO PR merge-readiness sweep. Next trigger cycle covers the tail. Error: {}', States.JsonToString($.sweepDispatchError))"
       },
       "ResultPath": "$.sweep_notify",
       "Catch": [
@@ -500,7 +512,7 @@
     },
     "NotifyCycleComplete": {
       "Type": "Task",
-      "Comment": "2026-07-28 operator ruling: emit ONE buzzing cycle-level COMPLETE roll-up naming every lane's terminal state and the sweep's dispatch outcome. Sits on the single convergence point ahead of CheckMapLaunchOutcome so it fires on BOTH terminal routings \u2014 a cycle that ends FAILED is the one whose roll-up matters most. Before this, GroomDispatchComplete was a bare Succeed and cycle completion had no notifier on ANY rail, so the three lanes reclaimed at bootstrap on the 12:00Z cycle (config-I4987/I4989) produced total Telegram silence. Payload passes the state ROOT (\"cycle.$\": \"$\") rather than named fields because $.mapFailure is ABSENT on the two healthy paths, and a Parameters reference to an absent field raises States.Runtime, which no Catch can intercept (groom-sweep-policy \u00a72.2).",
+      "Comment": "2026-07-28 operator ruling: emit ONE buzzing cycle-level COMPLETE roll-up naming every lane's terminal state and the sweep's dispatch outcome. Sits on the single convergence point ahead of CheckMapLaunchOutcome so it fires on BOTH terminal routings — a cycle that ends FAILED is the one whose roll-up matters most. Before this, GroomDispatchComplete was a bare Succeed and cycle completion had no notifier on ANY rail, so the three lanes reclaimed at bootstrap on the 12:00Z cycle (config-I4987/I4989) produced total Telegram silence. Payload passes the state ROOT (\"cycle.$\": \"$\") rather than named fields because $.mapFailure is ABSENT on the two healthy paths, and a Parameters reference to an absent field raises States.Runtime, which no Catch can intercept (groom-sweep-policy §2.2).",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
@@ -526,7 +538,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort per groom-sweep-policy \u00a78 \u2014 a notify hiccup must never change this execution's terminal state. The Lambda handler is itself total (it catches and returns an in-band error record rather than raising), so reaching this Catch means the invoke itself failed.",
+          "Comment": "Best-effort per groom-sweep-policy §8 — a notify hiccup must never change this execution's terminal state. The Lambda handler is itself total (it catches and returns an in-band error record rather than raising), so reaching this Catch means the invoke itself failed.",
           "Next": "CheckMapLaunchOutcome",
           "ResultPath": "$.cycleNotifyError"
         }
@@ -536,7 +548,7 @@
     },
     "CheckMapLaunchOutcome": {
       "Type": "Choice",
-      "Comment": "config#2311: every path (MapLaunches success, AllSkipped, RecordMapLaunchFailure) converges here AFTER the end-of-SF sweep has already been attempted, so the sweep's unconditional-coverage guarantee holds regardless of which branch set this. IsPresent (not BooleanEquals \u2014 the field is absent on the two healthy paths, and referencing an absent path in a non-IsPresent rule is a States.Runtime error) routes a genuine Map-iteration failure to GroomMapLaunchFailed so the execution still terminates FAILED for Fleet-SF Watch, instead of the pre-fix behavior where reaching this point meant the failure was silently absorbed.",
+      "Comment": "config#2311: every path (MapLaunches success, AllSkipped, RecordMapLaunchFailure) converges here AFTER the end-of-SF sweep has already been attempted, so the sweep's unconditional-coverage guarantee holds regardless of which branch set this. IsPresent (not BooleanEquals — the field is absent on the two healthy paths, and referencing an absent path in a non-IsPresent rule is a States.Runtime error) routes a genuine Map-iteration failure to GroomMapLaunchFailed so the execution still terminates FAILED for Fleet-SF Watch, instead of the pre-fix behavior where reaching this point meant the failure was silently absorbed.",
       "Choices": [
         {
           "Variable": "$.mapFailure",
@@ -549,19 +561,19 @@
     "GroomMapLaunchFailed": {
       "Type": "Fail",
       "Error": "GroomMapLaunchFailure",
-      "Cause": "One or more groom launch lanes failed (see $.mapFailure / the per-lane SNS alert). The end-of-SF PR sweep was still dispatched unconditionally (see $.sweep) \u2014 this execution is marked FAILED so Fleet-SF Watch alerts on the underlying lane failure."
+      "Cause": "One or more groom launch lanes failed (see $.mapFailure / the per-lane SNS alert). The end-of-SF PR sweep was still dispatched unconditionally (see $.sweep) — this execution is marked FAILED so Fleet-SF Watch alerts on the underlying lane failure."
     },
     "GroomDispatchComplete": {
       "Type": "Succeed",
-      "Comment": "Terminal success (config#2201/config#2311): every co-launched iteration reached its own GroomSucceeded/GroomSkipped, OR the zero-launches AllSkipped path \u2014 and in EITHER case the end-of-SF sweep dispatch was attempted, with its outcome recorded in $.sweep (launched box, concurrent-sweep skip, kill-switch skip, or dispatched:false failure record). A genuine Map-iteration failure never reaches here \u2014 CheckMapLaunchOutcome routes it to GroomMapLaunchFailed instead, after the sweep still fires."
+      "Comment": "Terminal success (config#2201/config#2311): every co-launched iteration reached its own GroomSucceeded/GroomSkipped, OR the zero-launches AllSkipped path — and in EITHER case the end-of-SF sweep dispatch was attempted, with its outcome recorded in $.sweep (launched box, concurrent-sweep skip, kill-switch skip, or dispatched:false failure record). A genuine Map-iteration failure never reaches here — CheckMapLaunchOutcome routes it to GroomMapLaunchFailed instead, after the sweep still fires."
     },
     "HandleDecideFailure": {
       "Type": "Task",
-      "Comment": "Top-level failure alert \u2014 reached ONLY by DecideLaunches's Catch (a genuine invoke-level failure computing the decision itself, before any box exists). Per-iteration launch/poll/relaunch failures use their OWN copy of HandleFailure/RecordLaneFailure inside MapLaunches's ItemProcessor, scoped to that one tier \u2014 ASL requires globally-unique state names even across a Map's nested ItemProcessor, hence the distinct Decide-prefixed names here.",
+      "Comment": "Top-level failure alert — reached ONLY by DecideLaunches's Catch (a genuine invoke-level failure computing the decision itself, before any box exists). Per-iteration launch/poll/relaunch failures use their OWN copy of HandleFailure/RecordLaneFailure inside MapLaunches's ItemProcessor, scoped to that one tier — ASL requires globally-unique state names even across a Map's nested ItemProcessor, hence the distinct Decide-prefixed names here.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine Backlog Groom \u2014 FAILED",
+        "Subject": "Alpha Engine Backlog Groom — FAILED",
         "Message.$": "States.Format('Backlog groom dispatch decide-phase failed. Error: {}', States.JsonToString($.error))"
       },
       "ResultPath": "$.failure_notify",
@@ -581,7 +593,7 @@
     "DecideFailExecution": {
       "Type": "Fail",
       "Error": "GroomDispatchFailure",
-      "Cause": "Backlog groom dispatch failed during the decide phase \u2014 see the SNS alert / Lambda logs for detail."
+      "Cause": "Backlog groom dispatch failed during the decide phase — see the SNS alert / Lambda logs for detail."
     }
   },
   "TimeoutSeconds": 72000

--- a/scripts/fault_injection_run.py
+++ b/scripts/fault_injection_run.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""fault_injection_run.py — exercise the groom dispatch's recovery paths on a
+schedule, against a staging state machine (alpha-engine-config-I5718).
+
+groom-sweep-policy §2.2 holds that *"a recovery path that has never executed is
+presumed broken"*, and §10.2 makes fault injection the standing gate that makes
+that enforceable: *"'presumed broken until executed' is only enforceable if
+something MAKES them execute."* Until this script, nothing did. Every recovery
+path in this system has been found broken at the moment it was first needed.
+
+**The verdict surface is the deliverable, not the runs.** Each failure mode
+resolves to exactly one of:
+
+    passed      — injected, and the recovery path reached its expected state
+    FAILED      — injected, and it did not
+    unverified  — not exercised in this programme
+
+`unverified` is never rendered as healthy and never omitted. A mode that was
+skipped, timed out, or has no scenario yet is *unverified*, and the run's exit
+code reflects it. That is §2.4 applied to the exercise programme itself: the
+absence of an exercise must not read as a passing one.
+
+Usage:
+    python3 scripts/fault_injection_run.py --deploy   # (re)build staging SF
+    python3 scripts/fault_injection_run.py            # run the programme
+    python3 scripts/fault_injection_run.py --dry-run  # show plan, touch nothing
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(
+    0, str(REPO_ROOT / "infrastructure" / "lambdas" / "groom-inject-mock")
+)
+
+from staging_definition import (  # noqa: E402
+    MOCK_LAMBDA,
+    build_staging_definition,
+    load_prod_definition,
+)
+
+REGION = "us-east-1"
+ACCOUNT_ID = "711398986525"
+STAGING_SF_NAME = "alpha-engine-groom-dispatch-inject"
+RESULT_BUCKET = "alpha-engine-research"
+RESULT_PREFIX = "groom/_control/fault-injection"
+
+#: What each scenario must PROVE. `terminal` is the execution status the
+#: staging run must reach; `must_visit` are states whose presence in the
+#: execution history is the actual evidence the recovery path ran.
+#:
+#: This is the part that makes the harness meaningful. Asserting only "the
+#: execution finished" would pass for a state machine that skipped every
+#: recovery state — the exact laundering §1 forbids.
+EXPECTATIONS: dict[str, dict] = {
+    "happy_path": {
+        "terminal": "SUCCEEDED",
+        "must_visit": ["LaunchGroomSpot", "DispatchEndOfSfSweep",
+                       "NotifyCycleComplete"],
+        "why": "control — if this fails the harness itself is broken",
+    },
+    "empty_enumeration": {
+        "terminal": "SUCCEEDED",
+        "must_visit": ["AllSkipped", "DispatchEndOfSfSweep"],
+        "why": "a zero-launch cycle must still dispatch the sweep (§2.5)",
+    },
+    "callback_never_arrives": {
+        "terminal": "FAILED",
+        "must_visit": ["LaunchGroomSpot", "CheckCompletionMarkerTaskToken",
+                       "HandleFailure"],
+        "why": "lane timeout must route to the marker check, then escalate",
+    },
+    "box_dies_mid_run": {
+        "terminal": "FAILED",
+        "must_visit": ["CheckCompletionMarkerTaskToken", "HandleFailure"],
+        "why": "same path as a lost callback; the SF cannot tell them apart",
+    },
+    "box_dies_mid_bootstrap": {
+        "terminal": "FAILED",
+        "must_visit": ["CheckCompletionMarkerTaskToken"],
+        "why": "a box that never became healthy must still be reclaimed",
+    },
+    "relaunch_guard_refuses": {
+        "terminal": "FAILED",
+        "must_visit": ["CheckCompletionMarkerTaskToken"],
+        "why": ("alpha-engine-config-I4987 — the relaunch fires because the box "
+                "is alive and its guard refuses because the box is alive. This "
+                "scenario is the regression guard for that fix."),
+    },
+    "callback_rejected": {
+        "terminal": "FAILED",
+        "must_visit": ["LaunchGroomSpot"],
+        "why": "an explicit failure callback must fail the lane, not hang it",
+    },
+    "decide_raises": {
+        "terminal": "FAILED",
+        "must_visit": ["HandleDecideFailure"],
+        "why": "enumeration failure must be caught, named, and never launch",
+    },
+    "malformed_decide_payload": {
+        "terminal": "SUCCEEDED",
+        "must_visit": ["AllSkipped"],
+        "why": ("a shape the Choice cannot match must fall to the zero-launch "
+                "path, not crash the execution"),
+    },
+    "ledger_write_fails": {
+        "terminal": "FAILED",
+        "must_visit": ["HandleFailure", "RecordLaneFailure", "LaneCompleted",
+                       "CheckMapLaneOutcomes", "SetMapFailureFromLanes",
+                       "DispatchEndOfSfSweep"],
+        "why": ("§2.7 — a registration failure is itself a paging condition. "
+                "This expectation originally named CheckCompletionMarkerTaskToken "
+                "and FAILED on the first full run: that state is reached on a "
+                "lane TIMEOUT, not on a lane that RAISES. A raise is caught into "
+                "HandleFailure -> RecordLaneFailure -> LaneCompleted so siblings "
+                "are not aborted (§2.5), then aggregated. The harness was right "
+                "and the expectation was wrong — corrected rather than relaxed. "
+                "It is also the only scenario that exercises SetMapFailureFromLanes, "
+                "so it is the regression guard for the I5718 Choice fix."),
+    },
+}
+
+
+def _clients():
+    import boto3
+    return (boto3.client("stepfunctions", region_name=REGION),
+            boto3.client("s3", region_name=REGION),
+            boto3.client("lambda", region_name=REGION))
+
+
+def _staging_arn() -> str:
+    return f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{STAGING_SF_NAME}"
+
+
+def deploy_staging(sfn, *, dry_run: bool) -> str:
+    """Create or update the staging machine from the PRODUCTION definition."""
+    definition = build_staging_definition(
+        load_prod_definition(REPO_ROOT), account_id=ACCOUNT_ID, region=REGION)
+    body = json.dumps(definition)
+    arn = _staging_arn()
+    # A DEDICATED role, never the production SF role. Reusing production's
+    # would (a) fail — it is scoped to the production Lambda and the real
+    # alerts topic, which is how the first injection run failed — and (b) be
+    # the wrong shape: a staging machine holding production's grants can reach
+    # production resources if the definition swap is ever incomplete. This
+    # role can invoke ONLY the mock and publish ONLY to the staging topic, so
+    # the isolation is enforced by IAM rather than by the swap being correct.
+    role = f"arn:aws:iam::{ACCOUNT_ID}:role/alpha-engine-groom-inject-sf-role"
+    if dry_run:
+        print(f"[dry-run] would deploy {arn} ({len(body)} bytes)")
+        return arn
+    try:
+        sfn.update_state_machine(stateMachineArn=arn, definition=body,
+                                 roleArn=role)
+        print(f"updated {STAGING_SF_NAME}")
+    except sfn.exceptions.StateMachineDoesNotExist:
+        sfn.create_state_machine(name=STAGING_SF_NAME, definition=body,
+                                 roleArn=role, type="STANDARD")
+        print(f"created {STAGING_SF_NAME}")
+    return arn
+
+
+def scenarios_from_deployed_mock(lam) -> dict[str, str]:
+    """Read the scenario list out of the DEPLOYED mock, never a local copy.
+
+    §2.7 derive-once. A local list would drift from the function that actually
+    answers, and the harness would silently stop covering a mode while still
+    reporting on it.
+    """
+    resp = lam.invoke(FunctionName=MOCK_LAMBDA,
+                      Payload=json.dumps({"mode": "list_scenarios"}).encode())
+    payload = json.loads(resp["Payload"].read().decode())
+    return payload["scenarios"]
+
+
+def run_scenario(sfn, arn: str, scenario: str, *, timeout_s: int = 240) -> dict:
+    """Start one staging execution and resolve it to a verdict."""
+    started = sfn.start_execution(
+        stateMachineArn=arn,
+        input=json.dumps({
+            "run_mode": "full", "trigger": "demand-all", "pr_budget": 1,
+            "schedule": f"inject-{scenario}",
+            "inject": {"scenario": scenario},
+        }),
+    )
+    exec_arn = started["executionArn"]
+
+    deadline = time.monotonic() + timeout_s
+    status = "RUNNING"
+    while time.monotonic() < deadline:
+        status = sfn.describe_execution(executionArn=exec_arn)["status"]
+        if status != "RUNNING":
+            break
+        time.sleep(3)
+    else:
+        # Never silently treat a hung injection as anything but unverified.
+        sfn.stop_execution(executionArn=exec_arn, error="InjectionTimeout")
+        return {"scenario": scenario, "verdict": "unverified",
+                "detail": f"execution still RUNNING after {timeout_s}s",
+                "execution": exec_arn}
+
+    visited = set()
+    paginator = sfn.get_paginator("get_execution_history")
+    for page in paginator.paginate(executionArn=exec_arn, maxResults=1000):
+        for event in page["events"]:
+            for key in ("stateEnteredEventDetails", "stateExitedEventDetails"):
+                name = (event.get(key) or {}).get("name")
+                if name:
+                    visited.add(name)
+
+    expected = EXPECTATIONS[scenario]
+    missing = [s for s in expected["must_visit"] if s not in visited]
+    terminal_ok = status == expected["terminal"]
+
+    if terminal_ok and not missing:
+        verdict, detail = "passed", f"reached {status} via {expected['must_visit']}"
+    else:
+        problems = []
+        if not terminal_ok:
+            problems.append(f"terminal {status} != expected {expected['terminal']}")
+        if missing:
+            problems.append(f"never visited {missing}")
+        verdict, detail = "FAILED", "; ".join(problems)
+
+    return {"scenario": scenario, "verdict": verdict, "detail": detail,
+            "execution": exec_arn, "terminal": status,
+            "why": expected["why"]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--deploy", action="store_true",
+                    help="(re)build the staging state machine, then exit")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--only", help="run a single scenario by name")
+    args = ap.parse_args()
+
+    sfn, s3, lam = _clients()
+
+    if args.deploy:
+        deploy_staging(sfn, dry_run=args.dry_run)
+        return 0
+
+    arn = deploy_staging(sfn, dry_run=args.dry_run)
+    known = scenarios_from_deployed_mock(lam)
+
+    # Every mode starts UNVERIFIED and must earn a different verdict.
+    results = {
+        name: {"scenario": name, "verdict": "unverified",
+               "detail": "not exercised in this run",
+               "failure_mode": known.get(name, "(no scenario declared)")}
+        for name in EXPECTATIONS
+    }
+
+    # A mode the mock declares but this driver has no expectation for is a
+    # COVERAGE HOLE, reported rather than skipped (§2.4 no-silent-caps).
+    for name, mode in known.items():
+        if name not in EXPECTATIONS:
+            results[name] = {"scenario": name, "verdict": "unverified",
+                             "detail": "mock declares it; driver has no expectation",
+                             "failure_mode": mode}
+
+    to_run = [args.only] if args.only else list(EXPECTATIONS)
+    for name in to_run:
+        if args.dry_run:
+            print(f"[dry-run] would inject {name}")
+            continue
+        print(f"injecting {name} ...", flush=True)
+        try:
+            outcome = run_scenario(sfn, arn, name)
+        except Exception as exc:  # noqa: BLE001 — a driver error is unverified,
+            # never a pass. Recorded with the cause so it cannot be mistaken
+            # for a clean run.
+            outcome = {"scenario": name, "verdict": "unverified",
+                       "detail": f"driver error: {exc}"}
+        outcome["failure_mode"] = known.get(name, "(not declared by the mock)")
+        results[name] = outcome
+        print(f"  {name}: {outcome['verdict']} — {outcome['detail']}")
+
+    passed = sum(1 for r in results.values() if r["verdict"] == "passed")
+    failed = sum(1 for r in results.values() if r["verdict"] == "FAILED")
+    unverified = sum(1 for r in results.values() if r["verdict"] == "unverified")
+
+    report = {
+        "schema_version": 1,
+        "passed": passed, "failed": failed, "unverified": unverified,
+        "results": results,
+    }
+    print(f"\nFAULT_INJECTION_DONE passed={passed} failed={failed} "
+          f"unverified={unverified}")
+
+    if not args.dry_run:
+        # Stamped by the caller, not by the script — Date.now() inside the run
+        # would make the artifact key unpredictable for the reader.
+        from datetime import datetime, timezone
+        stamp = datetime.now(timezone.utc)
+        report["run_at"] = stamp.isoformat()
+        key = f"{RESULT_PREFIX}/{stamp.strftime('%Y-%m-%d')}.json"
+        s3.put_object(Bucket=RESULT_BUCKET, Key=key,
+                      Body=json.dumps(report, indent=2).encode())
+        print(f"verdict surface -> s3://{RESULT_BUCKET}/{key}")
+
+    # Non-zero on FAILED or on any unverified mode: an exercise programme with
+    # holes in it is not a passing programme (§10.2).
+    return 1 if (failed or unverified) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -62,6 +62,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # rag/pipelines/ ingest-side scripts are scope-exempt — they write
 # to RAG-corpus S3 not the freshness-monitored production bucket).
 EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
+    # alpha-engine-config-I5718 — the §10.2 fault-injection verdict surface,
+    # s3://alpha-engine-research/groom/_control/fault-injection/{date}.json.
+    # One PUT per programme run (weekly, plus on any change to the dispatch
+    # definition or the harness).
+    #
+    # This artifact IS freshness-relevant and belongs in ARTIFACT_REGISTRY.yaml
+    # rather than grandfathered_paths: a stale verdict means
+    # the standing gate stopped running, and §10.2 holds that a failure mode
+    # not exercised in the current programme is UNVERIFIED, never passing. A
+    # gate that silently stops is the one failure this artifact exists to make
+    # visible. The registry lives in alpha-engine-config, so the entry rides a
+    # separate PR there — pinned here first so this repo's guard is honest
+    # about the new PUT site either way.
+    "scripts/fault_injection_run.py": 1,
     "builders/_price_cache_writeboth.py": 2,
     # universe_freshness.json + weekly/<date>/manifest.json (schema_drift_incidents,
     # config#1150) + feature_store/_freshness.json (ArcticDB freshness-monitor

--- a/tests/test_fault_injection_staging.py
+++ b/tests/test_fault_injection_staging.py
@@ -1,0 +1,228 @@
+"""tests/test_fault_injection_staging.py — the staging definition must be
+DERIVED from production, and the two dangerous swaps must be impossible to
+forget (alpha-engine-config-I5718).
+
+The harness's entire value rests on the staging topology being the production
+topology. These tests guard the derivation, not the AWS calls.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MOCK_DIR = REPO_ROOT / "infrastructure" / "lambdas" / "groom-inject-mock"
+sys.path.insert(0, str(MOCK_DIR))
+
+from staging_definition import (  # noqa: E402
+    MIN_TIMEOUT_SECONDS,
+    MOCK_LAMBDA,
+    PROD_LAMBDA,
+    TIMEOUT_DIVISOR,
+    build_staging_definition,
+    load_prod_definition,
+)
+
+ACCOUNT, REGION = "711398986525", "us-east-1"
+
+
+@pytest.fixture(scope="module")
+def prod() -> dict:
+    return load_prod_definition(REPO_ROOT)
+
+
+@pytest.fixture(scope="module")
+def staging(prod) -> dict:
+    return build_staging_definition(prod, account_id=ACCOUNT, region=REGION)
+
+
+def test_no_production_lambda_survives_the_swap(staging):
+    """The single most dangerous omission: a staging run launching real boxes."""
+    assert PROD_LAMBDA not in json.dumps(staging), (
+        "staging definition still references the PRODUCTION dispatcher — an "
+        "injection run would launch real spot boxes against the real backlog"
+    )
+    assert MOCK_LAMBDA in json.dumps(staging)
+
+
+def test_no_production_sns_topic_survives_the_swap(staging):
+    """The most obnoxious omission: every injection run paging Brian."""
+    raw = json.dumps(staging)
+    assert "alpha-engine-alerts" not in raw, (
+        "staging definition still publishes to the real alerts topic — every "
+        "scheduled injection run would page the operator"
+    )
+    assert "alpha-engine-groom-inject-alerts" in raw
+
+
+def test_topology_is_preserved_exactly(prod, staging):
+    """Same states, same order, same transitions — only the three swaps."""
+    assert set(prod["States"]) == set(staging["States"])
+
+    def transitions(defn):
+        out = {}
+        for name, state in defn["States"].items():
+            out[name] = (state.get("Type"), state.get("Next"),
+                         state.get("End"), json.dumps(state.get("Choices")))
+        return out
+
+    assert transitions(prod) == transitions(staging), (
+        "a state's type, Next, End or Choices changed — the staging machine is "
+        "no longer the production topology and the harness proves nothing"
+    )
+
+
+def test_timeouts_scale_but_preserve_ordering(prod, staging):
+    """Recovery logic branches on which budget fires FIRST — order must hold."""
+    def timeouts(node, acc=None):
+        acc = acc if acc is not None else []
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "TimeoutSeconds" and isinstance(v, (int, float)):
+                    acc.append(int(v))
+                else:
+                    timeouts(v, acc)
+        elif isinstance(node, list):
+            for item in node:
+                timeouts(item, acc)
+        return acc
+
+    p, s = timeouts(prod), timeouts(staging)
+    assert len(p) == len(s) and p, "timeout count changed"
+    assert all(v >= MIN_TIMEOUT_SECONDS for v in s), (
+        f"a scaled timeout fell below {MIN_TIMEOUT_SECONDS}s — the harness "
+        "would go flaky on cold starts, which is how it gets switched off"
+    )
+    # The lane budget must still exceed the short task budgets, or the
+    # timeout-then-relaunch path stops being reachable.
+    assert max(s) > min(s)
+    for prod_v, stg_v in zip(p, s):
+        assert stg_v == max(MIN_TIMEOUT_SECONDS, prod_v // TIMEOUT_DIVISOR)
+
+
+def test_lane_timeout_is_fast_enough_to_actually_run(staging):
+    """A harness nobody can wait for is a harness that never runs."""
+    lane = None
+    for state in staging["States"].values():
+        if state.get("Type") == "Map":
+            body = state.get("ItemProcessor") or state.get("Iterator")
+            lane = body["States"]["LaunchGroomSpot"]["TimeoutSeconds"]
+    assert lane is not None, "LaunchGroomSpot not found in the Map body"
+    assert lane <= 60, (
+        f"staging lane timeout is {lane}s; three relaunch attempts would take "
+        "over three minutes and the weekly programme would be skipped"
+    )
+
+
+def test_builder_refuses_a_definition_it_cannot_make_safe():
+    """If either swap finds nothing, FAIL — never emit a half-swapped machine."""
+    with pytest.raises(ValueError, match="names no"):
+        build_staging_definition(
+            {"States": {"X": {"Type": "Pass", "End": True}}},
+            account_id=ACCOUNT, region=REGION)
+
+
+def test_every_expectation_names_a_declared_scenario():
+    """The driver may not assert on a scenario the mock cannot produce."""
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "fault_injection_run", REPO_ROOT / "scripts" / "fault_injection_run.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mock_spec = importlib.util.spec_from_file_location(
+        "inject_mock", MOCK_DIR / "index.py")
+    mock = importlib.util.module_from_spec(mock_spec)
+    mock_spec.loader.exec_module(mock)
+
+    undeclared = set(mod.EXPECTATIONS) - set(mock.SCENARIOS)
+    assert not undeclared, (
+        f"driver expects scenarios the mock cannot produce: {sorted(undeclared)}"
+    )
+    # The reverse is a coverage hole, not an error — but it must be VISIBLE,
+    # and the driver reports it as `unverified` rather than skipping it.
+    uncovered = set(mock.SCENARIOS) - set(mod.EXPECTATIONS)
+    assert uncovered == set(), (
+        f"mock declares scenarios with no driver expectation: {sorted(uncovered)} "
+        "— add an expectation or remove the scenario"
+    )
+
+
+def test_every_expectation_asserts_a_state_not_just_a_status():
+    """`terminal` alone would pass for a machine that skipped every recovery."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "fault_injection_run", REPO_ROOT / "scripts" / "fault_injection_run.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    for name, exp in mod.EXPECTATIONS.items():
+        assert exp.get("must_visit"), (
+            f"{name} asserts only a terminal status — that would pass for an "
+            "execution that never entered a single recovery state"
+        )
+        assert exp.get("why"), f"{name} has no stated rationale"
+
+
+# ── I5718: the defect the harness's first successful run found ───────────────
+
+
+def test_every_choice_guards_the_path_it_reads(prod):
+    """ASL's `And` does not short-circuit path validity.
+
+    `CheckMapLaneOutcomes` guarded `$.mapOutcome[N]` with IsPresent and then
+    read `$.mapOutcome[N].laneOutcome.laneFailed` with BooleanEquals. But
+    `laneOutcome` is written ONLY by `RecordLaneFailure`, so a lane that
+    SUCCEEDED left that path absent and the comparison raised States.Runtime —
+    uncatchable by any Catch (groom-sweep-policy §2.2). A cycle in which every
+    lane succeeded could not complete.
+
+    It survived because a fully-successful Map has never occurred under this
+    definition: lost callbacks (alpha-engine-config-I4987) meant lanes timed
+    out, and the Map's Catch bypasses this state entirely. Fixing the callback
+    defect would have surfaced this immediately, in production.
+
+    Generalised to every Choice so the next one cannot repeat it: any variable
+    compared with a value comparator must ALSO be guarded by IsPresent on the
+    SAME path, unless it is a top-level field the state is guaranteed to have.
+    """
+    value_comparators = {
+        "BooleanEquals", "StringEquals", "NumericEquals", "NumericGreaterThan",
+        "NumericLessThan", "StringMatches", "NumericGreaterThanEquals",
+        "NumericLessThanEquals",
+    }
+
+    def choices_of(states):
+        for name, state in states.items():
+            if state.get("Type") == "Choice":
+                yield name, state.get("Choices", [])
+            if state.get("Type") == "Map":
+                body = state.get("ItemProcessor") or state.get("Iterator")
+                yield from choices_of(body["States"])
+
+    offenders = []
+    for state_name, choices in choices_of(prod["States"]):
+        for choice in choices:
+            conds = choice.get("And") or choice.get("Or") or [choice]
+            guarded = {c["Variable"] for c in conds
+                       if isinstance(c, dict) and c.get("IsPresent") is True}
+            for cond in conds:
+                if not isinstance(cond, dict) or "Variable" not in cond:
+                    continue
+                var = cond["Variable"]
+                if not (value_comparators & set(cond)):
+                    continue
+                # Nested paths are the risk; a bare `$.field` on a state's own
+                # guaranteed input is not.
+                if var.count(".") >= 2 and var not in guarded:
+                    offenders.append(f"{state_name}: {var}")
+
+    assert not offenders, (
+        "Choice condition(s) compare a nested path with no IsPresent guard on "
+        f"that same path — States.Runtime, uncatchable: {offenders}"
+    )


### PR DESCRIPTION
## §10.2 declared a standing gate that never existed

groom-sweep-policy §10.2 calls fault injection a **standing gate**. It had no code, no staging dispatch, and until today no issue (`alpha-engine-config-I5718`). §2.2 — *"a recovery path that has never executed is presumed broken"* — was unenforceable because nothing made them execute.

## What ships

- **`groom-inject-mock`** — a scripted stand-in with **no EC2/SSM/GitHub grants**. A flag on the production dispatcher was rejected: one bad conditional away from launching real boxes at the real backlog.
- **`staging_definition.py`** — derives the staging machine **from the production definition**. Exactly three transformations (Lambda→mock, SNS→staging topic, timeouts ÷720). A hand-written staging definition would drift and then report green about a machine that does not exist.
- **`fault_injection_run.py`** — 10 scenarios covering §10.2's minimum standing set. Asserts the **states visited**, not just the terminal status — which would pass for a machine that skipped every recovery state.
- **Verdict surface** at `s3://alpha-engine-research/groom/_control/fault-injection/`. Every mode starts `unverified` and must *earn* a verdict; `unverified` is never rendered as healthy and the run exits non-zero on it.
- **A dedicated staging SF role** scoped to the mock and staging topic only — isolation enforced by IAM, not by the swap being correct.
- Weekly schedule, plus on any change to the definition or the harness.

## The defect it found on its first successful run

```
States.Runtime — Invalid path '$.mapOutcome[0].laneOutcome.laneFailed'
```

ASL's `And` does not short-circuit path validity. The `IsPresent` guard was on `$.mapOutcome[N]` — the **iteration** — while `BooleanEquals` read `$.mapOutcome[N].laneOutcome.laneFailed`, and `laneOutcome` is written **only** by `RecordLaneFailure`. So a lane that **succeeded** left the path absent and the comparison raised `States.Runtime`, uncatchable by any Catch (§2.2).

**A groom cycle in which every lane succeeded could not complete.**

It went unnoticed because a fully-successful Map has never occurred under this definition: lost callbacks (`I4987`) meant lanes timed out instead, and the Map's Catch bypasses this state entirely. Fixing the callback defect would have surfaced this in production, on the first healthy cycle.

Fixed by guarding the path actually read, and generalised into `test_every_choice_guards_the_path_it_reads`, which scans every Choice in the definition for the same shape.

## One expectation was wrong, not the system

`ledger_write_fails` asserted `CheckCompletionMarkerTaskToken` — reached on a lane **timeout**, not on a lane that **raises**. Corrected to the real caught path (`HandleFailure → RecordLaneFailure → LaneCompleted → CheckMapLaneOutcomes → SetMapFailureFromLanes`), not relaxed. It is now the only scenario exercising `SetMapFailureFromLanes`, so it doubles as the regression guard for the Choice fix.

## Results

**Live: 10 passed, 0 failed, 0 unverified.** Suite: 3953 passed.

The dangerous-swap tests run **without credentials**, so a fork PR or a credential outage still catches those regressions rather than silently skipping the gate. If credentials are unavailable the gate reports UNVERIFIED and **fails**, rather than passing on a run that never happened.

## Related

- `alpha-engine-config-I5718`, `I4987`, `I5229`

---
**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)