### PR TITLE
[P1/mid] fix(expenses): price Neon from invoice-aligned v2 metrics — compute + storage were reported as unpriceable

### DIFF
--- a/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
+++ b/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
@@ -28,7 +28,7 @@
     "neon": {
       "label": "Neon Postgres",
       "monthly_budget_usd": 15.0,
-      "note": "mtd_cost_usd is computed from data-transfer overage only (500 GB/mo free egress, then $0.10/GB — neon.com/pricing, verified 2026-07-17); compute ($0.106/CU-hour) and storage ($0.35/GB-month) render unknown in detail.cost_components_unavailable because the project detail API exposes no CU-size or current-storage-size field to price them from (config#2913). No fixed_monthly_usd is set — if a manually-confirmed paid-plan invoice needs to override this estimate, set fixed_monthly_usd and replace this note."
+      "note": "mtd_cost_usd is the real bill: compute (CU-hours x $0.106), storage (GB-months x $0.35), public egress above the per-project 500 GB allowance (x $0.10/GB) and extra branches, all read from Neon's invoice-aligned consumption-history v2 metrics (available on Launch; only the v1 endpoints are Scale-gated). Launch has NO flat monthly fee — do NOT set fixed_monthly_usd here: the neon adapter deliberately ignores it and reports it as detail.fixed_monthly_usd_ignored, because a hardcoded figure outranking a measured one is the config#2913 defect."
     },
     "github_org": {
       "label": "GitHub (nousergon org)",

--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -21,9 +21,15 @@ Providers collected per run (adapter registry, one row each):
                        (``expenses/baselines/{YYYY-MM}.json``).
   - **deepseek**       ``/user/balance`` prepaid balance, diffed the same way
                        (top-ups make the diff conservative; noted on the row).
-  - **neon**           ``/api/v2/consumption_history/account`` — data-transfer
-                       GB vs the ``/alpha-engine/NEON_DATA_TRANSFER_QUOTA_GB``
-                       quota (free plan ⇒ $0 unless budgets say otherwise).
+  - **neon**           ``/api/v2/consumption_history/v2/projects`` — the
+                       invoice-aligned metrics Neon bills from
+                       (``compute_unit_seconds``, the four ``*_bytes_month``
+                       storage metrics, ``public_network_transfer_bytes``,
+                       ``extra_branches_month``), priced per project and
+                       summed: a real bill, not an estimate. Falls back to the
+                       per-project detail counters on plans where the v2
+                       endpoint is unreachable (Free), where the bill is $0 and
+                       the transfer quota is the binding constraint.
   - **github (org+user)** enhanced billing usage endpoint per account
                        (nousergon org + cipher813 user): billed $ across all
                        products + Actions minutes vs included quota (legacy
@@ -93,6 +99,7 @@ import json
 import logging
 import os
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
 
@@ -551,132 +558,266 @@ def _diff_row(row: dict, mw: dict, budgets: dict, key: str, counter_now: float,
 
 NEON_TRANSFER_FREE_GB = 500.0
 NEON_TRANSFER_OVERAGE_USD_PER_GB = 0.10
-# Neon Launch plan pricing (neon.com/pricing, verified live 2026-07-17): no
-# flat monthly fee ("pay for what you use, no monthly minimum"). Compute
-# $0.106/CU-hour and storage $0.35/GB-month are BOTH left unknown below — the
-# per-project detail object (the only endpoint this free/Launch-plan API key
-# can reach; ``consumption_history`` is Scale-plan-only, 403/404 confirmed
-# live) exposes ``compute_time_seconds`` (wall-clock active-compute seconds,
-# NOT CU-scaled — no CU-size/vCPU field is returned anywhere in this response
-# to convert it into CU-hours) and ``written_data_bytes`` (a cumulative WRITE
-# counter, not a point-in-time storage size — no ``logical_size_bytes`` or
-# equivalent current-size field is present either). Fabricating a $ figure
-# from either would be a guess dressed up as a bill; both render `None` with
-# the gap named in ``detail.cost_components_unavailable`` instead.
-NEON_COMPUTE_USD_PER_CU_HOUR = 0.106  # documented for when a CU-size field
-NEON_STORAGE_USD_PER_GB_MONTH = 0.35  # ever becomes available; unused today.
+# Neon Launch plan pricing (neon.com/pricing, verified live 2026-07-17 and
+# re-verified 2026-07-31): no flat monthly fee ("pay for what you use, no
+# monthly minimum").
+NEON_COMPUTE_USD_PER_CU_HOUR = 0.106
+NEON_STORAGE_USD_PER_GB_MONTH = 0.35
+NEON_EXTRA_BRANCH_USD_PER_MONTH = 1.50
+
+# The consumption-history **v2** endpoints ARE available on Launch (verified
+# live 2026-07-31 against both fleet projects) — only the v1
+# ``/consumption_history/account`` family is Scale-plan-only, which is what
+# this adapter previously probed before concluding compute and storage were
+# unpriceable (config#2913's residue). v2 returns the metrics Neon states
+# "align with usage-based billing and match your invoice"
+# (neon.com/docs/guides/consumption-metrics), so every line item on the row
+# below is a real charge, not an estimate.
+NEON_CONSUMPTION_V2_URL = "https://console.neon.tech/api/v2/consumption_history/v2/projects"
+NEON_COMPUTE_METRIC = "compute_unit_seconds"
+NEON_TRANSFER_METRIC = "public_network_transfer_bytes"
+NEON_BRANCHES_METRIC = "extra_branches_month"
+# Storage is billed as the SUM of four separate metrics; a project missing one
+# (no snapshots, no child branches) simply omits it from the response.
+NEON_STORAGE_METRICS = ("root_branch_bytes_month", "child_branch_bytes_month",
+                        "instant_restore_bytes_month", "snapshot_storage_bytes_month")
+NEON_V2_METRICS = (NEON_COMPUTE_METRIC, NEON_TRANSFER_METRIC, NEON_BRANCHES_METRIC,
+                   *NEON_STORAGE_METRICS)
+# Unit conversions, both magnitude-verified against live values 2026-07-31:
+#   compute_unit_seconds → CU-hours: / 3600 (CPU time already weighted by
+#     compute size — it is NOT wall-clock ``active_time_seconds``; the two
+#     differ by the average CU size, measured 43277 vs 128088 on the RAG
+#     project, i.e. ~0.34 CU).
+#   *_bytes_month → GB-months: / 1e9. Cross-checked on metron-prod, which
+#     existed for 5 of the period's 30 days at ~36 MB: root_branch_bytes_month
+#     6_264_182 / 1e9 = 0.0063 GB-month ≈ 0.036 GB × (5/30). A byte-HOURS
+#     reading (the wording used elsewhere in Neon's docs) would be off by 744x
+#     and is ruled out by that check.
+NEON_CU_SECONDS_PER_HOUR = 3600.0
+NEON_BYTES_MONTH_PER_GB_MONTH = 1e9
+_NEON_PRICING_NOTE = {
+    "consumption_history_v2":
+        "compute + storage + egress + branches priced from Neon's "
+        "invoice-aligned consumption metrics (a bill, not an estimate)",
+    "projects_api_fallback":
+        "consumption-history v2 unreachable on this plan — $ covers "
+        "data-transfer overage only; see detail.consumption_v2_error",
+}
+
+
+def _neon_rfc3339(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def neon_consumption_v2(headers: dict, org_id: str, start: datetime,
+                        end: datetime) -> dict[str, dict[str, float]]:
+    """``{project_id: {metric_name: total}}`` over ``[start, end)`` from the
+    invoice-aligned v2 endpoint. Every period bucket in the window is summed,
+    so a plan change mid-window (which opens a new ``period_id``) is included
+    rather than silently dropping one side of it."""
+    url = NEON_CONSUMPTION_V2_URL + "?" + urllib.parse.urlencode({
+        "from": _neon_rfc3339(start), "to": _neon_rfc3339(end),
+        "granularity": "monthly", "org_id": org_id,
+        "metrics": ",".join(NEON_V2_METRICS)})
+    doc = _http_json(url, headers)
+    out: dict[str, dict[str, float]] = {}
+    for proj in doc.get("projects", []):
+        bucket = out.setdefault(proj.get("project_id") or "unknown", {})
+        for period in proj.get("periods", []):
+            for frame in period.get("consumption", []):
+                for metric in frame.get("metrics", []):
+                    value = metric.get("value")
+                    if isinstance(value, (int, float)):
+                        name = metric.get("metric_name")
+                        bucket[name] = bucket.get(name, 0.0) + float(value)
+    return out
+
+
+def price_neon_project(metrics: dict[str, float]) -> dict:
+    """Price ONE project's invoice-aligned metric bundle (pure — unit-tested).
+
+    The 500 GB public-egress allowance is per PROJECT (neon.com/pricing):
+    applying it to a fleet-wide sum would hide one project's overage behind
+    another's headroom, which is the same shape as the 2026-07-16 lockout
+    (one workload's burst invisible inside a shared counter)."""
+    compute_cu_hours = metrics.get(NEON_COMPUTE_METRIC, 0.0) / NEON_CU_SECONDS_PER_HOUR
+    storage_gb_month = sum(metrics.get(m, 0.0) for m in NEON_STORAGE_METRICS
+                           ) / NEON_BYTES_MONTH_PER_GB_MONTH
+    transfer_gb = metrics.get(NEON_TRANSFER_METRIC, 0.0) / 1e9
+    extra_branch_months = metrics.get(NEON_BRANCHES_METRIC, 0.0)
+    compute_usd = compute_cu_hours * NEON_COMPUTE_USD_PER_CU_HOUR
+    storage_usd = storage_gb_month * NEON_STORAGE_USD_PER_GB_MONTH
+    transfer_usd = (max(0.0, transfer_gb - NEON_TRANSFER_FREE_GB)
+                    * NEON_TRANSFER_OVERAGE_USD_PER_GB)
+    branches_usd = extra_branch_months * NEON_EXTRA_BRANCH_USD_PER_MONTH
+    return {
+        "compute_cu_hours": round(compute_cu_hours, 3),
+        "compute_cost_usd": round(compute_usd, 4),
+        "storage_gb_month": round(storage_gb_month, 4),
+        "storage_cost_usd": round(storage_usd, 4),
+        "data_transfer_gb": round(transfer_gb, 3),
+        "data_transfer_cost_usd": round(transfer_usd, 4),
+        "extra_branch_months": round(extra_branch_months, 3),
+        "extra_branches_cost_usd": round(branches_usd, 4),
+        "total_cost_usd": round(compute_usd + storage_usd + transfer_usd + branches_usd, 4),
+    }
 
 
 def collect_neon(mw: dict, budgets: dict, secrets: dict) -> dict:
-    """Free-tier-compatible consumption read: the ``consumption_history``
-    endpoints are Scale-plan-only (verified 403/404 live, 2026-07-17), but the
-    per-project detail object carries current-consumption-period counters
-    (``data_transfer_bytes``, ``compute_time_seconds``, …) plus the period
-    bounds on every plan — sum across projects and pace against the period.
-    Only the data-transfer line is actually computable in $ from those
-    counters (see ``NEON_COMPUTE_USD_PER_CU_HOUR`` docstring above for why
-    compute + storage are NOT): a real partial bill, not a fabricated flat
-    fee, unless the operator sets an explicit ``fixed_monthly_usd`` override
-    (e.g. a manually-confirmed paid-plan invoice) in the budgets SSoT."""
-    row = _row("neon", "Neon Postgres", source="projects_api")
+    """Real Neon bill from the invoice-aligned consumption-history v2 metrics.
+
+    Every billed component — compute (CU-hours), storage (the four
+    ``*_bytes_month`` metrics), public egress above the per-project 500 GB
+    allowance, extra branches — is priced from the metrics Neon states match
+    the invoice, per project, and summed. This supersedes the transfer-only
+    estimate that preceded it: the v1 ``consumption_history`` endpoints ARE
+    Scale-plan-only (that part of config#2913 held), but the **v2** endpoints
+    are available on Launch, which is where compute and storage were hiding.
+
+    The project-detail counters are still read for project names, the
+    consumption-period bounds (Neon's period is NOT calendar-aligned — a plan
+    change opens a fresh one) and the free-plan-fit transfer quota signal, and
+    they are the fallback pricing source on plans where v2 is unreachable
+    (Free), where the bill is $0 by construction and the quota — not $ — is
+    the binding constraint.
+
+    ``fixed_monthly_usd`` is deliberately NOT honored for this provider: the
+    override exists for providers with no usable cost API, and a hardcoded
+    figure silently outranking a real measurement is exactly the defect
+    config#2913 was filed for (it shipped as $19/mo against a real ~$4/mo).
+    A configured value is reported in ``detail.fixed_monthly_usd_ignored`` so
+    the stale config is visible on the page rather than merely inert."""
+    row = _row("neon", "Neon Postgres", source="consumption_history_v2")
     if SSM_NEON not in secrets:
         row.update(status="not_configured", error=f"SSM {SSM_NEON} missing")
         return row
     headers = {"Authorization": f"Bearer {secrets[SSM_NEON]}", "Accept": "application/json"}
     listing = _http_json("https://console.neon.tech/api/v2/projects", headers)
-    sums: dict[str, float] = {}
+
+    projects: list[dict] = []
+    org_ids: list[str] = []
     period_start = period_end = None
-    project_names = []
     for proj in listing.get("projects", []):
         detail = _http_json(
             f"https://console.neon.tech/api/v2/projects/{proj['id']}", headers)
         p = detail.get("project", {})
-        project_names.append(p.get("name", proj["id"]))
-        for k in ("data_transfer_bytes", "compute_time_seconds",
-                  "active_time_seconds", "written_data_bytes"):
-            if isinstance(p.get(k), (int, float)):
-                sums[k] = sums.get(k, 0.0) + float(p[k])
+        org_id = p.get("org_id") or proj.get("org_id")
+        if org_id and org_id not in org_ids:
+            org_ids.append(org_id)
+        transfer_bytes = (float(p["data_transfer_bytes"])
+                          if isinstance(p.get("data_transfer_bytes"), (int, float)) else 0.0)
+        projects.append({"id": proj["id"], "name": p.get("name", proj["id"]),
+                         "org_id": org_id, "transfer_bytes": transfer_bytes})
         period_start = period_start or p.get("consumption_period_start")
         period_end = period_end or p.get("consumption_period_end")
-    transfer_gb = sums.get("data_transfer_bytes", 0.0) / 1e9
+
+    # Bill window = the WHOLE calendar month, not month-to-date: at monthly
+    # granularity Neon truncates both bounds to month boundaries, so a `to` of
+    # "now" collapses onto `from` and the request 400s with "'from' must be
+    # before 'to'" (hit live 2026-07-31). The response only ever contains
+    # consumption that has actually happened, so asking for the full month
+    # returns MTD.
+    window_end = mw["start"] + timedelta(seconds=mw["total_seconds"])
+    metrics_by_project: dict[str, dict[str, float]] = {}
+    pricing_source = "consumption_history_v2"
+    v2_error = None
+    for org_id in org_ids:
+        try:
+            metrics_by_project.update(
+                neon_consumption_v2(headers, org_id, mw["start"], window_end))
+        except RuntimeError as exc:
+            # Free plan (or a future entitlement change) — the endpoint is
+            # plan-gated. Named on the row, never silently treated as $0 spend.
+            v2_error = str(exc)[:200]
+            pricing_source = "projects_api_fallback"
+            logger.warning("Neon consumption v2 unavailable for org %s: %s", org_id, exc)
+
+    per_project = []
+    priced_bundles: list[dict[str, float]] = []
+    totals = {"compute_cu_hours": 0.0, "compute_cost_usd": 0.0,
+              "storage_gb_month": 0.0, "storage_cost_usd": 0.0,
+              "data_transfer_gb": 0.0, "data_transfer_cost_usd": 0.0,
+              "extra_branch_months": 0.0, "extra_branches_cost_usd": 0.0,
+              "total_cost_usd": 0.0}
+    for proj in projects:
+        # Fallback bundle carries transfer only: on the plans where v2 is
+        # gated (Free) there IS no compute/storage charge, so a $0 line for
+        # each is the true bill, not a silently-dropped component.
+        bundle = metrics_by_project.get(
+            proj["id"], {} if metrics_by_project
+            else {NEON_TRANSFER_METRIC: proj["transfer_bytes"]})
+        priced = price_neon_project(bundle)
+        priced_bundles.append(bundle)
+        per_project.append({"project": proj["name"], **priced})
+        for k in totals:
+            totals[k] = round(totals[k] + priced[k], 4)
+
+    # Transfer GB for the quota signal: the v2 public-transfer metric when we
+    # have it, else the project-detail counter (which is what the free plan
+    # meters against anyway) — both already folded into the totals above.
+    transfer_gb = totals["data_transfer_gb"]
     quota_gb = float(secrets.get(SSM_NEON_QUOTA_GB, 0) or 0) or None
-    # Pace against Neon's OWN consumption period when reported (it can start
-    # mid-calendar-month, e.g. after a plan change), else the calendar month.
-    observed_frac = mw["elapsed_frac"]
+
+    # Two different denominators, deliberately:
+    #   quota_frac — fraction of NEON's consumption period elapsed, for the
+    #     GB-vs-quota projection (the free-plan-fit signal, config-I2790).
+    #   cost_frac  — fraction of the CALENDAR month the measurement covers,
+    #     for the $ projection, since a plan-change period start means the
+    #     month's early days carry no billable data at all.
+    quota_frac = mw["elapsed_frac"]
+    cost_frac = mw["elapsed_frac"]
     if period_start and period_end:
         try:
             ps = datetime.fromisoformat(period_start.replace("Z", "+00:00"))
             pe = datetime.fromisoformat(period_end.replace("Z", "+00:00"))
             total = (pe - ps).total_seconds()
             if total > 0:
-                observed_frac = max((_now_utc() - ps).total_seconds() / total, 0.0)
+                quota_frac = max((_now_utc() - ps).total_seconds() / total, 0.0)
+            covered = (_now_utc() - max(ps, mw["start"])).total_seconds()
+            cost_frac = min(max(covered / mw["total_seconds"], 0.0), mw["elapsed_frac"])
         except ValueError:
             logger.warning("unparseable Neon consumption period: %s → %s",
                            period_start, period_end)
-    projected_gb = None
-    if observed_frac >= MIN_PROJECTION_FRAC:
-        projected_gb = transfer_gb / observed_frac
+    projected_gb = transfer_gb / quota_frac if quota_frac >= MIN_PROJECTION_FRAC else None
 
-    # Data transfer overage is the ONE line item this endpoint can actually
-    # price: 500 GB/mo free egress, then $0.10/GB (neon.com/pricing, verified
-    # live 2026-07-17). Compute and storage are genuinely uncomputable from
-    # the fields this API key can reach — see the module-level constants'
-    # docstring — and MUST surface as unknown, not silently dropped or
-    # counted as $0.
-    transfer_mtd_usd = max(0.0, transfer_gb - NEON_TRANSFER_FREE_GB) * NEON_TRANSFER_OVERAGE_USD_PER_GB
-    transfer_projected_usd = None
-    if observed_frac >= MIN_PROJECTION_FRAC:
-        transfer_projected_usd = (max(0.0, (transfer_gb / observed_frac) - NEON_TRANSFER_FREE_GB)
-                                   * NEON_TRANSFER_OVERAGE_USD_PER_GB)
-    cost_components_unavailable = [
-        {"component": "compute", "unit": "CU-hour", "reason":
-         "compute_time_seconds is wall-clock active-compute time, not "
-         "CU-scaled — the project detail API returns no CU-size/vCPU field "
-         "to convert it into billable CU-hours"},
-        {"component": "storage", "unit": "GB-month", "reason":
-         "written_data_bytes is a cumulative write counter, not a "
-         "point-in-time storage size — the project detail API returns no "
-         "logical_size_bytes (or equivalent current-size) field"},
-    ]
+    # Month-end $ is projected on USAGE and then priced, never by scaling the
+    # dollars: the egress line is a hinge (free below 500 GB/project, $0.10/GB
+    # above), so doubling a $10 overage gives $20 where the real month-end
+    # charge is $70. Compute/storage/branches are linear, so this is exact for
+    # them and correct for transfer.
+    projected_month_end_usd = None
+    if cost_frac >= MIN_PROJECTION_FRAC:
+        scale = 1.0 + (1.0 - mw["elapsed_frac"]) / cost_frac
+        projected_month_end_usd = round(sum(
+            price_neon_project({k: v * scale for k, v in bundle.items()})["total_cost_usd"]
+            for bundle in priced_bundles), 4)
 
     fixed_override = _fixed_usd(budgets, "neon")
-    if fixed_override is not None:
-        # Explicit operator override (e.g. a manually-confirmed paid-plan
-        # invoice) — takes precedence over the computed estimate below, same
-        # as every other provider's fixed_monthly_usd escape hatch.
-        mtd_cost_usd = float(fixed_override)
-        projected_month_end_usd = float(fixed_override)
-    else:
-        mtd_cost_usd = round(transfer_mtd_usd, 4)
-        projected_month_end_usd = (round(transfer_projected_usd, 4)
-                                    if transfer_projected_usd is not None else None)
-
     row.update(
-        mtd_cost_usd=mtd_cost_usd,
+        source=pricing_source,
+        mtd_cost_usd=totals["total_cost_usd"],
         projected_month_end_usd=projected_month_end_usd,
         quota={"unit": "GB data transfer", "used": round(transfer_gb, 3),
                "limit": quota_gb,
                "projected": round(projected_gb, 3) if projected_gb is not None else None},
-        pace=_pace(projected_gb, quota_gb),
-        detail={"projects": project_names,
-                "compute_hours": round(sums.get("compute_time_seconds", 0.0) / 3600, 2),
-                "compute_cost_usd": None,
-                "written_gb": round(sums.get("written_data_bytes", 0.0) / 1e9, 3),
-                "storage_cost_usd": None,
-                "data_transfer_cost_usd": round(transfer_mtd_usd, 4),
+        detail={"projects": [p["name"] for p in projects],
+                "by_project": per_project,
+                **totals,
                 "consumption_period": f"{period_start} → {period_end}",
-                "cost_components_unavailable": (None if fixed_override is not None
-                                                 else cost_components_unavailable)},
-        # Prefer an operator note from the budgets SSoT (e.g. a temporary
-        # paid-plan explanation) so what the operator recorded reaches the page;
-        # fall back to a note that names the estimate's gaps when no override
-        # is configured, so the console never implies this is a full bill.
-        note=_cfg_note(budgets, "neon")
-             or (None if fixed_override is not None else
-                 "estimated from data transfer overage only — compute and "
-                 "storage costs are unknown (see detail.cost_components_unavailable); "
-                 "actual bill will be higher if either is nonzero"),
+                "pricing_source": pricing_source,
+                "consumption_v2_error": v2_error,
+                "fixed_monthly_usd_ignored": fixed_override,
+                # Always present, even when an operator note wins the `note`
+                # field: a stale operator note describing the OLD estimate
+                # must not be the only pricing explanation on the page.
+                "pricing_note": _NEON_PRICING_NOTE[pricing_source]},
+        note=_cfg_note(budgets, "neon") or _NEON_PRICING_NOTE[pricing_source],
     )
+    _finish_usd_row(row, mw, _budget_usd(budgets, "neon"), observed_frac=cost_frac)
+    # Either binding constraint puts the row "over": the $ budget (pace already
+    # set by _finish_usd_row) or the transfer quota that gates the free plan.
+    if _pace(projected_gb, quota_gb) == "over":
+        row["pace"] = "over"
     row["budget_usd"] = _budget_usd(budgets, "neon")
     return row
 
@@ -854,9 +995,9 @@ def fixed_rows(budgets: dict, produced_keys: set[str]) -> list[dict]:
 # month's finalized actual, then diffs it against what the prior month's own
 # ``expenses/monthly/{YYYY-MM}.json`` rollup last recorded — never re-derives
 # a provider's arithmetic from scratch (same anchor-to-provider principle the
-# AWS forecast fix codified). Neon has no closed-period historical read on
-# this API tier (its adapter only ever sees the CURRENT consumption period) —
-# reconciled as "not_available" rather than guessed.
+# AWS forecast fix codified). Neon re-queries its consumption-history v2
+# metrics for the closed month directly (the window is arbitrary, so the
+# final charge is read, not approximated).
 # ---------------------------------------------------------------------------
 
 def _prior_month_window(now: datetime) -> dict:
@@ -962,16 +1103,36 @@ def reconcile_counter_diff(s3, prior_period: str, current_period: str, key: str,
              "month rollover and this run")
 
 
-def reconcile_neon(prior_doc: dict | None) -> dict:
-    """Neon's Launch-plan API exposes only the CURRENT consumption period
-    (``consumption_history`` is Scale-plan-only, 403/404 verified live) —
-    there is no closed-period historical read to re-query, so reconciliation
-    is marked not_available rather than approximated from snapshots (Neon's
-    own period boundaries aren't calendar-month-aligned)."""
+def reconcile_neon(prior_mw: dict, secrets: dict, prior_doc: dict | None) -> dict:
+    """Closed-month true-up from the same invoice-aligned v2 metrics the live
+    row uses — the endpoint accepts an arbitrary historical window (history
+    from 2024-03-01, monthly granularity up to a year back), so the prior
+    month's FINAL charge is a real re-query, not an approximation. Only the
+    v1 endpoints are Scale-plan-gated, which is what previously made this row
+    ``not_available``."""
+    if SSM_NEON not in secrets:
+        return _reconciliation_row("neon", prior_doc, None, status="not_configured",
+                                   note=f"SSM {SSM_NEON} missing")
+    headers = {"Authorization": f"Bearer {secrets[SSM_NEON]}", "Accept": "application/json"}
+    listing = _http_json("https://console.neon.tech/api/v2/projects", headers)
+    org_ids = []
+    for proj in listing.get("projects", []):
+        org_id = proj.get("org_id")
+        if org_id and org_id not in org_ids:
+            org_ids.append(org_id)
+    if not org_ids:
+        return _reconciliation_row("neon", prior_doc, None, status="not_available",
+                                   note="no Neon org id on any project — cannot "
+                                        "query consumption history")
+    total = 0.0
+    for org_id in org_ids:
+        metrics = neon_consumption_v2(headers, org_id, prior_mw["start"], prior_mw["end"])
+        for bundle in metrics.values():
+            total += price_neon_project(bundle)["total_cost_usd"]
     return _reconciliation_row(
-        "neon", prior_doc, None, status="not_available",
-        note="Neon's API exposes only the current consumption period — no "
-             "historical/closed-period endpoint is reachable on this plan")
+        "neon", prior_doc, round(total, 4),
+        note="re-queried from Neon's invoice-aligned consumption metrics for "
+             "the closed month")
 
 
 def reconcile_github(prior_mw: dict, budgets: dict, secrets: dict, *, account: str,
@@ -1016,7 +1177,7 @@ def run_reconciliation(s3, now: datetime, budgets: dict, secrets: dict) -> dict:
     fenced("deepseek", lambda: reconcile_counter_diff(
         s3, prior_mw["period"], now.strftime("%Y-%m"), "deepseek",
         "deepseek_neg_balance", prior_doc))
-    fenced("neon", lambda: reconcile_neon(prior_doc))
+    fenced("neon", lambda: reconcile_neon(prior_mw, secrets, prior_doc))
     fenced("github_org", lambda: reconcile_github(
         prior_mw, budgets, secrets, account=GITHUB_ORG, kind="org", prior_doc=prior_doc))
     fenced("github_user", lambda: reconcile_github(

--- a/infrastructure/lambdas/expense-collector/test_handler.py
+++ b/infrastructure/lambdas/expense-collector/test_handler.py
@@ -223,96 +223,192 @@ class TestDiffRow:
         assert row["mtd_cost_usd"] == 0.0  # top-up mid-month, never negative
 
 
+def neon_v2_doc(*projects: tuple[str, dict]) -> dict:
+    """Shape of a ``consumption_history/v2/projects`` response."""
+    return {"projects": [
+        {"project_id": pid, "periods": [{"period_id": "per-1", "period_plan": "launch",
+          "period_start": "2026-07-01T00:00:00Z",
+          "consumption": [{"timeframe_start": "2026-07-01T00:00:00Z",
+                           "timeframe_end": "2026-08-01T00:00:00Z",
+                           "metrics": [{"metric_name": k, "value": v}
+                                       for k, v in metrics.items()]}]}]}
+        for pid, metrics in projects]}
+
+
+def neon_routes(*, v2: dict | Exception, projects: dict | None = None) -> dict:
+    """Route table with the v2 consumption endpoint FIRST (its URL does not
+    contain ``/api/v2/projects``, but ordering keeps the intent obvious)."""
+    default = {"project": {
+        "name": "nousergon-rag", "org_id": "org-1",
+        "data_transfer_bytes": 8_000_000,
+        "consumption_period_start": "2026-07-01T00:00:00Z",
+        "consumption_period_end": "2026-08-01T00:00:00Z"}}
+    return {
+        "/consumption_history/v2/projects": v2,
+        "/api/v2/projects/p1": projects or default,
+        "/api/v2/projects": {"projects": [{"id": "p1", "org_id": "org-1"}]},
+    }
+
+
+class TestNeonPricing:
+    """``price_neon_project`` is the whole bill in one pure function — the
+    unit conversions were magnitude-verified against the live account
+    2026-07-31 (see the constants' comment in index.py)."""
+
+    def test_live_verified_conversions(self):
+        priced = index.price_neon_project({
+            "compute_unit_seconds": 43_277,          # → 12.021 CU-h
+            "root_branch_bytes_month": 1_059_273_298,  # → 1.0593 GB-month
+            "instant_restore_bytes_month": 34_025_675,  # → 0.0340 GB-month
+            "public_network_transfer_bytes": 421_855_072,  # 0.42 GB, inside 500
+        })
+        assert priced["compute_cu_hours"] == pytest.approx(12.021, abs=1e-3)
+        assert priced["compute_cost_usd"] == pytest.approx(12.021 * 0.106, abs=1e-3)
+        assert priced["storage_gb_month"] == pytest.approx(1.0933, abs=1e-3)
+        assert priced["storage_cost_usd"] == pytest.approx(1.0933 * 0.35, abs=1e-3)
+        assert priced["data_transfer_cost_usd"] == 0.0  # inside the allowance
+        assert priced["total_cost_usd"] == pytest.approx(1.6572, abs=2e-3)
+
+    def test_transfer_allowance_is_per_project(self):
+        """500 GB of egress is included PER PROJECT — two projects at 400 GB
+        each are both inside it; summing first would fabricate a 300 GB
+        overage."""
+        each = index.price_neon_project(
+            {"public_network_transfer_bytes": 400_000_000_000})
+        assert each["data_transfer_cost_usd"] == 0.0
+        over = index.price_neon_project(
+            {"public_network_transfer_bytes": 600_000_000_000})
+        assert over["data_transfer_cost_usd"] == pytest.approx(10.0)
+
+    def test_extra_branches_priced(self):
+        priced = index.price_neon_project({"extra_branches_month": 2.0})
+        assert priced["extra_branches_cost_usd"] == pytest.approx(3.0)
+        assert priced["total_cost_usd"] == pytest.approx(3.0)
+
+
 class TestNeonPeriodPacing:
     def test_period_aware_projection(self, monkeypatch):
         """Neon's consumption period can start mid-calendar-month (plan
-        change) — pacing must use ITS bounds, not the calendar month's."""
+        change) — the GB-vs-quota pacing must use ITS bounds, not the calendar
+        month's."""
         monkeypatch.setattr(index, "_now_utc", lambda: NOW)
-        monkeypatch.setattr(index, "_http_json", http_router({
-            "/api/v2/projects/p1": {"project": {
-                "name": "nousergon", "data_transfer_bytes": 2_500_000_000,
-                "compute_time_seconds": 7200,
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=neon_v2_doc(("p1", {"public_network_transfer_bytes": 2_500_000_000})),
+            projects={"project": {
+                "name": "nousergon-rag", "org_id": "org-1",
+                "data_transfer_bytes": 2_500_000_000,
                 # Half the period elapsed at NOW (7/17 12:00): 2.5 GB → 5 GB
                 "consumption_period_start": "2026-07-14T12:00:00Z",
-                "consumption_period_end": "2026-07-20T12:00:00Z"}},
-            "/api/v2/projects": {"projects": [{"id": "p1"}]},
-        }))
-        mw = index._month_window(NOW)
-        row = index.collect_neon(mw, {}, {index.SSM_NEON: "k",
-                                          index.SSM_NEON_QUOTA_GB: "5"})
+                "consumption_period_end": "2026-07-20T12:00:00Z"}})))
+        row = index.collect_neon(index._month_window(NOW), {},
+                                 {index.SSM_NEON: "k", index.SSM_NEON_QUOTA_GB: "5"})
         assert row["quota"]["used"] == pytest.approx(2.5)
         assert row["quota"]["projected"] == pytest.approx(5.0)
         assert row["pace"] is None or row["pace"] == "under"  # 5.0 !> 5 GB
 
-    def test_operator_note_and_fixed_cost_surface(self, monkeypatch):
-        """A budgets note + fixed_monthly_usd (e.g. temporary paid plan) must
-        reach the row — the fixed-cost branch used to blank the note."""
+    def test_compute_and_storage_are_priced_not_unknown(self, monkeypatch):
+        """The whole point of config#2913's follow-up: compute and storage are
+        REAL line items read from the invoice-aligned v2 metrics, not `None`
+        with an excuse. 7200 CU-s = 2 CU-h = $0.212; 2 GB-month = $0.70."""
         monkeypatch.setattr(index, "_now_utc", lambda: NOW)
-        monkeypatch.setattr(index, "_http_json", http_router({
-            "/api/v2/projects/p1": {"project": {"name": "nousergon",
-                "data_transfer_bytes": 8_000_000,
-                "consumption_period_start": "2026-07-01T00:00:00Z",
-                "consumption_period_end": "2026-08-01T00:00:00Z"}},
-            "/api/v2/projects": {"projects": [{"id": "p1"}]},
-        }))
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=neon_v2_doc(("p1", {"compute_unit_seconds": 7200,
+                                   "root_branch_bytes_month": 2_000_000_000,
+                                   "public_network_transfer_bytes": 8_000_000})))))
+        row = index.collect_neon(index._month_window(NOW), {}, {index.SSM_NEON: "k"})
+        assert row["detail"]["compute_cost_usd"] == pytest.approx(0.212)
+        assert row["detail"]["storage_cost_usd"] == pytest.approx(0.70)
+        assert row["detail"]["data_transfer_cost_usd"] == 0.0
+        assert row["mtd_cost_usd"] == pytest.approx(0.912)
+        assert row["source"] == "consumption_history_v2"
+        assert "cost_components_unavailable" not in row["detail"]
+        assert row["detail"]["by_project"][0]["project"] == "nousergon-rag"
+
+    def test_fixed_override_is_ignored_but_reported(self, monkeypatch):
+        """A stale ``fixed_monthly_usd`` (the $19 that config#2913 found on
+        this row) must NOT outrank a measured bill — it is reported in detail
+        so the stale config is visible, never used as the number."""
+        monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=neon_v2_doc(("p1", {"compute_unit_seconds": 7200})))))
         budgets = {"providers": {"neon": {
             "fixed_monthly_usd": 19.0, "note": "Launch plan — TEMPORARY"}}}
         row = index.collect_neon(index._month_window(NOW), budgets,
                                  {index.SSM_NEON: "k"})
