### PR TITLE
[P1/mid] fix(sf): DataPhase2 dispatches to spot instead of a 900s lambda:invoke

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -601,6 +601,7 @@ def collect(
         return {"status": "skipped", "reason": "no tickers"}
 
     logger.info("Collecting alternative data for %d tickers", len(tickers))
+    _assert_scope_stable(s3, bucket, s3_prefix, run_date, len(tickers))
 
     if dry_run:
         return {
@@ -875,10 +876,99 @@ def load_from_s3(
 
 # -- Ticker resolution -------------------------------------------------------
 
+class ScopeChangedUnexpectedly(RuntimeError):
+    """The resolved ticker count moved by more than the allowed factor.
+
+    alpha-engine-config-I5814. On 2026-07-21 this collector's input went from
+    27 to 902 tickers overnight because an unrelated producer swap changed the
+    file it resolved its scope from. Nothing failed, nothing warned; the only
+    symptom was a 33x wall-clock increase that broke through the Lambda ceiling
+    on the next weekly run and was diagnosed nine days later.
+
+    A scope change is legitimate — the universe does grow — but it is a
+    DECISION, and a decision that arrives as a silent 33x is not one. Raising
+    here converts it into a one-line, same-run answer.
+    """
+
+
+# Widest run-over-run change treated as ordinary universe churn. S&P 500+400
+# reconstitution moves a handful of names quarterly; anything past +-30% is a
+# scope change, not churn.
+_SCOPE_CHANGE_TOLERANCE = 0.30
+
+
+def _assert_scope_stable(
+    s3, bucket: str, s3_prefix: str, run_date: str, n_tickers: int
+) -> None:
+    """Compare this run's ticker count against the most recent prior manifest.
+
+    Fail-open on a MISSING baseline (first run ever, or a new partition
+    scheme) — there is nothing to compare against and refusing to collect
+    would be worse than collecting. Fail-CLOSED on a baseline that exists and
+    disagrees, which is the case this guard is for.
+    """
+    prior_key = None
+    prior_n = None
+    for days_back in range(1, 15):
+        dt = date.fromisoformat(run_date) - timedelta(days=days_back)
+        key = f"{s3_prefix}weekly/{dt}/alternative/manifest.json"
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            manifest = json.loads(obj["Body"].read())
+        except Exception:  # noqa: BLE001 — absence is the fail-open case
+            continue
+        value = manifest.get("tickers_requested")
+        if isinstance(value, (int, float)) and value > 0:
+            prior_key, prior_n = key, int(value)
+            break
+
+    if prior_n is None:
+        logger.warning(
+            "Alternative scope: no prior manifest within 14 days of %s — "
+            "collecting %d tickers with no baseline to compare against, so a "
+            "scope change cannot be detected this run.",
+            run_date, n_tickers,
+        )
+        return
+
+    ratio = n_tickers / prior_n
+    # round() before comparing: 1300/1000 gives 0.30000000000000004, so a
+    # bare `>` would reject a ratio that is exactly at the declared bound.
+    if round(abs(ratio - 1.0), 6) > _SCOPE_CHANGE_TOLERANCE:
+        raise ScopeChangedUnexpectedly(
+            f"alternative: resolved {n_tickers} tickers, prior run "
+            f"({prior_key}) requested {prior_n} — a {ratio:.2f}x change, past "
+            f"the {_SCOPE_CHANGE_TOLERANCE:.0%} churn tolerance. Either the "
+            "constituent universe genuinely moved this much (record why and "
+            "widen the tolerance deliberately) or something upstream changed "
+            "this collector's scope without meaning to — which is exactly "
+            "what happened on 2026-07-21 when 27 became 902 "
+            "(alpha-engine-config-I5814)."
+        )
+    logger.info(
+        "Alternative scope: %d tickers, %.2fx the prior run's %d — within the "
+        "%.0f%% churn tolerance.",
+        n_tickers, ratio, prior_n, _SCOPE_CHANGE_TOLERANCE * 100,
+    )
+
+
 def _load_promoted_tickers(
     s3, bucket: str, signals_key: str | None, run_date: str
 ) -> list[str]:
-    """Extract promoted tickers from the latest signals.json."""
+    """Extract promoted tickers from the latest signals.json.
+
+    DEPRECATED as the production scope resolver (alpha-engine-config-I5814).
+    ``weekly_collector._run_phase2`` now passes the constituent universe
+    explicitly, from the same ``constituents.json`` phase 1 hands to
+    ``fundamentals.collect``. This remains only for direct/ad-hoc calls that
+    pass a ``signals_key``.
+
+    Do NOT restore this as the default. ``signals.json``'s ``universe`` array
+    is a sizing envelope for the executor (alpha-engine-config-I5809), so
+    resolving scope from it makes this collector's cost and coverage a
+    function of whichever signals producer is champion — measured on
+    2026-07-21 as a silent 27 -> 902 step.
+    """
     if not signals_key:
         signals_key = f"signals/{run_date}/signals.json"
 

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -55,4 +55,4 @@ boto3>=1.34.0
 # The exemption is removed and the tier-model floor is asserted explicitly in
 # tests/test_lib_pin_lockstep.py::test_groom_dispatcher_pin_can_express_the_policy_tier_table.
 # Bump this in lockstep with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 krepis>=0.14.0

--- a/infrastructure/sf_budgets.py
+++ b/infrastructure/sf_budgets.py
@@ -139,6 +139,29 @@ STAGE_BUDGETS: dict[str, StageBudget] = {
         max_budget_seconds=21_600,  # config#2938 ruling 2: hard 6h cap
         pipeline_segment="branch_a",
     ),
+    "DataPhase2": StageBudget(
+        name="DataPhase2",
+        current_timeout_seconds=5_400,
+        # MEASURED, not estimated — the only entry in this table that is.
+        # alpha-engine-config-I5759, execution 1e856026 (2026-07-30): 402 of
+        # 903 tickers in 900s of steady state, 2.16-2.24 s/ticker, FLAT for
+        # the whole run. The number is not a throughput estimate, it is a
+        # provider-imposed serial FLOOR: _fetch_all_alternative makes two
+        # _finnhub_get calls per ticker and collectors/finnhub_client.py
+        # sleeps _FINNHUB_MIN_INTERVAL (1.1s) while HOLDING _finnhub_lock,
+        # so 2 x 1.1 = 2.2 s/ticker no matter how many workers
+        # collectors/alternative.py's ThreadPoolExecutor runs. Concurrency
+        # cannot move it; only fewer calls per ticker or a faster provider
+        # tier can. That is why this stage left Lambda rather than being
+        # parallelised harder.
+        per_ticker_cost_seconds=2.2,
+        # Spot launch + AL2023 bootstrap (python/git/clone/config) measured at
+        # ~7 min across the sibling stages, plus margin for the ArcticDB and
+        # S3 preflight legs.
+        fixed_overhead_seconds=900,
+        max_budget_seconds=10_800,
+        pipeline_segment="branch_a",
+    ),
     # ── Model/training stages (NOT universe-scaling — scale with
     #    model count and strategy complexity, not ticker count) ──────────
     "PredictorTraining": StageBudget(

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -14,6 +14,10 @@
 #       (full price-cache refresh: weekly_collector.py --phase 1)
 #   SF state RAGIngestion  → --rag-only
 #       (rag/pipelines/run_weekly_ingestion.sh)
+#   SF state DataPhase2    → --phase2-only
+#       (alt-data refresh: weekly_collector.py --phase 2 — moved off a
+#        lambda:invoke by alpha-engine-config-I5759; its ~33-min serial floor
+#        does not fit Lambda's 900s maximum at the current universe size)
 #
 # Each SF state polls its own spot's completion independently (Wait /
 # CheckStatus / RetryGate / Reissue loop in step_function.json), so a
@@ -49,6 +53,7 @@
 #   ./infrastructure/spot_data_weekly.sh --morning-enrich-only  # one spot: morning enrich (SF: MorningEnrich)
 #   ./infrastructure/spot_data_weekly.sh --phase1-only          # one spot: DataPhase1 (SF: DataPhase1)
 #   ./infrastructure/spot_data_weekly.sh --rag-only             # one spot: RAG ingestion (SF: RAGIngestion)
+#   ./infrastructure/spot_data_weekly.sh --phase2-only          # one spot: alt data (SF: DataPhase2)
 #   ./infrastructure/spot_data_weekly.sh --data-only            # manual rerun: morning-enrich + phase1
 #   ./infrastructure/spot_data_weekly.sh                        # manual full bundle: enrich + phase1 + rag
 #   ./infrastructure/spot_data_weekly.sh --smoke-only      # quick validation, then terminate
@@ -233,6 +238,7 @@ while [[ $# -gt 0 ]]; do
         --data-only) RUN_MODE="data-only"; shift ;;
         --morning-enrich-only) RUN_MODE="morning-enrich-only"; shift ;;
         --phase1-only) RUN_MODE="phase1-only"; shift ;;
+        --phase2-only) RUN_MODE="phase2-only"; shift ;;
         --launch-only) RUN_MODE="launch-only"; shift ;;
         --id-artifact-key) ID_ARTIFACT_KEY="$2"; shift 2 ;;
         --max-runtime-seconds) MAX_RUNTIME_SECONDS="$2"; MAX_RUNTIME_EXPLICIT=1; shift 2 ;;
