### PR TITLE
fix(groom): make the completion check real, and stop paging a finished lane as dead

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1384,6 +1384,161 @@ _RECONCILE_ACTIONED_PREFIX = "groom/_control/reconciled"
 # unmatched expectation IS the signal (§2.7).
 _ALIVE_STATES = frozenset({"running", "pending"})
 
+#: Where groom_driver.py writes its run artifact: `groom/{YYYY-MM-DD}/{token}.json`.
+#: alpha-engine-config-I5914 — this is the SECOND, earlier completion signal.
+#: The driver logs `[driver] run artifact written` BEFORE `groom_run: agent
+#: exited`, and the box's own completion marker is written later still, during
+#: wind-down. A lane reclaimed between those two points has finished all of its
+#: work and left NO completion marker, so every consumer that keys off the
+#: marker alone concludes the run was lost.
+#:
+#: Measured 2026-07-31 20:00 UTC: the high-only lane wrote
+#: `groom/2026-07-31/303ace0ac87148e0a21c5ba235bb5f4e.json` at 20:35:50Z with
+#: `FINAL: 4 closed, engaged=10/10, stop='queue drained'` and rc=0, was reclaimed
+#: at 20:38Z, and was then paged as a lane DEATH.
+_RUN_ARTIFACT_PREFIX = "groom"
+
+
+def _lane_run_completed(run_token: str, days: list[str]) -> str:
+    """Return the S3 key proving this run finished, or "" if none exists.
+
+    Checks the box's completion marker first (the authoritative signal) and
+    falls back to the run artifact (written earlier, so it survives a reclaim
+    during wind-down).
+
+    ``days`` must cover the run's OWN UTC date, which is not necessarily the
+    caller's: the artifact is date-partitioned by when the run started, so a
+    lane launched at 23:5x writes to the previous day's prefix.
+
+    Best-effort by design — a probe failure returns "" and the caller falls back
+    to its pre-existing behaviour. Degrading to "page a death" or "allow a
+    relaunch" is safe; degrading to silence would not be.
+    """
+    if not run_token:
+        return ""
+    s3 = boto3.client("s3", region_name=REGION)
+    candidates = [f"{_RECONCILE_COMPLETED_PREFIX}/{run_token}.json"]
+    candidates += [f"{_RUN_ARTIFACT_PREFIX}/{day}/{run_token}.json" for day in days]
+    for key in candidates:
+        try:
+            s3.head_object(Bucket=_RESEARCH_BUCKET, Key=key)
+            return key
+        except Exception:
+            continue
+    return ""
+
+
+def _scan_days(now: datetime) -> list[str]:
+    """Today and yesterday, UTC — see _reconcile_lane_death for why both."""
+    return [(now - timedelta(days=offset)).strftime("%Y-%m-%d") for offset in (0, 1)]
+
+
+def _latest_ledger_entry_for_lane(tier_tag: str, days: list[str]) -> dict:
+    """The most recent dispatch-ledger entry for one lane, or {}.
+
+    alpha-engine-config-I5914. The SF's relaunch ladder does not know the run
+    token of the attempt that just died — the token is minted inside this Lambda
+    per attempt and only ever travels back through the task-token callback,
+    which by definition did not fire. The ledger is the one durable record that
+    ties a lane to its attempts, so the lane is resolved by tier and the newest
+    entry taken.
+    """
+    if not tier_tag:
+        return {}
+    s3 = boto3.client("s3", region_name=REGION)
+    paginator = s3.get_paginator("list_objects_v2")
+    best: dict = {}
+    best_sort = None
+    for day in days:
+        prefix = f"{_DISPATCH_LEDGER_PREFIX}/{day}/"
+        try:
+            pages = paginator.paginate(Bucket=_RESEARCH_BUCKET, Prefix=prefix)
+            for page in pages:
+                for obj in page.get("Contents", []):
+                    # Recency key: LastModified when S3 supplies it, else the
+                    # day+key ordering. Deliberately `.get` — indexing a field
+                    # that a paginator page happens not to carry raises INSIDE
+                    # the loop and the outer handler then discards the whole
+                    # day's scan, so one missing field silently loses every
+                    # entry rather than one.
+                    sort_key = (obj.get("LastModified"), f"{day}/{obj['Key']}")
+                    try:
+                        raw = s3.get_object(
+                            Bucket=_RESEARCH_BUCKET, Key=obj["Key"])["Body"].read()
+                        entry = json.loads(raw.decode())
+                    except Exception:
+                        continue
+                    if entry.get("tier_tag") != tier_tag:
+                        continue
+                    if best_sort is not None and _le_sort(sort_key, best_sort):
+                        continue
+                    best, best_sort = entry, sort_key
+        except Exception as exc:
+            logger.warning("ledger scan failed for %s/%s: %s", tier_tag, day, exc)
+    return best
+
+
+def _le_sort(a: tuple, b: tuple) -> bool:
+    """`a <= b` for (LastModified|None, key) pairs, None sorting oldest.
+
+    A plain tuple comparison raises when one side's timestamp is None and the
+    other's is a datetime, which would abort the scan it is meant to order.
+    """
+    at, bt = a[0], b[0]
+    if at is not None and bt is not None:
+        return (at, a[1]) <= (bt, b[1])
+    if at is None and bt is None:
+        return a[1] <= b[1]
+    return at is None  # a missing timestamp is treated as older
+
+
+def _handle_retry_marker(event: dict) -> dict:
+    """Answer the SF's ONE question before a relaunch: did this lane finish?
+
+    alpha-engine-config-I5914. The ``CheckCompletionMarkerTaskToken`` state has
+    existed since config#1645 and its result was NEVER READ: it wrote
+    ``$.markerResult`` and handed straight to ``CheckRetryBudget``, a Choice on
+    ``$.retry_count`` vs ``$.max_retries`` alone. The state's NAME asserted a
+    guard the state machine did not have — and the invocation it made was the
+    expensive ``decide_only`` backlog enumeration, whose output was discarded.
+
+    That was harmless only while the ladder was unreachable for reclaimed lanes
+    (the I5919 catch gap). Inverting the catch default made the ladder live for
+    every reclaim, which turns "relaunch without checking completion" into
+    "re-run a lane that already drained its queue" — duplicate spend against
+    the daily dispatch ceiling, on GitHub state a completed run already
+    dispositioned.
+
+    Returns ``{"lane_completed": bool, "run_token": str, "evidence": str}``.
+    Fails SOFT to ``lane_completed: false``: an unreadable ledger must not
+    suppress a legitimate relaunch, and the retry budget still bounds the loop.
+    """
+    now = datetime.now(ZoneInfo("UTC"))
+    days = _scan_days(now)
+    # The lane identity rides `launchDecision` (the Map item), NOT the top level:
+    # the SF passes it as a nested object rather than merging it, so a plain
+    # `event["issue_filter"]` reads empty and every lane would resolve to the
+    # same tier_tag. Top-level is accepted as a fallback for direct invokes.
+    decision = event.get("launchDecision") or {}
+    issue_filter = str(decision.get("issue_filter")
+                       or event.get("issue_filter") or "")
+    run_mode = _resolve_run_mode(
+        {**event, "run_mode": decision.get("run_mode") or event.get("run_mode")}
+        if decision else event)
+    tier_tag = _tier_tag(run_mode, issue_filter) if issue_filter else ""
+    entry = _latest_ledger_entry_for_lane(tier_tag, days)
+    run_token = str(entry.get("run_token") or "")
+    evidence = _lane_run_completed(run_token, days)
+    logger.info(
+        "retry-marker check: lane=%s run_token=%s completed=%s evidence=%s",
+        tier_tag or "?", run_token or "?", bool(evidence), evidence or "-")
+    return {
+        "lane_completed": bool(evidence),
+        "run_token": run_token,
+        "tier_tag": tier_tag,
+        "evidence": evidence,
+    }
+
 
 def _reconcile_lane_death() -> dict:
     """Reconciler entry point — enumerate open expectations, check each one
@@ -1449,7 +1604,8 @@ def _reconcile_lane_death() -> dict:
 
     if not open_expectations:
         return {"reconciled": True, "open_expectations": 0, "deaths": 0,
-                "overdue": 0, "checked_at": now.isoformat()}
+                "overdue": 0, "reclaimed_post_run": 0,
+                "checked_at": now.isoformat()}
 
     # 2. Batch describe-instances for all instance_ids.
     instance_ids = [e["instance_id"] for e in open_expectations
@@ -1466,12 +1622,16 @@ def _reconcile_lane_death() -> dict:
             # Fail-safe: treat ALL as unknown (not dead) — never page on a
             # broken EC2 API. The next reconciler tick retries.
             return {"reconciled": True, "open_expectations": len(open_expectations),
-                    "deaths": 0, "overdue": 0, "describe_error": str(exc),
-                    "checked_at": now.isoformat()}
+                    "deaths": 0, "overdue": 0, "reclaimed_post_run": 0,
+                    "describe_error": str(exc), "checked_at": now.isoformat()}
 
     # 3. Check each expectation.
     deaths = 0
     overdue_count = 0
+    # I5914: counted and returned separately from `deaths`. Folding it into the
+    # death count would keep reporting a successful cycle as a failed one on the
+    # console, which is the surface this whole path feeds.
+    reclaimed_post_run = 0
     sfn = boto3.client("stepfunctions", region_name=REGION)
     for exp in open_expectations:
         instance_id = exp.get("instance_id", "")
@@ -1496,26 +1656,54 @@ def _reconcile_lane_death() -> dict:
         if not page:
             continue
 
-        if state is None or state not in _ALIVE_STATES:
-            deaths += 1
-        else:
-            overdue_count += 1
-
-        # Page via the cycle notification rail (buzzing, #groom thread).
         tier_tag = exp.get("tier_tag", "unknown")
         schedule_label = exp.get("schedule", "unknown")
-        text = (
-            f"🔴 Groom lane DEATH — {reason}\n"
-            f"tier={tier_tag}  schedule={schedule_label}\n"
-            f"run_token={exp.get('run_token')}  instance={instance_id}"
-        )
-        _notify_cycle(
-            text, severity="error",
-            dedup_key=f"{_CYCLE_FLOW_NAME}:lane_death:{exp.get('run_token', '')}",
-            context={"expectation": {k: v for k, v in exp.items()
-                                     if not k.startswith("_")},
-                     "reason": reason, "instance_state": state},
-        )
+        run_token = str(exp.get("run_token") or "")
+
+        # alpha-engine-config-I5914: instance state is not a proxy for run
+        # completion. A lane that finished its work and was reclaimed during
+        # wind-down — before it could write its completion marker — is dead by
+        # EC2 state and successful by every measure that matters. Probing the
+        # run artifact separates the two; without it both render as an
+        # identical 🔴 DEATH and the operator cannot tell loss from noise.
+        gone = state is None or state not in _ALIVE_STATES
+        evidence = _lane_run_completed(run_token, scan_days) if gone else ""
+
+        if gone and evidence:
+            reclaimed_post_run += 1
+            outcome = "lane_reclaimed_post_run"
+            _notify_cycle(
+                f"🟡 Groom lane reclaimed AFTER completing — {reason}\n"
+                f"tier={tier_tag}  schedule={schedule_label}\n"
+                f"run_token={run_token}  instance={instance_id}\n"
+                f"work completed; evidence={evidence}",
+                # WARNING, not error: no work was lost. Paging this at error
+                # severity is what made a successful cycle read as a failed one.
+                severity="warning",
+                dedup_key=f"{_CYCLE_FLOW_NAME}:lane_reclaimed_post_run:{run_token}",
+                context={"expectation": {k: v for k, v in exp.items()
+                                         if not k.startswith("_")},
+                         "reason": reason, "instance_state": state,
+                         "completion_evidence": evidence},
+            )
+        else:
+            if gone:
+                deaths += 1
+                outcome = "lane_died"
+            else:
+                overdue_count += 1
+                outcome = "overdue"
+            # Page via the cycle notification rail (buzzing, #groom thread).
+            _notify_cycle(
+                f"🔴 Groom lane DEATH — {reason}\n"
+                f"tier={tier_tag}  schedule={schedule_label}\n"
+                f"run_token={run_token}  instance={instance_id}",
+                severity="error",
+                dedup_key=f"{_CYCLE_FLOW_NAME}:lane_death:{run_token}",
+                context={"expectation": {k: v for k, v in exp.items()
+                                         if not k.startswith("_")},
+                         "reason": reason, "instance_state": state},
+            )
 
         # Close the expectation BEFORE the send-task-failure below. Ordering is
         # deliberate: if the marker write fails we must not have already paged
@@ -1526,12 +1714,15 @@ def _reconcile_lane_death() -> dict:
         try:
             boto3.client("s3", region_name=REGION).put_object(
                 Bucket=_RESEARCH_BUCKET,
-                Key=f"{_RECONCILE_ACTIONED_PREFIX}/{exp.get('run_token', '')}.json",
+                Key=f"{_RECONCILE_ACTIONED_PREFIX}/{run_token}.json",
                 Body=json.dumps({
-                    "outcome": "lane_died" if state not in _ALIVE_STATES else "overdue",
+                    # I5914: three outcomes, not two. Every consumer of this key
+                    # was previously told `lane_died` for a run that succeeded.
+                    "outcome": outcome,
                     "reason": reason,
                     "instance_id": instance_id,
                     "instance_state": state,
+                    "completion_evidence": evidence,
                     "actioned_at": now.isoformat(),
                 }).encode(),
                 ContentType="application/json")
@@ -1565,6 +1756,7 @@ def _reconcile_lane_death() -> dict:
 
     return {"reconciled": True, "open_expectations": len(open_expectations),
             "deaths": deaths, "overdue": overdue_count,
+            "reclaimed_post_run": reclaimed_post_run,
             "checked_at": now.isoformat()}
 
 
@@ -2587,6 +2779,12 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         # for the same reason — no live schedule or other caller sets a
         # top-level `mode`, so this cannot collide with any shape below.
         return _handle_cycle_complete(event)
+    if event.get("retryMarker"):
+        # alpha-engine-config-I5914: the SF's CheckCompletionMarkerTaskToken
+        # state. Checked BEFORE decide_only below — the SF payload carries both
+        # keys, and until this branch existed the invocation fell through to the
+        # backlog enumeration whose result the state machine then discarded.
+        return _handle_retry_marker(event)
     if event.get("mode") == "reconcile":
         # config-I5229 (lane-death pager): EventBridge Scheduler (~5 min
         # cadence) invokes this mode to screen open expectations against

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2916,3 +2916,173 @@ def test_pool_spans_more_than_one_instance_family(monkeypatch):
         f"pool spans only {families} — separate capacity pools require separate "
         "FAMILIES, not just separate sizes"
     )
+
+
+# ── Completion-aware lane classification (alpha-engine-config-I5914) ──────────
+#
+# Instance state is not a proxy for run completion. A lane that finished its
+# work and was reclaimed during wind-down — before writing its completion
+# marker — is dead by EC2 state and successful by every measure that matters.
+#
+# Measured 2026-07-31 20:00 UTC: the high-only lane wrote
+# groom/2026-07-31/303ace0ac87148e0a21c5ba235bb5f4e.json at 20:35:50Z with
+# "FINAL: 4 closed, engaged=10/10, stop='queue drained'" and rc=0, was reclaimed
+# at 20:38Z, and was paged as a 🔴 lane DEATH indistinguishable from the sibling
+# lane that genuinely lost four chunks of work.
+
+def _artifact_key(run_token: str, *, days_ago: int = 0) -> str:
+    from datetime import datetime, timedelta, timezone
+    day = (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+    return f"groom/{day}/{run_token}.json"
+
+
+def _dead_lane_objects(run_token: str, **extra) -> dict:
+    objs = {
+        _ledger_key(run_token): json.dumps({
+            "run_token": run_token, "tier_tag": "high-only",
+            "schedule": "0 20 * * *", "instance_id": "i-dead",
+            "deadline_utc": _future_deadline(),
+        }).encode(),
+    }
+    objs.update(extra)
+    return objs
+
+
+def test_completed_lane_reclaimed_post_run_is_not_paged_as_a_death(monkeypatch):
+    """The 2026-07-31 high-only case, replayed."""
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects(
+        "tok-done", **{_artifact_key("tok-done"): b'{"final": true}'}))
+    notifications = _spy_notify(monkeypatch, idx)
+    out = idx.handler({"mode": "reconcile"}, None)
+
+    assert out["deaths"] == 0, "a completed lane must not count as a death"
+    assert out["reclaimed_post_run"] == 1
+    assert len(notifications) == 1
+    text, kw = notifications[0]
+    assert kw["severity"] == "warning", (
+        "a lane that completed its work must not page at error severity"
+    )
+    assert "DEATH" not in text
+    assert "completing" in text or "completed" in text
+
+
+def test_lane_with_no_artifact_still_pages_as_a_death(monkeypatch):
+    """The genuine-loss case must keep its existing behaviour exactly."""
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects("tok-lost"))
+    notifications = _spy_notify(monkeypatch, idx)
+    out = idx.handler({"mode": "reconcile"}, None)
+
+    assert out["deaths"] == 1
+    assert out["reclaimed_post_run"] == 0
+    text, kw = notifications[0]
+    assert kw["severity"] == "error"
+    assert "DEATH" in text
+
+
+def test_actioned_marker_records_the_true_outcome(monkeypatch):
+    """Every consumer of this key was being told `lane_died` for a success."""
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects(
+        "tok-done", **{_artifact_key("tok-done"): b"{}"}))
+    _spy_notify(monkeypatch, idx)
+    idx.handler({"mode": "reconcile"}, None)
+
+    written = getattr(idx._test_s3, "_objects", {})
+    key = "groom/_control/reconciled/tok-done.json"
+    assert key in written, f"expectation not closed; wrote {list(written)}"
+    record = json.loads(written[key].decode() if isinstance(written[key], bytes)
+                        else written[key])
+    assert record["outcome"] == "lane_reclaimed_post_run"
+    assert record["completion_evidence"], "the proving key must be recorded"
+
+
+def test_completion_probe_covers_the_previous_day_partition(monkeypatch):
+    """The artifact is partitioned by the RUN's UTC date, not the tick's.
+
+    A lane launched at 23:5x writes to the previous day's prefix; probing only
+    today would re-page it as a death every tick until the ledger aged out.
+    """
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects(
+        "tok-x", **{_artifact_key("tok-x", days_ago=1): b"{}"}))
+    _spy_notify(monkeypatch, idx)
+    out = idx.handler({"mode": "reconcile"}, None)
+    assert out["reclaimed_post_run"] == 1 and out["deaths"] == 0
+
+
+def test_completion_marker_alone_still_proves_completion(monkeypatch):
+    """The pre-existing signal keeps working — the artifact is additive."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok-m"): json.dumps({
+            "run_token": "tok-m", "tier_tag": "mid-only",
+            "schedule": "0 20 * * *", "instance_id": "i-dead",
+            "deadline_utc": _future_deadline(),
+        }).encode(),
+        "groom/_control/completed/tok-m.json": b'{"outcome": "success"}',
+    })
+    notifications = _spy_notify(monkeypatch, idx)
+    out = idx.handler({"mode": "reconcile"}, None)
+    # A completion marker closes the expectation BEFORE the death check, so this
+    # lane is never even an open expectation.
+    assert out["deaths"] == 0 and not notifications
+
+
+# ── The SF's relaunch guard is real now (alpha-engine-config-I5914) ───────────
+#
+# CheckCompletionMarkerTaskToken has existed since config#1645 writing
+# $.markerResult that NOTHING read: CheckRetryBudget branched on retry_count vs
+# max_retries alone. The state's NAME asserted a guard the machine did not have.
+
+def test_retry_marker_reports_completion_for_a_finished_lane(monkeypatch):
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok-fin"): json.dumps({
+            "run_token": "tok-fin", "tier_tag": "high-only",
+            "schedule": "0 20 * * *", "instance_id": "i-1",
+        }).encode(),
+        _artifact_key("tok-fin"): b"{}",
+    })
+    out = idx.handler({"retryMarker": True, "run_mode": "full",
+                       "launchDecision": {"issue_filter": "high-only"}}, None)
+    assert out["lane_completed"] is True
+    assert out["run_token"] == "tok-fin"
+    assert out["evidence"]
+
+
+def test_retry_marker_reports_incomplete_for_a_truncated_lane(monkeypatch):
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok-cut"): json.dumps({
+            "run_token": "tok-cut", "tier_tag": "high-only",
+            "schedule": "0 20 * * *", "instance_id": "i-1",
+        }).encode(),
+    })
+    out = idx.handler({"retryMarker": True, "run_mode": "full",
+                       "launchDecision": {"issue_filter": "high-only"}}, None)
+    assert out["lane_completed"] is False, (
+        "a lane with no artifact must stay relaunchable"
+    )
+
+
+def test_retry_marker_resolves_the_lane_from_launch_decision(monkeypatch):
+    """The lane identity is NESTED under launchDecision, not top-level.
+
+    Reading `event["issue_filter"]` resolves empty for every lane, so all three
+    would share one tier_tag and answer for each other.
+    """
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok-high"): json.dumps({
+            "run_token": "tok-high", "tier_tag": "high-only",
+            "schedule": "0 20 * * *", "instance_id": "i-1",
+        }).encode(),
+        _artifact_key("tok-high"): b"{}",
+    })
+    # Asking about a DIFFERENT lane must not match high-only's artifact.
+    out = idx.handler({"retryMarker": True, "run_mode": "full",
+                       "launchDecision": {"issue_filter": "low-only"}}, None)
+    assert out["tier_tag"] == "low-only"
+    assert out["lane_completed"] is False
+
+
+def test_retry_marker_fails_soft_when_the_ledger_is_unreadable(monkeypatch):
+    """An unreadable ledger must not suppress a legitimate relaunch."""
+    idx = _load(monkeypatch, s3_objects={})
+    out = idx.handler({"retryMarker": True, "run_mode": "full",
+                       "launchDecision": {"issue_filter": "mid-only"}}, None)
+    assert out["lane_completed"] is False

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -208,6 +208,7 @@
                   "decide_only": true
                 },
                 "schedInput.$": "$.schedInput",