-        assert row["mtd_cost_usd"] == 19.0
-        assert row["projected_month_end_usd"] == 19.0
-        assert row["note"] == "Launch plan — TEMPORARY"
+        assert row["mtd_cost_usd"] == pytest.approx(0.212)
+        assert row["detail"]["fixed_monthly_usd_ignored"] == 19.0
+        assert row["note"] == "Launch plan — TEMPORARY"  # operator note still lands
+        # …but a stale operator note must never be the ONLY pricing story on
+        # the page: the adapter's own explanation is always in detail.
+        assert "invoice-aligned" in row["detail"]["pricing_note"]
 
-    def test_computed_transfer_overage_cost(self, monkeypatch):
-        """No fixed_monthly_usd override configured (config#2913): mtd_cost_usd
-        must be a REAL computed estimate from data-transfer overage — 500 GB/mo
-        free egress, then $0.10/GB (neon.com/pricing, verified 2026-07-17) — not
-        the fabricated flat $19/mo the row used to hard-set regardless of usage.
-        600 GB used, full-month period, NOW at exactly 50% elapsed ⇒ 100 GB
-        overage MTD ($10.00), straight-line-projected usage 1200 GB month-end
-        ⇒ 700 GB overage ($70.00)."""
-        monkeypatch.setattr(index, "_now_utc",
-                            lambda: datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
-        monkeypatch.setattr(index, "_http_json", http_router({
-            "/api/v2/projects/p1": {"project": {
-                "name": "nousergon", "data_transfer_bytes": 600_000_000_000,
-                "compute_time_seconds": 7200, "written_data_bytes": 5_000_000_000,
-                "consumption_period_start": "2026-07-01T00:00:00Z",
-                "consumption_period_end": "2026-08-01T00:00:00Z"}},
-            "/api/v2/projects": {"projects": [{"id": "p1"}]},
-        }))
-        mw = index._month_window(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
-        row = index.collect_neon(mw, {}, {index.SSM_NEON: "k"})
+    def test_transfer_overage_projection(self, monkeypatch):
+        """600 GB used, full-month period, NOW at exactly 50% elapsed ⇒ 100 GB
+        overage MTD ($10.00), straight-line-projected 1200 GB month-end ⇒ 700
+        GB overage ($70.00)."""
+        now = datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(index, "_now_utc", lambda: now)
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=neon_v2_doc(("p1", {"public_network_transfer_bytes": 600_000_000_000})))))
+        row = index.collect_neon(index._month_window(now), {}, {index.SSM_NEON: "k"})
         assert row["mtd_cost_usd"] == pytest.approx(10.0)
         assert row["projected_month_end_usd"] == pytest.approx(70.0)
