### PR TITLE
chore: add CODEOWNERS (repository-baseline-policy §3.3)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Ownership of record for this repository.
+#
+# Required of EVERY repo, public and private, by repository-baseline-policy.md
+# §3.3. Measured 2026-07-30: 0 of 26 active repos had one — the only clause in
+# that policy at zero.
+#
+# This file gates nothing today: `require_code_owner_reviews` is off across the
+# fleet, so it adds no review requirement. That is the point. Its value is that
+# ownership is RECORDED before the day it is needed — a second contributor, an
+# agent asking who reviews a change, or an incident needing an owner. Each of
+# those is a day when writing it down is too late to help.
+#
+# A pattern matching nothing, or an owner who does not exist, is worse than an
+# absent file: it asserts an owner and delivers none.
+
+* @cipher813


### PR DESCRIPTION
Adds `.github/CODEOWNERS`, required of every repository — public and private — by
`repository-baseline-policy.md` §3.3 (nous-ergon-ops-PR290).

**Measured 2026-07-30: 0 of 26 active repos had one.** It was the only clause in
that policy sitting at zero, fleet-wide.

## This changes no behaviour today

`require_code_owner_reviews` is **off on every repo** (verified before opening
this, precisely so a fleet-wide file drop could not silently start blocking
PRs). So this adds no review requirement and no gate.

That is deliberate, and it is the policy's stated reason for requiring the file
anyway: its value is that ownership is **recorded before the day it is needed**
— a second contributor, an agent asking who reviews a change, an incident
needing an owner. Each of those is a day when writing it down is too late to
help.

## Content

`* @cipher813` — one owner, every path. The policy forbids a pattern matching
nothing or an owner who does not exist, because both are worse than an absent
file: they assert an owner and deliver none.

One of 26 sibling PRs, one per active repo. No merge order — they are
independent and touch one new file each.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