@@ -263,6 +269,38 @@ if [ "$RUN_MODE" = "rag-only" ] && [ "$MAX_RUNTIME_EXPLICIT" != "1" ]; then
     # +300s so the box's own shutdown watchdog is a BACKSTOP that fires after
     # the outer SF executionTimeout/cleanup, never before the sweep completes.
     MAX_RUNTIME_SECONDS=21900
+fi
+
+# ── alpha-engine-config-I5759: phase2-only alt-data budget ───────────────────
+# DataPhase2 (collectors/alternative.py) cannot fit in Lambda and never could
+# at the current universe size. Its wall clock is set by two module-global
+# rate limiters that sleep while holding a lock, so it is SERIAL regardless of
+# how many workers the ThreadPoolExecutor has:
+#
+#   collectors/finnhub_client.py  _finnhub_lock + _FINNHUB_MIN_INTERVAL 1.1s
+#   collectors/alternative.py     _fmp_lock     + _FMP_MIN_INTERVAL     1.0s
+#
+# _fetch_all_alternative makes TWO _finnhub_get calls per ticker
+# (stock/recommendation, stock/earnings), so the floor is 2 x 1.1 = 2.2s per
+# ticker. Measured live 2026-07-30 on execution 1e856026: 2.16-2.24 s/ticker,
+# FLAT across the whole run, 402 of 903 tickers done when the 900s Lambda
+# MAXIMUM killed it. 903 x 2.2s = ~2000s, i.e. 2.2x a ceiling that cannot be
+# raised. Adding workers cannot move a provider-imposed serial floor; the only
+# correct fix is compute that can run for 33 minutes.
+#
+# Budget chain (load-bearing — each strictly less than the next, asserted by
+# tests/test_data_phase2_spot_budget_wiring.py):
+#   3600  workload run_ssm timeout      (~1.8x the measured 2000s need)
+#   4200  MAX_RUNTIME_SECONDS watchdog  (spot-side shutdown BACKSTOP)
+#   5400  SF executionTimeout           (covers launch + bootstrap + workload)
+#   5460  SF DataPhase2 TimeoutSeconds
+# If the workload budget ever meets the watchdog, systemd shuts the box down
+# mid-loop and the manifest is never written — the alpha-engine-config-I5208
+# failure mode, reintroduced by config drift.
+PHASE2_ONLY_EXECUTION_TIMEOUT_SECONDS=5400        # = SF DataPhase2 executionTimeout
+PHASE2_ONLY_WORKLOAD_TIMEOUT_SECONDS=3600
+if [ "$RUN_MODE" = "phase2-only" ] && [ "$MAX_RUNTIME_EXPLICIT" != "1" ]; then
+    MAX_RUNTIME_SECONDS=4200
 fi
 
 # launch-only contract: the id artifact is how the weekday SF finds the
@@ -865,6 +903,102 @@ RAG_ONLY
         --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
         && echo "Heartbeat emitted: rag-ingestion" \
         || echo "WARNING: Failed to emit heartbeat for rag-ingestion (non-fatal)"