-        assert row["detail"]["data_transfer_cost_usd"] == pytest.approx(10.0)
 
-    def test_compute_and_storage_surface_as_unknown_not_zero(self, monkeypatch):
-        """Compute (no CU-size field to convert compute_time_seconds into
-        CU-hours) and storage (written_data_bytes is cumulative writes, not a
-        point-in-time size — no logical_size_bytes field) are genuinely
-        uncomputable from this endpoint: they must render None/unknown and be
-        named in detail.cost_components_unavailable, never fabricated as 0 or
-        silently dropped from the row (config#2913 fail-loud discipline)."""
+    def test_v2_unavailable_falls_back_and_says_so(self, monkeypatch):
+        """On a plan where the v2 endpoint is gated (Free), the row must fall
+        back to the transfer counter, NAME the failure, and not pass off a
+        partial figure as the full bill."""
         monkeypatch.setattr(index, "_now_utc", lambda: NOW)
-        monkeypatch.setattr(index, "_http_json", http_router({
-            "/api/v2/projects/p1": {"project": {
-                "name": "nousergon", "data_transfer_bytes": 8_000_000,
-                "compute_time_seconds": 7200, "written_data_bytes": 5_000_000_000,
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=RuntimeError("HTTP 404 from consumption_history/v2: not found"),
+            projects={"project": {
+                "name": "nousergon-rag", "org_id": "org-1",
+                "data_transfer_bytes": 600_000_000_000,
                 "consumption_period_start": "2026-07-01T00:00:00Z",
-                "consumption_period_end": "2026-08-01T00:00:00Z"}},
-            "/api/v2/projects": {"projects": [{"id": "p1"}]},
-        }))
+                "consumption_period_end": "2026-08-01T00:00:00Z"}})))
         row = index.collect_neon(index._month_window(NOW), {}, {index.SSM_NEON: "k"})
