### PR TITLE
[P0/mid] fix(features): read the WHOLE alt-data partition, reconcile against the manifest

### DIFF
--- a/features/compute.py
+++ b/features/compute.py
@@ -728,8 +728,69 @@ def _load_cached_fundamentals(s3, bucket: str, date_str: str) -> dict[str, dict]
     return {}
 
 
+class AlternativeCoverageError(RuntimeError):
+    """DataPhase2 published alternative data that this reader could not read.
+
+    Raised only for the unambiguous case: the manifest states N>0 tickers were
+    written and we loaded ZERO. Every alternative feature would silently become
+    0.0 for the whole universe, which is indistinguishable from a genuine zero
+    (see ``compute_and_write``'s ``val ... else 0.0``) — a red run is the honest
+    outcome. A PARTIAL shortfall is logged at ERROR rather than raised, so the
+    daily append still lands on a provider hiccup.
+    """
+
+
+def _alt_entry_from_payload(ticker_data: dict) -> dict:
+    """Project one raw per-ticker alt payload onto the feature-store shape.
+
+    ``or {}`` rather than ``.get(k, {})`` throughout: a sub-section that is
+    present-but-null (a provider returning ``null`` for a section it could not
+    fill) would otherwise raise ``AttributeError`` on the nested ``.get`` and,
+    before this was extracted, be swallowed by a bare ``except Exception: pass``
+    — dropping that ticker's alternative data entirely and invisibly.
+    """
+    eps = ticker_data.get("eps_revision") or {}
+    consensus = ticker_data.get("analyst_consensus") or {}
+    options = ticker_data.get("options_flow") or {}
+    surprise = eps.get("surprise_pct")
+    if surprise is None:
+        surprise = consensus.get("surprise_pct", 0.0)
+    return {
+        "earnings": {
+            "surprise_pct": surprise,
+            "days_since_earnings": eps.get("days_since_earnings", 0.0),
+        },
+        "revisions": {
+            "eps_revision_4w": eps.get("revision_4w", 0.0),
+            "revision_streak": eps.get("streak", 0),
+        },
+        "options": {
+            "put_call_ratio": options.get("put_call_ratio"),
+            "iv_rank": options.get("iv_rank"),
+            "atm_iv": options.get("expected_move_pct"),
+        },
+    }
+
+
 def _load_cached_alternative(s3, bucket: str) -> dict[str, dict]:
-    """Load cached alternative data from the most recent DataPhase2 output."""
+    """Load cached alternative data from the most recent DataPhase2 output.
+
+    Reads EVERY object under the partition, and reconciles what it loaded
+    against the count DataPhase2 recorded in ``manifest.json``.
+
+    Why the reconciliation exists (alpha-engine-config-I5811): this function
+    used to call ``list_objects_v2`` ONCE with ``MaxKeys=200`` and no
+    pagination, so it silently returned at most the alphabetically-first 200
+    tickers of a partition holding up to 903. Every ticker past the cap got
+    ``alt_data.get(ticker, {})`` -> ``{}`` -> ``0.0`` for all seven registered
+    ``alternative``-family features (``earnings_surprise_pct``,
+    ``days_since_earnings``, ``eps_revision_4w``, ``revision_streak``,
+    ``put_call_ratio``, ``iv_rank``, ``iv_vs_rv`` — see ``features/registry.py``
+    ``CATALOG``), for every one of the five feature-store writers that call
+    this. A ceiling with no counterpart on the write side reports success at
+    any universe size, so nothing failed and nothing said so; the population
+    that kept real values was decided by the alphabet.
+    """
     try:
         # Find latest weekly date
         obj = s3.get_object(Bucket=bucket, Key="market_data/latest_weekly.json")
@@ -737,44 +798,92 @@ def _load_cached_alternative(s3, bucket: str) -> dict[str, dict]:
         latest_date = latest.get("date", "")
         prefix = f"market_data/weekly/{latest_date}/alternative/"
 
