### PR TITLE
[P1/low] fix(groom): one authoritative runtime bound — the box outlived the lane by 3 hours

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -255,9 +255,33 @@ GROOM_REPO = os.environ.get("GROOM_REPO", "nousergon/alpha-engine-config")
 GROOM_BRANCH = os.environ.get("GROOM_BRANCH", "main")
 # The BOX reads the PAT via its instance profile (this Lambda does not).
 GROOM_GH_PAT_SSM = os.environ.get("GROOM_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat")
-# Hard ceiling for the on-box SSM command (matches the bootstrap watchdog). The
-# in-run soft budget (~340 min) is the binding stop; this is the backstop.
-MAX_RUNTIME_SECONDS = int(os.environ.get("GROOM_MAX_RUNTIME_SECONDS", "21600"))
+# ONE authoritative runtime bound for a lane (groom-sweep-policy §2.1: "where
+# two mechanisms bound the same thing, the TIGHTER one is the real budget
+# regardless of intent").
+#
+# Measured 2026-07-30, three copies that did NOT agree:
+#
+#   SF LaunchGroomSpot TimeoutSeconds  10800s (180 min)  <- tightest, the REAL budget
+#   this constant                      21600s (360 min)  -> SSM command timeout
+#                                                        -> the reconciler's deadline_utc
+#   groom_spot_bootstrap.sh watchdog   21600s (360 min)  -> the box's own kill
+#
+# The comment above this line claimed it "matches the bootstrap watchdog" — it
+# did, and both were wrong, because the SF had been tightened to 180 min
+# without them. The consequence is not cosmetic: the SF gives up on the lane at
+# 180 min and fires a relaunch while the ORIGINAL box is still working for
+# another three hours, and the relaunch's concurrent-tier guard then refuses
+# because that box is alive. That is exactly the alpha-engine-config-I4987
+# no-op relaunch, manufactured on a timer.
+#
+# The reconciler was mis-armed the same way: its deadline_utc was now + 360 min,
+# so a lane the SF had already abandoned would not read as overdue for another
+# three hours.
+#
+# 10800 is therefore the value, and it is BOUND to the SF definition by
+# test_runtime_bound_is_single_and_authoritative — both files live in this
+# repo, so the binding is enforceable rather than aspirational.
+MAX_RUNTIME_SECONDS = int(os.environ.get("GROOM_MAX_RUNTIME_SECONDS", "10800"))
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("GROOM_SSM_ONLINE_BUDGET_SEC", "180"))
 CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
 
