### PR TITLE
[P1/mid] feat(groom): give the sweep its own schedule — it was hostage to groom health

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -422,6 +422,77 @@ EOF
       || { echo "ERROR: reconciler rule ${RECON_SCHED_NAME} not found after create/update" >&2; exit 1; }
   fi
 
+  # --- 2e-ter. INDEPENDENT sweep schedules (Brian's ruling 2026-07-30).
+  #
+  # Until now the PR sweep ran only as DispatchEndOfSfSweep, the last state of
+  # the groom cycle — so sweep frequency was hostage to groom health. That is
+  # not theoretical: on 2026-07-30 two of three cycles ended in
+  # `concurrent_cycle_skip`, and the sweep did not run on either. The sweep has
+  # no dependency on groom OUTPUT (it classifies open PRs), so the coupling
+  # bought nothing.
+  #
+  # These rules give it its own trigger, interleaved 4h after each groom:
+  #
+  #   groom  04:00 12:00 20:00 UTC   (9pm / 5am / 1pm PT — unchanged)
+  #   sweep  00:00 08:00 16:00 UTC   (5pm / 1am / 9am PT)
+  #
+  # DispatchEndOfSfSweep is deliberately KEPT. groom-sweep-policy §2.5 makes it
+  # the unconditional tail-catcher — "making it conditional on groom success
+  # starves it exactly when it is most needed" — and removing it is an
+  # orchestration change requiring a policy amendment, not a schedule tweak.
+  # Keeping both yields a sweep roughly every 4h at one cheap box per run.
+  #
+  # Collisions are already handled: the dispatcher tags sweep boxes
+  # `groom-issue-filter=sweep`, distinct from every groom tier tag, so the
+  # config#1979 concurrent guard skips when a prior sweep box is still live.
+  #
+  # NAMED OUTSIDE SCHED_PREFIX on purpose. Step 2f prunes any live rule under
+  # `alpha-engine-scheduled-groom-` that is absent from SCHED_NAMES, and
+  # SCHED_NAMES entries target the STEP FUNCTION (a full groom cycle). These
+  # target the LAMBDA with run_mode=sweep, so a shared prefix would have them
+  # deleted on the next deploy.
+  SWEEP_SCHED_NAMES=(
+    "alpha-engine-groom-sweep-0000-daily"
+    "alpha-engine-groom-sweep-0800-daily"
+    "alpha-engine-groom-sweep-1600-daily"
+  )
+  SWEEP_SCHED_CRONS=(
+    "cron(0 0 * * ? *)"
+    "cron(0 8 * * ? *)"
+    "cron(0 16 * * ? *)"
+  )
+  # Mirrors the DispatchEndOfSfSweep payload in step_function_groom.json:
+  # a literal launch_decided sweep event. `issue_filter` is inert for
+  # run_mode=sweep but the launch path validates it, so it is passed
+  # explicitly rather than defaulted.
+  for i in "${!SWEEP_SCHED_NAMES[@]}"; do
+    sname="${SWEEP_SCHED_NAMES[$i]}"
+    scron="${SWEEP_SCHED_CRONS[$i]}"
+    sweep_target=$(cat <<EOF
+{"Arn":"${FN_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"{\\\"run_mode\\\":\\\"sweep\\\",\\\"launch_decided\\\":true,\\\"model\\\":\\\"deepseek-v4-flash\\\",\\\"issue_filter\\\":\\\"mid-only\\\",\\\"schedule\\\":\\\"${sname}\\\"}"}
+EOF
+)
+    if aws scheduler get-schedule --name "${sname}" --region "${REGION}" \
+        --query 'Name' --output text >/dev/null 2>&1; then
+      echo "  Updating sweep rule: ${sname} → ${scron}"
+      run aws scheduler update-schedule --name "${sname}" \
+        --schedule-expression "${scron}" --schedule-expression-timezone "UTC" \
+        --flexible-time-window '{"Mode":"OFF"}' --target "${sweep_target}" \
+        --region "${REGION}" --query 'ScheduleArn' --output text
+    else
+      echo "  Creating sweep rule: ${sname} → ${scron}"
+      run aws scheduler create-schedule --name "${sname}" \
+        --schedule-expression "${scron}" --schedule-expression-timezone "UTC" \
+        --flexible-time-window '{"Mode":"OFF"}' --target "${sweep_target}" \
+        --region "${REGION}" --query 'ScheduleArn' --output text
+    fi
+    if ! $DRY_RUN; then
+      aws scheduler get-schedule --name "${sname}" --region "${REGION}" \
+        --query 'Name' --output text >/dev/null \
+        || { echo "ERROR: sweep rule ${sname} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
   # --- 2f. Prune reconciliation: delete any live rule under SCHED_PREFIX that is
   # no longer in SCHED_NAMES (so dropping a cadence above removes it live too,
   # rather than silently orphaning a still-firing schedule). Added 2026-06-29

--- a/tests/test_groom_cycle_notifications.py
+++ b/tests/test_groom_cycle_notifications.py
@@ -535,3 +535,73 @@ def test_lanes_that_launched_are_unaffected_by_the_skip_classifier(dispatcher):
     assert out["lanes"] == 2
     assert out["skip_reason"] is None
     assert out["skip_healthy"] is None, "skip_healthy is meaningless when lanes ran"
+
+
+# ── Independent sweep schedules (Brian's ruling 2026-07-30) ──────────────────
+
+
+def _deploy_sh() -> str:
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[1] / "infrastructure" / "lambdas"
+            / "scheduled-groom-dispatcher" / "deploy.sh").read_text(encoding="utf-8")
+
+
+def test_sweep_has_its_own_schedules_not_only_the_groom_tail():
+    """The sweep must not be hostage to groom health.
+
+    It ran only as DispatchEndOfSfSweep — the last state of the groom cycle —
+    so when two of three cycles ended in `concurrent_cycle_skip` on 2026-07-30,
+    the sweep did not run on either. It has no dependency on groom OUTPUT, so
+    the coupling bought nothing.
+    """
+    sh = _deploy_sh()
+    assert "SWEEP_SCHED_NAMES=(" in sh, "no independent sweep schedules defined"
+    for hhmm in ("0000", "0800", "1600"):
+        assert f"alpha-engine-groom-sweep-{hhmm}-daily" in sh, (
+            f"missing the {hhmm} UTC sweep rule")
+
+
+def test_sweep_rules_sit_outside_the_pruned_prefix():
+    """Step 2f deletes any rule under SCHED_PREFIX absent from SCHED_NAMES.
+
+    SCHED_NAMES entries target the STEP FUNCTION (a full groom cycle); the
+    sweep rules target the LAMBDA with run_mode=sweep. Sharing the prefix would
+    have them silently deleted on the very next deploy.
+    """
+    import re
+    sh = _deploy_sh()
+    prefix = re.search(r'SCHED_PREFIX="([^"]+)"', sh).group(1)
+    block = sh.split("SWEEP_SCHED_NAMES=(", 1)[1].split(")", 1)[0]
+    for name in re.findall(r'"([^"]+)"', block):
+        assert not name.startswith(prefix), (
+            f"sweep rule {name!r} starts with the pruned prefix {prefix!r} — "
+            "it would be deleted on the next deploy"
+        )
+
+
+def test_sweep_schedule_interleaves_with_the_groom():
+    """Each sweep must land between grooms, not on top of one.
+
+    groom 04/12/20 UTC daily, sweep 00/08/16 UTC — every daily groom is swept
+    4h later. The Sun 09:00 UTC weekly slot is an extra and is excluded: it is
+    not part of the daily interleave.
+    """
+    import re
+    sh = _deploy_sh()
+
+    def hours(block_name: str) -> list[int]:
+        block = sh.split(block_name, 1)[1].split(")\n", 1)[0]
+        # Daily rules only: `cron(0 H * * ? *)`. The weekly is `? * SUN *`.
+        return sorted(int(h) for h in
+                      re.findall(r'cron\(0 (\d+) \* \* \? \*\)', block))
+
+    groom = hours("SCHED_CRONS=(")
+    sweep = hours("SWEEP_SCHED_CRONS=(")
+    assert groom and sweep, f"could not parse schedules: groom={groom} sweep={sweep}"
+    assert not (set(groom) & set(sweep)), (
+        f"a sweep fires at the same hour as a groom: {sorted(set(groom) & set(sweep))}"
+    )
+    for g in groom:
+        assert any((s - g) % 24 == 4 for s in sweep), (
+            f"groom at {g:02d}:00 UTC has no sweep 4h later; sweeps={sweep}"
+        )


### PR DESCRIPTION
## Brian's ruling 2026-07-30

The PR sweep ran **only** as `DispatchEndOfSfSweep`, the last state of the groom cycle — so its frequency depended on the groom succeeding. Not theoretical: two of three cycles today ended in `concurrent_cycle_skip` and **the sweep did not run on either**. The sweep classifies *open PRs* and has no dependency on groom output, so the coupling bought nothing.

| | UTC | PT |
|---|---|---|
| **Groom** | 04:00, 12:00, 20:00 | 9pm, 5am, 1pm *(unchanged)* |
| **Sweep** | 00:00, 08:00, 16:00 | 5pm, 1am, 9am *(new)* |

Both 8h apart, every groom swept **4h later**. The 8h spacing is what keeps the 180min x 2-attempt lane budget (6h) under the interval — a 6h grid would sit exactly on the boundary.

## `DispatchEndOfSfSweep` is deliberately kept

groom-sweep-policy §2.5 makes it the unconditional tail-catcher — *"making it conditional on groom success starves it exactly when it is most needed"* — and removing it is an orchestration change needing a policy amendment, not a schedule tweak.

Keeping both yields a sweep roughly every 4h at one cheap box per run. Collisions are already handled: sweep boxes carry `groom-issue-filter=sweep`, distinct from every groom tier tag, so the config#1979 concurrent guard skips when a prior sweep box is still live.

## Naming, and why it matters

The rules sit **outside** `SCHED_PREFIX` on purpose. Step 2f prunes any live rule under `alpha-engine-scheduled-groom-` absent from `SCHED_NAMES` — and those entries target the **Step Function** (a full groom cycle) while these target the **Lambda** with `run_mode=sweep`. A shared prefix would silently delete them on the next deploy. A test asserts they stay outside it.

## On prime time

The 20:00 UTC groom **stays** in peak spot demand, deliberately. All four of today's reclaims were that slot (`instance-terminated-no-capacity`, `t4g.medium`, `us-east-1b`/`1f`).

The remedy is the capacity work already shipped — a four-family arm64 pool plus on-demand escalation on the final relaunch, which the `LaneDeath` routing fix made reachable again. Traced in the live definition: with `max_retries: 1`, `PrepRelaunch` takes `retry_count 0 -> 1` and `CheckForceOnDemand` fires `SetForceOnDemand`, so **the second and final attempt is unconditionally on-demand**. Scheduling around peak was the weaker lever and is not used.

## Tests

Three, all mutation-verified:
- the sweep has its own rules
- they sit outside the pruned prefix (giving one the `alpha-engine-scheduled-groom-` prefix fails)
- no sweep shares an hour with a groom, and each daily groom is swept 4h later (moving a sweep onto 12:00 fails)

`pytest tests/` — **3977 passed**. One pre-existing unrelated failure (`WaitForThinkTank`, needs a cross-repo lib change).

## Related

- `alpha-engine-config-I4989`, `I4987`, `I5372`

---
**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)