### PR TITLE
feat(groom): real spot retry ladder — invert the catch default and rotate instance types

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -417,6 +417,56 @@ def _resolve_force_on_demand(event: dict) -> bool:
     return bool(event.get("force_on_demand", False))
 
 
+def _resolve_attempt(event: dict) -> int:
+    """alpha-engine-config-I5923: which launch ATTEMPT this is for the lane —
+    0 for the initial launch, 1..max_retries for each bounded relaunch. Set by
+    the dispatch Step Function (``$.fod.attempt``, seeded 0 in the Map's
+    ItemSelector and bumped in PrepRelaunch/SetForceOnDemand). Drives the
+    instance-type pool rotation in :func:`_rotated_instance_types`.
+
+    Absent or malformed → 0. This is deliberately NOT fail-loud: the value only
+    selects WHICH capacity pool is tried first, so a bad value degrades to the
+    pre-rotation behaviour rather than blocking a launch. A launch that does not
+    happen is strictly worse than one that starts at the wrong pool offset."""
+    try:
+        return max(0, int(event.get("attempt", 0)))
+    except (TypeError, ValueError):
+        logger.warning("malformed attempt %r — treating as 0", event.get("attempt"))
+        return 0
+
+
+def _rotated_instance_types(tier_tag: str, attempt: int) -> list[str]:
+    """Return INSTANCE_TYPES rotated so a different family leads each attempt.
+
+    alpha-engine-config-I5923 (Brian ruling 2026-07-31: "we should be attempting
+    different instance types before using on demand. at least two different
+    types"). ``krepis.ec2_spot.launch`` walks ``for instance_type in
+    instance_types: for subnet_id in subnets`` in FIXED order and rotates only
+    on a launch-time capacity ERROR. A mid-run reclamation is not a launch
+    error, so every relaunch previously restarted at ``t4g.medium`` — the very
+    pool that had just proved exhausted. Bumping max_retries alone would have
+    produced three attempts against one capacity pool.
+
+    The offset also folds in the LANE (alpha-engine-config-I4989): the three
+    lanes co-launch with MaxConcurrency=3 and, sharing one ordered pool, all
+    landed on the same type in the same AZ — so one capacity event took the
+    whole cycle (measured 2026-07-30 and again 2026-07-31). Lane ordinal plus
+    attempt separates both axes with one formula.
+
+    The rotation is a ROTATION, not a truncation: every type stays reachable on
+    every attempt, just in a different order, so a genuinely scarce window still
+    walks the entire pool before the caller escalates to on-demand.
+    """
+    if not INSTANCE_TYPES:
+        return INSTANCE_TYPES
+    # Deterministic per-lane ordinal. sorted() rather than a hand-kept dict so a
+    # new lane cannot silently collide with an existing one's offset.
+    lanes = sorted(_VALID_ISSUE_FILTERS) if _VALID_ISSUE_FILTERS else []
+    lane_ordinal = lanes.index(tier_tag) if tier_tag in lanes else 0
+    offset = (lane_ordinal + attempt) % len(INSTANCE_TYPES)
+    return INSTANCE_TYPES[offset:] + INSTANCE_TYPES[:offset]
+
+
 def _resolve_soft_limit_min(event: dict) -> int | None:
     """Optional bounded-test override — NOT set by any of the 3 live schedules
     (their SCHED_INPUTS carry no such key), only by a manual `aws lambda invoke`
@@ -591,7 +641,8 @@ export GROOM_RUN_TOKEN={run_token}
 
 
 def _launch_instance(force_on_demand: bool = False,
-                     tier_tag: str = "") -> tuple[str, str]:
+                     tier_tag: str = "",
+                     attempt: int = 0) -> tuple[str, str]:
     """Launch the groom box; spot first, on-demand fallback on capacity exhaustion
     OR when force_on_demand (config#1645: the dispatch SF's last bounded relaunch
     attempt after repeated mid-run spot interruption — skip straight to on-demand
@@ -605,8 +656,15 @@ def _launch_instance(force_on_demand: bool = False,
     retains lane attribution for the full 90-day CloudTrail retention window.
     """
     extra_tags = {GROOM_TIER_TAG_KEY: tier_tag} if tier_tag else None
+    # I5923: rotate the pool by (lane, attempt) so a relaunch after a mid-run
+    # reclamation leads with a DIFFERENT capacity pool than the one that just
+    # died, and so co-launched lanes do not all lead with the same type.
+    instance_types = _rotated_instance_types(tier_tag, attempt)
+    logger.info("launch attempt %d for lane %s — instance-type order: %s "
+                "(force_on_demand=%s)", attempt, tier_tag or "?",
+                ",".join(instance_types), force_on_demand)
     return spot_dispatch.launch_with_fallback(
-        INSTANCE_TYPES, SUBNETS,
+        instance_types, SUBNETS,
         image_id=AMI_ID,
         key_name=KEY_NAME,
         security_group_ids=[SECURITY_GROUP],
@@ -1530,7 +1588,8 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
                        force_on_demand: bool = False,
                        queue_manifest_key: str = "",
                        backend: str = "",
-                       task_token: str = "") -> dict:
+                       task_token: str = "",
+                       attempt: int = 0) -> dict:
     """Launch + bootstrap the groom box. Fail-loud — any error RAISES.
 
     ``backend`` (quota-fallback 3-repo feature, default ``""`` = unchanged
@@ -1595,7 +1654,8 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
         logger.warning("dispatch ledger pre-launch write failed (non-fatal): %s", exc)
 
     instance_id, market = _launch_instance(force_on_demand=force_on_demand,
-                                           tier_tag=tier_tag)
+                                           tier_tag=tier_tag,
+                                           attempt=attempt)
     logger.info("launched groom box %s (%s)", instance_id, market)
 
     # config#5303: the load-bearing groom-issue-filter tag is now passed as
@@ -2388,11 +2448,13 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     soft_limit_min = _resolve_soft_limit_min(event)
     pr_budget = _resolve_pr_budget(event)
     force_on_demand = _resolve_force_on_demand(event)
+    attempt = _resolve_attempt(event)
     schedule_label = str(event.get("schedule") or "unknown")
     logger.info(
         "scheduled groom trigger: run_mode=%s model=%s issue_filter=%s soft_limit_min=%s "
-        "pr_budget=%s force_on_demand=%s schedule=%s decide_only=%s launch_decided=%s",
-        run_mode, model, issue_filter, soft_limit_min, pr_budget, force_on_demand, schedule_label,
+        "pr_budget=%s force_on_demand=%s attempt=%s schedule=%s decide_only=%s launch_decided=%s",
+        run_mode, model, issue_filter, soft_limit_min, pr_budget, force_on_demand, attempt,
+        schedule_label,
         bool(event.get("decide_only")), bool(event.get("launch_decided")),
     )
 
@@ -2468,6 +2530,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             queue_manifest_key=queue_manifest_key,
             backend=_resolve_launch_decided_backend(event),
             task_token=_task_token(event),
+            attempt=attempt,
         )
         # demand-all path did (_write_trigger_record/_write_skip_record),
         # leaving sweep-mode (and any other launch_decided) dispatches with
@@ -2617,5 +2680,6 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         run_mode, schedule_label, model, issue_filter, soft_limit_min, pr_budget, force_on_demand,
         queue_manifest_key=queue_manifest_key,
         backend=backend,
+        attempt=attempt,
     )
     return {"groom": result}

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2675,3 +2675,105 @@ def test_actioned_marker_is_not_written_to_the_completed_prefix(monkeypatch):
         "lane would read as a successful one"
     )
     assert actioned, "no reconciled/ marker written; the expectation stays open"
