### PR TITLE
[P1/low] fix(deploy): build Scheduler targets with json.dumps — the heredoc emitted invalid JSON

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -386,10 +386,13 @@ EOF
   # short Lambda invocation.
   RECON_SCHED_NAME="alpha-engine-groom-lane-reconciler-5min"
   RECON_SCHED_CRON="rate(5 minutes)"
-  recon_target=$(cat <<EOF
-{"Arn":"${FN_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"{\\\"mode\\\":\\\"reconcile\\\"}"}
-EOF
-)
+  # Built with python3, NOT a heredoc. In an unquoted heredoc bash unescapes
+  # only \$, \`, \\ and \<newline> — a backslash before a double quote is
+  # PRESERVED. So `\\\"` emitted `\\"` rather than `\"`, and every
+  # create-schedule call died on `Invalid JSON: Expecting ',' delimiter`.
+  # Counting backslashes through two layers of quoting is not a thing to get
+  # right by inspection; json.dumps cannot get it wrong.
+  recon_target=$(python3 -c 'import json,sys; print(json.dumps({"Arn": sys.argv[1], "RoleArn": sys.argv[2], "Input": json.dumps({"mode": "reconcile"})}))' "${FN_ARN}" "${SCHED_ROLE_ARN}")
   echo "  Applying Scheduler invoke-Lambda policy for the reconciler"
   run aws iam put-role-policy \
     --role-name "${SCHED_ROLE_NAME}" \
@@ -468,10 +471,7 @@ EOF
   for i in "${!SWEEP_SCHED_NAMES[@]}"; do
     sname="${SWEEP_SCHED_NAMES[$i]}"
     scron="${SWEEP_SCHED_CRONS[$i]}"
-    sweep_target=$(cat <<EOF
-{"Arn":"${FN_ARN}","RoleArn":"${SCHED_ROLE_ARN}","Input":"{\\\"run_mode\\\":\\\"sweep\\\",\\\"launch_decided\\\":true,\\\"model\\\":\\\"deepseek-v4-flash\\\",\\\"issue_filter\\\":\\\"mid-only\\\",\\\"schedule\\\":\\\"${sname}\\\"}"}
-EOF
-)
+    sweep_target=$(python3 -c 'import json,sys; print(json.dumps({"Arn": sys.argv[1], "RoleArn": sys.argv[2], "Input": json.dumps({"run_mode": "sweep", "launch_decided": True, "model": "deepseek-v4-flash", "issue_filter": "mid-only", "schedule": sys.argv[3]})}))' "${FN_ARN}" "${SCHED_ROLE_ARN}" "${sname}")
     if aws scheduler get-schedule --name "${sname}" --region "${REGION}" \
         --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating sweep rule: ${sname} → ${scron}"


### PR DESCRIPTION
## What broke

Applying the new sweep schedules failed on every `create-schedule`:

```
ParamValidation: Invalid JSON: Expecting ',' delimiter: line 1 column 208
```

## Cause — a heredoc rule that is easy to get wrong by inspection

In an **unquoted** heredoc, bash unescapes only `\$`, `` \` ``, `\\` and `\<newline>`. **A backslash before a double quote is preserved.** So the source `\\\"` emitted `\\"` rather than `\"`, and the `--target` payload was malformed.

This affected the **reconciler** rule too. It had never surfaced because that schedule was created by hand on 2026-07-30 with a directly-quoted CLI argument — `deploy.sh`'s version of it had never actually run.

## Fix

Both targets are now built with `python3 -c ... json.dumps(...)`. Counting backslashes through two layers of quoting is not something to get right by inspection; `json.dumps` cannot get it wrong, and the instance-specific values ride as `argv` rather than through string interpolation.

## Note for the next person: `--dry-run` did not catch this

`run()` echoes the command without executing it, so a malformed argument prints happily and only fails for real. I validated instead by parsing every emitted `--target` out of the dry-run output and `json.loads`-ing both it **and** its nested `Input`:

```
targets checked=8 valid=8
```

including the 4 pre-existing groom rules.

## Applied live

| Schedule | Expression |
|---|---|
| alpha-engine-groom-sweep-0000-daily | cron(0 0 * * ? *) |
| alpha-engine-groom-sweep-0800-daily | cron(0 8 * * ? *) |
| alpha-engine-groom-sweep-1600-daily | cron(0 16 * * ? *) |
| alpha-engine-groom-lane-reconciler-5min | rate(5 minutes) |
| alpha-engine-scheduled-groom-0400/1200/2000-daily | unchanged |
| alpha-engine-scheduled-groom-sun0900-weekly | unchanged |

All 8 confirmed present with the expected cron expressions.

`pytest tests/` — **3977 passed**. One pre-existing unrelated failure (`WaitForThinkTank`).

## Related

- `nousergon-data-PR1179` — the sweep schedules this makes deployable
- `alpha-engine-config-I4989`

---
**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)