+    exit 0
+fi
+
+# ── Phase2-only run (SF state DataPhase2) ───────────────────────────────────
+# alpha-engine-config-I5759. Mirrors the rag-only block above: a self-contained
+# workload that runs on its own spot, emits its own heartbeat, and exits — so a
+# DataPhase2 failure costs nothing already spent by DataPhase1 or RAGIngestion.
+#
+# No secret pre-fetch block (unlike rag-only): every provider key this phase
+# touches is resolved at call time through nousergon_lib.secrets.get_secret,
+# which reads SSM directly under the box's instance role. rag-only pre-fetches
+# only because rag.preflight's check_env_vars asserts on os.environ.
+#
+# NOT given a spot-orphan-reaper WATCH_KINDS row, deliberately: this box is the
+# same class as DataPhase1's and RAGIngestion's — bounded by the systemd
+# watchdog armed in the bootstrap step and by the dispatcher's cleanup trap —
+# and neither sibling carries one. The reaper's watch-kind rows cover the four
+# box classes with no dispatcher holding them (ci-watch, sf-watch, alert-drain,
+# thinktank). Adding a fifth here would introduce a mechanism this stage's
+# siblings do not use rather than mirroring them.
+if [ "$RUN_MODE" = "phase2-only" ]; then
+    # Friday shell-run dry path. The pre-spot DataPhase2 was a lambda:invoke
+    # whose Payload carried dry_run.$ = $.data_phase2_dry; the spot states
+    # express the same intent through $.preflight_args, which
+    # ApplyShellRunDefaults sets to --preflight-only. Forwarding it to
+    # weekly_collector.py is a STRONGER guarantee than the old dry_run flag:
+    # --preflight-only exits 0 immediately after DataPreflight("phase2") and
+    # strictly BEFORE run_weekly(), the sole function in that module that
+    # performs any collector fetch or any S3 write, so every fetch/write path
+    # is statically unreachable rather than branch-suppressed.
+    PHASE2_COLLECTOR_ARGS=""
+    if [ "$PREFLIGHT_ONLY" = "1" ]; then
+        PHASE2_COLLECTOR_ARGS="--preflight-only"
+        echo ""
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "  PHASE2-ONLY PREFLIGHT-ONLY (boot + phase2 preflight, NO fetch/write)"
+        echo "═══════════════════════════════════════════════════════════════"
+    fi
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  PHASE2-ONLY RUN: alternative data (MorningEnrich/DataPhase1/RAG separate)"
+    echo "═══════════════════════════════════════════════════════════════"
+    # Printed, not just declared: when this stage times out the first question
+    # is which link of the chain fired, and the answer should be in the log
+    # rather than reconstructed from three files.
+    echo "  Budget chain  : workload ${PHASE2_ONLY_WORKLOAD_TIMEOUT_SECONDS}s"\
+         "< watchdog ${MAX_RUNTIME_SECONDS}s"\
+         "< SF executionTimeout ${PHASE2_ONLY_EXECUTION_TIMEOUT_SECONDS}s"
+    run_ssm "phase2-only" "$PHASE2_ONLY_WORKLOAD_TIMEOUT_SECONDS" <<PHASE2_ONLY
+set -eo pipefail
+${ENV_SOURCE}
+cd /home/ec2-user/alpha-engine-data
+
+# Spot-side log capture — same rationale as the rag-only block: SSM caps
+# StandardOutputContent at 24KB and this phase logs one line per ticker for
+# ~900 tickers, so the inline capture is guaranteed to truncate. The tee'd
+# copy lands in S3 on EVERY exit path, including the SIGKILL-free timeout.
+LOG_FILE=/tmp/data-phase2.log
+exec > >(tee -a "\$LOG_FILE") 2>&1
+upload_log() {
+    local exit_code=\$?
+    local s3_key="health/data_phase2_log/\$(date +%Y-%m-%d)/\$(date +%Y%m%dT%H%M%SZ -u)-exit\${exit_code}.log"
+    aws s3 cp "\$LOG_FILE" "s3://${S3_BUCKET}/\$s3_key" --region "\${AWS_REGION:-us-east-1}" 2>/dev/null \\
+        && echo "[log-upload] s3://${S3_BUCKET}/\$s3_key" \\
+        || echo "[log-upload] WARNING: failed to upload \$LOG_FILE to S3"
+}
+trap upload_log EXIT
+
+echo "──────────────────────────────────────────────────────────────"
+echo "Starting weekly_collector.py --phase 2 at \$(date)"
+echo "──────────────────────────────────────────────────────────────"
+if ! \$PYTHON_BIN weekly_collector.py --phase 2 ${PHASE2_COLLECTOR_ARGS} 2>&1; then
+    echo "ERROR: weekly_collector.py --phase 2 ${PHASE2_COLLECTOR_ARGS} failed." >&2
+    exit 1
+fi
+echo "DataPhase2 complete at \$(date)"
+PHASE2_ONLY
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  Phase2-only run complete. Instance will be terminated."
+    echo "═══════════════════════════════════════════════════════════════"
+
+    if [ "$PREFLIGHT_ONLY" = "1" ]; then
+        echo "Preflight-only run — heartbeat deliberately NOT emitted (a preflight is not a completed collection)."
+        exit 0
+    fi
+
+    aws cloudwatch put-metric-data \
+        --namespace "AlphaEngine" \
+        --metric-name "Heartbeat" \
+        --dimensions "Process=data-phase2" \
+        --value 1 --unit "Count" \
+        --region "${AWS_REGION:-us-east-1}" 2>/dev/null \
+        && echo "Heartbeat emitted: data-phase2" \
+        || echo "WARNING: Failed to emit heartbeat for data-phase2 (non-fatal)"
     exit 0
 fi
 

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1569,26 +1569,42 @@
             },
             "DataPhase2": {
               "Type": "Task",
-              "Comment": "Phase 2: alternative data for promoted tickers (Lambda). Successor is CheckSkipEvalJudge (post-2026-05-07 reorder) — judge + agent-justification triple run on Research's decision_artifacts/, no dependency on Predictor or Backtester output, so they run before predictor training to land their results in S3 before Evaluator generates the weekly email. TimeoutSeconds 900 (2026-07-30, was 600): the concurrent ThreadPoolExecutor in collectors/alternative.py overlaps I/O-bound API calls so the Lambda completes in ~3-5 min for 900+ tickers (was ~30 at original design), but 600 s left zero headroom for a provider degradation. 900 s is the Lambda max standard timeout — the Lambda's own timeout (deploy.sh LAMBDA_TIMEOUT) must move in lockstep.",
-              "Resource": "arn:aws:states:::lambda:invoke",
+              "Comment": "Phase 2: alternative data for the tracked universe, dispatched to EC2 SPOT (alpha-engine-config-I5759). PREVIOUSLY a direct lambda:invoke against alpha-engine-data-collector:live — TimeoutSeconds 600, raised to 900 by alpha-engine-data#1171, which is the Lambda MAXIMUM and still not enough. Measured live 2026-07-30 on execution 1e856026: the Lambda was killed at exactly 900,000 ms having completed 402 of 903 tickers (alphabetically through HON). The rate was 2.16-2.24 s/ticker and FLAT for the whole run — not a degradation curve, a floor. _fetch_all_alternative makes two _finnhub_get calls per ticker and collectors/finnhub_client.py serialises every one of them behind _finnhub_lock with a 1.1s sleep held INSIDE the lock, so 2 x 1.1 = 2.2 s/ticker regardless of how many workers collectors/alternative.py's ThreadPoolExecutor has. 903 x 2.2s = ~2000s, 2.2x a ceiling that cannot be raised. This is the same class as alpha-engine-config-I5208 (daily Think Tank) and alpha-engine-config-I5758 (weekly ThinkTankCoverage): long-running work parked on Lambda, where the ceiling is a hard wall rather than a tunable. UNLIKE the RAG scope fix (alpha-engine-config-I5700), narrowing is NOT the answer here: this stage's per-ticker output feeds seven registered feature-store columns in the `alternative` family (features/registry.py CATALOG, all consumers='predictor') for the WHOLE ArcticDB universe, and a ticker with no alt data gets 0.0 — indistinguishable from a real zero. It legitimately needs the universe; it needed different compute. The dispatcher fires an SSM command that returns as soon as it is accepted, so this state only LAUNCHES; the bounded poll quartet below waits for the box, mirroring DataPhase1 / WaitForDataPhase1 / CheckDataPhase1Status / DataPhase1Wait. Budget chain (load-bearing, asserted by tests/test_data_phase2_spot_budget_wiring.py): the workload run_ssm timeout (3600s) < the spot watchdog MAX_RUNTIME_SECONDS (4200s) < this state's executionTimeout (5400s) < this state's TimeoutSeconds (5460s). If the workload budget ever meets the watchdog, systemd shuts the box down mid-loop and the manifest is never written.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
               "Parameters": {
-                "FunctionName": "alpha-engine-data-collector:live",
-                "Payload": {
-                  "phase": 2,
-                  "dry_run.$": "$.data_phase2_dry"
-                }
+                "DocumentName": "AWS-RunShellScript",
+                "InstanceIds.$": "$.ec2_instance_id",
+                "Parameters": {
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
+                  "executionTimeout": [
+                    "5400"
+                  ]
+                },
+                "TimeoutSeconds": 5400
               },
-              "TimeoutSeconds": 900,
+              "TimeoutSeconds": 5460,
               "Retry": [
                 {
                   "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException",
-                    "States.TaskFailed"
+                    "States.TaskFailed",
+                    "States.Timeout"
                   ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
+                  "Comment": "config#2279 gold 4+2 ladder, same as every other spot-stage sendCommand. Re-issue is idempotent here for the declared reason: this state fails only on pre-execution API failures (the launcher never ran); once the command is delivered, WaitForDataPhase2 owns the outcome.",
+                  "MaxAttempts": 4,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
+                },
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 2.0,
+                  "MaxDelaySeconds": 300,
+                  "JitterStrategy": "FULL"
                 }
               ],
               "Catch": [
@@ -1601,7 +1617,144 @@
                 }
               ],
               "ResultPath": "$.data_phase2_result",
-              "Next": "CheckSkipEvalJudge"
+              "Next": "InitDataPhase2PollCount"
+            },
+            "InitDataPhase2PollCount": {
+              "Type": "Pass",
+              "Comment": "Poll-iteration budget seed. alpha-engine-config-I5687 recorded that all 15 existing SSM poll loops in this pipeline are unbounded and instance-liveness-blind, which cost 5h11m of blind polling on 2026-07-29. This loop ships bounded rather than adding a 16th instance of that defect. Bound is derived: the SF executionTimeout (5400s) / the DataPhase2Wait interval (30s) = 180 polls, +20% slack = 216.",
+              "Result": 0,
+              "ResultPath": "$.data_phase2_polls",
+              "Next": "WaitForDataPhase2"
+            },
+            "WaitForDataPhase2": {
+              "Type": "Task",
+              "Comment": "Poll the DataPhase2 SSM command until it reaches a terminal status.",
+              "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+              "Parameters": {
+                "CommandId.$": "$.data_phase2_result.Command.CommandId",
+                "InstanceId.$": "$.ec2_instance_id[0]"
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Ssm.InvocationDoesNotExistException",
+                    "Ssm.InvocationDoesNotExist"
+                  ],
+                  "Comment": "sendCommand returns as soon as the command is accepted, so the invocation record can lag the returned CommandId by a beat.",
+                  "MaxAttempts": 10,
+                  "IntervalSeconds": 30,
+                  "BackoffRate": 1.5
+                },
+                {
+                  "ErrorEquals": [
+                    "Ssm.SdkClientException",
+                    "States.Timeout"
+                  ],
+                  "MaxAttempts": 2,
+                  "IntervalSeconds": 5,
+                  "BackoffRate": 1.5
+                }
+              ],
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "BranchAFailed",
+                  "ResultPath": "$.error"
+                }
+              ],
+              "ResultSelector": {
+                "Status.$": "$.Status",
+                "ResponseCode.$": "$.ResponseCode",
+                "StatusDetails.$": "$.StatusDetails",
+                "StandardErrorContent.$": "$.StandardErrorContent"
+              },
+              "ResultPath": "$.data_phase2_poll",
+              "Next": "CheckDataPhase2Status"
+            },
+            "CheckDataPhase2Status": {
+              "Type": "Choice",
+              "Comment": "Budget exhaustion falls through to the Default arm, i.e. it is treated as a FAILED poll rather than a silent success — a bound whose exhaustion converges on the happy path is not a bound.",
+              "Choices": [
+                {
+                  "Variable": "$.data_phase2_poll.Status",
+                  "StringEquals": "Success",
+                  "Next": "CheckSkipEvalJudge"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.data_phase2_polls",
+                      "IsPresent": true
+                    },
+                    {
+                      "Or": [
+                        {
+                          "Variable": "$.data_phase2_poll.Status",
+                          "StringEquals": "InProgress"
+                        },
+                        {
+                          "Variable": "$.data_phase2_poll.Status",
+                          "StringEquals": "Pending"
+                        }
+                      ]
+                    },
+                    {
+                      "Variable": "$.data_phase2_polls",
+                      "NumericLessThan": 216
+                    }
+                  ],
+                  "Next": "DataPhase2Wait"
+                }
+              ],
+              "Default": "DataPhase2RetryGate"
+            },
+            "DataPhase2Wait": {
+              "Type": "Pass",
+              "Comment": "Increment the poll counter, then wait. A Pass+Wait pair rather than a bare Wait so the budget in CheckDataPhase2Status actually advances — a counter that never increments is an unbounded loop wearing a bound.",
+              "Parameters": {
+                "polls.$": "States.MathAdd($.data_phase2_polls, 1)"
+              },
+              "ResultPath": "$.data_phase2_poll_count",
+              "Next": "DataPhase2PollWait"
+            },
+            "DataPhase2PollWait": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "MergeDataPhase2PollCount"
+            },
+            "MergeDataPhase2PollCount": {
+              "Type": "Pass",
+              "InputPath": "$.data_phase2_poll_count.polls",
+              "ResultPath": "$.data_phase2_polls",
+              "Next": "WaitForDataPhase2"
+            },
+            "DataPhase2RetryGate": {
+              "Type": "Choice",
+              "Comment": "One bounded re-issue, mirroring DataPhase1RetryGate. A second failure is a real failure and takes Branch A down rather than looping: alt data is a model input, and a silent skip would write 0.0 into seven feature-store columns for the whole universe.",
+              "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.data_phase2_attempts",
+                      "IsPresent": true
+                    },
+                    {
+                      "Variable": "$.data_phase2_attempts",
+                      "NumericGreaterThanEquals": 1
+                    }
+                  ],
+                  "Next": "PublishResearchFailureImmediate"
+                }
+              ],
+              "Default": "DataPhase2Reissue"
+            },
+            "DataPhase2Reissue": {
+              "Type": "Pass",
+              "Result": 1,
+              "ResultPath": "$.data_phase2_attempts",
+              "Next": "DataPhase2"
             },
             "CheckSkipEvalJudge": {
               "Type": "Choice",

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -23,4 +23,4 @@ feedparser>=6.0.14
 anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.26
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -16,6 +16,13 @@
     "export HOME=/home/ec2-user",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_weekly.sh --phase1-only"
   ],