+
+
+# ── Spot retry ladder: instance-type rotation (alpha-engine-config-I5923) ─────
+#
+# Brian ruling 2026-07-31: "we should be attempting different instance types
+# before using on demand. at least two different types. otherwise we are
+# practically defaulting to on demand during prime time."
+#
+# `krepis.ec2_spot.launch` walks `for instance_type in instance_types: for
+# subnet_id in subnets` in FIXED order and rotates only on a launch-time
+# capacity ERROR. A mid-run reclamation is not a launch error, so before this
+# change every relaunch restarted at the head of the pool — the exact type that
+# had just proved exhausted. The state-machine half (max_retries, the attempt
+# counter on both relaunch paths) is pinned in
+# tests/test_groom_instance_type_rotation.py.
+
+def test_rotation_changes_the_leading_type_each_attempt(monkeypatch):
+    """Consecutive attempts for one lane must not lead with the same type."""
+    idx = _load(monkeypatch)
+    leads = [idx._rotated_instance_types("mid-only", n)[0] for n in range(3)]
+    assert len(set(leads)) == 3, (
+        f"attempts 0..2 lead with {leads} — a relaunch must not re-enter the "
+        "capacity pool that just failed"
+    )
+
+
+def test_rotation_is_a_rotation_not_a_truncation(monkeypatch):
+    """Every type stays reachable on every attempt.
+
+    A genuinely scarce window must still be able to walk the whole pool before
+    the caller escalates to on-demand; the rotation changes ORDER, not
+    membership.
+    """
+    idx = _load(monkeypatch)
+    for attempt in range(len(idx.INSTANCE_TYPES) + 2):
+        rotated = idx._rotated_instance_types("mid-only", attempt)
+        assert sorted(rotated) == sorted(idx.INSTANCE_TYPES)
+
+
+def test_co_launched_lanes_lead_with_different_types(monkeypatch):
+    """alpha-engine-config-I4989 — the three lanes must not converge.
+
+    They co-launch with MaxConcurrency=3; sharing one ordered pool put all three
+    on the same type in the same AZ, so one capacity event took the whole cycle
+    (measured 2026-07-30 and again 2026-07-31).
+    """
+    idx = _load(monkeypatch)
+    leads = {
+        lane: idx._rotated_instance_types(lane, 0)[0]
+        for lane in ("low-only", "mid-only", "high-only")
+    }
+    assert len(set(leads.values())) == 3, f"lanes converge on one pool: {leads}"
+
+
+def test_rotation_survives_an_absent_or_malformed_attempt(monkeypatch):
+    """Degrade to the pre-rotation order, never raise.
+
+    The value only selects WHICH pool is tried first, so a launch that does not
+    happen is strictly worse than one starting at the wrong offset.
+    """
+    idx = _load(monkeypatch)
+    assert idx._resolve_attempt({}) == 0
+    assert idx._resolve_attempt({"attempt": None}) == 0
+    assert idx._resolve_attempt({"attempt": "not-a-number"}) == 0
+    assert idx._resolve_attempt({"attempt": -5}) == 0
+    assert idx._resolve_attempt({"attempt": "2"}) == 2
+    assert idx._rotated_instance_types("unknown-lane", 0) == idx.INSTANCE_TYPES
+
+
+def test_launch_passes_the_rotated_pool_to_the_launcher(monkeypatch):
+    """End-to-end: the rotation must actually reach ec2_spot.launch.
+
+    A rotation computed and then discarded at the call site is the failure this
+    guards — the whole defect being fixed is that the launcher was always handed
+    the same fixed-order list.
+    """
+    seen = {}
+
+    def _launch(types_, subnets, **kw):
+        seen["types"] = list(types_)
+        return "i-rot"
+
+    idx = _load(monkeypatch, launch_impl=_launch,
+                env={"GROOM_DISPATCH_ENABLED": "true"})
+    idx.handler({"run_mode": "full", "schedule": "0 20 * * *",
+                 "issue_filter": "mid-only", "launch_decided": True,
+                 "attempt": 2}, None)
+    expected = idx._rotated_instance_types("mid-only", 2)
+    assert seen["types"] == expected, (
+        f"launcher received {seen.get('types')}, expected the rotated pool "
+        f"{expected} — the rotation was computed and discarded"
+    )
+
+
+def test_pool_spans_more_than_one_instance_family(monkeypatch):
+    """Two types in one family is diversification in name only (I4989)."""
+    idx = _load(monkeypatch)
+    families = {t.split(".")[0] for t in idx.INSTANCE_TYPES}
+    assert len(families) >= 3, (
+        f"pool spans only {families} — separate capacity pools require separate "
+        "FAMILIES, not just separate sizes"
+    )

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -77,10 +77,11 @@
         "schedInput.$": "$.schedInput",
         "launchDecision.$": "$$.Map.Item.Value",
         "retry_count": 0,