@@ -525,6 +549,13 @@ def _bootstrap_command(run_mode: str, run_url: str, model: str, issue_filter: st
     # the run through DeepSeek instead of Claude — this Lambda passes the flag
     # through verbatim, it does not select the DeepSeek model itself.
     backend_export = f"export GROOM_BACKEND={backend}\n" if backend else ""
+    # Push the ONE authoritative runtime bound to the box so its watchdog
+    # cannot drift from the SF's lane timeout. groom_spot_bootstrap.sh reads
+    # `${MAX_RUNTIME_SECONDS:-...}`, so its own default becomes a fallback for
+    # manual runs only — every dispatched box now inherits this value.
+    # Without this export the box killed itself at its own 360-min default
+    # while the SF had already abandoned the lane at 180 (see the constant).
+    runtime_bound_export = f"export MAX_RUNTIME_SECONDS={MAX_RUNTIME_SECONDS}\n"
     # Arming the DeepSeek fallback dispatch: when a Claude-backed groom run
     # hits quota exhaustion, the on-box groom_run.sh checks this flag and —
     # if enabled — invokes this Lambda again with mode=fallback to launch a
@@ -555,7 +586,7 @@ cd /home/ec2-user/alpha-engine-config
 export GROOM_MODEL={model}
 export GROOM_ISSUE_FILTER={issue_filter}
 export GROOM_RUN_TOKEN={run_token}
-{pr_budget_export}{manifest_export}{fallback_enabled_export}{backend_export}{task_token_export}exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
+{pr_budget_export}{manifest_export}{fallback_enabled_export}{backend_export}{runtime_bound_export}{task_token_export}exec bash infrastructure/groom_spot_bootstrap.sh --mode {run_mode} --run-url "{run_url}"{soft_limit_flag}
 """
 
 

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -282,3 +282,63 @@ def test_lane_death_catch_precedes_the_catch_all():
     assert order.index(("LaneDeath",)) < order.index(("States.ALL",)), (
         "the LaneDeath Catch sits after States.ALL and is therefore unreachable"
     )
+
+
+# ── §2.1: ONE authoritative runtime bound for a lane ─────────────────────────
+
+
+def _dispatcher_max_runtime() -> int:
+    import re
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "infrastructure" / "lambdas"
+           / "scheduled-groom-dispatcher" / "index.py").read_text()
+    m = re.search(r'GROOM_MAX_RUNTIME_SECONDS",\s*"(\d+)"', src)
+    assert m, "could not read MAX_RUNTIME_SECONDS from the dispatcher"
+    return int(m.group(1))
+
+
+def test_runtime_bound_is_single_and_authoritative():
+    """The box must never outlive the lane the SF is waiting on.
+
+    groom-sweep-policy §2.1: "where two mechanisms bound the same thing, the
+    TIGHTER one is the real budget regardless of intent."
+
+    Measured 2026-07-30 — three copies that did not agree:
+
+        SF LaunchGroomSpot TimeoutSeconds   10800s (180 min)  <- real budget
+        dispatcher MAX_RUNTIME_SECONDS      21600s (360 min)
+        bootstrap watchdog default          21600s (360 min)
+
+    The failure is not cosmetic. The SF abandons the lane at 180 min and fires
+    a relaunch while the ORIGINAL box works on for another three hours; the
+    relaunch's concurrent-tier guard then refuses because that box is alive —
+    the alpha-engine-config-I4987 no-op relaunch, manufactured on a timer. The
+    reconciler was mis-armed identically: deadline_utc was now + 360 min, so a
+    lane the SF had already given up on stayed 'not overdue' for three hours.
+    """
+    lane_timeout = _lane_state()["TimeoutSeconds"]
+    box_bound = _dispatcher_max_runtime()
+    assert box_bound <= lane_timeout, (
+        f"the box may run {box_bound}s but the SF abandons the lane at "
+        f"{lane_timeout}s — every timeout leaves an orphan box that blocks its "
+        "own relaunch"
+    )
+
+
+def test_the_runtime_bound_reaches_the_box():
+    """A constant the box never receives is not a bound.
+
+    groom_spot_bootstrap.sh reads `${MAX_RUNTIME_SECONDS:-<default>}`. If the
+    dispatcher does not export it, the box silently uses its own default and
+    the value tested above governs nothing on the machine it is about.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "infrastructure" / "lambdas"
+           / "scheduled-groom-dispatcher" / "index.py").read_text()
+    assert "export MAX_RUNTIME_SECONDS=" in src, (
+        "the dispatcher never exports MAX_RUNTIME_SECONDS, so the box falls "
+        "back to its own default and the two can diverge freely"
+    )
+    assert "{runtime_bound_export}" in src, (
+        "the export is built but never interpolated into the bootstrap command"
+    )


### PR DESCRIPTION
## Brian's ask, and what measuring it found

> "make sure these can't run more than their stated time period of ~360 minutes"

Three copies of the bound, none agreeing — and the stated period is no longer 360:

| Mechanism | Value | Governs |
|---|---|---|
| SF `LaunchGroomSpot` TimeoutSeconds | **10800s (180 min)** | the lane the SF waits on — **tightest, so the real budget** |
| dispatcher `MAX_RUNTIME_SECONDS` | 21600s (360 min) | SSM command timeout, reconciler `deadline_utc` |
| bootstrap watchdog default | 21600s (360 min) | the box's own kill |

groom-sweep-policy §2.1: *"where two mechanisms bound the same thing, the TIGHTER one is the real budget regardless of intent."* The SF was tightened to 180 min (bringing 2 attempts under the 8h cadence) without the other two following.

## Why this is not cosmetic

The SF abandons the lane at 180 min and fires a relaunch **while the original box works on for another three hours**. The relaunch's concurrent-tier guard then refuses because that box is still alive.

That is the `alpha-engine-config-I4987` no-op relaunch — **manufactured on a timer**, on the happy path, every time a lane runs long. Not a rare race.

The reconciler was mis-armed identically: `deadline_utc` was `now + 360 min`, so a lane the SF had already given up on stayed "not overdue" for three hours.

## Fixes

- `MAX_RUNTIME_SECONDS` 21600 → **10800**, so the SSM command timeout and the reconciler deadline match the lane the SF actually waits on.
- The dispatcher now **exports** `MAX_RUNTIME_SECONDS` into the bootstrap command. The bootstrap reads `${MAX_RUNTIME_SECONDS:-…}`, so its default becomes a fallback for manual runs only and every dispatched box inherits the one value. **A constant the box never receives is not a bound.**
- Two tests binding the dispatcher constant to the SF definition and asserting the export is actually interpolated. Both files are in this repo, so the binding is enforceable rather than aspirational. Both mutation-verified.

## Resulting composition

**180 min per box · 2 attempts = 6h worst case · under the 8h trigger interval · 7h top-level ceiling as backstop.**

`pytest tests/` — **3964 passed**. One pre-existing unrelated failure (`WaitForThinkTank`, needs a cross-repo lib change).

## Related

- `alpha-engine-config-I5372` (budget composition), `I4987` (the no-op relaunch this was silently causing), `I5229`

---
**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)