-        assert row["detail"]["compute_cost_usd"] is None
-        assert row["detail"]["storage_cost_usd"] is None
-        unavailable = {c["component"] for c in row["detail"]["cost_components_unavailable"]}
-        assert unavailable == {"compute", "storage"}
-        assert "unknown" in row["note"] or "cost_components_unavailable" in row["note"]
-        # Negligible transfer (8 MB, well under the 500 GB free tier) ⇒ the
-        # ONE computable line item is legitimately $0 — distinct from "unknown".
-        assert row["mtd_cost_usd"] == 0.0
-        assert row["detail"]["data_transfer_cost_usd"] == 0.0
+        assert row["source"] == "projects_api_fallback"
+        assert row["detail"]["pricing_source"] == "projects_api_fallback"
+        assert "404" in row["detail"]["consumption_v2_error"]
+        assert "v2 unreachable" in row["note"]
+        assert row["mtd_cost_usd"] == pytest.approx(10.0)  # transfer overage only
+        assert row["quota"]["used"] == pytest.approx(600.0)
+
+    def test_query_window_is_month_aligned(self, monkeypatch):
+        """At monthly granularity Neon truncates BOTH bounds to month
+        boundaries — a `to` of "now" collapses onto `from` and the request
+        400s ("'from' must be before 'to'", hit live 2026-07-31). The window
+        must span the whole calendar month."""
+        seen = {}
+
+        def _fake_http(url, headers=None):
+            if "/consumption_history/v2/projects" in url:
+                seen["url"] = url
+                return neon_v2_doc(("p1", {"compute_unit_seconds": 3600}))
+            if "/api/v2/projects/p1" in url:
+                return {"project": {"name": "nousergon-rag", "org_id": "org-1",
+                                    "data_transfer_bytes": 0,
+                                    "consumption_period_start": "2026-07-01T00:00:00Z",
+                                    "consumption_period_end": "2026-08-01T00:00:00Z"}}
+            return {"projects": [{"id": "p1", "org_id": "org-1"}]}
+
+        monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+        monkeypatch.setattr(index, "_http_json", _fake_http)
+        index.collect_neon(index._month_window(NOW), {}, {index.SSM_NEON: "k"})
+        assert "from=2026-07-01T00%3A00%3A00Z" in seen["url"]
+        assert "to=2026-08-01T00%3A00%3A00Z" in seen["url"]
+
+    def test_cost_and_quota_pace_both_bind(self, monkeypatch):
+        """Over the $ budget with transfer nowhere near the quota still paces
+        over — and vice versa (the free-plan quota is the other constraint)."""
+        monkeypatch.setattr(index, "_now_utc", lambda: NOW)
+        monkeypatch.setattr(index, "_http_json", http_router(neon_routes(
+            v2=neon_v2_doc(("p1", {"compute_unit_seconds": 200_000})))))  # 55.6 CU-h
+        row = index.collect_neon(index._month_window(NOW),
+                                 {"providers": {"neon": {"monthly_budget_usd": 2.0}}},
+                                 {index.SSM_NEON: "k", index.SSM_NEON_QUOTA_GB: "5000"})
+        assert row["mtd_cost_usd"] > 2.0
+        assert row["pace"] == "over"
 
 
 class TestFixedRows:
@@ -373,12 +469,17 @@ def env(monkeypatch):
             "data": {"total_credits": 50.0, "total_usage": 42.5}},
         "api.deepseek.com/user/balance": {
             "balance_infos": [{"currency": "USD", "total_balance": "15.00"}]},
+        "/consumption_history/v2/projects": neon_v2_doc(
+            ("p1", {"public_network_transfer_bytes": 3_000_000_000,
+                    "compute_unit_seconds": 7200,
+                    "root_branch_bytes_month": 500_000_000})),
         "/api/v2/projects/p1": {"project": {
-            "name": "nousergon", "data_transfer_bytes": 3_000_000_000,
+            "name": "nousergon", "org_id": "org-1",
+            "data_transfer_bytes": 3_000_000_000,
             "compute_time_seconds": 7200,
             "consumption_period_start": "2026-07-01T00:00:00Z",
             "consumption_period_end": "2026-08-01T00:00:00Z"}},
-        "/api/v2/projects": {"projects": [{"id": "p1"}]},
+        "/api/v2/projects": {"projects": [{"id": "p1", "org_id": "org-1"}]},
         "organizations/nousergon/settings/billing/usage": {"usageItems": [
             {"product": "Actions", "unitType": "Minutes", "quantity": 1400,
              "netAmount": 0.0, "repositoryName": "alpha-engine-config"},
@@ -468,7 +569,10 @@ class TestHandler:
 
         # Totals: ok+fixed rows only; error row flags incomplete
         assert doc["totals"]["incomplete"] is True
-        expected_mtd = 12.34 + 2.0 + 2.5 + 5.0 + 0.0 + 1.5 + 200.0
+        # neon 0.39 = 2 CU-h ($0.212) + 0.5 GB-month ($0.175); its 3 GB of
+        # egress is inside the per-project allowance. It used to contribute
+        # $0.00 because compute and storage were reported as unpriceable.
+        expected_mtd = 12.34 + 2.0 + 2.5 + 5.0 + 0.39 + 1.5 + 200.0
         assert doc["totals"]["mtd_usd"] == pytest.approx(expected_mtd)
 
         # First-of-day snapshot written with the raw counters
@@ -844,10 +948,32 @@ class TestReconcileCounterDiff:
 
 
 class TestReconcileNeon:
-    def test_always_not_available(self):
-        row = index.reconcile_neon({"providers": [{"key": "neon", "mtd_cost_usd": 1.0}]})
-        assert row["status"] == "not_available"
-        assert "historical" in row["note"] or "current consumption period" in row["note"]
+    def test_closed_month_requeried_from_v2(self, monkeypatch):
+        """The prior month's FINAL charge is re-read from the same
+        invoice-aligned metrics (v2 accepts an arbitrary historical window) —
+        this row used to be permanently not_available."""
+        seen = {}
+
+        def _fake_http(url, headers=None):
+            if "/consumption_history/v2/projects" in url:
+                seen["url"] = url
+                return neon_v2_doc(("p1", {"compute_unit_seconds": 36_000,
+                                           "root_branch_bytes_month": 1_000_000_000}))
+            return {"projects": [{"id": "p1", "org_id": "org-1"}]}
+
+        monkeypatch.setattr(index, "_http_json", _fake_http)
+        pmw = index._prior_month_window(NOW)
+        row = index.reconcile_neon(pmw, {index.SSM_NEON: "k"},
+                                   {"providers": [{"key": "neon", "mtd_cost_usd": 1.0}]})
+        # 10 CU-h ($1.06) + 1 GB-month ($0.35) = $1.41 final
+        assert row["actual_final"] == pytest.approx(1.41)
+        assert row["status"] == "ok"
+        assert "from=2026-06-01T00%3A00%3A00Z" in seen["url"]
+        assert "to=2026-07-01T00%3A00%3A00Z" in seen["url"]
+
+    def test_not_configured_without_key(self):
+        row = index.reconcile_neon(index._prior_month_window(NOW), {}, None)
+        assert row["status"] == "not_configured"
         assert row["actual_final"] is None
 
 
@@ -911,7 +1037,9 @@ class TestRunReconciliation:
         assert doc["period"] == "2026-06"
         assert doc["providers"]["aws"]["actual_final"] == pytest.approx(12.34)
         assert "aws" in doc["flagged"]  # (12.34-5.0)/5.0 = 146% >> 8% threshold
-        assert doc["providers"]["neon"]["status"] == "not_available"
+        # no Neon key in this fixture's secrets → honest not_configured (the
+        # row is a real re-query when the key is present, see TestReconcileNeon)
+        assert doc["providers"]["neon"]["status"] == "not_configured"
         # openrouter/deepseek reconciled purely from the two baselines above,
         # with zero HTTP calls (the unrouted http_router({}) would raise if hit).
         assert doc["providers"]["openrouter"]["actual_final"] == pytest.approx(12.5)
@@ -934,7 +1062,7 @@ class TestRunReconciliation:
         doc = json.loads(s3.store["expenses/reconciliation/2026-06.json"])
         assert doc["providers"]["aws"]["status"] == "error"
         assert "CE down" in doc["providers"]["aws"]["note"]
-        assert doc["providers"]["neon"]["status"] == "not_available"
+        assert doc["providers"]["neon"]["status"] == "not_configured"
 
 
 class TestHandlerReconcileMode:


### PR DESCRIPTION
## What

The console's Neon row reported **$0.00/mo against a real $1.88 MTD bill**. Compute and storage rendered `None` under `detail.cost_components_unavailable`, on the finding that the project-detail API exposes no CU-size or current-storage field to price them from.

That finding was about the **v1** `consumption_history` endpoints, which are genuinely Scale-plan-gated. The **v2** endpoints (`/consumption_history/v2/projects`) are available on Launch and return the metrics Neon states "align with usage-based billing and match your invoice" — verified live 2026-07-31 against both fleet projects. That is where compute and storage were hiding.

## Live result (2026-07-31, billing window 2026-07-17 → 2026-08-01)

| | compute | storage | egress | total |
|---|---|---|---|---|
| `nousergon-rag` | 12.02 CU-h → $1.27 | 1.093 GB-month → $0.38 | 0.42 GB (in allowance) → $0 | **$1.66** |
| `metron-prod` | 2.08 CU-h → $0.22 | 0.007 GB-month → $0.00 | 0.02 GB → $0 | **$0.22** |
| **row** | | | | **$1.88 MTD / $1.92 projected** |

## Changes

- **Every billed component priced, per project, then summed** — compute (CU-hours × $0.106), storage (the four `*_bytes_month` metrics → GB-months × $0.35), public egress above the allowance (× $0.10/GB), extra branches (× $1.50). Unit conversions are magnitude-verified against live values, cross-checked on `metron-prod` (existed 5 of 30 days at ~36 MB ⇒ 0.0063 GB-month) to rule out a byte-hours reading that would be off by 744×.
- **The 500 GB egress allowance is per PROJECT, not per fleet.** Summing first would hide one project's overage behind another's headroom — the same shape as the 2026-07-16 lockout.
- **Month-end $ is projected on usage and then priced**, never by scaling dollars: the egress line is a hinge, so doubling a $10 overage yields $20 where the real month-end charge is $70.
- **`fixed_monthly_usd` is no longer honored for this provider** — reported as `detail.fixed_monthly_usd_ignored` instead. A hardcoded figure silently outranking a measurement is exactly the defect config#2913 was filed for (it shipped as $19/mo against a real ~$4/mo run rate), and Launch has no flat fee. `detail.pricing_note` is now always present, so a stale operator note in the budgets SSoT can never be the only pricing explanation on the page.
- **Month-close reconciliation is a real closed-month re-query.** v2 accepts an arbitrary historical window (history from 2024-03-01), so the prior month's final charge is read rather than marked `not_available` forever.
- **Query window spans the whole calendar month.** At monthly granularity Neon truncates both bounds to month boundaries, so a `to` of "now" collapses onto `from` and the request 400s with "'from' must be before 'to'". Hit live during verification; regression-tested.
- **Fallback retained** for plans where v2 is gated (Free): transfer-only pricing with the failure named on the row (`detail.consumption_v2_error`, `source: projects_api_fallback`) rather than passed off as $0 spend.

## SOTA alignment

The institutional approach is to bill from the vendor's own invoice-aligned metrics rather than a locally reconstructed estimate — that is what this does, so no delta. The prior row was a documented-gap estimate; the gap turned out to be an endpoint-version assumption, not a vendor limitation.

## Testing

- `test_handler.py`: 56 passed, run through CI's own `run_handler_tests.sh` harness.
- New coverage: pure-function pricing against the live-verified conversions, per-project allowance, extra branches, v2-unavailable fallback naming its failure, the ignored-override path, month-aligned query window, both pace constraints, closed-month reconciliation.
- Repo tests referencing the collector: 30 passed.
- Adapter executed end-to-end against the live Neon account (read-only) — output in the table above.

## Deploy

Auto-deploys on merge via `deploy-expense-collector.yml` (code-only path, no cadence change). No post-merge step.

## Out of scope, filed

- alpha-engine-config-I5851 — the Neon usage monitor watches egress only, on one hardcoded project.
- alpha-engine-config-I5852 — RAG corpus retention policy (storage is now a visible, growing cost line).
- The live `expense_budgets.json` may still carry the stale `$19` `fixed_monthly_usd` and its old note. Neither can distort the number any more; clearing them is cosmetic and noted in alpha-engine-config-I2850.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