-        "max_retries": 1,
+        "max_retries": 3,
         "fod": {
           "force_on_demand": false,
-          "launch_decided": true
+          "launch_decided": true,
+          "attempt": 0
         }
       },
       "Catch": [
@@ -138,11 +139,20 @@
               },
               {
                 "ErrorEquals": [
-                  "States.ALL"
+                  "GroomFailed",
+                  "InjectedCallbackRejected"
                 ],
-                "Comment": "Launch failure (spot+on-demand exhaustion, SSM send failure, etc.) — the Lambda already terminates any partially-launched box before re-raising.",
+                "Comment": "alpha-engine-config-I5919: the TERMINAL allowlist. GroomFailed is groom_spot_bootstrap.sh's finish() trap firing on a non-zero run exit — the box ran, the run itself failed, and relaunching would only repeat it. InjectedCallbackRejected is the fault-injection harness (groom-inject-mock) deliberately rejecting a callback; it must stay terminal or the injection loops. These two are the ONLY names that must not reach the relaunch ladder.",
                 "Next": "HandleFailure",
                 "ResultPath": "$.error"
+              },
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Comment": "alpha-engine-config-I5919 — DEFAULT INVERTED 2026-07-31. This catch used to route States.ALL to HandleFailure (terminal) and enumerate the RECOVERABLE names above it, which made the default for any unenumerated error TERMINAL. The on-box early spot-interruption watcher (groom_spot_bootstrap.sh L297) sends error=SpotInterrupted — never enumerated — so EVERY reclaim it detected skipped the relaunch ladder entirely. Measured live on the 2026-07-31 20:00 UTC cycle: both reclaimed lanes went TaskFailed(SpotInterrupted) -> HandleFailure -> RecordLaneFailure -> LaneCompleted, never entering CheckCompletionMarkerTaskToken. That watcher fires on the IMDS interruption NOTICE (~2 min before termination) so it always beats the reconciler's LaneDeath, meaning the correctly-wired name was unreachable on the path that actually fires. This is the SAME defect I5229/I5512 fixed for LaneDeath by adding one name to an allowlist — an allowlist whose default is termination reproduces the bug for every producer nobody swept. Inverting it makes RECOVERY the default: a new or unswept error name now reaches the ladder, and CheckCompletionMarkerTaskToken already guards against relaunching a lane whose work actually completed. Launch-side failures (spot+on-demand exhaustion, SSM send failure) also land here now; that is intended — they are bounded by max_retries and the last rung is on-demand. ResultPath is $.timeoutError, the SAME field the States.Timeout catch writes, because GroomRetriesExhausted references it downstream; a differently-named field would leave $.timeoutError absent and raise an uncatchable States.Runtime (groom-sweep-policy §2.2).",
+                "Next": "CheckCompletionMarkerTaskToken",
+                "ResultPath": "$.timeoutError"
               }
             ],
             "ResultPath": "$.callbackOutput",
