### PR TITLE
fix(groom): split --bootstrap on the IAM boundary — schedules and the SF definition now deploy on merge (I5805)

### DIFF
--- a/.github/workflows/deploy-scheduled-groom-dispatcher.yml
+++ b/.github/workflows/deploy-scheduled-groom-dispatcher.yml
@@ -7,24 +7,35 @@ name: Deploy scheduled-groom-dispatcher
 # until someone remembered to run deploy.sh by hand. This closes that gap for
 # the CODE path only.
 #
-# Separation of concerns: this deploys CODE only (deploy.sh with NO flag —
-# unlike freshness-monitor, this script's default/flagless run IS already
-# code-only; --bootstrap is what ADDS the IAM-role-creation + EventBridge
-# Scheduler wiring, not the reverse, so no new script flag was needed here).
-# A change to SCHED_NAMES/SCHED_CRONS/SCHED_INPUTS (a schedule/cadence change)
-# still requires an operator to run `deploy.sh --bootstrap` by hand — the
-# github-actions-lambda-deploy OIDC role deliberately has no iam:CreateRole /
-# iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber incidents in 2
-# months traced to auto-applied IAM writes; see nous-ergon-ops/infrastructure/iam/README.md).
-# It DOES already have scheduler:Create/Update/DeleteSchedule + a scoped
-# iam:PassRole — a future refinement could split deploy.sh's --bootstrap into
-# an IAM-role-creation step (still operator-only) and a schedule-rules-only
-# step (auto-deployable), but that needs a deliberate script redesign +
-# live-AWS validation, not bundled into this workflow-only change.
+# alpha-engine-config-I5805 closes the rest of that gap. The refinement this
+# header used to describe as future work — "split deploy.sh's --bootstrap into
+# an IAM-role-creation step (still operator-only) and a schedule-rules-only step
+# (auto-deployable)" — is done, so this workflow now deploys all three moving
+# parts on merge:
 #
-# IAM: no new grant needed — LambdaUpdate already covers
-# arn:...:function:alpha-engine-* (nous-ergon-ops/infrastructure/iam/github-actions-lambda-
-# deploy.json), which already includes this function.
+#   1. Lambda code           flagless deploy.sh, step 3   (LambdaUpdate)
+#   2. SF definition         flagless deploy.sh, step 3b  (InfraDeploySFDefinition)
+#   3. Scheduler rules       --reconcile-schedules        (InfraDeployResourceCRUD)
+#
+# Why it mattered: nousergon-data#1179 gave the PR sweep three independent daily
+# schedules on 2026-07-30. This workflow ran green on that merge and created
+# none of them, because the schedule block was behind --bootstrap. The sweep
+# stayed hostage to groom health — the exact condition #1179 removed in source
+# and never removed in production.
+#
+# What remains operator-only: `deploy.sh --bootstrap-iam`, which creates the
+# three IAM roles and puts their inline policies. The OIDC role deliberately has
+# no iam:CreateRole / iam:PutRolePolicy (fleet-wide policy after 4 IAM-clobber
+# incidents in 2 months traced to auto-applied IAM writes; see
+# nous-ergon-ops/infrastructure/iam/README.md). That step is genuinely
+# first-time-only — it does not gate any cadence or definition change.
+#
+# IAM: the only new grant this needed is scheduler:ListSchedules, for the prune
+# loop in block 2f (nous-ergon-ops/infrastructure/iam/github-actions-lambda-
+# deploy/github-actions-lambda-deploy-policy.json, InfraDeployResourceRead).
+# Everything else was already held: scheduler:{Create,Update,Delete}Schedule and
+# scheduler:GetSchedule, states:UpdateStateMachine on alpha-engine-groom-dispatch,
+# and iam:PassRole on alpha-engine-*.
 
 on:
   push:
@@ -54,7 +65,7 @@ permissions:
 
 jobs:
   deploy:
-    name: Deploy scheduled-groom-dispatcher Lambda (code-only)
+    name: Deploy scheduled-groom-dispatcher (code + SF definition + schedules)
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -75,9 +86,15 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Deploy scheduled-groom-dispatcher (code-only — no --bootstrap)
+      - name: Deploy code + Step Function definition
         working-directory: alpha-engine-data
         run: bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+
+      # Separate step, not a flag on the one above, so the log makes it obvious
+      # which half failed. Both run under the same OIDC role; neither writes IAM.
+      - name: Reconcile EventBridge Scheduler rules (upsert + prune)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --reconcile-schedules
 
       - name: Report deployed version
         working-directory: alpha-engine-data
@@ -87,6 +104,15 @@ jobs:
             --function-name alpha-engine-scheduled-groom-dispatcher \
             --query "Configuration.[LastModified,CodeSha256]" \
             --output text
+
+      # Assert the OUTCOME, not the exit status of the step that should have
+      # produced it. Every rule the source declares must exist live, in state
+      # ENABLED, after this workflow runs — a deploy that reports success while
+      # a schedule is missing is the failure mode this whole change exists to
+      # remove, and it is exactly what a green run looked like on 2026-07-30.
+      - name: Assert every declared schedule exists live
+        working-directory: alpha-engine-data
+        run: python3 infrastructure/scheduler/check-schedule-drift.py
 
       - name: Append to system-wide deploy changelog
         if: always()

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -31,6 +31,7 @@ on:
       - 'infrastructure/cloudformation/alpha-engine-orchestration.yaml'
       - 'infrastructure/deploy-infrastructure.sh'
       - 'infrastructure/step_function*.json'
+      - 'infrastructure/scheduler/**'
       - '.github/workflows/sf-arn-drift-check.yml'
   schedule:
     - cron: '30 9 * * *'   # daily, alongside the IAM sweep