-        resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=200)
-        contents = resp.get("Contents", [])
+        # Paginate. The producer writes one object per ticker; a single
+        # list_objects_v2 page is 1000 keys and the universe is ~903 today,
+        # so an unpaginated read is latently wrong even without the MaxKeys
+        # cap that made it actively wrong.
+        keys: list[str] = []
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for item in page.get("Contents", []):
+                key = item["Key"]
+                if key.endswith("manifest.json") or not key.endswith(".json"):
+                    continue
+                keys.append(key)
 
         alt_data: dict[str, dict] = {}
-        for item in contents:
-            key = item["Key"]
-            if key.endswith("manifest.json") or not key.endswith(".json"):
-                continue
+        unreadable: list[str] = []
+        for key in keys:
             ticker = key.split("/")[-1].replace(".json", "")
             try:
                 obj = s3.get_object(Bucket=bucket, Key=key)
-                ticker_data = json.loads(obj["Body"].read())
-                alt_data[ticker] = {
-                    "earnings": {
-                        "surprise_pct": ticker_data.get("eps_revision", {}).get("surprise_pct",
-                                        ticker_data.get("analyst_consensus", {}).get("surprise_pct", 0.0)),
-                        "days_since_earnings": ticker_data.get("eps_revision", {}).get("days_since_earnings", 0.0),
-                    },
-                    "revisions": {
-                        "eps_revision_4w": ticker_data.get("eps_revision", {}).get("revision_4w", 0.0),
-                        "revision_streak": ticker_data.get("eps_revision", {}).get("streak", 0),
-                    },
-                    "options": {
-                        "put_call_ratio": ticker_data.get("options_flow", {}).get("put_call_ratio"),
-                        "iv_rank": ticker_data.get("options_flow", {}).get("iv_rank"),
-                        "atm_iv": ticker_data.get("options_flow", {}).get("expected_move_pct"),
-                    },
-                }
-            except Exception:
-                pass
+                alt_data[ticker] = _alt_entry_from_payload(json.loads(obj["Body"].read()))
+            except Exception as exc:  # noqa: BLE001 — recorded, then reported below
+                unreadable.append(f"{ticker}: {type(exc).__name__}")
 
-        if alt_data:
-            log.info("Loaded cached alternative data for %d tickers from %s", len(alt_data), latest_date)
+        if unreadable:
+            # Was a bare `except Exception: pass`. A per-ticker read failure is
+            # a silently-zeroed feature row, so it is named rather than dropped.
+            log.error(
+                "Alternative data: %d of %d objects unreadable under %s — those "
+                "tickers get 0.0 for every alternative feature. First 10: %s",
+                len(unreadable), len(keys), prefix, unreadable[:10],
+            )
+
+        expected = _expected_alternative_count(s3, bucket, prefix)
+        if expected is None:
+            log.warning(
+                "Alternative data: no readable manifest at %smanifest.json — "
+                "loaded %d tickers with no producer count to reconcile against, "
+                "so an under-read cannot be detected this run.",
+                prefix, len(alt_data),
+            )
+        elif len(alt_data) < expected:
+            if not alt_data:
+                raise AlternativeCoverageError(
+                    f"Alternative data: manifest at {prefix}manifest.json reports "
+                    f"{expected} tickers written for {latest_date}, loaded ZERO. "
+                    "Every alternative feature would be 0.0 for the whole universe "
+                    "and indistinguishable from a genuine zero."
+                )
+            log.error(
+                "Alternative data coverage SHORTFALL for %s: loaded %d of %d "
+                "tickers the producer recorded (%.1f%%). The %d missing tickers "
+                "get 0.0 for every alternative feature, which is not "
+                "distinguishable downstream from a real zero.",
+                latest_date, len(alt_data), expected,
+                100.0 * len(alt_data) / expected, expected - len(alt_data),
+            )
+        else:
+            log.info(
+                "Loaded cached alternative data for %d tickers from %s "
+                "(manifest recorded %d — full coverage)",
+                len(alt_data), latest_date, expected,
+            )
         return alt_data
 
+    except AlternativeCoverageError:
+        raise
     except Exception as exc:
         log.warning("No cached alternative data loaded — alternative features will use defaults: %s", exc)
         return {}