@@ -216,7 +226,7 @@
           },
           "CheckRetryBudget": {
             "Type": "Choice",
-            "Comment": "config#1645: marker is absent (box died mid-run) — relaunch if attempts remain, else give up and alert. Bounded to max_retries (1, i.e. up to 2 total launch attempts per iteration) so a genuinely bad AWS day can't spot-cycle indefinitely.",
+            "Comment": "config#1645: marker is absent (box died mid-run) — relaunch if attempts remain, else give up and alert. Bounded to max_retries (3, i.e. up to 4 total launch attempts per iteration) so a genuinely bad AWS day can't spot-cycle indefinitely. alpha-engine-config-I5923 (Brian ruling 2026-07-31): max_retries was 1, which made the SINGLE relaunch also the LAST one, so CheckForceOnDemand forced it to on-demand — the lane went spot -> on-demand with ZERO alternate spot capacity pools tried. During prime time, when reclamation is most likely, that is effectively defaulting to on-demand. At 3 the ladder is attempt 0 spot, retries 1 and 2 spot on DIFFERENT instance types (the dispatcher rotates the pool by $.fod.attempt), retry 3 on-demand.",
             "Choices": [
               {
                 "Variable": "$.retry_count",
@@ -234,13 +244,17 @@
               "launchDecision.$": "$.launchDecision",
               "max_retries.$": "$.max_retries",
               "retry_count.$": "States.MathAdd($.retry_count, 1)",
-              "fod.$": "$.fod"
+              "fod": {
+                "force_on_demand.$": "$.fod.force_on_demand",
+                "launch_decided": true,
+                "attempt.$": "States.MathAdd($.retry_count, 1)"
+              }
             },
             "Next": "CheckForceOnDemand"
           },
           "CheckForceOnDemand": {
             "Type": "Choice",
-            "Comment": "config#1645: if this relaunch is the LAST allowed attempt (retry_count now equals max_retries), force on-demand so a bad spot-capacity window still guarantees completion instead of trying the same flaky market a third time.",
+            "Comment": "config#1645: if this relaunch is the LAST allowed attempt (retry_count now equals max_retries), force on-demand so a bad spot-capacity window still guarantees completion instead of trying the same flaky market a fourth time. With max_retries=3 (I5923) the two intermediate retries stay on SPOT and land on different instance types via the $.fod.attempt pool rotation — on-demand is now the terminal rung of a real ladder rather than the second step of a two-step one.",
             "Choices": [
               {
                 "Variable": "$.retry_count",
@@ -260,7 +274,8 @@
               "retry_count.$": "$.retry_count",
               "fod": {
                 "force_on_demand": true,
-                "launch_decided": true
+                "launch_decided": true,
+                "attempt.$": "$.retry_count"
               }
             },
             "Next": "LaunchGroomSpot"

--- a/tests/test_groom_instance_type_rotation.py
+++ b/tests/test_groom_instance_type_rotation.py
@@ -1,0 +1,105 @@
+"""Pins the spot retry ladder's capacity diversification.
+
+Origin — Brian ruling 2026-07-31 (alpha-engine-config-I5923): "we should be
+attempting different instance types before using on demand. at least two
+different types. otherwise we are practically defaulting to on demand during
+prime time."
+
+Two independent defects produced that behaviour:
+
+  1. ``max_retries`` was 1, so the SINGLE relaunch was also the LAST one and
+     ``CheckForceOnDemand`` forced it to on-demand. The lane went spot ->
+     on-demand having tried exactly ONE spot capacity pool.
+
+  2. ``krepis.ec2_spot.launch`` walks ``for instance_type in instance_types:
+     for subnet_id in subnets`` in FIXED order and rotates only on a launch-time
+     capacity ERROR. A mid-run reclamation is not a launch error, so every
+     relaunch restarted at the head of the pool — the type that had just proved
+     exhausted. Raising max_retries alone would have bought three attempts
+     against ONE pool.
+
+Fixing either alone leaves the ruling unmet, so both are pinned here.
+
+This module pins the STATE MACHINE half — that the ladder has room for spot
+attempts and that both relaunch paths carry the counter the rotation reads. The
+rotation function itself is tested in the dispatcher's own co-located
+``test_handler.py``, which already carries the boto3/ec2_spot stubs its import
+needs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_groom.json"
+
+@pytest.fixture(scope="module")
+def item_selector() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]["MapLaunches"]["ItemSelector"]
+
+
+@pytest.fixture(scope="module")
+def lane_states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]["MapLaunches"]["ItemProcessor"]["States"]
+
+
+# ── The ladder has room for spot attempts before the on-demand rung ───────────
+
+def test_ladder_leaves_at_least_two_spot_retries_before_on_demand(item_selector):
+    """Brian ruling: at least two DIFFERENT types tried on spot first.
+
+    CheckForceOnDemand fires when retry_count == max_retries, so the number of
+    spot attempts is max_retries (attempt 0 plus retries 1..max_retries-1) and
+    the final retry is the on-demand rung. max_retries must therefore be >= 3
+    to give three spot attempts.
+    """
+    max_retries = item_selector["max_retries"]
+    spot_attempts = max_retries  # attempt 0 .. max_retries-1
+    assert spot_attempts >= 3, (
+        f"max_retries={max_retries} yields only {spot_attempts} spot attempt(s) "
+        "before the forced on-demand rung. The ruling requires at least two "
+        "DIFFERENT instance types tried on spot first."
+    )
+
+
+def test_initial_attempt_is_seeded(item_selector):
+    """The pool rotation is driven by $.fod.attempt; it must start defined."""
+    assert item_selector["fod"]["attempt"] == 0
+    assert item_selector["retry_count"] == 0
+
+
+def test_relaunch_states_carry_the_attempt_counter(lane_states):
+    """Both relaunch paths must emit `attempt`, or the rotation is inert.
+
+    PrepRelaunch reaches LaunchGroomSpot directly (non-final retries) and
+    SetForceOnDemand reaches it on the final one. A path that drops `attempt`
+    silently reverts that attempt to the head of the pool.
+    """
+    for name in ("PrepRelaunch", "SetForceOnDemand"):
+        fod = lane_states[name]["Parameters"]["fod"]
+        assert "attempt" in fod or "attempt.$" in fod, (
+            f"{name} drops fod.attempt — that attempt would restart at the head "
+            "of the instance-type pool, i.e. the pool that just failed"
+        )
+
+
+def test_prep_relaunch_attempt_matches_its_own_incremented_retry_count(lane_states):
+    """`attempt` and `retry_count` must advance together.
+
+    PrepRelaunch cannot read its own output, so both fields independently
+    compute States.MathAdd($.retry_count, 1). If they drift, the rotation
+    offset stops tracking the ladder position.
+    """
+    params = lane_states["PrepRelaunch"]["Parameters"]
+    assert params["retry_count.$"] == params["fod"]["attempt.$"], (
+        "PrepRelaunch's retry_count and fod.attempt must be the same expression"
+    )
+
+
+def test_set_force_on_demand_preserves_the_attempt(lane_states):
+    """The on-demand rung still reports its ladder position for observability."""
+    assert lane_states["SetForceOnDemand"]["Parameters"]["fod"]["attempt.$"] == "$.retry_count"

--- a/tests/test_sf_groom_error_name_contract.py
+++ b/tests/test_sf_groom_error_name_contract.py
@@ -1,0 +1,192 @@
+"""Binds every ``send-task-failure`` error name to LaunchGroomSpot's Catch.
+
+Origin — alpha-engine-config-I5919, measured on the 2026-07-31 20:00 UTC cycle.
+
+``LaunchGroomSpot``'s Catch was an ALLOWLIST of recoverable error names
+(``States.Timeout``, ``LaneDeath``) with ``States.ALL`` routed to the terminal
+``HandleFailure``. The default for any unenumerated name was therefore
+TERMINATION. The on-box early spot-interruption watcher sends
+``error="SpotInterrupted"`` — a name nobody had swept into the list — so every
+spot reclamation it detected skipped the bounded-relaunch ladder entirely::
+
+    TaskFailed(SpotInterrupted) -> HandleFailure -> RecordLaneFailure -> LaneCompleted
+
+Both reclaimed lanes that cycle recorded zero relaunches and zero on-demand
+escalations. That watcher fires on the IMDS interruption NOTICE (~2 min before
+termination), so it always beats the lane reconciler's ``LaneDeath`` — the one
+name that WAS wired was unreachable on the path that actually fires.
+
+This is the same defect I5229/I5512 fixed for ``LaneDeath`` by adding a single
+name to the allowlist. Adding one name does not survive the class: the next
+producer to invent an error name reintroduces it silently, because nothing fails
+when the producers and the catch list drift apart. They live in different repos.
+
+Two guards, in order of what they protect:
+
+  1. The catch DEFAULT must be recovery, not termination — ``States.ALL`` routes
+     to the relaunch ladder and only an explicit terminal allowlist bypasses it.
+  2. Every error name any producer actually sends must be accounted for: either
+     on the terminal allowlist deliberately, or reaching the ladder.
+
+Guard 1 is what makes the class safe going forward; guard 2 is what makes the
+drift visible when someone re-inverts guard 1.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_groom.json"
+_DISPATCHER = (
+    _REPO_ROOT / "infrastructure" / "lambdas" / "scheduled-groom-dispatcher" / "index.py"
+)
+_INJECT_MOCK = (
+    _REPO_ROOT / "infrastructure" / "lambdas" / "groom-inject-mock" / "index.py"
+)
+
+#: The state the bounded-relaunch ladder begins at. Reaching it means the lane
+#: gets a completion-marker check and, if the work really was lost, a relaunch.
+_LADDER_ENTRY = "CheckCompletionMarkerTaskToken"
+
+#: The only error names that may legitimately bypass the ladder.
+#:
+#: ``GroomFailed`` — groom_spot_bootstrap.sh's finish() trap on a non-zero run
+#: exit. The box ran; the RUN failed. A relaunch would repeat it on fresh
+#: hardware and fail identically, burning the ladder against a deterministic
+#: failure.
+#:
+#: ``InjectedCallbackRejected`` — the fault-injection harness deliberately
+#: rejecting a callback. It must stay terminal or the injection loops.
+_TERMINAL_ERRORS = {"GroomFailed", "InjectedCallbackRejected"}
+
+#: Names the Step Functions service itself raises, which no producer file
+#: contains as a literal.
+_SERVICE_ERRORS = {"States.Timeout"}
+
+#: `--error "Name"` (shell, bootstrap) and `error="Name"` / `error='Name'`
+#: (boto3, Lambdas).
+_ERROR_LITERAL = re.compile(
+    r"""(?:--error\s+["']|(?<![A-Za-z_])error\s*=\s*["'])([A-Za-z][A-Za-z0-9_.]*)["']"""
+)
+
+
+@pytest.fixture(scope="module")
+def lane_states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]["MapLaunches"]["ItemProcessor"]["States"]
+
+
+@pytest.fixture(scope="module")
+def catch(lane_states) -> list[dict]:
+    return lane_states["LaunchGroomSpot"]["Catch"]
+
+
+def _routes(catch: list[dict]) -> dict[str, str]:
+    """Flatten the Catch into {error_name: destination_state}."""
+    return {name: entry["Next"] for entry in catch for name in entry["ErrorEquals"]}
+
+
+def test_catch_default_is_recovery_not_termination(catch):
+    """I5919 — the inversion itself.
+
+    ``States.ALL`` must reach the ladder. While it routed to HandleFailure,
+    every error name nobody had swept was silently terminal.
+    """
+    routes = _routes(catch)
+    assert "States.ALL" in routes, "LaunchGroomSpot must keep a States.ALL catch"
+    assert routes["States.ALL"] == _LADDER_ENTRY, (
+        "States.ALL must route to the relaunch ladder so an unenumerated error "
+        "name defaults to RECOVERY. Routing it to a terminal state is the I5919 "
+        "defect: SpotInterrupted was never enumerated and every reclaim it "
+        "detected skipped the ladder."
+    )
+
+
+def test_states_all_catch_writes_the_timeout_error_field(catch):
+    """groom-sweep-policy §2.2 — GroomRetriesExhausted reads $.timeoutError.
+
+    Every catch reaching the ladder must write that SAME field. A differently
+    named one leaves $.timeoutError absent on this path and raises an
+    UNCATCHABLE States.Runtime downstream.
+    """
+    for entry in catch:
+        if entry["Next"] == _LADDER_ENTRY:
+            assert entry.get("ResultPath") == "$.timeoutError", (
+                f"catch for {entry['ErrorEquals']} reaches the ladder but writes "
+                f"{entry.get('ResultPath')!r}, not $.timeoutError"
+            )
+
+
+def test_terminal_allowlist_is_explicit_and_minimal(catch):
+    """Only the deliberately-terminal names may bypass the ladder."""
+    terminal = {
+        name
+        for entry in catch
+        if entry["Next"] != _LADDER_ENTRY
+        for name in entry["ErrorEquals"]
+        if name != "States.ALL"
+    }
+    assert terminal == _TERMINAL_ERRORS, (
+        f"terminal error names drifted: {terminal} != {_TERMINAL_ERRORS}. Adding "
+        "a name here removes its relaunch coverage — justify it in the Catch "
+        "Comment and update _TERMINAL_ERRORS in the same change."
+    )
+
+
+def test_terminal_names_are_ordered_before_the_states_all_catch(catch):
+    """Step Functions evaluates Catch entries in order.
+
+    A States.ALL entry placed first would swallow the terminal names and send a
+    genuinely-failed run around the ladder forever.
+    """
+    names_in_order = [entry["ErrorEquals"] for entry in catch]
+    all_index = next(i for i, names in enumerate(names_in_order) if "States.ALL" in names)
+    for i, names in enumerate(names_in_order):
+        if set(names) & _TERMINAL_ERRORS:
+            assert i < all_index, (
+                "terminal error names must be enumerated BEFORE the States.ALL "
+                "catch or they never match"
+            )
+
+
+@pytest.mark.parametrize("path", [_DISPATCHER, _INJECT_MOCK])
+def test_producer_source_is_readable(path: Path):
+    """Fail loud rather than vacuously pass.
+
+    A source-scanning contract test that silently passes when its input is
+    missing is worse than no test — it reports coverage it does not have.
+    """
+    assert path.is_file(), f"producer source not found: {path}"
+    assert path.read_text().strip(), f"producer source is empty: {path}"
+
+
+def test_every_producer_error_name_is_accounted_for(catch):
+    """Guard 2 — no producer name is unclassified.
+
+    Scans the in-repo producers for ``send_task_failure`` error literals. The
+    on-box bootstrap (``alpha-engine-config/infrastructure/groom_spot_bootstrap.sh``,
+    the producer of ``SpotInterrupted`` and ``GroomFailed``) lives in another
+    repo and is NOT readable from here — which is precisely why the inversion
+    above is the primary guard rather than this scan. This asserts the names
+    this repo can see; the inversion covers the ones it cannot.
+    """
+    found: set[str] = set()
+    for path in (_DISPATCHER, _INJECT_MOCK):
+        found |= set(_ERROR_LITERAL.findall(path.read_text()))
+    # Names unrelated to the task-token contract (e.g. a boto3 kwarg elsewhere)
+    # are still fine: everything not terminal reaches the ladder by default.
+    unclassified = {
+        n for n in found
+        if n not in _TERMINAL_ERRORS and n not in _SERVICE_ERRORS
+    }
+    routes = _routes(catch)
+    for name in unclassified:
+        destination = routes.get(name, routes["States.ALL"])
+        assert destination == _LADDER_ENTRY, (
+            f"producer error name {name!r} routes to {destination!r}, which is "
+            "not the relaunch ladder and is not on the terminal allowlist"
+        )

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -103,7 +103,22 @@ def test_prep_relaunch_carries_the_fields_its_successors_read(states):
     for key in _PRESERVE_PATHS:
         assert key in params, f"PrepRelaunch must carry {key} through relaunch"
     assert params["retry_count.$"] == "States.MathAdd($.retry_count, 1)"
-    assert "fod.$" in params
+    # I5923: `fod` is CONSTRUCTED here rather than passed through verbatim,
+    # because it now carries `attempt` — the instance-type pool offset, which
+    # must advance with retry_count. A Pass cannot read its own output, so the
+    # increment is computed twice from the same input.
+    fod = params["fod"]
+    assert set(fod) == {"force_on_demand.$", "launch_decided", "attempt.$"}, (
+        f"PrepRelaunch's fod keys drifted: {sorted(fod)}"
+    )
+    assert fod["force_on_demand.$"] == "$.fod.force_on_demand", (
+        "PrepRelaunch must preserve the inbound force_on_demand — constructing "
+        "fod from scratch must not silently reset an escalation already made"
+    )
+    assert fod["attempt.$"] == params["retry_count.$"], (
+        "fod.attempt must advance with retry_count or the pool rotation stops "
+        "tracking the ladder position"
+    )
     assert st["Next"] == "CheckForceOnDemand"
 
 
@@ -113,7 +128,13 @@ def test_set_force_on_demand_carries_the_fields_its_successors_read(states):
     for key in _PRESERVE_PATHS:
         assert key in params
     assert st["Next"] == "LaunchGroomSpot"
-    assert params["fod"] == {"force_on_demand": True, "launch_decided": True}
+    assert params["fod"] == {
+        "force_on_demand": True,
+        "launch_decided": True,
+        # I5923: the on-demand rung reports its ladder position too, so the
+        # launch log and the dispatch ledger say WHICH attempt escalated.
+        "attempt.$": "$.retry_count",
+    }
 
 
 def test_no_state_references_a_retired_poll_loop_field(states):
@@ -184,15 +205,46 @@ def test_every_lane_task_declares_a_timeout(states):
     assert not missing, f"Task states with no declared timeout: {missing}"
 
 
+#: The groom dispatch cadence: 04:00, 12:00 and 20:00 UTC (EventBridge Scheduler
+#: `alpha-engine-scheduled-groom-{0400,1200,2000}-daily`, verified live
+#: 2026-07-31). The cycle-singleton guard (alpha-engine-config-I5371) skips a
+#: dispatch while an earlier execution is still RUNNING, so an execution that can
+#: outlive this interval starves the following cycle.
+_CYCLE_CADENCE_SECONDS = 8 * 3600
+
+
 def test_state_machine_declares_a_global_ceiling():
-    """A runaway backstop, not a budget — the per-lane timeout is the budget."""
+    """A runaway backstop, not a budget — the per-lane timeout is the budget.
+
+    alpha-engine-config-I5923 restated this invariant. It previously required
+    ``ceiling > lane_timeout * (max_retries + 1)`` — that every attempt in the
+    ladder could independently burn the FULL lane timeout. That held only while
+    max_retries was 1 (2 x 3h = 6h < the 7h ceiling) and it was never the real
+    requirement: a relaunch is triggered BY a death, so a sequence of N attempts
+    each running the full healthy duration cannot occur — the first such attempt
+    would have succeeded. Requiring headroom for it forced a ceiling of 12h at
+    max_retries=3, which exceeds the 8h cycle cadence and would have let one
+    stuck execution starve the next cycle through the I5371 singleton guard.
+
+    The two bounds that ARE load-bearing:
+
+      * lower — room for one attempt that dies near its own ceiling PLUS one
+        full healthy retry, so recovery is never preempted mid-run;
+      * upper — strictly under the cycle cadence, so a stuck execution can
+        never suppress the following cycle.
+    """
     doc = json.loads(_SF_PATH.read_text())
     ceiling = doc.get("TimeoutSeconds")
     assert ceiling, "the state machine must declare a top-level TimeoutSeconds"
     lane = doc["States"]["MapLaunches"]["ItemProcessor"]["States"]["LaunchGroomSpot"]
-    max_attempts = doc["States"]["MapLaunches"]["ItemSelector"]["max_retries"] + 1
-    assert ceiling > lane["TimeoutSeconds"] * max_attempts, (
-        "the global ceiling must not preempt a legitimate full relaunch sequence"
+    assert ceiling > lane["TimeoutSeconds"] * 2, (
+        "the global ceiling must leave room for one near-ceiling death plus one "
+        "full healthy retry"
+    )
+    assert ceiling < _CYCLE_CADENCE_SECONDS, (
+        "the global ceiling must stay under the 8h cycle cadence — an execution "
+        "that can outlive the interval starves the next cycle via the I5371 "
+        "cycle-singleton guard"
     )
 
 


### PR DESCRIPTION
## Why

The 2026-07-31 20:00 UTC groom cycle lost two of three lanes to spot capacity reclamation and produced **zero relaunches and zero on-demand escalations**. Two independent defects; either alone is sufficient.

### 1. The relaunch ladder was unreachable

`LaunchGroomSpot`'s `Catch` was an **allowlist of recoverable error names** (`States.Timeout`, `LaneDeath`) with `States.ALL` routed to the terminal `HandleFailure` — so the default for any unenumerated name was *termination*. The on-box early spot-interruption watcher (`alpha-engine-config/infrastructure/groom_spot_bootstrap.sh` L297) sends `error="SpotInterrupted"`, which nobody had swept into the list.

Execution `476a6cfe-c098-4cfb-8a61-2a240576c2e7`, both reclaimed lanes:

```
TaskFailed(error=SpotInterrupted, cause={"phase":"bootstrap","instance_id":""})
  → LaunchGroomSpot TaskStateExited → HandleFailure → RecordLaneFailure → LaneCompleted
```

`CheckCompletionMarkerTaskToken`, `CheckRetryBudget`, `PrepRelaunch`, `CheckForceOnDemand`, `SetForceOnDemand` were never entered.

That watcher fires on the IMDS interruption **notice** (~2 min before termination), so it always beats the lane reconciler's `LaneDeath` — **the one name that was correctly wired is unreachable on the path that actually fires.**

This is the same defect I5229/I5512 fixed for `LaneDeath` by adding a single name to the allowlist. An allowlist whose default is termination reproduces the bug for every producer nobody sweeps, and the producers live in a different repo from the catch list, so nothing fails when they drift.

### 2. The ladder escalated to on-demand after one capacity pool

Brian's ruling, 2026-07-31: *"we should be attempting different instance types before using on demand. at least two different types. otherwise we are practically defaulting to on demand during prime time."*

`max_retries` was `1`, so the single relaunch was also the last one and `CheckForceOnDemand` forced it to on-demand. Raising it alone would not have helped: `krepis.ec2_spot.launch` walks `for instance_type in instance_types: for subnet_id in subnets` in fixed order and rotates **only on a launch-time capacity error**. A mid-run reclamation is not a launch error, so every relaunch restarted at `t4g.medium` — the pool that had just proved exhausted. Three attempts against one pool.

Measured us-east-1a spot prices, 2026-07-31: `t4g.medium` 0.0188, `c6g.large` 0.0215, `c7g.large` 0.0228, `t4g.large` 0.0256, `m6g.large` 0.0412, `m7g.large` 0.0421. `t4g.medium` **on-demand is 0.0336** — above four of the five alternate spot pools that were never tried.

## What changed

**Catch default inverted.** `States.ALL` → `CheckCompletionMarkerTaskToken` (the ladder). An explicit terminal allowlist bypasses it: `GroomFailed` (the run itself failed — relaunching repeats it) and `InjectedCallbackRejected` (fault-injection harness). Recovery is now the default for any new or unswept error name, and the completion-marker check already guards against relaunching a lane whose work finished.

**`max_retries` 1 → 3.** Attempt 0 plus retries 1 and 2 on spot, retry 3 forced on-demand.

**Per-attempt instance-type rotation.** `$.fod.attempt` is seeded 0 in the Map's `ItemSelector` and advanced in `PrepRelaunch`/`SetForceOnDemand`; the dispatcher rotates `INSTANCE_TYPES` by `(lane_ordinal + attempt) % len(pool)`. A **rotation, not a truncation** — every type stays reachable on every attempt, so a genuinely scarce window still walks the whole pool before escalating.

The lane term also fixes the co-launch convergence (alpha-engine-config#4989): the three lanes run at `MaxConcurrency: 3` and, sharing one ordered pool, all led with the same type in the same AZ, so one capacity event took the whole cycle — measured 2026-07-30 and again 2026-07-31.

**Global-ceiling invariant restated, not raised.** `test_state_machine_declares_a_global_ceiling` required `ceiling > lane_timeout × (max_retries + 1)`. At `max_retries: 3` that demands 12h, which exceeds the 8h cycle cadence (`alpha-engine-scheduled-groom-{0400,1200,2000}-daily`) and would let one stuck execution starve the next cycle via the alpha-engine-config#5371 singleton guard. A relaunch is triggered *by* a death, so N full-duration attempts cannot occur — the first such attempt would have succeeded. Now bounded **below** by one near-ceiling death plus one full healthy retry, and **above** by the cadence. The current 25200s satisfies both.

## Verification

- `aws stepfunctions validate-state-machine-definition` → `{"result": "OK", "diagnostics": []}` (confirms the nested `States.MathAdd` in `PrepRelaunch.Parameters.fod` is legal).
- 224 groom/spot tests in `tests/` green; 155 dispatcher tests in `test_handler.py` green.
- New: `tests/test_sf_groom_error_name_contract.py` — pins the inversion, pins that every ladder-bound catch writes `$.timeoutError` (a differently-named field raises an uncatchable `States.Runtime` at `GroomRetriesExhausted`), pins terminal-before-`States.ALL` ordering, and scans the in-repo producers for `send_task_failure` error literals. The cross-repo bootstrap producer is not readable from here — which is exactly why the inversion is the primary guard and the scan is the secondary one.
- New: `tests/test_groom_instance_type_rotation.py` (ladder depth, attempt threading) and rotation tests in `test_handler.py`, including an end-to-end assertion that the rotated pool is the list actually handed to the launcher — a rotation computed and discarded is the failure mode being fixed.

Two dispatcher tests (`test_launched_instance_gets_tagged_with_its_tier`, `test_sweep_box_tagged_with_distinct_sweep_lane`) fail on a laptop with `nousergon_lib` 0.124.21 installed globally; they assert the `LaunchMarket` tag added in 0.124.23. This repo pins v0.124.27, and all 155 pass against it. Pre-existing on `main`, unrelated to this change.

## Deployment

`.github/workflows/deploy-scheduled-groom-dispatcher.yml` triggers on both `infrastructure/step_function_groom.json` and the Lambda source, so the merge deploys the state machine and the dispatcher together. No post-merge step.

The definition change does not affect in-flight executions — Step Functions binds the definition at execution start. The currently-running 20:00 cycle finishes on the old definition; the 04:00 UTC cycle picks up the new one.

## Out of scope, filed

- alpha-engine-config#5914 — the reconciler pages `🔴 lane DEATH` for a lane that *completed* (instance state used as a proxy for run completion; the 07-31 `high-only` lane drained its queue and wrote its artifact before being reclaimed).
- alpha-engine-config#5919 deliverables 3 and 4 — the bootstrap's cause payload carries `"instance_id":""` (unauthenticated IMDS call against `HttpTokens: required`) and a hardcoded `"phase":"bootstrap"`. Both live in `alpha-engine-config`, not this repo.

Closes nousergon/alpha-engine-config#5919
Closes nousergon/alpha-engine-config#5923

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