@@ -60,3 +61,11 @@ jobs:
 
       - name: SF lambda:invoke Lambda-existence check (codified vs live)
         run: python3 infrastructure/step-functions/check-lambda-existence.py
+
+      # alpha-engine-config-I5805. The out-of-band half of schedule coverage.
+      # deploy-scheduled-groom-dispatcher.yml reconciles + asserts on every
+      # merge, which closes drift caused by a merge; this catches what no merge
+      # can see — a rule disabled or retimed in the console, or one belonging to
+      # a dispatcher whose repo has no deploy workflow at all.
+      - name: EventBridge Scheduler rule drift (codified vs live)
+        run: python3 infrastructure/scheduler/check-schedule-drift.py

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -59,27 +59,38 @@
 # deliberately lacks iam:CreateRole/iam:PutRolePolicy, a fleet-wide policy
 # after 4 IAM-clobber incidents in 2 months — see infrastructure/iam/README.md).
 #
-# CODE auto-deploys on merge to main via
-# `.github/workflows/deploy-scheduled-groom-dispatcher.yml` (path-filtered to
-# `infrastructure/lambdas/scheduled-groom-dispatcher/**`), which runs this
-# script with NO flags (this script's default/flagless run is already
-# code-only — --bootstrap is what ADDS IAM-role-creation + EventBridge
-# Scheduler wiring on top, not the reverse) under the github-actions-lambda-
-# deploy OIDC role (LambdaUpdate grant on `alpha-engine-*`, no IAM-role-create).
-# A SCHED_NAMES/SCHED_CRONS/SCHED_INPUTS change (a schedule/cadence change,
-# e.g. this file's own 2026-07-02 Sat-skip removal) still needs an operator to
-# run `--bootstrap` by hand — merging alone has ZERO effect on the live
-# EventBridge Scheduler rule. CUTOVER (config#1432, historical): after a
-# manual --smoke spot run validates end-to-end, deploy this AND disable the
-# GHA `schedule:` crons in backlog-groom.yml together (so there is no
-# double-groom and no gap). NOTE: --smoke fires a REAL groom on a REAL spot box.
+# CODE, SF DEFINITION and SCHEDULES all auto-deploy on merge to main via
+# `.github/workflows/deploy-scheduled-groom-dispatcher.yml`, which runs this
+# script twice: flagless (Lambda code + SF definition) and then
+# `--reconcile-schedules` (EventBridge Scheduler upsert + prune), both under
+# the github-actions-lambda-deploy OIDC role.
+#
+# alpha-engine-config-I5805 is why the schedule half is here at all. It used to
+# sit inside --bootstrap next to the IAM-role creation, so the OIDC role — which
+# deliberately lacks iam:CreateRole/iam:PutRolePolicy (fleet single-writer rule
+# after 4 IAM-clobber incidents in 2 months) — could not run it, and a merged
+# cadence change did nothing until an operator ran a command by hand. It was not
+# run: nousergon-data#1179 added three independent sweep schedules on 2026-07-30
+# and none of them was ever created. Splitting on the IAM boundary rather than
+# on "first time vs not" is what makes the schedule half CI-runnable.
+#
+# What still needs an operator: --bootstrap-iam, i.e. creating the three IAM
+# roles and their inline policies, plus first-ever creation of the Lambda and
+# the Step Function. That is genuinely first-time-only.
+#
+# CUTOVER (config#1432, historical): after a manual --smoke spot run validates
+# end-to-end, deploy this AND disable the GHA `schedule:` crons in
+# backlog-groom.yml together (so there is no double-groom and no gap).
+# NOTE: --smoke fires a REAL groom on a REAL spot box.
 #
 # Usage:
-#   bash .../scheduled-groom-dispatcher/deploy.sh             # update code only (also the CI auto-deploy path)
-#   bash .../scheduled-groom-dispatcher/deploy.sh --bootstrap # operator-only: create/update IAM roles + wire EventBridge Scheduler
-#   bash .../scheduled-groom-dispatcher/deploy.sh --apply-iam # re-apply iam-policy.json only (no bootstrap side effects, config#2825)
-#   bash .../scheduled-groom-dispatcher/deploy.sh --dry-run   # show actions, do not apply
-#   bash .../scheduled-groom-dispatcher/deploy.sh --smoke     # invoke once with a synthetic schedule event (⚠ fires a REAL groom)
+#   bash .../deploy.sh                        # code + SF definition (the CI path, step 1)
+#   bash .../deploy.sh --reconcile-schedules  # + upsert/prune Scheduler rules (the CI path, step 2)
+#   bash .../deploy.sh --bootstrap-iam        # operator-only: create IAM roles, Lambda, SF
+#   bash .../deploy.sh --bootstrap            # both of the above (unchanged meaning)
+#   bash .../deploy.sh --apply-iam            # re-apply iam-policy.json only (config#2825)
+#   bash .../deploy.sh --dry-run              # show actions, do not apply
+#   bash .../deploy.sh --smoke                # synthetic schedule event (⚠ fires a REAL groom)
 
 set -euo pipefail
 
@@ -141,18 +152,48 @@ case "${DRY_RUN:-false}" in
   true|1|yes|TRUE|YES) DRY_RUN=true ;;
   *) DRY_RUN=false ;;
 esac
