### PR TITLE
fix(scheduler): scope the post-deploy assertion to its own dispatcher (I5805 follow-up)

### DIFF
--- a/.github/workflows/deploy-scheduled-groom-dispatcher.yml
+++ b/.github/workflows/deploy-scheduled-groom-dispatcher.yml
@@ -110,9 +110,17 @@ jobs:
       # ENABLED, after this workflow runs — a deploy that reports success while
       # a schedule is missing is the failure mode this whole change exists to
       # remove, and it is exactly what a green run looked like on 2026-07-30.
+      #
+      # --source scopes it to THIS dispatcher's rules. The unscoped run belongs
+      # to the daily sweep in sf-arn-drift-check.yml: this deploy cannot create
+      # expense-collector's schedules, and failing it on their absence would
+      # make a correct deploy red forever. Those three are tracked as
+      # alpha-engine-config-I5815.
       - name: Assert every declared schedule exists live
         working-directory: alpha-engine-data
-        run: python3 infrastructure/scheduler/check-schedule-drift.py
+        run: |
+          python3 infrastructure/scheduler/check-schedule-drift.py \
+            --source infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
 
       - name: Append to system-wide deploy changelog
         if: always()

--- a/infrastructure/scheduler/check-schedule-drift.py
+++ b/infrastructure/scheduler/check-schedule-drift.py
@@ -38,10 +38,21 @@ Drift cases (all exit non-zero):
   * ``source-error``      — the arrays in a deploy.sh do not pair up (a name
                             with no cron, or vice versa). The script is broken.
 
+**Scope matters.** A deploy workflow must pass ``--source`` naming its own
+deploy.sh, so it asserts only rules it can itself create. The unscoped run is
+for the daily sweep, which owns no deploy and is therefore free to fail on
+anything. Getting this backwards makes a correct deploy red forever on a
+sibling's defect, and a check that is always red is a check nobody reads. The
+first version of this script did exactly that: the groom deploy went red on
+three missing rules belonging to expense-collector and
+sf-watch-reclaim-sweep-handler (real defects, tracked as
+alpha-engine-config-I5815 — but not ones the groom deploy can fix).
+
 Usage:
-  ./infrastructure/scheduler/check-schedule-drift.py             # every discovered rule
-  ./infrastructure/scheduler/check-schedule-drift.py --rule NAME # one rule
-  ./infrastructure/scheduler/check-schedule-drift.py --json      # machine-readable
+  ./infrastructure/scheduler/check-schedule-drift.py                # every discovered rule
+  ./infrastructure/scheduler/check-schedule-drift.py --source PATH  # one deploy.sh
+  ./infrastructure/scheduler/check-schedule-drift.py --rule NAME    # one rule
+  ./infrastructure/scheduler/check-schedule-drift.py --json         # machine-readable
 
 Requires AWS creds with ``scheduler:GetSchedule`` and ``scheduler:ListSchedules``.
 In CI this runs twice, under two different identities and for two different
@@ -203,8 +214,30 @@ def _live_names_under(prefix: str) -> list[str]:
     return out.split() if out else []
 
 
-def check(rule_filter: str | None = None) -> tuple[list[dict], int]:
+def check(
+    rule_filter: str | None = None, source_filter: str | None = None
+) -> tuple[list[dict], int]:
     rules, findings, prefixes = discover_codified_rules()
+
+    if source_filter:
+        # Scope to one dispatcher. A deploy workflow may only assert the rules
+        # it is itself responsible for: the groom deploy cannot create
+        # expense-collector's schedules, so failing it on their absence turns a
+        # correct deploy red forever and trains everyone to ignore the check.
+        # Fleet-wide coverage belongs to the daily sweep, which owns no deploy.
+        rules = [r for r in rules if r["source_file"] == source_filter]
+        findings = [f for f in findings if f.get("source_file") == source_filter]
+        if not rules:
+            print(
+                f"No codified rules found in {source_filter!r} — check the path",
+                file=sys.stderr,
+            )
+            return findings, 0
+        # Prefix-scoped orphan detection is meaningless under a source filter:
+        # a prefix can be shared, and the filtered rule set is not the full
+        # denominator. Skip it rather than report every sibling as orphaned.
+        prefixes = set()
+
     if rule_filter:
         rules = [r for r in rules if r["name"] == rule_filter]
         if not rules:
@@ -256,11 +289,18 @@ def check(rule_filter: str | None = None) -> tuple[list[dict], int]:
 def main() -> int:
     ap = argparse.ArgumentParser(description="EventBridge Scheduler drift check")
     ap.add_argument("--rule", help="check a single rule by name")
+    ap.add_argument(
+        "--source",
+        help=(
+            "scope to one deploy.sh (repo-relative path). Use this in a deploy "
+            "workflow so it asserts only the rules it can itself create."
+        ),
+    )
     ap.add_argument("--json", action="store_true", help="machine-readable output")
     args = ap.parse_args()
 
     try:
-        findings, checked = check(args.rule)
+        findings, checked = check(args.rule, args.source)
     except RuntimeError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -268,7 +308,8 @@ def main() -> int:
     if args.json:
         print(json.dumps({"checked": checked, "findings": findings}, indent=2))
     else:
-        print(f"scheduler drift — {checked} codified rule(s) checked")
+        scope = f" from {args.source}" if args.source else ""
+        print(f"scheduler drift — {checked} codified rule(s) checked{scope}")
         if not findings:
             print(
                 "  ✓ every codified rule exists live, ENABLED, "

--- a/tests/test_scheduler_reconcile_is_ci_runnable.py
+++ b/tests/test_scheduler_reconcile_is_ci_runnable.py
@@ -209,3 +209,52 @@ class TestDriftCheckerSeesEveryDeclaredRule:
         assert errors and errors[0]["kind"] == "source-error", (
             f"unbalanced arrays should produce a source-error, got {errors}"
         )
+
+
+class TestDeployAssertionIsScopedToItsOwnDispatcher:
+    """A deploy may only assert rules it can itself create.
+
+    alpha-engine-config-I5805 follow-up. The first version of the assertion
+    ran unscoped, so the groom deploy failed on three rules belonging to
+    `expense-collector` and `sf-watch-reclaim-sweep-handler` — real defects, but
+    ones this workflow has no power to fix. A deploy gate that cannot be made
+    green by the deploy is a gate everyone learns to ignore.
+    """
+
+    GROOM_DEPLOY_SH = (
+        "infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh"
+    )
+
+    def test_deploy_workflow_scopes_the_assertion(self):
+        wf = WORKFLOW.read_text(encoding="utf-8")
+        assert f"--source {self.GROOM_DEPLOY_SH}" in wf, (
+            "the post-deploy assertion must pass --source naming this "
+            "dispatcher's deploy.sh; unscoped belongs to the daily sweep only"
+        )
+
+    def test_daily_sweep_stays_unscoped(self):
+        """Fleet-wide coverage has to live somewhere, and it is the sweep."""
+        sweep = (
+            REPO_ROOT / ".github" / "workflows" / "sf-arn-drift-check.yml"
+        ).read_text(encoding="utf-8")
+        assert "check-schedule-drift.py" in sweep
+        assert "--source" not in sweep.split("check-schedule-drift.py")[1][:200], (
+            "sf-arn-drift-check.yml must run the checker UNSCOPED — it owns no "
+            "deploy, so it is the only place a sibling dispatcher's missing "
+            "schedule can surface"
+        )
+
+    def test_source_filter_selects_only_that_dispatcher(self):
+        checker = _load_checker()
+        rules, _, _ = checker.discover_codified_rules()
+        scoped = [r for r in rules if r["source_file"] == self.GROOM_DEPLOY_SH]
+        assert scoped, "no rules discovered for the groom dispatcher"
+        assert len(scoped) < len(rules), (
+            "the groom dispatcher should own a strict subset of fleet rules — "
+            "if it owns all of them the scoping test proves nothing"
+        )
+        # The 8 this dispatcher owns: 4 groom + 3 sweep + 1 reconciler.
+        assert len(scoped) == 8, (
+            f"expected 8 rules for the groom dispatcher, found {len(scoped)}: "
+            f"{sorted(r['name'] for r in scoped)}"
+        )


### PR DESCRIPTION
The assertion added in #1184 ran unscoped. Its first live run did exactly what
it was built to do — 14 rules checked, the three new alpha-engine-groom-sweep-*
confirmed live and ENABLED — and then failed the deploy on three OTHER rules:

  missing-in-aws  alpha-engine-expense-collector-reconcile-monthly
  missing-in-aws  alpha-engine-sf-watch-reclaim-sweep-0645-daily
  missing-in-aws  alpha-engine-sf-watch-reclaim-sweep-1445-daily

Those are real, and they are the same I5805 defect in two more dispatchers
whose deploys also run deploy.sh flagless — filed as alpha-engine-config-I5815,
including that the reclaim sweep has therefore never fired on a cadence.

But the groom deploy cannot create them. A gate that the deploy has no power to
turn green is a gate that goes permanently red and then gets ignored, which
would cost more than the three missing rules do. Ownership has to match
authority: the deploy asserts what it deploys, the daily sweep asserts the
fleet.

  deploy-scheduled-groom-dispatcher.yml   --source <its own deploy.sh>   8 rules
  sf-arn-drift-check.yml                  unscoped                      14 rules

--source also suppresses prefix-scoped orphan detection, which is meaningless
under a filter: the filtered set is not the full denominator, so every sibling
under a shared prefix would report as orphaned.

Three tests assert the split stays right, including that sf-arn-drift-check.yml
stays UNSCOPED — if both callers were scoped, no surface would ever report a
sibling dispatcher's missing schedule, and I5815 would have stayed invisible.

Also corrects three comments that cited alpha-engine-config-I5811 for these
findings. 5811 is an unrelated open P0; the correct reference is I5815.

4029 passed, 8 skipped.

Refs: alpha-engine-config-I5805, alpha-engine-config-I5815

---

**Test plan (run before opening):** `pytest tests/ -q -p no:randomly` in the repo `.venv` on pinned `nousergon-lib` v0.124.26 → **4032 passed, 8 skipped, 0 failed**.

**Verified live:** `nousergon-data` deploy run [30603122173](https://github.com/nousergon/nousergon-data/actions/runs/30603122173) confirms the I5805 fix landed — `alpha-engine-groom-sweep-{0000,0800,1600}-daily` all returned ARNs from `create-schedule` and appear in no drift finding, i.e. live, ENABLED, expressions matching.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)