### PR TITLE
[P2/low] fix(overseer): declare box-health + deploy-on-merge alert classes (I5326)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -801,6 +801,21 @@ alert_classes:
     intake: cw-alarm
     response: drain-queue
 
+  # ── infra (box health + deploy-on-merge — config-I3211 alert-drain registry) ──
+  # Both emitters were added without declaring a class; the config-I3211
+  # completeness chokepoint reported them as undeclared every drain run until
+  # rows matched the emitted source strings exactly (alpha-engine-config#5326).
+  - class: box_health
+    source: "box-health"
+    severities: [warning, critical]
+    intake: bus
+    response: drain-queue
+  - class: deploy_on_merge
+    source: "deploy-on-merge"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
+
   # ── DRAIN-BLIND rows (every one carries its migration or declaration) ──
   - class: executor_emergency_shutdown
     source: "raw-sns:executor/emergency_shutdown.py"


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** low

Closes nousergon/alpha-engine-config#5326

Add `alert_classes` rows for the two undeclared emitters the config-I3211
completeness chokepoint reports on every drain run:

- `box-health` — severities `[warning, critical]` (warning escalates to critical
  via the CW alarm path), intake `bus`, response `drain-queue`.
- `deploy-on-merge` — severity `[critical]` (a deploy that fails its console
  health check and auto-reverts is production-affecting), intake `bus`,
  response `drain-queue`.

Both rows match the emitted `source` strings exactly, per the 2026-07-29
operator ruling (box-health warning, deploy-on-merge critical).

**Validated:** `playbooks.yaml` validates against `playbooks.schema.json`;
42/42 `test_overseer_playbook_registry.py` tests pass locally (incl.
`test_alert_classes_present_and_unique`). Verify end-to-end by re-running the
next `drain-*` run and confirming these two stop being reported as undeclared.