+                "launchDecision.$": "$.launchDecision",
                 "retryMarker": true
               }
             },
@@ -228,6 +229,20 @@
             "Type": "Choice",
             "Comment": "config#1645: marker is absent (box died mid-run) — relaunch if attempts remain, else give up and alert. Bounded to max_retries (3, i.e. up to 4 total launch attempts per iteration) so a genuinely bad AWS day can't spot-cycle indefinitely. alpha-engine-config-I5923 (Brian ruling 2026-07-31): max_retries was 1, which made the SINGLE relaunch also the LAST one, so CheckForceOnDemand forced it to on-demand — the lane went spot -> on-demand with ZERO alternate spot capacity pools tried. During prime time, when reclamation is most likely, that is effectively defaulting to on-demand. At 3 the ladder is attempt 0 spot, retries 1 and 2 spot on DIFFERENT instance types (the dispatcher rotates the pool by $.fod.attempt), retry 3 on-demand.",
             "Choices": [
+              {
+                "And": [
+                  {
+                    "Variable": "$.markerResult.Payload.lane_completed",
+                    "IsPresent": true
+                  },
+                  {
+                    "Variable": "$.markerResult.Payload.lane_completed",
+                    "BooleanEquals": true
+                  }
+                ],
+                "Comment": "alpha-engine-config-I5914: the lane finished its work and was reclaimed during wind-down, before it could write its completion marker. Relaunching it would re-run a queue that is already dispositioned — duplicate spend against the daily dispatch ceiling, on GitHub state a completed run already acted on. This branch is what makes the state ABOVE actually a check: until 2026-07-31 CheckCompletionMarkerTaskToken wrote $.markerResult and NOTHING read it, so the ladder relaunched purely on retry budget. The IsPresent guard is load-bearing and paired deliberately — CheckCompletionMarkerTaskToken's own Catch routes here with $.markerResult ABSENT, and a bare BooleanEquals on a missing path is an evaluation error, not a non-match.",
+                "Next": "GroomSucceeded"
+              },
               {
                 "Variable": "$.retry_count",
                 "NumericLessThanPath": "$.max_retries",

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -394,3 +394,81 @@ def test_the_runtime_bound_reaches_the_box():
     assert "{runtime_bound_export}" in src, (
         "the export is built but never interpolated into the bootstrap command"
     )
+
+
+# ── The completion check actually gates the relaunch (I5914) ──────────────────
+#
+# CheckCompletionMarkerTaskToken has existed since config#1645 writing
+# $.markerResult that NOTHING read: CheckRetryBudget branched on retry_count vs
+# max_retries alone. The state's NAME asserted a guard the state machine did not
+# have, and the invocation it made was the expensive decide_only backlog
+# enumeration whose output was then discarded.
+#
+# That was inert only while the ladder was unreachable for reclaimed lanes (the
+# I5919 catch gap). Inverting the catch default made the ladder live for every
+# reclaim, which turns "relaunch without checking completion" into "re-run a
+# lane that already drained its queue".
+
+def test_retry_budget_checks_completion_before_spending_a_retry(states):
+    """The completion branch must exist AND be evaluated first.
+
+    Choice rules are evaluated in order; a retry-budget rule placed ahead of the
+    completion rule would relaunch a finished lane whenever budget remained.
+    """
+    choices = states["CheckRetryBudget"]["Choices"]
+    blob = json.dumps(choices)
+    assert "lane_completed" in blob, (
+        "CheckRetryBudget never consults the completion result — $.markerResult "
+        "is written by the state above and read by nobody"
+    )
+    first = json.dumps(choices[0])
+    assert "lane_completed" in first, (
+        "the completion check must be the FIRST choice rule, ahead of the "
+        "retry-budget rule"
+    )
+    assert "retry_count" in json.dumps(choices[1:]), (
+        "the retry-budget rule must still exist after the completion rule"
+    )
+
+
+def test_completion_branch_does_not_relaunch(states):
+    """A completed lane must terminate the iteration, not re-enter the ladder."""
+    completed = states["CheckRetryBudget"]["Choices"][0]
+    assert completed["Next"] == "GroomSucceeded", (
+        f"completed lane routes to {completed['Next']!r} — anything that "
+        "reaches LaunchGroomSpot again re-runs a dispositioned queue"
+    )
+    assert states["GroomSucceeded"]["Type"] == "Succeed"
+
+
+def test_completion_branch_guards_against_an_absent_marker_result(states):
+    """CheckCompletionMarkerTaskToken's own Catch routes here WITHOUT the field.
+
+    A bare BooleanEquals on a missing path is an evaluation error, not a
+    non-match, so the IsPresent guard is load-bearing rather than defensive.
+    """
+    completed = states["CheckRetryBudget"]["Choices"][0]
+    assert "And" in completed, "the completion rule must be an And-guarded pair"
+    ops = [set(rule) - {"Variable", "Comment"} for rule in completed["And"]]
+    assert {"IsPresent"} in ops, "no IsPresent guard on $.markerResult"
+    assert {"BooleanEquals"} in ops, "no BooleanEquals on the completion flag"
+    catch_targets = {c["Next"] for c in states["CheckCompletionMarkerTaskToken"]["Catch"]}
+    assert "CheckRetryBudget" in catch_targets, (
+        "this test's premise changed: the marker-check Catch no longer reaches "
+        "CheckRetryBudget, so re-derive whether the IsPresent guard is still "
+        "load-bearing"
+    )
+
+
+def test_marker_check_receives_the_lane_identity(states):
+    """The Lambda cannot resolve WHICH lane to check without launchDecision.
+
+    Without it every lane resolves to the same tier_tag and the three lanes
+    answer for each other.
+    """
+    payload = states["CheckCompletionMarkerTaskToken"]["Parameters"]["Payload"]
+    assert payload.get("launchDecision.$") == "$.launchDecision", (
+        "CheckCompletionMarkerTaskToken must pass launchDecision or the "
+        "completion check cannot identify the lane"
+    )
+    assert payload.get("retryMarker") is True


### PR DESCRIPTION
## Why

Two defects sharing one root: **instance state was used as a proxy for run completion**, and the state machine's completion guard was decorative.

### 1. `CheckCompletionMarkerTaskToken` checked nothing

The state has existed since config#1645 writing `$.markerResult` — and **nothing read it**. `CheckRetryBudget` branched on `$.retry_count` vs `$.max_retries` alone:

```json
"CheckRetryBudget": {
  "Type": "Choice",
  "Choices": [{"Variable": "$.retry_count", "NumericLessThanPath": "$.max_retries", "Next": "PrepRelaunch"}],
  "Default": "GroomRetriesExhausted"
}
```

The state's *name* asserted a guard the machine did not have, and the invocation it made was the expensive `decide_only` backlog enumeration whose output was then discarded.

This was inert only while the ladder was unreachable for reclaimed lanes (the alpha-engine-config#5919 catch gap). **Inverting that default in nousergon-data-PR1195 made the ladder live for every reclaim** — which turns "relaunch without checking completion" into "re-run a lane that already drained its queue": duplicate spend against the daily dispatch ceiling, acting on GitHub state a completed run already dispositioned. PR1195's body claimed this state already guarded against that; it did not, and this PR is what makes the claim true.

The SF could not ask the question before: the run token is minted per attempt *inside* the Lambda and only travels back through the task-token callback, which by definition did not fire. The lane is now resolved from `launchDecision` (newly passed into the payload — without it every lane resolves to the same `tier_tag` and the three lanes answer for each other) and matched to its newest dispatch-ledger entry.

`CheckRetryBudget` gains a **first** choice routing a completed lane to `GroomSucceeded`. The `IsPresent` guard is paired deliberately: `CheckCompletionMarkerTaskToken`'s own `Catch` reaches this state with `$.markerResult` **absent**, and a bare `BooleanEquals` on a missing path is an evaluation error, not a non-match.

### 2. The reconciler paged a completed lane as a death

Measured 2026-07-31 20:00 UTC — lane `high-only`, run token `303ace0ac87148e0a21c5ba235bb5f4e`, instance `i-0f43bbe4bf4e8803d`:

- `20:35:50Z` — run artifact written, `[driver] FINAL: 4 closed, engaged=10/10, stop='queue drained'`, `rc=0`
- `20:38Z` — reclaimed, `instance-terminated-no-capacity`
- `20:40Z` — paged `🔴 Groom lane DEATH`, indistinguishable from the sibling `low-only` lane that genuinely lost four chunks

The reconcile marker recorded `"outcome": "lane_died"` for a successful run, and every consumer of that key inherited the wrong fact.

## What changed

Both paths now probe the **run artifact** (`groom/{YYYY-MM-DD}/{run_token}.json`), which the driver writes *before* the completion handshake and which therefore survives a reclaim during wind-down. The box's completion marker remains the primary signal; the artifact is the additive fallback.

Three outcomes instead of two:

| outcome | condition | severity |
|---|---|---|
| `lane_died` | no artifact, no marker | error — 🔴, unchanged |
| `lane_reclaimed_post_run` | artifact present | **warning** — names what completed |
| `overdue` | alive, past deadline | error, unchanged |

`reclaimed_post_run` is counted and returned separately from `deaths`; folding it in would keep reporting a successful cycle as a failed one on the console, which is the surface this path feeds.

The probe covers **today and yesterday** — the artifact is partitioned by the *run's* UTC date, so a lane launched at 23:5x writes to the previous day's prefix and probing only today would re-page it every tick until the ledger aged out.

**Also hardened the ledger scan.** It indexed `obj["LastModified"]`, and a page lacking that field raised *inside* the loop where the outer handler discarded the whole day's scan — one missing field silently losing every entry rather than one. Surfaced by a test fixture; fixed in the code, not the fixture.

## Test plan

Run before opening:

- `227` groom/spot tests in `tests/` — green
- `173` dispatcher tests in `test_handler.py` — green
- `aws stepfunctions validate-state-machine-definition` → `{"result": "OK", "diagnostics": []}`

New coverage:

- `test_handler.py` — the 2026-07-31 case replayed as a fixture; the genuine-loss case asserted unchanged (still `severity="error"`, still `DEATH`); marker outcome; previous-day partition; completion-marker-alone still short-circuits; lane resolved from `launchDecision` and **not** matching a sibling lane's artifact; fail-soft on an unreadable ledger.
- `test_sf_groom_relaunch_wiring.py` — the completion rule exists, is **first**, routes to a `Succeed` rather than back into the ladder, carries the `IsPresent`/`BooleanEquals` pair, and `launchDecision` is in the marker-check payload. One of these asserts its own premise (that the marker-check `Catch` still reaches `CheckRetryBudget`) so the guard cannot quietly become unnecessary without saying so.

Ruff reports 13 findings in `test_handler.py` — all pre-existing on `main` (verified against `origin/main` directly), none added here. Ruff is not a CI gate in this repo.

## Deployment

`.github/workflows/deploy-scheduled-groom-dispatcher.yml` triggers on both `infrastructure/step_function_groom.json` and the Lambda source, so the merge deploys both together. No post-merge step. Step Functions binds the definition at execution start, so any in-flight cycle finishes on the current definition.

## Related

- nousergon-data-PR1195 (merged) — inverted the catch default; this PR supplies the completion guard that change assumes.
- alpha-engine-config-PR5930 — the on-box half: authenticated IMDS and a live run phase in the failure payloads. Independent; either order.

Closes nousergon/alpha-engine-config#5914

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