-BOOTSTRAP=false
+# alpha-engine-config-I5805 splits the old monolithic --bootstrap in two, along
+# the line that actually matters: which grants the caller needs.
+#
+#   BOOTSTRAP_IAM       creates IAM roles and puts inline policies. Needs
+#                       iam:CreateRole + iam:PutRolePolicy, which the GHA OIDC
+#                       role deliberately does NOT have (fleet single-writer
+#                       rule after 4 IAM-clobber incidents). Operator-only, and
+#                       first-time-only in practice.
+#   RECONCILE_SCHEDULES upserts + prunes the EventBridge Scheduler rules. Needs
+#                       ONLY scheduler:{Get,List,Create,Update,Delete}Schedule
+#                       and a scoped iam:PassRole — all of which
+#                       github-actions-lambda-deploy already holds. Safe to run
+#                       on every merge, and now does.
+#
+# --bootstrap keeps its old meaning (both) so every runbook, every comment and
+# every operator habit that predates the split still does what it says.
+BOOTSTRAP_IAM=false
+RECONCILE_SCHEDULES=false
 APPLY_IAM=false
 SMOKE=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
-    --bootstrap) BOOTSTRAP=true ;;
+    --bootstrap) BOOTSTRAP_IAM=true; RECONCILE_SCHEDULES=true ;;
+    --bootstrap-iam) BOOTSTRAP_IAM=true ;;
+    --reconcile-schedules) RECONCILE_SCHEDULES=true ;;
     --apply-iam) APPLY_IAM=true ;;
     --smoke) SMOKE=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
 done