+
+
+def _expected_alternative_count(s3, bucket: str, prefix: str) -> int | None:
+    """``tickers_succeeded`` from DataPhase2's manifest, or None if unreadable.
+
+    The producer writes the manifest BEFORE its own quality gate can raise, so
+    it is present even on a degraded Phase 2 — which is exactly the run where a
+    reader most needs to know how many rows it should have seen.
+    """
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=f"{prefix}manifest.json")
+        manifest = json.loads(obj["Body"].read())
+    except Exception as exc:  # noqa: BLE001 — absence is reported by the caller
+        log.debug("Alternative manifest unreadable at %smanifest.json: %s", prefix, exc)
+        return None
+    value = manifest.get("tickers_succeeded")
+    return int(value) if isinstance(value, (int, float)) else None
 
 
 # ── Main computation ─────────────────────────────────────────────────────────

--- a/tests/test_alt_data_read_coverage.py
+++ b/tests/test_alt_data_read_coverage.py
@@ -1,0 +1,219 @@
+"""``_load_cached_alternative`` must read the WHOLE partition and say so.
+
+alpha-engine-config-I5811. The reader used to call ``list_objects_v2`` once
+with ``MaxKeys=200`` and no pagination, so a 903-ticker partition resolved to
+the alphabetically-first 200 and every ticker past the cut got 0.0 for all
+seven registered ``alternative``-family features — indistinguishable from a
+genuine zero, in every one of the five feature-store writers.
+
+The regression test that matters is the first one: it fails against the old
+implementation for exactly the production reason (partition > 200).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from features.compute import (
+    AlternativeCoverageError,
+    _load_cached_alternative,
+)
+
+
+PREFIX = "market_data/weekly/2026-07-30/alternative/"
+
+
+def _payload(ticker: str) -> dict:
+    return {
+        "ticker": ticker,
+        "eps_revision": {
+            "surprise_pct": 1.5,
+            "days_since_earnings": 0.25,
+            "revision_4w": 0.02,
+            "streak": 3,
+        },
+        "analyst_consensus": {"surprise_pct": 9.9},
+        "options_flow": {
+            "put_call_ratio": 0.8,
+            "iv_rank": 0.4,
+            "expected_move_pct": 0.05,
+        },
+    }
+
+
+class _Body:
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+class _Paginator:
+    """Pages at 1000 keys, matching the real list_objects_v2 page size."""
+
+    def __init__(self, keys: list[str]) -> None:
+        self._keys = keys
+
+    def paginate(self, **_kwargs):
+        for start in range(0, len(self._keys), 1000):
+            yield {"Contents": [{"Key": k} for k in self._keys[start:start + 1000]]}
+
+
+class FakeS3:
+    """Minimal S3 double: latest_weekly pointer, per-ticker objects, manifest."""
+
+    def __init__(
+        self,
+        tickers: list[str],
+        *,
+        manifest_count: int | None = None,
+        unreadable: set[str] | None = None,
+        omit_manifest: bool = False,
+    ) -> None:
+        self.tickers = tickers
+        self.manifest_count = len(tickers) if manifest_count is None else manifest_count
+        self.unreadable = unreadable or set()
+        self.omit_manifest = omit_manifest
+        self.list_calls = 0
+
+    def _keys(self) -> list[str]:
+        # Sorted, like S3 returns them — the old cap took the first 200 of these.
+        return sorted(f"{PREFIX}{t}.json" for t in self.tickers) + [f"{PREFIX}manifest.json"]
+
+    def get_paginator(self, name: str) -> _Paginator:
+        assert name == "list_objects_v2"
+        self.list_calls += 1
+        return _Paginator(self._keys())
+
+    def list_objects_v2(self, **kwargs):  # pragma: no cover - old code path only
+        raise AssertionError(
+            "unpaginated list_objects_v2 is the defect this module tests for"
+        )
+
+    def get_object(self, Bucket: str, Key: str):  # noqa: N803 - boto3 kwarg casing
+        if Key == "market_data/latest_weekly.json":
+            return {"Body": _Body(json.dumps({"date": "2026-07-30"}).encode())}
+        if Key == f"{PREFIX}manifest.json":
+            if self.omit_manifest:
+                raise KeyError(Key)
+            return {
+                "Body": _Body(
+                    json.dumps({
+                        "run_date": "2026-07-30",
+                        "tickers_requested": self.manifest_count,
+                        "tickers_succeeded": self.manifest_count,
+                    }).encode()
+                )
+            }
+        ticker = Key.split("/")[-1].replace(".json", "")
+        if ticker in self.unreadable:
+            raise RuntimeError("simulated S3 read failure")
+        if ticker not in self.tickers:
+            raise KeyError(Key)
+        return {"Body": _Body(json.dumps(_payload(ticker)).encode())}
+
+
+def _universe(n: int) -> list[str]:
+    """N distinct tickers whose sort order spans the whole alphabet."""
+    return [f"{chr(65 + i // 26)}{chr(65 + i % 26)}{i:04d}" for i in range(n)]
+
+
+def test_reads_every_ticker_past_the_old_200_cap():
+    """The regression. 903 objects in, 903 tickers out — not 200."""
+    tickers = _universe(903)
+    s3 = FakeS3(tickers)
+
+    alt = _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert len(alt) == 903
+    assert set(alt) == set(tickers)
+    # The tail of the alphabet is what the cap silently dropped.
+    assert alt[sorted(tickers)[-1]]["earnings"]["surprise_pct"] == 1.5
+
+
+def test_paginates_beyond_one_list_page():
+    """More than 1000 keys must still resolve fully."""
+    tickers = _universe(1500)
+    alt = _load_cached_alternative(FakeS3(tickers), "alpha-engine-research")
+    assert len(alt) == 1500
+
+
+def test_zero_loaded_against_a_nonempty_manifest_raises():
+    """Provably-published data that reads as nothing is a red run, not 0.0s."""
+    tickers = _universe(10)
+    s3 = FakeS3(tickers, unreadable=set(tickers))
+
+    with pytest.raises(AlternativeCoverageError) as exc:
+        _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert "loaded ZERO" in str(exc.value)
+
+
+def test_partial_shortfall_is_reported_at_error_but_does_not_raise(caplog):
+    """A provider hiccup degrades loudly; it does not fail the daily append."""
+    tickers = _universe(100)
+    s3 = FakeS3(tickers, unreadable=set(sorted(tickers)[:5]))
+
+    with caplog.at_level("ERROR"):
+        alt = _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert len(alt) == 95
+    text = caplog.text
+    assert "coverage SHORTFALL" in text
+    assert "95 of 100" in text
+    # The consequence is named, not just the count.
+    assert "0.0" in text
+
+
+def test_unreadable_objects_are_named_not_swallowed(caplog):
+    tickers = _universe(20)
+    s3 = FakeS3(tickers, unreadable={sorted(tickers)[0]})
+
+    with caplog.at_level("ERROR"):
+        _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert "objects unreadable" in caplog.text
+    assert sorted(tickers)[0] in caplog.text
+
+
+def test_missing_manifest_warns_that_under_read_is_undetectable(caplog):
+    tickers = _universe(30)
+    s3 = FakeS3(tickers, omit_manifest=True)
+
+    with caplog.at_level("WARNING"):
+        alt = _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert len(alt) == 30
+    assert "no producer count to reconcile against" in caplog.text
+
+
+def test_null_subsection_does_not_drop_the_ticker():
+    """A present-but-null section used to raise and be swallowed per-ticker."""
+    tickers = ["AAA0000"]
+    s3 = FakeS3(tickers)
+    original = s3.get_object
+
+    def _with_null_sections(Bucket: str, Key: str):  # noqa: N803
+        if Key.endswith("AAA0000.json"):
+            return {
+                "Body": _Body(
+                    json.dumps({
+                        "ticker": "AAA0000",
+                        "eps_revision": None,
+                        "analyst_consensus": None,
+                        "options_flow": None,
+                    }).encode()
+                )
+            }
+        return original(Bucket=Bucket, Key=Key)
+
+    s3.get_object = _with_null_sections
+
+    alt = _load_cached_alternative(s3, "alpha-engine-research")
+
+    assert "AAA0000" in alt
+    assert alt["AAA0000"]["earnings"]["surprise_pct"] == 0.0
+    assert alt["AAA0000"]["options"]["iv_rank"] is None


### PR DESCRIPTION
## Root cause

`features/compute.py::_load_cached_alternative` called `list_objects_v2` **once** with `MaxKeys=200` and no pagination. The partition `market_data/weekly/{date}/alternative/` holds one object per universe ticker — 903 today — so the reader resolved the **alphabetically-first 200** and dropped the rest. Present since `b5cbfba5` (2026-04-03).

Every dropped ticker hits `alt_data.get(ticker, {})` → `{}`, and `compute_and_write`'s `val = latest[f] if f in latest.index else 0.0` writes **0.0**. Missing alternative data has therefore been indistinguishable from a genuine zero in the feature store.

**Blast radius** — seven registered `alternative`-family columns in `features/registry.py::CATALOG`, all `consumers='predictor'`:

`earnings_surprise_pct` · `days_since_earnings` · `eps_revision_4w` · `revision_streak` · `put_call_ratio` · `iv_rank` · `iv_vs_rv`

Five feature-store writers import the same function, so all are affected: `builders/daily_append.py:1421` (daily morning path), `builders/promote_ohlcv_only_schema.py:248`, `builders/backfill.py:458`, `builders/migrate_universe_crsp_basis.py:731`, and `features/compute.py` itself.

The generative defect is a **ceiling on the read side with no counterpart on the write side**. `list_objects_v2` returns success at any universe size, so nothing failed and nothing said so; which tickers kept real values was decided by the alphabet. Same class as the `avg_volume_20d` units mismatch in the fleet standing rules.

## Change

1. **Paginate** via `get_paginator("list_objects_v2")`. A single page is 1000 keys, so the unpaginated read was latently wrong even without the `MaxKeys` cap.
2. **Reconcile against the producer's own count** — `manifest.json::tickers_succeeded`, which DataPhase2 writes *before* its quality gate can raise and is therefore present on degraded runs too:
   - `loaded == expected` → INFO stating full coverage
   - `0 < loaded < expected` → **ERROR** naming the shortfall and its consequence
   - `loaded == 0`, `expected > 0` → raises `AlternativeCoverageError`
   - manifest unreadable → WARNING stating an under-read cannot be detected this run
3. **Partial shortfall deliberately does not raise.** This runs on the daily morning path; a provider hiccup must not fail `MorningArcticAppend`. Only the unambiguous case (published data reading as nothing) is fatal.
4. **`except Exception: pass` → counted, named ERROR** listing affected tickers.
5. **`_alt_entry_from_payload` extracted, using `or {}`** so a present-but-null section (`"eps_revision": null`) no longer raises into that swallow and silently drop the ticker.

## Deliberately not changed

The missing-value sentinel stays `0.0`. Moving it to NaN alters model inputs for every alt column and is a champion/challenger-gated decision, not a bug fix. Detection first.

`_load_cached_fundamentals` (`features/compute.py:713`) has a similar `MaxKeys=100`, but it lists **date-partitioned** files and takes the newest — a latent bound, not a live defect. Left alone.

## Testing

`tests/test_alt_data_read_coverage.py` — 7 tests. The first is the regression and fails against the pre-fix implementation for exactly the production reason (903-object partition → 200 loaded).

```
tests/test_alt_data_read_coverage.py .......                    7 passed
```

Full suite: `4023 passed, 8 skipped`. Two failures in `test_pipeline_status_registry_source_check.py` are a **local venv artifact, not a regression** — the shared `.venv` carries `nousergon-lib 0.124.23` against this repo's `v0.124.26` pin, so the registry entries for `WaitForThinkTank` (#1172) and the four Evaluator drift-gate states (#805) are absent locally. CI on `main` at `094d8970` is green, and CI here resolves the pinned version. Filed as `alpha-engine-config-I5812`.

## Follow-up (filed, not in this PR)

Coverage is currently only a log line. It should be a durable number on the console — a `fleet_check_result` envelope under `ops/checks/` recording loaded/expected per run.

Closes nousergon/alpha-engine-config#5811

**Related:** `alpha-engine-config-I5759` (DataPhase2's timeout truncates the *write* side of this same partition — the follow-on PR moves it to spot) · `alpha-engine-config-I5809` (the scope question this settles: DataPhase2's output feeds universe-wide model features, so it legitimately needs the universe and belongs on a different substrate, not a narrower scope)

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