+  "DataPhase2": [
+    "set -eo pipefail",
+    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "cd /home/ec2-user/alpha-engine-data",
+    "export HOME=/home/ec2-user",
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
+  ],
   "DriftDetection": [
     "set -eo pipefail",
     "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",

--- a/tests/test_alt_data_scope_resolution.py
+++ b/tests/test_alt_data_scope_resolution.py
@@ -1,0 +1,191 @@
+"""DataPhase2's scope comes from constituents.json, and cannot move silently.
+
+alpha-engine-config-I5814 (Brian ruling 2026-07-31: universe, on spot).
+
+The regression these guard against, measured: on 2026-07-21 this collector's
+input went from 27 to 902 tickers overnight, because it resolved its scope from
+``signals/{date}/signals.json::universe`` and an unrelated producer swap
+(config-I2515 / config#1580) replaced a promoted list with the whole board.
+Nothing failed and nothing warned; the only symptom was a 33x wall-clock
+increase that broke the 600s Lambda ceiling on the next weekly run.
+
+Two independent fixes, one test module:
+  1. the scope is resolved from constituents.json, the same artifact phase 1
+     hands to fundamentals.collect, so it no longer tracks the champion;
+  2. a run-over-run cardinality assertion, so the NEXT silent scope change
+     fails in the same run instead of nine days later.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import collectors.alternative as alternative
+from collectors.alternative import ScopeChangedUnexpectedly, _assert_scope_stable
+
+
+PREFIX = "market_data/"
+
+
+class _Body:
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+class ManifestS3:
+    """S3 double serving one prior manifest at a chosen age."""
+
+    def __init__(self, prior: dict[str, int] | None = None) -> None:
+        # {"2026-07-24": 903, ...}
+        self.prior = prior or {}
+
+    def get_object(self, Bucket: str, Key: str):  # noqa: N803
+        for run_date, count in self.prior.items():
+            if Key == f"{PREFIX}weekly/{run_date}/alternative/manifest.json":
+                return {"Body": _Body(json.dumps({
+                    "run_date": run_date,
+                    "tickers_requested": count,
+                    "tickers_succeeded": count,
+                }).encode())}
+        raise KeyError(Key)
+
+
+def test_the_actual_regression_would_have_raised():
+    """27 -> 902 is what happened on 2026-07-21. It must not be collectable."""
+    s3 = ManifestS3({"2026-07-20": 27})
+    with pytest.raises(ScopeChangedUnexpectedly) as exc:
+        _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-21", 902)
+    message = str(exc.value)
+    assert "902" in message and "27" in message
+    # The message must name the decision, not just the numbers.
+    assert "scope" in message.lower()
+
+
+def test_a_large_shrink_also_raises():
+    """The guard is symmetric — silently collecting 27 when the universe is
+    903 is the same defect pointed the other way, and would show up as seven
+    feature columns quietly emptying out."""
+    s3 = ManifestS3({"2026-07-24": 903})
+    with pytest.raises(ScopeChangedUnexpectedly):
+        _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 60)
+
+
+def test_ordinary_reconstitution_churn_passes():
+    """S&P 500+400 reconstitution moves a handful of names. That is not a
+    scope change and must not page anyone."""
+    s3 = ManifestS3({"2026-07-24": 903})
+    _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 911)
+    _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 890)
+
+
+def test_boundary_is_the_declared_tolerance():
+    s3 = ManifestS3({"2026-07-24": 1000})
+    # +30% exactly — inside.
+    _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 1300)
+    with pytest.raises(ScopeChangedUnexpectedly):
+        _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 1301)
+
+
+def test_no_baseline_fails_open_but_says_so(caplog):
+    """First run of a new partition scheme has nothing to compare against.
+    Refusing to collect would be worse than collecting — but the run must say
+    that the check did not happen, or a silent pass reads as a silent OK."""
+    s3 = ManifestS3({})
+    with caplog.at_level("WARNING"):
+        _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 903)
+    assert "no prior manifest" in caplog.text
+    assert "cannot be detected" in caplog.text
+
+
+def test_baseline_older_than_the_lookback_is_not_used():
+    """15 days back is outside the window; treated as no baseline."""
+    s3 = ManifestS3({"2026-07-10": 27})
+    _assert_scope_stable(s3, "alpha-engine-research", PREFIX, "2026-07-25", 903)
+
+
+def test_collect_runs_the_guard_before_fetching(monkeypatch):
+    """The assertion must gate the fetch, not report on it afterwards —
+    otherwise a 33x scope change still costs 33x the wall clock before anyone
+    hears about it."""
+    calls: list[str] = []
+
+    def _fake_assert(*_args, **_kwargs):
+        calls.append("guard")
+        raise ScopeChangedUnexpectedly("boom")
+
+    def _fail_if_fetched(*_args, **_kwargs):  # pragma: no cover
+        calls.append("fetch")
+        raise AssertionError("fetched despite a scope-change failure")
+
+    monkeypatch.setattr(alternative, "_assert_scope_stable", _fake_assert)
+    monkeypatch.setattr(alternative, "_fetch_all_alternative", _fail_if_fetched)
+    monkeypatch.setattr(alternative.boto3, "client", lambda *a, **k: ManifestS3({}))
+
+    with pytest.raises(ScopeChangedUnexpectedly):
+        alternative.collect(
+            bucket="alpha-engine-research",
+            s3_prefix=PREFIX,
+            run_date="2026-07-31",
+            tickers=["AAPL", "MSFT"],
+        )
+    assert calls == ["guard"]
+
+
+def test_phase2_resolves_from_constituents_not_signals(monkeypatch):
+    """The scope must come from the same artifact phase 1 gives fundamentals.
+    Reading signals.json is what let an unrelated producer swap move it."""
+    import weekly_collector as wc
+
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        wc.constituents, "load_from_s3",
+        lambda bucket, prefix: {"tickers": ["AAA", "BBB", "CCC"]},
+    )
+
+    def _fake_collect(**kwargs):
+        captured.update(kwargs)
+        return {"status": "ok", "tickers_processed": 3, "tickers_failed": 0}
+
+    monkeypatch.setattr(wc.alternative, "collect", _fake_collect)
+    monkeypatch.setattr(wc, "_build_registry", lambda *a, **k: None)
+    monkeypatch.setattr(wc, "_finalize", lambda *a, **k: None)
+
+    class _Args:
+        date = "2026-07-31"
+        dry_run = False
+        phase = 2
+
+    wc._run_phase2({"bucket": "alpha-engine-research"}, _Args())
+
+    assert captured["tickers"] == ["AAA", "BBB", "CCC"]
+    # signals.json must not be consulted at all on this path.
+    assert "signals_key" not in captured
+
+
+def test_phase2_refuses_to_run_without_constituents(monkeypatch):
+    """No silent narrowing. A missing constituents artifact used to fall
+    through to signals.json — that fallback IS how the scope moved."""
+    import weekly_collector as wc
+
+    monkeypatch.setattr(wc.constituents, "load_from_s3", lambda bucket, prefix: None)
+    monkeypatch.setattr(wc, "_build_registry", lambda *a, **k: None)
+    monkeypatch.setattr(
+        wc.alternative, "collect",
+        lambda **k: pytest.fail("collected without a constituent universe"),
+    )
+
+    class _Args:
+        date = "2026-07-31"
+        dry_run = False
+        phase = 2
+
+    with pytest.raises(wc._CollectorError) as exc:
+        wc._run_phase2({"bucket": "alpha-engine-research"}, _Args())
+    assert "constituents.json" in str(exc.value)
+    assert "signals.json" in str(exc.value)

--- a/tests/test_data_phase2_spot_budget_wiring.py
+++ b/tests/test_data_phase2_spot_budget_wiring.py
@@ -1,0 +1,185 @@
+"""DataPhase2's budget chain must stay ordered across three files.
+
+alpha-engine-config-I5759. DataPhase2 moved off a `lambda:invoke` (900s hard
+maximum, and it needs ~33 min) onto the spot dispatch->poll quartet. Its
+runtime bound is now expressed in three places that can drift independently:
+
+    infrastructure/spot_data_weekly.sh   workload timeout + box watchdog
+    infrastructure/step_function.json    SSM executionTimeout + SF TimeoutSeconds
+    infrastructure/sf_budgets.py         the declared stage budget
+
+The ordering is load-bearing, not cosmetic. If the workload budget ever meets
+the box watchdog, systemd shuts the instance down mid-loop and the manifest is
+never written — the alpha-engine-config-I5208 failure mode, reintroduced by
+config drift. This is the same guard shape as
+tests/test_rag_ingestion_news_budget_wiring.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from infrastructure.sf_budgets import STAGE_BUDGETS
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_JSON = _REPO_ROOT / "infrastructure" / "step_function.json"
+_LAUNCHER = _REPO_ROOT / "infrastructure" / "spot_data_weekly.sh"
+
+# Measured 2026-07-30 on weekly execution 1e856026: 402 of 903 tickers in 900s
+# of steady state. Two _finnhub_get calls per ticker x _FINNHUB_MIN_INTERVAL
+# (1.1s) slept while holding _finnhub_lock = a serial floor no amount of
+# ThreadPoolExecutor concurrency can move.
+_MEASURED_SECONDS_PER_TICKER = 2.2
+_UNIVERSE_AT_MEASUREMENT = 903
+
+
+def _shell_const(name: str) -> int:
+    text = _LAUNCHER.read_text()
+    match = re.search(rf"^{re.escape(name)}=(\d+)", text, re.MULTILINE)
+    assert match, f"{name} not found in {_LAUNCHER.name}"
+    return int(match.group(1))
+
+
+def _phase2_watchdog_seconds() -> int:
+    """MAX_RUNTIME_SECONDS as set by the phase2-only default branch."""
+    text = _LAUNCHER.read_text()
+    match = re.search(
+        r'if \[ "\$RUN_MODE" = "phase2-only" \].*?MAX_RUNTIME_SECONDS=(\d+)',
+        text,
+        re.DOTALL,
+    )
+    assert match, "the phase2-only MAX_RUNTIME_SECONDS default branch is missing"
+    return int(match.group(1))
+
+
+@pytest.fixture(scope="module")
+def data_phase2_state() -> dict:
+    sf = json.loads(_SF_JSON.read_text())
+    branch_a = sf["States"]["ResearchPredictorParallel"]["Branches"][0]["States"]
+    assert "DataPhase2" in branch_a, "DataPhase2 left Branch A"
+    return branch_a["DataPhase2"]
+
+
+def test_data_phase2_dispatches_to_spot_not_lambda(data_phase2_state):
+    """The regression that started this. A lambda:invoke here CANNOT hold the
+    workload: the floor is ~2000s and Lambda's maximum is 900s."""
+    assert data_phase2_state["Resource"] == "arn:aws:states:::aws-sdk:ssm:sendCommand"
+    commands = data_phase2_state["Parameters"]["Parameters"]["commands.$"]
+    assert "spot_data_weekly.sh --phase2-only" in commands
+
+
+def test_launcher_accepts_the_phase2_only_flag():
+    text = _LAUNCHER.read_text()
+    assert "--phase2-only) RUN_MODE=\"phase2-only\"" in text
+    assert 'if [ "$RUN_MODE" = "phase2-only" ]; then' in text
+
+
+def test_budget_chain_is_strictly_ordered(data_phase2_state):
+    """workload < box watchdog < SSM executionTimeout <= SF TimeoutSeconds."""
+    workload = _shell_const("PHASE2_ONLY_WORKLOAD_TIMEOUT_SECONDS")
+    watchdog = _phase2_watchdog_seconds()
+    execution_timeout = int(
+        data_phase2_state["Parameters"]["Parameters"]["executionTimeout"][0]
+    )
+    sf_timeout = data_phase2_state["TimeoutSeconds"]
+
+    assert workload < watchdog, (
+        f"workload budget {workload}s >= box watchdog {watchdog}s — systemd "
+        "would shut the box down mid-collection and the manifest would never "
+        "be written (the alpha-engine-config-I5208 failure mode)."
+    )
+    assert watchdog < execution_timeout, (
+        f"box watchdog {watchdog}s >= SSM executionTimeout {execution_timeout}s "
+        "— SSM would give up before the box's own backstop fires, so a hung "
+        "run would be reported as a command failure with no box-side log."
+    )
+    assert execution_timeout <= sf_timeout, (
+        f"SSM executionTimeout {execution_timeout}s > SF TimeoutSeconds "
+        f"{sf_timeout}s — the SF would abandon a command still legitimately "
+        "running."
+    )
+
+
+def test_declared_execution_timeout_matches_the_shell_constant(data_phase2_state):
+    """The shell's documentation constant and the SF must agree; a constant
+    that drifts from the thing it documents is worse than no constant."""
+    assert _shell_const("PHASE2_ONLY_EXECUTION_TIMEOUT_SECONDS") == int(
+        data_phase2_state["Parameters"]["Parameters"]["executionTimeout"][0]
+    )
+
+
+def test_stage_budget_matches_the_sf_execution_timeout(data_phase2_state):
+    budget = STAGE_BUDGETS["DataPhase2"]
+    assert budget.current_timeout_seconds == int(
+        data_phase2_state["Parameters"]["Parameters"]["executionTimeout"][0]
+    )
+    assert budget.pipeline_segment == "branch_a"
+
+
+def test_workload_budget_covers_the_measured_serial_floor():
+    """The budget must clear the floor with real headroom, and the headroom
+    must be stated in tickers rather than left as a feeling."""
+    workload = _shell_const("PHASE2_ONLY_WORKLOAD_TIMEOUT_SECONDS")
+    floor = _UNIVERSE_AT_MEASUREMENT * _MEASURED_SECONDS_PER_TICKER
+    assert workload > floor * 1.5, (
+        f"workload budget {workload}s leaves under 1.5x headroom over the "
+        f"measured {floor:.0f}s floor for {_UNIVERSE_AT_MEASUREMENT} tickers."
+    )
+    # How far the universe can grow before this budget is the binding
+    # constraint. Stated so a future universe expansion trips a review here
+    # rather than a Saturday timeout.
+    headroom_tickers = int(workload / _MEASURED_SECONDS_PER_TICKER)
+    assert headroom_tickers >= 1_600, (
+        f"the workload budget covers only {headroom_tickers} tickers at the "
+        f"measured {_MEASURED_SECONDS_PER_TICKER}s/ticker floor."
+    )
+
+
+def test_poll_bound_covers_the_execution_timeout(data_phase2_state):
+    """The poll loop must be able to outlast the work it waits for, or the
+    bound fails runs that were about to succeed."""
+    sf = json.loads(_SF_JSON.read_text())
+    branch_a = sf["States"]["ResearchPredictorParallel"]["Branches"][0]["States"]
+    wait_seconds = branch_a["DataPhase2PollWait"]["Seconds"]
+    bound = next(
+        cond["NumericLessThan"]
+        for choice in branch_a["CheckDataPhase2Status"]["Choices"]
+        if "And" in choice
+        for cond in choice["And"]
+        if "NumericLessThan" in cond
+    )
+    execution_timeout = int(
+        data_phase2_state["Parameters"]["Parameters"]["executionTimeout"][0]
+    )
+    assert bound * wait_seconds >= execution_timeout, (
+        f"poll bound {bound} x {wait_seconds}s = {bound * wait_seconds}s is "
+        f"below the SSM executionTimeout {execution_timeout}s — the loop would "
+        "give up on a command SSM is still willing to run."
+    )
+
+
+def test_preflight_only_reaches_the_collector():
+    """Friday shell-run dry path. --preflight-only must be forwarded to
+    weekly_collector.py, which exits 0 before run_weekly() — the sole function
+    performing any collector fetch or S3 write."""
+    text = _LAUNCHER.read_text()
+    assert 'PHASE2_COLLECTOR_ARGS="--preflight-only"' in text
+    assert "weekly_collector.py --phase 2 ${PHASE2_COLLECTOR_ARGS}" in text
+
+
+def test_preflight_only_does_not_emit_a_heartbeat():
+    """A preflight is not a completed collection. Emitting the heartbeat on
+    the dry path would make the Friday shell run indistinguishable from a real
+    Saturday collection to every freshness monitor watching that dimension."""
+    text = _LAUNCHER.read_text()
+    phase2_block = text.split('if [ "$RUN_MODE" = "phase2-only" ]; then', 1)[1]
+    phase2_block = phase2_block.split("\n# ── Full / data-only", 1)[0]
+    guard_index = phase2_block.index('if [ "$PREFLIGHT_ONLY" = "1" ]; then\n        echo "Preflight-only run')
+    heartbeat_index = phase2_block.index('--dimensions "Process=data-phase2"')
+    assert guard_index < heartbeat_index, (
+        "the preflight guard must precede the heartbeat emission"
+    )

--- a/tests/test_pipeline_status_registry_source_check.py
+++ b/tests/test_pipeline_status_registry_source_check.py
@@ -96,7 +96,8 @@ def test_every_substantive_state_has_registry_entry(label, json_path):
     fails here instead of days/weeks later as a dashboard "Registry drift"
     cell. Fix: add the new state name + ArchivePageRef or ArtifactReason to
     ``nousergon_lib.pipeline_status.registry`` (companion nousergon-lib PR),
-    bump the lib version, then bump this repo's pin in requirements.txt."""
+    let the lib's merge-time auto-bump tag the new version, then bump this
+    repo's pin in requirements.txt to that tag."""
     assert json_path.exists(), f"{label} SF JSON not found at {json_path}"
 
     substantive = _all_substantive_states(json_path)
@@ -112,7 +113,9 @@ def test_every_substantive_state_has_registry_entry(label, json_path):
         f"{sorted(missing)}. This is the config#1115/#1120/#2372/#2430 drift "
         f"class recurring again. Add each state to the registry in "
         f"nousergon-lib with an ArchivePageRef deep-link or an explicit "
-        f"ArtifactReason string, bump the lib version, then bump this "
+        f"ArtifactReason string, merge that lib PR (auto-version-bump.yml is "
+        f"the single version writer — config-I2716 — and version-bump-check.yml "
+        f"FORBIDS version edits inside a lib PR), then bump this "
         f"repo's requirements.txt pin in the SAME PR that adds the state — "
         f"do not merge the SF JSON change ahead of the registry entry."
     )

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -801,7 +801,18 @@ class TestJudgeChainBeforePredictor:
         predictor training. This is the load-bearing invariant — if
         someone ever rewires DataPhase2.Next to CheckSkipPredictorTraining
         (the pre-reorder target), the judge chain bypass is silent."""
-        assert states["DataPhase2"]["Next"] == "CheckSkipEvalJudge"
+        # alpha-engine-config-I5759 moved DataPhase2 from a lambda:invoke to
+        # the spot dispatch->poll quartet, so the success edge is no longer
+        # DataPhase2.Next — it is the Success arm of CheckDataPhase2Status.
+        # The invariant is unchanged and still load-bearing: whatever the
+        # stage's success edge IS, it must enter the judge chain.
+        assert states["DataPhase2"]["Next"] == "InitDataPhase2PollCount"
+        success_arm = [
+            c for c in states["CheckDataPhase2Status"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert len(success_arm) == 1, "CheckDataPhase2Status lost its Success arm"
+        assert success_arm[0]["Next"] == "CheckSkipEvalJudge"
         assert (
             states["CheckSkipDataPhase2"]["Choices"][0]["Next"]
             == "CheckSkipEvalJudge"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -159,6 +159,18 @@ _SPOT_STATES = {
         "bash infrastructure/spot_data_weekly.sh --rag-only",
         "/var/log/rag-ingestion.log",
     ),
+    # alpha-engine-config-I5759: DataPhase2 moved OFF lambda:invoke onto spot,
+    # so its Friday dry path moved with it — out of _DRY_LAMBDA_STATES (where
+    # it was ("dry_run.$", "$.data_phase2_dry")) and into this table, routed
+    # dry by the same States.Format($.preflight_args) suffix every other spot
+    # stage uses. That is a STRONGER dry guarantee than the Payload flag it
+    # replaces: --preflight-only exits weekly_collector.py immediately after
+    # DataPreflight("phase2") and strictly BEFORE run_weekly(), the sole
+    # function in that module performing any collector fetch or S3 write.
+    "DataPhase2": (
+        "bash infrastructure/spot_data_weekly.sh --phase2-only",
+        "/var/log/data-phase2.log",
+    ),
     "PredictorTraining": (
         "bash infrastructure/spot_train.sh --full-only",
         "/var/log/predictor-training.log",
@@ -194,6 +206,12 @@ _SPOT_STATES = {
 # skipped) via an input-var ref so the absent path is behaviourally
 # identical. DataPhase2/Regime* were dry from the keystone; the
 # skip-exception rewire ADDED the eval-judge chain + rationale-clustering
+# NOTE (alpha-engine-config-I5759): DataPhase2 LEFT this map when it moved
+# to spot — it is now in _SPOT_STATES above, routed dry via
+# --preflight-only. $.data_phase2_dry survives in InitializeInput's
+# defaults floor as an unread control var; removing it is a separate
+# change because ApplyShellRunDefaults and the offcycle presets also set
+# it, and a half-removed control var is worse than an unread one.
 # (research #202 added dry_run_llm) + replay-concordance + counterfactual
 # (backtester #225 added dry_run_llm) — all reusing the canonical
 # $.research_dry shell-run-dry signal (already true under shell_run / false
@@ -210,7 +228,6 @@ _SPOT_STATES = {
 # test_signals_envelope_preflight_signal below, not by the dry-flag map.
 # state name → (Payload key carrying the dry flag, input var it references).
 _DRY_LAMBDA_STATES = {
-    "DataPhase2": ("dry_run.$", "$.data_phase2_dry"),
     "RegimeSubstrate": ("action.$", "$.regime_action"),
     "RegimeRetrospectiveEval": ("action.$", "$.regime_action"),
     # Skip-exception rewire — eval-judge chain + agent-justification triple.
@@ -402,6 +419,14 @@ def orig_spot_cmds() -> dict:
       scope). `MorningEnrich`/`DataPhase1`/`RAGIngestion` are unchanged
       (they invoke `spot_data_weekly.sh`, which self-exports the region via
       its own `ENV_SOURCE` heredoc and never sourced `.env` directly).
+
+    - **Extended 2026-07-31** (alpha-engine-config-I5759) with a `DataPhase2`
+      entry. That state was a `lambda:invoke` pre-keystone, so unlike every
+      other key here it has NO pre-keystone form to be byte-identical to —
+      its entry was captured at the commit that moved it to spot. The
+      guarantee it carries is therefore "this command has not drifted since
+      the spot migration", not "identical to the pre-keystone Saturday path".
+      A future spot state added here inherits the same weaker-but-real pin.
 
     - **Regenerated 2026-07-27** as part of the krepis `--correlation-id`
       fix. krepis 0.18.8 made the correlation id mandatory (`run` exits 2

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -101,7 +101,6 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # alpha-engine-config-I2515 Phase B: keeps the no_agent champion-baseline
     # shadow alive for the producer leaderboard post graph-runner removal.
     "ChallengerShadow": frozenset({"mode", "date.$"}),
-    "DataPhase2": frozenset({"dry_run.$", "phase"}),
     "EvalJudgeSubmitFirstSaturday": frozenset(
         {"date.$", "dry_run_llm.$", "force_sonnet_pass", "capture_lookback_days"}
     ),
@@ -643,7 +642,13 @@ class TestEODSFTopLevelFieldsClosed:
 # REVERSED — ModelZooSelect is back inline in Branch B (the Sunday child SF and
 # the advisory child SF are retired; the weekly SF runs the full pre-split
 # pattern again, all-Saturday).
-_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 10
+# 10 → 11 on alpha-engine-config-I5759 (2026-07-31): DataPhase2 was
+# repointed from a lambda:invoke to the spot dispatch->poll quartet. Its
+# wall clock is a provider-imposed serial floor (2 Finnhub calls/ticker x
+# a 1.1s sleep held inside a module-global lock = 2.2 s/ticker, measured
+# flat at 903 tickers), so ~33 min against Lambda's 900s HARD maximum —
+# a ceiling no further bump can raise.
+_EXPECTED_SATURDAY_SPOT_STATE_COUNT = 11
 
 
 def _spot_states(sf_path: Path) -> list[str]:
@@ -675,14 +680,14 @@ def _spot_states(sf_path: Path) -> list[str]:
 
 
 class TestSaturdaySFSpotStateCount:
-    """Closes the spot-state set as exactly 9 (see the count-history
+    """Closes the spot-state set at the declared count (see the count-history
     changelog comment above `_EXPECTED_SATURDAY_SPOT_STATE_COUNT`).
     Pre-rewire test_sf_friday_shell_run_wiring.py parametrizes over the
     expected names but doesn't assert an EXACT count — an orphaned legacy
     spot state from an incomplete refactor would slip through.
     """
 
-    def test_exactly_nine_spot_states_in_saturday_sf(self):
+    def test_spot_state_count_is_exactly_the_declared_count(self):
         spots = _spot_states(_SF_SATURDAY)
         assert len(spots) == _EXPECTED_SATURDAY_SPOT_STATE_COUNT, (
             f"Saturday SF should have EXACTLY "

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -274,8 +274,46 @@ class TestBranchAContents:
         assert branch_a["CheckSkipDataPhase2"]["Default"] == "DataPhase2"
 
     def test_eval_chain_after_dataphase2_in_branch_a(self, branch_a):
-        assert branch_a["DataPhase2"]["Next"] == "CheckSkipEvalJudge"
+        # alpha-engine-config-I5759: DataPhase2 dispatches to spot, so its
+        # success edge is the Success arm of CheckDataPhase2Status rather
+        # than DataPhase2.Next. Same shape as RAGIngestion above it.
+        assert branch_a["DataPhase2"]["Next"] == "InitDataPhase2PollCount"
+        success_arm = [
+            c for c in branch_a["CheckDataPhase2Status"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert len(success_arm) == 1
+        assert success_arm[0]["Next"] == "CheckSkipEvalJudge"
         assert branch_a["CheckSkipEvalJudge"]["Default"] == "ComputeEvalCadence"
+
+    def test_data_phase2_poll_loop_is_bounded(self, branch_a):
+        """alpha-engine-config-I5687: a poll loop added AFTER that finding
+        ships with its budget, and budget exhaustion must not converge on the
+        success path — an exhausted bound that reaches CheckSkipEvalJudge
+        would render a timed-out collection as a completed one."""
+        assert branch_a["InitDataPhase2PollCount"]["Result"] == 0
+        assert branch_a["InitDataPhase2PollCount"]["ResultPath"] == "$.data_phase2_polls"
+        bound = [
+            c for c in branch_a["CheckDataPhase2Status"]["Choices"]
+            if "And" in c
+        ]
+        assert len(bound) == 1, "the bounded in-progress arm is missing"
+        caps = [
+            cond["NumericLessThan"] for cond in bound[0]["And"]
+            if "NumericLessThan" in cond
+        ]
+        assert caps == [216], f"poll bound changed to {caps} without updating this test"
+        # The counter must actually advance, or the bound is decorative.
+        assert (
+            branch_a["DataPhase2Wait"]["Parameters"]["polls.$"]
+            == "States.MathAdd($.data_phase2_polls, 1)"
+        )
+        assert branch_a["MergeDataPhase2PollCount"]["ResultPath"] == "$.data_phase2_polls"
+        # Exhaustion falls to the retry gate, never to the judge chain.
+        assert branch_a["CheckDataPhase2Status"]["Default"] == "DataPhase2RetryGate"
+        assert branch_a["DataPhase2RetryGate"]["Choices"][0]["Next"] == (
+            "PublishResearchFailureImmediate"
+        )
 
     def test_eval_judge_quartet_preserved(self, branch_a):
         assert branch_a["EvalJudgePollChoice"]["Type"] == "Choice"

--- a/tests/test_sf_retry_ladder_convention.py
+++ b/tests/test_sf_retry_ladder_convention.py
@@ -38,6 +38,11 @@ _WEEKLY = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_functi
 SPOT_STAGE_SEND_STATES = {
     "MorningEnrich",
     "DataPhase1",
+    # alpha-engine-config-I5759: repointed from lambda:invoke to the spot
+    # dispatch->poll quartet; it carries the same gold 4+2 ladder as its
+    # siblings because re-issue is idempotent for the same reason (the send
+    # state fails only pre-execution; the WaitFor* loop owns delivered runs).
+    "DataPhase2",
     "RAGIngestion",
     "PredictorTraining",
     "ResolveZooSpecs",

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -656,7 +656,7 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
 
 
 def _run_phase2(config: dict, args: argparse.Namespace) -> dict:
-    """Phase 2: alternative data for promoted tickers (after research)."""
+    """Phase 2: alternative data for the constituent universe (after research)."""
     bucket = config["bucket"]
     market_prefix = config.get("market_data", {}).get("s3_prefix", "market_data/")
     run_date = args.date or default_run_date()
@@ -670,13 +670,50 @@ def _run_phase2(config: dict, args: argparse.Namespace) -> dict:
         "collectors": {},
     }
 
+    # Scope resolution (alpha-engine-config-I5814, Brian ruling 2026-07-31).
+    #
+    # Phase 2 resolves its ticker list from constituents.json — the SAME source
+    # phase 1 passes to fundamentals.collect — rather than from
+    # signals/{date}/signals.json's `universe` array.
+    #
+    # Why: the seven `alternative`-family columns in features/registry.py are
+    # written for every ticker in the ArcticDB universe, so this collector's
+    # scope IS the constituent universe. Resolving it from signals.json made
+    # that scope a function of whichever producer happens to be champion:
+    # measured 2026-07-21, the retirement of the multi-agent Research stage
+    # (config-I2515 / config#1580) swapped a 27-name promoted list for a
+    # 902-row board, so this collector's input grew 33x overnight with no
+    # change to its own code. Its Lambda duration went 126-215s -> ~2000s and
+    # it broke through the 600s ceiling on the next weekly run.
+    #
+    # signals.json's `universe` is a SIZING ENVELOPE for the executor, not a
+    # scope (alpha-engine-config-I5809). constituents.json is the universe
+    # definition, and it is what every other universe-wide collector reads.
+    universe_tickers: list[str] = []
+    existing = constituents.load_from_s3(bucket, market_prefix)
+    if existing:
+        universe_tickers = list(existing.get("tickers") or [])
+    if not universe_tickers:
+        # No silent narrowing. A missing constituents artifact used to fall
+        # through to signals.json, which is exactly how the scope moved
+        # without anyone deciding it.
+        raise _CollectorError(
+            "alternative",
+            "constituents.json unreadable or empty at "
+            f"{market_prefix}weekly/<latest>/constituents.json — refusing to "
+            "collect alternative data against an implicit ticker list. Fix the "
+            "constituents artifact rather than falling back to "
+            "signals.json::universe (alpha-engine-config-I5814).",
+        )
+
     logger.info("=" * 60)
     logger.info("COLLECTING: alternative data (Phase 2)")
     logger.info("=" * 60)
     results["collectors"]["alternative"] = _phase_collect(
         reg, "alternative",
         lambda: alternative.collect(
-            bucket=bucket, s3_prefix=market_prefix, run_date=run_date, dry_run=dry_run,
+            bucket=bucket, s3_prefix=market_prefix, run_date=run_date,
+            tickers=universe_tickers, dry_run=dry_run,
         ),
         artifact_key=f"{market_prefix}weekly/{run_date}/alternative/manifest.json",
     )


### PR DESCRIPTION
## Root cause

`DataPhase2` cannot fit in Lambda and never could at the current universe size.

Measured on weekly execution `1e856026` (2026-07-30), `/aws/lambda/alpha-engine-data-collector` RequestId `d736f00f`:

```
23:56:49  Collecting alternative data for 903 tickers
23:57:17  first completions: AA, AAON, A, AAL
00:11:46  last completion: HON              <- 402 of 903
00:11:48  Duration: 900000.00 ms  Status: timeout
```

900,000 ms is the **Lambda maximum**, already raised from 600s by `#1171`. The state fails hard (`Catch → BranchAFailed`), so it took the whole execution down — the third weekly failure in a row attributed to a stage that had simply outgrown its substrate.

**The rate was 2.16–2.24 s/ticker and flat for the entire run.** That is a floor, not a degradation curve:

- `_fetch_all_alternative` makes **two** `_finnhub_get` calls per ticker (`collectors/alternative.py:1069` `stock/recommendation`, `:1092` `stock/earnings`)
- `collectors/finnhub_client.py:105-109` sleeps `_FINNHUB_MIN_INTERVAL` (1.1s) **while holding** `_finnhub_lock`

So every worker in `#1171`'s 20-wide `ThreadPoolExecutor` serialises behind one global lock: 2 × 1.1 = 2.2 s/ticker regardless of worker count. 903 × 2.2s ≈ 2000s against a 900s ceiling that cannot be raised again. `alternative.py:650-652` asserts the FMP limiter is "the sole serialisation point" — it is not; Finnhub is a second, harder one with no daily cap, and it sets the floor.

Same class as `alpha-engine-config-I5208` (daily Think Tank) and `I5758` (weekly `ThinkTankCoverage`): long-running work parked on Lambda, where the ceiling is a hard wall rather than a tunable.

## Why narrowing the scope is NOT the fix

Unlike the RAG corpus (`alpha-engine-config-I5700`, where the fetch set should have been the decision set all along), this stage's per-ticker output feeds **seven registered feature-store columns** in the `alternative` family — `earnings_surprise_pct`, `days_since_earnings`, `eps_revision_4w`, `revision_streak`, `put_call_ratio`, `iv_rank`, `iv_vs_rv` (`features/registry.py::CATALOG`, all `consumers='predictor'`) — for the **whole ArcticDB universe**. A ticker with no alt data gets `0.0`, indistinguishable from a real zero.

It legitimately needs the universe. It needed different compute.

## Change

**`infrastructure/spot_data_weekly.sh`** — a `--phase2-only` mode mirroring `--rag-only`: self-contained workload, its own `data-phase2` heartbeat, S3 log upload on every exit path (this phase logs one line per ticker for ~900 tickers, so SSM's 24KB inline cap is guaranteed to truncate). No secret pre-fetch block: every provider key resolves through `nousergon_lib.secrets.get_secret` under the box's instance role.

Budget chain, printed in the run banner so a timeout says which link fired:

```
3600  workload run_ssm timeout       (~1.8x the measured 2000s floor)
4200  MAX_RUNTIME_SECONDS watchdog   (spot-side shutdown backstop)
5400  SF executionTimeout            (launch + bootstrap + workload)
5460  SF DataPhase2 TimeoutSeconds
```

**`infrastructure/step_function.json`** — `DataPhase2` becomes `ssm:sendCommand` plus a **bounded** poll quartet (216 polls × 30s), carrying the config#2279 gold 4+2 retry ladder like every other spot stage. `alpha-engine-config-I5687` found all 15 existing poll loops unbounded and liveness-blind; this one ships with its budget rather than becoming the 16th. Budget exhaustion falls to `DataPhase2RetryGate` → `PublishResearchFailureImmediate`, never to `CheckSkipEvalJudge` — an exhausted bound converging on the success path would render a timed-out collection as a completed one.

**Friday shell-run dry path moves with the stage** — out of `_DRY_LAMBDA_STATES` (where it was `dry_run.$` → `$.data_phase2_dry`) and into the spot table, routed by the same `States.Format($.preflight_args)` suffix every other spot stage uses. This is a *stronger* guarantee than the flag it replaces: `--preflight-only` exits `weekly_collector.py` immediately after `DataPreflight("phase2")` and strictly before `run_weekly()`, the sole function in that module performing any collector fetch or S3 write. The heartbeat is deliberately **not** emitted on that path — a preflight is not a completed collection.

**`infrastructure/sf_budgets.py`** — a `DataPhase2` entry whose `per_ticker_cost_seconds` is **measured** (2.2) rather than estimated, the only such entry in the table. It makes the growth headroom explicit: ~2045 tickers before this budget binds.

**No `spot-orphan-reaper` `WATCH_KINDS` row**, deliberately. This box is the same class as `DataPhase1`'s and `RAGIngestion`'s — bounded by the systemd watchdog armed in the bootstrap step and by the dispatcher's cleanup trap — and neither sibling carries one. The reaper's four rows cover box classes with no dispatcher holding them (ci-watch, sf-watch, alert-drain, thinktank). A fifth here would introduce a mechanism this stage's siblings do not use.

**Stale guidance corrected** — `tests/test_pipeline_status_registry_source_check.py`'s failure message told the reader to "bump the lib version" inside a nousergon-lib PR. `version-bump-check.yml` has forbidden exactly that since `config-I2716`; `auto-version-bump.yml` is the single version writer. The message now names the real procedure.

## Cross-repo

One PR per repo. **Merge order: `nousergon-lib-PR278` first, then this PR.**

`nousergon-lib-PR278` adds `WAIT_GROUPING["WaitForDataPhase2"] = "DataPhase2"`. This PR pins `v0.124.27` — the version that merge produces — across all 28 lockstep sites (`requirements.txt`, `Dockerfile`, `requirements-daily-news.txt`, `deploy-infrastructure.yml`, and 24 Lambda requirement files), enforced by `tests/test_lib_pin_lockstep.py`.

**This PR's `test` check will be red until PR278 is merged and tagged.** That is the lockstep working, not a defect. If another lib PR merges first, `v0.124.27` will be someone else's tag and the registry test stays red — loudly, not silently.

Deployment needs no post-merge step: `deploy-infrastructure.yml` runs `update-state-machine` on every push to `main`.

## Test plan

```
pytest tests/test_data_phase2_spot_budget_wiring.py -q         9 passed
pytest tests/ -q                        4031 passed, 8 skipped, 2 failed
```

The 2 failures are `test_pipeline_status_registry_source_check.py`, the cross-repo lockstep above. Proven to be exactly that and nothing else:

```
PYTHONPATH=<nousergon-lib PR278 worktree>/src pytest tests/test_pipeline_status_registry_source_check.py -q
7 passed
```

`bash -n` and `shellcheck --severity=error` clean on `spot_data_weekly.sh`.

New coverage — `tests/test_data_phase2_spot_budget_wiring.py`: the budget chain is strictly ordered across all three files; the shell constant and the SF agree; the stage budget matches the SF; the workload budget clears the measured serial floor with ≥1.5× headroom and covers ≥1600 tickers; the poll bound outlasts the executionTimeout; `--preflight-only` reaches the collector; the preflight path emits no heartbeat. Plus `test_data_phase2_poll_loop_is_bounded` in the parallel-wiring suite.

Rehearsal-path: `run_weekly_offcycle.sh` — the Friday shell-run exercises this exact definition path with `preflight_args=" --preflight-only"`, which now reaches `weekly_collector.py --phase 2 --preflight-only` on the real spot.

Closes nousergon/alpha-engine-config#5759

**Related:** `alpha-engine-data-PR1185` (the read side of this same partition — the reader capped at 200 objects) · `alpha-engine-config-I5809` (the scope question this settles) · `alpha-engine-config-I5813` (whether the collector Lambda still has a live invoker)

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