+
+# `--reconcile-schedules` ALONE is a schedules-only run: it skips packaging
+# (docker pip + handler tests), the code push and the SF definition push. The
+# CI deploy therefore invokes this script twice without paying for the ~2min
+# package build twice, and an operator repairing live schedule drift does not
+# have to redeploy code to do it. Combined with --bootstrap or run flagless,
+# everything happens as before.
+CODE_DEPLOY=true
+if $RECONCILE_SCHEDULES && ! $BOOTSTRAP_IAM && ! $APPLY_IAM && ! $SMOKE; then
+  CODE_DEPLOY=false
+fi
 
 run() {
   if $DRY_RUN; then
@@ -168,6 +209,8 @@ run() {
 
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
+
+if $CODE_DEPLOY; then
 
 python3 -c "
 import ast
@@ -201,7 +244,11 @@ ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
-# ----- 2. Bootstrap (first-time only) ---------------------------------------
+else
+  echo "Schedules-only run (--reconcile-schedules): skipping handler tests + packaging."
+fi
+
+# ----- 2. IAM + resource bootstrap (operator-only, first-time only) ---------
 
 # ----- Apply IAM only (config#2825, no bootstrap side effects) -------------
 if $APPLY_IAM; then
@@ -211,8 +258,8 @@ if $APPLY_IAM; then
   echo "  ✓ IAM applied."
 fi
 
-if $BOOTSTRAP; then
-  echo "Bootstrapping ${FUNCTION_NAME}..."
+if $BOOTSTRAP_IAM; then
+  echo "Bootstrapping IAM + resources for ${FUNCTION_NAME}..."
 
   # --- 2a. Lambda execution role + inline policy ---
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
@@ -284,6 +331,8 @@ if $BOOTSTRAP; then
     sleep 10
   fi
 
+  # CREATE only. The UPDATE half moved to step 3b, which runs unconditionally
+  # (alpha-engine-config-I5805) — see the comment there for why.
   if ! aws stepfunctions describe-state-machine --state-machine-arn "${SF_ARN}" \
       --query 'name' --output text >/dev/null 2>&1; then
     echo "  Creating Step Function: ${SF_NAME}"
@@ -296,13 +345,7 @@ if $BOOTSTRAP; then
       --region "${REGION}" \
       --query 'stateMachineArn' --output text
   else
-    echo "  Step Function exists, updating definition: ${SF_NAME}"
-    run aws stepfunctions update-state-machine \
-      --state-machine-arn "${SF_ARN}" \
-      --definition "file://${SF_DEFINITION_FILE}" \
-      --role-arn "${SF_ROLE_ARN}" \
-      --region "${REGION}" \
-      --query 'updateDate' --output text
+    echo "  Step Function exists — definition update happens in step 3b"
   fi
 
   # --- 2d. EventBridge Scheduler execution role (start THIS SF only) ---
@@ -327,10 +370,40 @@ EOF
     --policy-name "${SCHED_POLICY_NAME}" \
     --policy-document "${SCHED_INVOKE_POLICY}"
 
+  # The reconciler and the sweep rules both target the LAMBDA directly rather
+  # than the SF, so the Scheduler role needs lambda:InvokeFunction on top of
+  # states:StartExecution. This grant used to live inside block 2e-bis, next to
+  # the rule it serves — which meant the whole schedule section required
+  # iam:PutRolePolicy and could therefore never run in CI. Grants live here;
+  # rules live below (alpha-engine-config-I5805).
+  echo "  Applying Scheduler invoke-Lambda policy (reconciler + sweep rules)"
+  run aws iam put-role-policy \
+    --role-name "${SCHED_ROLE_NAME}" \
+    --policy-name "${SCHED_POLICY_NAME}-recon-invoke" \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
+
   if ! $DRY_RUN; then
     echo "  Waiting 10s for Scheduler role propagation..."
     sleep 10
   fi
+fi
+
+# ----- 2bis. Schedule reconciliation (IAM-free — runs on every merge) --------
+#
+# alpha-engine-config-I5805. Everything below upserts or prunes EventBridge
+# Scheduler rules and nothing below writes IAM, so github-actions-lambda-deploy
+# can run it. Before the split these blocks sat inside --bootstrap alongside the
+# role creation, so a merged cadence change was inert until an operator
+# remembered a manual command. It was not remembered: nousergon-data#1179 gave
+# the PR sweep its own three daily schedules on 2026-07-30 and they were never
+# created — the sweep stayed coupled to groom health, which is the exact defect
+# that PR was written to remove.
+#
+# Note this block does NOT gate on the rules already existing. It is a
+# reconciler: source is the truth, live is made to match, every run.
+
+if $RECONCILE_SCHEDULES; then
+  echo "Reconciling EventBridge Scheduler rules against source..."
 
   # --- 2e. The EventBridge Scheduler rules (target = SF, not the Lambda) ---
   for i in "${!SCHED_NAMES[@]}"; do
@@ -392,12 +465,9 @@ EOF
   # create-schedule call died on `Invalid JSON: Expecting ',' delimiter`.
   # Counting backslashes through two layers of quoting is not a thing to get
   # right by inspection; json.dumps cannot get it wrong.
+  # The lambda:InvokeFunction grant this rule depends on is applied in block 2d
+  # (--bootstrap-iam), not here — see the note there.
   recon_target=$(python3 -c 'import json,sys; print(json.dumps({"Arn": sys.argv[1], "RoleArn": sys.argv[2], "Input": json.dumps({"mode": "reconcile"})}))' "${FN_ARN}" "${SCHED_ROLE_ARN}")
-  echo "  Applying Scheduler invoke-Lambda policy for the reconciler"
-  run aws iam put-role-policy \
-    --role-name "${SCHED_ROLE_NAME}" \
-    --policy-name "${SCHED_POLICY_NAME}-recon-invoke" \
-    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
 
   if aws scheduler get-schedule --name "${RECON_SCHED_NAME}" --region "${REGION}" \
       --query 'Name' --output text >/dev/null 2>&1; then
@@ -519,6 +589,8 @@ fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 
+if $CODE_DEPLOY; then
+
 echo "Updating Lambda function code: ${FUNCTION_NAME}"
 run aws lambda update-function-code \
   --function-name "${FUNCTION_NAME}" \
@@ -534,6 +606,42 @@ fi
 
 echo "✓ Code deployed."
 
+# ----- 3b. Update the Step Function definition (always, idempotent) ----------
+#
+# alpha-engine-config-I5805. This used to live in block 2c, behind --bootstrap,
+# which made a definition-only change inert on merge. That is not theoretical
+# and it is already documented as fixed when it was not: I5512 added
+# `infrastructure/step_function_groom.json` to the deploy workflow's path
+# filter, so the workflow FIRED on a definition change — and then ran the
+# flagless, code-only path, which never touched the state machine. The trigger
+# was correct and the deploy was a no-op, which is worse than not firing: the
+# green check reads as "deployed".
+#
+# The definition is code. It deploys on every run, exactly like index.py above.
+# github-actions-lambda-deploy already holds states:UpdateStateMachine on
+# `alpha-engine-groom-dispatch` (InfraDeploySFDefinition) and a scoped
+# iam:PassRole on `alpha-engine-*` (InfraDeployPassRole) — no new grant.
+#
+# Fail-loud if the state machine is absent: that means a first-time deploy that
+# skipped --bootstrap-iam, and silently continuing would leave the schedules
+# below pointing at an ARN that does not resolve.
+echo "Updating Step Function definition: ${SF_NAME}"
+if aws stepfunctions describe-state-machine --state-machine-arn "${SF_ARN}" \
+    --query 'name' --output text >/dev/null 2>&1; then
+  run aws stepfunctions update-state-machine \
+    --state-machine-arn "${SF_ARN}" \
+    --definition "file://${SF_DEFINITION_FILE}" \
+    --role-arn "${SF_ROLE_ARN}" \
+    --region "${REGION}" \
+    --query 'updateDate' --output text
+  echo "  ✓ Definition deployed."
+elif $DRY_RUN; then
+  echo "DRY: state machine ${SF_NAME} absent — would require --bootstrap-iam"
+else
+  echo "ERROR: state machine ${SF_NAME} does not exist. Run with --bootstrap-iam first." >&2
+  exit 1
+fi
+
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \
@@ -545,6 +653,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+fi  # end CODE_DEPLOY (steps 3, 3b and the env update)
 
 # ----- 4. Smoke (synthetic schedule event, via the SF — the real live path) --
 

--- a/infrastructure/scheduler/check-schedule-drift.py
+++ b/infrastructure/scheduler/check-schedule-drift.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""check-schedule-drift.py — Diff codified EventBridge Scheduler rules against
+live AWS state.
+
+**Background (alpha-engine-config-I5805).** Every ``infrastructure/lambdas/
+<name>/deploy.sh`` that owns a Scheduler rule declares it as literal shell
+arrays — ``SCHED_NAMES`` / ``SCHED_CRONS``, and in the groom dispatcher's case
+also ``SWEEP_SCHED_NAMES`` / ``SWEEP_SCHED_CRONS`` and a singular
+``RECON_SCHED_NAME`` / ``RECON_SCHED_CRON``. Until 2026-07-31 those arrays were
+only pushed to AWS from inside ``--bootstrap``, a flag no automation passed. The
+consequence was a whole class of silent no-ops: ``nousergon-data#1179`` gave the
+PR sweep three independent daily schedules, merged green, deployed green, and
+created nothing. The sweep stayed coupled to groom health for as long as nobody
+happened to look.
+
+The structural fix is ``deploy.sh --reconcile-schedules`` running on every merge.
+This script is the backstop for what that cannot see: a rule edited or disabled
+in the console, a deploy that half-succeeded, a rule that was never created
+because its repo has no deploy workflow at all. It is deliberately a SEPARATE
+mechanism from the reconciler — a reconciler that reports on itself is not a
+detector (``groom-sweep-policy.md`` §2.2).
+
+Modelled on ``infrastructure/eventbridge/check-drift.py``: discovery by glob +
+regex over the deploy scripts, no hardcoded rule registry to keep in sync, so a
+rule added to a deploy.sh is covered by this check the moment it lands.
+
+Drift cases (all exit non-zero):
+  * ``missing-in-aws``    — codified rule does not exist live. This is the
+                            I5805 case and the reason the script exists.
+  * ``expression-drift``  — live ``ScheduleExpression`` differs from source.
+  * ``disabled``          — rule exists but ``State != ENABLED``. A disabled
+                            schedule is indistinguishable from a working one in
+                            every surface except this check.
+  * ``orphaned``          — a live rule under a declared ``SCHED_PREFIX`` that
+                            source no longer declares. The prune loop in
+                            deploy.sh should have removed it; if one survives,
+                            something is still firing that nobody codifies.
+  * ``source-error``      — the arrays in a deploy.sh do not pair up (a name
+                            with no cron, or vice versa). The script is broken.
+
+Usage:
+  ./infrastructure/scheduler/check-schedule-drift.py             # every discovered rule
+  ./infrastructure/scheduler/check-schedule-drift.py --rule NAME # one rule
+  ./infrastructure/scheduler/check-schedule-drift.py --json      # machine-readable
+
+Requires AWS creds with ``scheduler:GetSchedule`` and ``scheduler:ListSchedules``.
+In CI this runs twice, under two different identities and for two different
+reasons: in ``deploy-scheduled-groom-dispatcher.yml`` as the post-deploy outcome
+assertion (``github-actions-lambda-deploy``), and in ``sf-arn-drift-check.yml``
+on the daily out-of-band sweep (``github-actions-iam-drift-check``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = SCRIPT_DIR.parent.parent
+LAMBDAS_DIR = REPO_ROOT / "infrastructure" / "lambdas"
+
+# Bash array literals: NAME=(\n  "a"\n  "b"\n). The leading \s* is load-bearing,
+# not defensive: SWEEP_SCHED_NAMES is declared INSIDE an `if` block and so is
+# indented. Anchoring at column 0 found the four groom rules and silently missed
+# the three sweep ones — which is precisely the "zero found reads as does-not-
+# exist" failure this whole check exists to catch, reproduced inside the checker.
+_ARRAY_RE_TMPL = r"^\s*{name}=\(\n(.*?)\n\s*\)"
+# Individual quoted entries inside an array body.
+_ENTRY_RE = re.compile(r'^\s*"([^"]+)"\s*$', re.MULTILINE)
+# Singular scalar assignments (the reconciler rule).
+_SCALAR_RE_TMPL = r'^\s*{name}="([^"]+)"'
+# SCHED_PREFIX="alpha-engine-scheduled-groom-"
+_PREFIX_RE = re.compile(r'^\s*SCHED_PREFIX="([^"]+)"', re.MULTILINE)
+
+# (names_var, crons_var) pairs to discover. Order matters only for output.
+_ARRAY_PAIRS = [
+    ("SCHED_NAMES", "SCHED_CRONS"),
+    ("SWEEP_SCHED_NAMES", "SWEEP_SCHED_CRONS"),
+]
+_SCALAR_PAIRS = [
+    ("RECON_SCHED_NAME", "RECON_SCHED_CRON"),
+]
+
+
+def _extract_array(text: str, var: str) -> list[str] | None:
+    """Return the quoted entries of a bash array literal, or None if absent."""
+    m = re.search(
+        _ARRAY_RE_TMPL.format(name=re.escape(var)), text, re.DOTALL | re.MULTILINE
+    )
+    if not m:
+        return None
+    return _ENTRY_RE.findall(m.group(1))
+
+
+def _extract_scalar(text: str, var: str) -> str | None:
+    m = re.search(_SCALAR_RE_TMPL.format(name=re.escape(var)), text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def discover_codified_rules() -> tuple[list[dict], list[dict], set[str]]:
+    """Scan every `infrastructure/lambdas/*/deploy.sh` for Scheduler rules.
+
+    Returns (rules, source_errors, prefixes) where each rule is
+    {"name", "expression", "source_file"}.
+    """
+    rules: list[dict] = []
+    errors: list[dict] = []
+    prefixes: set[str] = set()
+
+    for deploy_sh in sorted(LAMBDAS_DIR.glob("*/deploy.sh")):
+        text = deploy_sh.read_text(encoding="utf-8")
+        rel = str(deploy_sh.relative_to(REPO_ROOT))
+
+        for names_var, crons_var in _ARRAY_PAIRS:
+            names = _extract_array(text, names_var)
+            crons = _extract_array(text, crons_var)
+            if names is None and crons is None:
+                continue
+            if names is None or crons is None:
+                errors.append({
+                    "source_file": rel,
+                    "kind": "source-error",
+                    "detail": (
+                        f"{names_var} and {crons_var} must both be present; "
+                        f"found {names_var}={'yes' if names is not None else 'no'}, "
+                        f"{crons_var}={'yes' if crons is not None else 'no'}"
+                    ),
+                })
+                continue
+            if len(names) != len(crons):
+                errors.append({
+                    "source_file": rel,
+                    "kind": "source-error",
+                    "detail": (
+                        f"{names_var} has {len(names)} entries but {crons_var} "
+                        f"has {len(crons)} — they are paired by index"
+                    ),
+                })
+                continue
+            for name, cron in zip(names, crons):
+                rules.append({
+                    "name": name, "expression": cron, "source_file": rel,
+                })
+
+        for name_var, cron_var in _SCALAR_PAIRS:
+            name = _extract_scalar(text, name_var)
+            cron = _extract_scalar(text, cron_var)
+            if name is None and cron is None:
+                continue
+            if name is None or cron is None:
+                errors.append({
+                    "source_file": rel,
+                    "kind": "source-error",
+                    "detail": f"{name_var} and {cron_var} must both be present",
+                })
+                continue
+            rules.append({"name": name, "expression": cron, "source_file": rel})
+
+        prefix = _PREFIX_RE.search(text)
+        if prefix:
+            prefixes.add(prefix.group(1))
+
+    return rules, errors, prefixes
+
+
+def _aws(args: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(["aws"] + args, capture_output=True, text=True, check=False)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _live_schedule(name: str) -> dict | None:
+    """Return {"expression", "state"} for a live rule, or None if absent."""
+    rc, out, err = _aws([
+        "scheduler", "get-schedule", "--name", name,
+        "--query", "[ScheduleExpression,State]", "--output", "text",
+    ])
+    if rc != 0:
+        if "ResourceNotFoundException" in err:
+            return None
+        # Anything else — AccessDenied, throttling, a bad region — must NOT be
+        # reported as "missing". A permissions failure that reads as absence
+        # would make this check grade itself green by losing its own access.
+        raise RuntimeError(f"aws scheduler get-schedule --name {name}: {err}")
+    parts = out.split("\t")
+    if len(parts) != 2:
+        raise RuntimeError(f"unexpected get-schedule output for {name}: {out!r}")
+    return {"expression": parts[0], "state": parts[1]}
+
+
+def _live_names_under(prefix: str) -> list[str]:
+    rc, out, err = _aws([
+        "scheduler", "list-schedules", "--name-prefix", prefix,
+        "--query", "Schedules[].Name", "--output", "text",
+    ])
+    if rc != 0:
+        raise RuntimeError(
+            f"aws scheduler list-schedules --name-prefix {prefix}: {err}"
+        )
+    return out.split() if out else []
+
+
+def check(rule_filter: str | None = None) -> tuple[list[dict], int]:
+    rules, findings, prefixes = discover_codified_rules()
+    if rule_filter:
+        rules = [r for r in rules if r["name"] == rule_filter]
+        if not rules:
+            print(f"No codified rule named {rule_filter!r}", file=sys.stderr)
+            return findings, 0
+
+    codified_names = {r["name"] for r in rules}
+
+    for rule in rules:
+        live = _live_schedule(rule["name"])
+        if live is None:
+            findings.append({
+                "rule": rule["name"], "kind": "missing-in-aws",
+                "source_file": rule["source_file"],
+                "detail": f"codified as {rule['expression']} but does not exist live",
+            })
+            continue
+        if live["expression"] != rule["expression"]:
+            findings.append({
+                "rule": rule["name"], "kind": "expression-drift",
+                "source_file": rule["source_file"],
+                "detail": f"source={rule['expression']} live={live['expression']}",
+            })
+        if live["state"] != "ENABLED":
+            findings.append({
+                "rule": rule["name"], "kind": "disabled",
+                "source_file": rule["source_file"],
+                "detail": f"live state is {live['state']}, expected ENABLED",
+            })
+
+    # Orphan sweep, only over prefixes source actually claims to own. A live
+    # rule outside every declared prefix is not this check's business.
+    if not rule_filter:
+        for prefix in sorted(prefixes):
+            for live_name in _live_names_under(prefix):
+                if live_name not in codified_names:
+                    findings.append({
+                        "rule": live_name, "kind": "orphaned",
+                        "source_file": f"(none — under declared prefix {prefix})",
+                        "detail": (
+                            "live rule under a codified prefix that no deploy.sh "
+                            "declares; the prune loop should have removed it"
+                        ),
+                    })
+
+    return findings, len(rules)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="EventBridge Scheduler drift check")
+    ap.add_argument("--rule", help="check a single rule by name")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    try:
+        findings, checked = check(args.rule)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"checked": checked, "findings": findings}, indent=2))
+    else:
+        print(f"scheduler drift — {checked} codified rule(s) checked")
+        if not findings:
+            print(
+                "  ✓ every codified rule exists live, ENABLED, "
+                "with a matching expression"
+            )
+        for f in findings:
+            print(f"  ✗ [{f['kind']}] {f.get('rule', f['source_file'])}")
+            print(f"      {f['detail']}")
+            print(f"      source: {f['source_file']}")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scheduler_reconcile_is_ci_runnable.py
+++ b/tests/test_scheduler_reconcile_is_ci_runnable.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""The schedule-reconciliation path must stay runnable by CI, forever.
+
+alpha-engine-config-I5805. ``nousergon-data#1179`` declared three independent
+sweep schedules on 2026-07-30. They merged, the deploy workflow ran green, and
+none of the three was ever created — the block that creates them sat inside
+``--bootstrap``, a flag the workflow does not pass and cannot pass, because
+``--bootstrap`` also writes IAM and the OIDC role deliberately has no
+``iam:PutRolePolicy``.
+
+The fix splits the flag on the IAM boundary. These tests assert the property
+that split bought, so it cannot be quietly given back:
+
+  1. The reconcile block writes NO IAM. One ``aws iam`` call inside it and the
+     whole block becomes operator-only again — silently, since the failure is an
+     AccessDenied on a merge nobody is watching.
+  2. The deploy workflow actually invokes it.
+  3. The workflow asserts the OUTCOME afterwards, rather than trusting its own
+     exit status. A deploy step that succeeds while a schedule is missing is
+     exactly what 2026-07-30 looked like.
+  4. Every schedule array a deploy.sh declares is reachable by the drift
+     checker's discovery — a rule the checker cannot see is a rule nobody
+     checks, and reads as "no drift".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_SH = (
+    REPO_ROOT
+    / "infrastructure"
+    / "lambdas"
+    / "scheduled-groom-dispatcher"
+    / "deploy.sh"
+)
+WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "deploy-scheduled-groom-dispatcher.yml"
+)
+DRIFT_CHECKER = REPO_ROOT / "infrastructure" / "scheduler" / "check-schedule-drift.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_schedule_drift", DRIFT_CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _reconcile_block() -> str:
+    """The body of `if $RECONCILE_SCHEDULES; then ... fi`.
+
+    Located by brace-free line scanning rather than a regex over the whole file,
+    because the block contains its own nested if/fi pairs.
+    """
+    lines = DEPLOY_SH.read_text(encoding="utf-8").splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "if $RECONCILE_SCHEDULES; then":
+            start = i
+            break
+    assert start is not None, (
+        "deploy.sh has no `if $RECONCILE_SCHEDULES; then` block — the "
+        "IAM-free schedule path has been removed or renamed"
+    )
+
+    depth = 0
+    for i in range(start, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("if ") or stripped == "if":
+            depth += 1
+        elif stripped == "fi" or stripped.startswith("fi "):
+            depth -= 1
+            if depth == 0:
+                return "\n".join(lines[start : i + 1])
+    pytest.fail("unterminated `if $RECONCILE_SCHEDULES` block in deploy.sh")
+
+
+class TestReconcileBlockIsIamFree:
+    def test_block_exists(self):
+        assert "$RECONCILE_SCHEDULES" in DEPLOY_SH.read_text(encoding="utf-8")
+
+    def test_no_iam_writes_inside_the_reconcile_block(self):
+        """The whole point of the split. One `aws iam` call undoes it."""
+        block = _reconcile_block()
+        offenders = [
+            line.strip()
+            for line in block.splitlines()
+            if re.search(r"\baws iam\b", line) and not line.strip().startswith("#")
+        ]
+        assert not offenders, (
+            "The reconcile block must not write IAM — github-actions-lambda-deploy "
+            "has no iam:PutRolePolicy, so an IAM call here silently makes the "
+            "whole block operator-only again (alpha-engine-config-I5805).\n"
+            "Offending lines:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_reconcile_block_still_creates_the_sweep_rules(self):
+        """The three rules I5805 exists because of."""
+        block = _reconcile_block()
+        for name in (
+            "alpha-engine-groom-sweep-0000-daily",
+            "alpha-engine-groom-sweep-0800-daily",
+            "alpha-engine-groom-sweep-1600-daily",
+        ):
+            assert name in block, f"{name} is not created in the reconcile block"
+
+    def test_bootstrap_still_implies_both_halves(self):
+        """`--bootstrap` predates the split and must keep its old meaning."""
+        text = DEPLOY_SH.read_text(encoding="utf-8")
+        m = re.search(r"--bootstrap\)\s*(.+?);;", text)
+        assert m, "no `--bootstrap)` case arm found"
+        arm = m.group(1)
+        assert "BOOTSTRAP_IAM=true" in arm and "RECONCILE_SCHEDULES=true" in arm, (
+            f"--bootstrap must still set both halves; got: {arm!r}"
+        )
+
+
+class TestDeployWorkflowRunsIt:
+    def test_workflow_invokes_reconcile_schedules(self):
+        wf = WORKFLOW.read_text(encoding="utf-8")
+        assert "--reconcile-schedules" in wf, (
+            "deploy-scheduled-groom-dispatcher.yml must run "
+            "`deploy.sh --reconcile-schedules`, or a merged cadence change is "
+            "inert again (alpha-engine-config-I5805)"
+        )
+
+    def test_workflow_asserts_the_outcome_after_deploying(self):
+        """Not the step's exit status — the live state it was supposed to produce."""
+        wf = WORKFLOW.read_text(encoding="utf-8")
+        assert "check-schedule-drift.py" in wf, (
+            "the deploy workflow must assert every declared schedule exists live "
+            "after reconciling; a green deploy with a missing schedule is the "
+            "2026-07-30 failure mode"
+        )
+
+    def test_workflow_watches_the_sf_definition_path(self):
+        wf = WORKFLOW.read_text(encoding="utf-8")
+        assert "infrastructure/step_function_groom.json" in wf
+
+
+class TestDriftCheckerSeesEveryDeclaredRule:
+    def test_discovery_finds_the_sweep_rules(self):
+        """Indented arrays included — they live inside an `if` block.
+
+        The first draft of the checker anchored its array regex at column 0 and
+        found 11 of 14 rules, missing exactly the sweep ones. Zero findings on an
+        invisible rule reads as "no drift", which is the same class of bug the
+        checker is for.
+        """
+        checker = _load_checker()
+        rules, errors, _ = checker.discover_codified_rules()
+        assert not errors, f"source errors in deploy scripts: {errors}"
+        names = {r["name"] for r in rules}
+        for expected in (
+            "alpha-engine-groom-sweep-0000-daily",
+            "alpha-engine-groom-sweep-0800-daily",
+            "alpha-engine-groom-sweep-1600-daily",
+            "alpha-engine-scheduled-groom-0400-daily",
+            "alpha-engine-groom-lane-reconciler-5min",
+        ):
+            assert expected in names, (
+                f"{expected} is declared in a deploy.sh but the drift checker "
+                f"does not discover it. Found: {sorted(names)}"
+            )
+
+    def test_discovery_covers_more_than_the_groom_dispatcher(self):
+        """The defect class is fleet-wide; the checker must be too.
+
+        Fixing this on the groom dispatcher alone would be the 'fixed on the
+        daily path, not the critical one' pattern — every deploy.sh declaring
+        SCHED_NAMES has the same exposure.
+        """
+        checker = _load_checker()
+        rules, _, _ = checker.discover_codified_rules()
+        sources = {r["source_file"] for r in rules}
+        assert len(sources) >= 3, (
+            f"drift checker only discovered rules in {sources} — it should cover "
+            "every infrastructure/lambdas/*/deploy.sh that declares SCHED_NAMES"
+        )
+
+    def test_every_discovered_rule_has_a_nonempty_expression(self):
+        checker = _load_checker()
+        rules, _, _ = checker.discover_codified_rules()
+        assert rules, "discovered no scheduler rules at all"
+        for rule in rules:
+            assert rule["expression"].startswith(("cron(", "rate(", "at(")), (
+                f"{rule['name']} has expression {rule['expression']!r}, which is "
+                "not a valid EventBridge Scheduler expression"
+            )
+
+    def test_unbalanced_arrays_are_reported_as_source_errors(self, tmp_path):
+        """A name with no cron must fail loudly, not silently drop the rule."""
+        checker = _load_checker()
+        fake = tmp_path / "infrastructure" / "lambdas" / "broken"
+        fake.mkdir(parents=True)
+        (fake / "deploy.sh").write_text(
+            'SCHED_NAMES=(\n  "a"\n  "b"\n)\nSCHED_CRONS=(\n  "cron(0 1 * * ? *)"\n)\n',
+            encoding="utf-8",
+        )
+        checker.LAMBDAS_DIR = tmp_path / "infrastructure" / "lambdas"
+        checker.REPO_ROOT = tmp_path
+        _, errors, _ = checker.discover_codified_rules()
+        assert errors and errors[0]["kind"] == "source-error", (
+            f"unbalanced arrays should produce a source-error, got {errors}"
+        )


### PR DESCRIPTION
#1179 declared three independent sweep schedules on 2026-07-30. This workflow
ran green on that merge, and again 23 minutes later, and created none of them.
Verified: the full log of the latest run contains zero occurrences of
"groom-sweep". The sweep stayed coupled to groom health for the whole day —
the exact defect #1179 removed in source and never removed in production.

Root cause is the flag boundary, not the schedule code. --bootstrap bundled two
unrelated things: IAM role creation, which needs iam:CreateRole/PutRolePolicy
that the OIDC role deliberately lacks, and EventBridge Scheduler wiring, which
needs neither. Bundled, the union is operator-only, so the schedule half could
never run in CI. deploy-scheduled-groom-dispatcher.yml's own header has named
this exact split as the fix since it was written; this does it.

  --bootstrap-iam        roles + inline policies + first-ever Lambda/SF create.
                         Operator-only, genuinely first-time-only.
  --reconcile-schedules  upsert + prune Scheduler rules. Needs only
                         scheduler:* and a scoped iam:PassRole. Runs on merge.
  --bootstrap            both, unchanged meaning, so every runbook and habit
                         that predates the split still does what it says.

Alone, --reconcile-schedules skips packaging, the code push and the SF push, so
the workflow's two invocations do not pay for the docker pip build twice — and
an operator repairing live drift does not have to redeploy code to do it.

The reconciler's lambda:InvokeFunction grant moved out of block 2e-bis into 2d.
Left where it was, one aws iam call would have kept the entire schedule section
operator-only — which is how the original defect happened.

The SF definition had the same disease, one layer down. I5512 added
step_function_groom.json to this workflow's path filter, so the workflow FIRED
on a definition change and then ran the flagless path, which never touched the
state machine. Trigger correct, deploy a no-op, check green. That is worse than
not firing. The definition is code; it now deploys in step 3b on every run,
under grants the role already holds.

Detection, deliberately separate from the reconciler (§2.2 — a reconciler
confirming its own work is not a detector):
  - infrastructure/scheduler/check-schedule-drift.py discovers every schedule
    array across all infrastructure/lambdas/*/deploy.sh (14 rules, 5
    dispatchers — the class is fleet-wide, not groom-specific) and diffs each
    against live: missing-in-aws, expression-drift, disabled, orphaned,
    source-error. AccessDenied raises rather than reading as absence, so the
    check cannot grade itself green by losing its own access.
  - Runs in the deploy workflow as a post-deploy OUTCOME assertion, not a
    trust-the-exit-status. A green deploy with a missing schedule is precisely
    what 2026-07-30 looked like.
  - Runs again daily in sf-arn-drift-check.yml for what no merge can see: a
    rule disabled or retimed in the console.

The checker's first draft anchored its array regex at column 0 and found 11 of
14 rules, missing exactly the three sweep ones — SWEEP_SCHED_NAMES is indented
inside an if block. Zero findings on an invisible rule reads as "no drift".
Caught by the test that now asserts it.

tests/test_scheduler_reconcile_is_ci_runnable.py asserts the properties rather
than describing them: no aws iam call inside the reconcile block, the workflow
invokes it, the workflow asserts the outcome afterwards, --bootstrap still
implies both halves, and every declared rule is discoverable.

4029 passed, 8 skipped, 0 failed (repo .venv, nousergon-lib pinned v0.124.26).

An earlier revision of this body claimed a pre-existing unrelated failure on main
and cited alpha-engine-config-I5810. That was wrong and I5810 is closed as invalid:
the shared .venv held nousergon-lib 0.124.23 against a requirements.txt pin of
v0.124.26, and the registry entries I reported as missing are present in the pinned
version. CI was green throughout. Suite is clean on the correct pin.

Requires nous-ergon-ops PR (scheduler:ListSchedules) to merge FIRST.

Refs: alpha-engine-config-I5805, #1179, #1172

---

**Merge order:** `nous-ergon-ops-PR312` FIRST (grants `scheduler:ListSchedules` to `github-actions-lambda-deploy`, which the prune loop in block 2f needs), then this PR.

**Test plan (run before opening):**
- `pytest tests/ -q -p no:randomly` in the repo `.venv`, on the pinned `nousergon-lib` v0.124.26 → **4029 passed, 8 skipped, 0 failed**.
- `bash -n deploy.sh` clean; `DRY_RUN=1 deploy.sh --reconcile-schedules` exercised end to end, emitting all 4 groom + 3 sweep + 1 reconciler upserts and the prune loop, with packaging skipped.
- `check-schedule-drift.py` discovery verified locally: 14 rules across 5 dispatchers, zero source errors.
- `tests/test_scheduler_reconcile_is_ci_runnable.py` → 11 passed.

Closes #5805

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
