### PR TITLE
[P1/mid] fix(iam): declare POLICY_NAME in thinktank-spot-dispatcher deploy.sh — close the drift-check coverage gap (alpha-engine-config#6061)

### DIFF
--- a/infrastructure/install-daily-news.sh
+++ b/infrastructure/install-daily-news.sh
@@ -10,12 +10,54 @@
 #
 # daily-news.service itself does its own code refresh on every run (`git
 # reset --hard` in scripts/run_daily_news_standalone.sh) — this script only
-# handles the SEPARATE concern of the unit FILES landing in
-# /etc/systemd/system/, which a plain code pull never touches.
+# handles the SEPARATE concerns of the unit FILES landing in
+# /etc/systemd/system/ and the venv the unit's runner invokes.
 set -euo pipefail
 
 REPO_DIR="/home/ec2-user/alpha-engine-data"
 UNIT_DIR="${REPO_DIR}/infrastructure/systemd"
+VENV_DIR="${REPO_DIR}/.venv"
+VENV_PY="${VENV_DIR}/bin/python"
+
+# ── Slim venv provisioning (alpha-engine-config#6063) ───────────────────────
+# Mirrors install-metron-intraday.sh: the shared .venv was created with
+# AL2023's default python3.9, but requirements-daily-news.txt pins
+# boto3>=1.43.59 (Python 3.10+) and numpy>=2.4.6 (Python 3.11+), so pip
+# install failed on every run and the venv could never advance — the
+# RAG-ingest deps config-I5702 added never landed. Rebuild on python3.12
+# (the interpreter metron-intraday provisions on this same box) when missing
+# or stale. The unit's runner (scripts/run_daily_news_standalone.sh)
+# self-heals the venv identically on every run, so this is install-time
+# readiness, not the load-bearing path. The only other .venv consumer on the
+# box, systemd-unit-drift-check.service, runs a stdlib-only script
+# (infrastructure/systemd/check-systemd-unit-drift.py) — 3.12-safe.
+if [ ! -x "$VENV_PY" ] || ! "$VENV_PY" -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
+    echo "provisioning ${VENV_DIR} (python3.12)…"
+    command -v python3.12 >/dev/null || {
+        echo "FATAL: python3.12 not found. requirements-daily-news.txt pins boto3>=1.43.59," >&2
+        echo "which needs Python 3.10+, and numpy>=2.4.6 which needs Python 3.11+. The" >&2
+        echo "3.9 venv cannot be repaired by older wheels — install python3.12 before" >&2
+        echo "running this (alpha-engine-config#6063)." >&2
+        exit 1
+    }
+    # .venv is gitignored and fully reproducible from requirements-daily-news.txt.
+    rm -rf "$VENV_DIR"
+    sudo -u ec2-user python3.12 -m venv "$VENV_DIR"
+fi
+sudo -u ec2-user "${VENV_DIR}/bin/pip" install -q --upgrade pip
+sudo -u ec2-user "${VENV_DIR}/bin/pip" install -q -r "${REPO_DIR}/requirements-daily-news.txt"
+
+# ── PREFLIGHT: prove the venv can import the run's real closure BEFORE
+# enabling the timer (mirrors install-metron-intraday.sh — the 2026-07-29
+# incident class: an enable-time claim made without testing moves the failure
+# from install time, where a human is watching, to run time, where it is a
+# silent background job). The RAG chain's lazy imports sit inside
+# daily_news.py's fail-soft try/except, so a missing dependency would
+# otherwise be swallowed into rag_status=error with no page.
+if ! sudo -u ec2-user "$VENV_PY" -c 'import collectors.daily_news; from rag.pipelines._watermarks import WatermarkStore; from rag.pipelines.ingest_news import ingest_articles; from rag.pipelines.run_news_pipeline import NEWS_DOC_TYPE, NEWS_SOURCE, _load_ticker_sector_map'; then
+    echo "FATAL: preflight import failed — the daily-news venv cannot import the run's dependency closure (alpha-engine-config#6063). See the traceback above." >&2
+    exit 1
+fi
 
 cp "${UNIT_DIR}/daily-news.service" /etc/systemd/system/daily-news.service
 cp "${UNIT_DIR}/daily-news.timer" /etc/systemd/system/daily-news.timer

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -24,6 +24,12 @@ REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 FUNCTION_NAME="alpha-engine-thinktank-spot-dispatcher"
 ROLE_NAME="alpha-engine-thinktank-spot-dispatcher-role"
+# Authoritative inline-policy assignment — the consolidated drift checker
+# (nous-ergon-ops/infrastructure/iam/check-drift.py --lambdas-root) maps each
+# lambda's iam-policy.json to a live policy via these two top-level lines; a
+# policy file without both is a coverage gap that fails the IAM drift sweep
+# (alpha-engine-config#6061, config#2340 surface 3).
+POLICY_NAME="alpha-engine-thinktank-spot-dispatcher-role-policy"
 RULE_NAME="alpha-research-thinktank-daily"
 # Same topic the alarms this cutover replaces already publish to, so the
 # rotation does not silently change where a Think Tank page lands.
@@ -53,7 +59,7 @@ if [ "$BOOTSTRAP" -eq 1 ]; then
         --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
         --region "$REGION" >/dev/null 2>&1 || echo "    (role exists)"
     aws iam put-role-policy --role-name "$ROLE_NAME" \
-        --policy-name "${ROLE_NAME}-policy" \
+        --policy-name "$POLICY_NAME" \
         --policy-document "file://$SCRIPT_DIR/iam-policy.json" \
         --region "$REGION"
     echo "    waiting for IAM propagation..."

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -1,19 +1,25 @@
-# Slim dependency set for running ONLY the standalone daily-news collector
-# (`python -m collectors.daily_news`) on a memory/disk-constrained host.
+# Slim dependency set for running the standalone daily-news collector
+# (`python -m collectors.daily_news`) on the shared dashboard box (t3.small).
 #
 # Why this exists: the full `requirements.txt` pulls the entire data stack
-# (arcticdb, voyageai, edgartools, beautifulsoup4/lxml, jsonschema, yfinance,
-# lib[arcticdb,rag,contracts], ...) — ~1.5 GB installed. The daily-news
-# collector imports NONE of those; its true external surface is just the
-# packages below (verified by tracing `collectors.daily_news`'s import
-# closure: nlp.loughran_mcdonald, news_aggregator_async, news_sources/*,
-# data/derived/news_{aggregates,articles}, polygon_client). This lets the
-# collector run on the shared dashboard box (t3.small) without the heavy
-# stack. Measured peak RSS of a full 96-ticker run: ~0.17 GB.
+# (arcticdb, edgartools, beautifulsoup4/lxml, jsonschema, yfinance,
+# lib[arcticdb,contracts], ...) — ~1.5 GB installed. The daily-news
+# collector's true external surface is the packages below (verified by
+# tracing `collectors.daily_news`'s import closure: nlp.loughran_mcdonald,
+# news_aggregator_async, news_sources/*, data/derived/news_{aggregates,articles},
+# polygon_client) PLUS the RAG corpus-ingest chain config-I5702 added
+# (rag.pipelines.{ingest_news,_watermarks,run_news_pipeline} →
+# nousergon_lib.rag → psycopg2-binary/pgvector, and voyageai embeddings at
+# embed time). The DB deps ride the lib's [rag] extra so they stay in
+# lockstep with the lib pin; voyageai has no lib extra and mirrors
+# requirements.txt's own pin. Measured peak RSS of a full 96-ticker run:
+# ~0.17 GB.
 #
 # Keep in lockstep with the lib pin in requirements.txt. If a future change
 # adds an import to the daily-news chain, add the dep here too (the standalone
-# run will fail loud on a missing import).
+# run will fail loud on a missing import — the 2026-07-30 config-I5702 wiring
+# missed exactly this and every daily run's corpus ingest failed for days,
+# alpha-engine-config#6063).
 boto3>=1.43.59
 pandas>=2.0
 pyarrow>=25.0.0
@@ -23,4 +29,5 @@ feedparser>=6.0.14
 anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
-nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+voyageai>=0.5.0
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27

--- a/scripts/run_daily_news_standalone.sh
+++ b/scripts/run_daily_news_standalone.sh
@@ -3,8 +3,8 @@
 #
 # Mirrors the weekday SF's RunDailyNews command, but adapted to run OUTSIDE
 # the trading Step Function on the shared dashboard EC2 box, using a slim,
-# news-only venv (requirements-daily-news.txt) so it doesn't need the full
-# data stack (arcticdb/voyageai/etc.). Triggered by daily-news.timer at
+# news-focused venv (requirements-daily-news.txt) so it doesn't need the full
+# data stack (arcticdb/edgartools/etc.). Triggered by daily-news.timer at
 # 04:00 PT — ahead of the 05:00 morning-signal run that consumes the
 # data/news_*_daily/ artifact. Also still consumed by the dashboard
 # "Daily News" console page.
@@ -26,6 +26,35 @@ cd "$REPO"
 # Upload the run log to S3 on exit for observability (best-effort, never fatal).
 trap 'aws s3 cp "$LOG" "s3://alpha-engine-research/_ssm_logs/daily-news-standalone/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log" --only-show-errors 2>/dev/null || true' EXIT
 
+# ── Slim venv self-heal (alpha-engine-config#6063) ──────────────────────────
+# The box's .venv was created with AL2023's default python3.9. The slim
+# requirements pin boto3>=1.43.59 (Python 3.10+) and numpy>=2.4.6 (Python
+# 3.11+), so `pip install` failed on EVERY run there and the venv could never
+# advance — the RAG-ingest deps config-I5702 added therefore never landed and
+# every standalone run silently skipped corpus warming. The only other .venv
+# consumer on the box, systemd-unit-drift-check.service, runs a stdlib-only
+# script (infrastructure/systemd/check-systemd-unit-drift.py) — 3.12-safe.
+# Rebuild on python3.12 (the fleet standard; the interpreter
+# install-metron-intraday.sh provisions on this same box) when missing or
+# stale. Idempotent: a healthy >=3.11 venv is left untouched.
+ensure_venv() {
+    local venv_py="$REPO/.venv/bin/python"
+    if [ ! -x "$venv_py" ] || ! "$venv_py" -c 'import sys; exit(0 if sys.version_info >= (3, 11) else 1)'; then
+        echo "provisioning $REPO/.venv (python3.12)…"
+        command -v python3.12 >/dev/null || {
+            echo "FATAL: python3.12 not found. requirements-daily-news.txt pins" >&2
+            echo "boto3>=1.43.59 (Python 3.10+) and numpy>=2.4.6 (Python 3.11+);" >&2
+            echo "the box's 3.9 venv cannot be repaired by older wheels, it must" >&2
+            echo "be rebuilt on python3.12. Install it before re-running." >&2
+            exit 1
+        }
+        # .venv is gitignored and fully reproducible from the requirements
+        # file below — a stale-interpreter rebuild is safe to discard.
+        rm -rf "$REPO/.venv"
+        python3.12 -m venv "$REPO/.venv"
+    fi
+}
+
 {
   echo "=== daily-news standalone run $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
   # Refresh code + slim deps (fail-loud on checkout divergence, pip install failure).
@@ -37,6 +66,7 @@ trap 'aws s3 cp "$LOG" "s3://alpha-engine-research/_ssm_logs/daily-news-standalo
   git -C "$CONFIG_REPO" fetch origin
   git -C "$CONFIG_REPO" reset --hard origin/main
 
+  ensure_venv
   .venv/bin/pip install -q -r requirements-daily-news.txt
 
   # Verify HEAD matches origin/main (divergence guard)
@@ -52,6 +82,38 @@ set -a
 # shellcheck disable=SC1091
 source /home/ec2-user/.alpha-engine.env 2>/dev/null || true
 set +a
+
+# ── RAG corpus-ingest secrets (alpha-engine-config#6063) ────────────────────
+# RAG_DATABASE_URL + VOYAGE_API_KEY come from SSM Parameter Store, NOT the
+# SCP'd .env — the Phase-2 SSM migration spot_data_weekly.sh documents
+# (2026-04-17 SF failure: RAG_DATABASE_URL truncated at an unquoted & in the
+# .env; SSM stores the value as an opaque string, no shell-parse fragility).
+# The dashboard role's tracked alpha-engine-ssm-read.json grants
+# ssm:GetParameter on /alpha-engine/*. Fail-loud: the RAG ingest is a designed
+# part of this run (config-I5702) — a missing secret is an environment error
+# that fails EVERY run, and the silent-degradation variant is exactly the bug
+# this fix closes (the ingest itself stays fail-soft in daily_news.py for
+# service-level failures: pgvector down, Voyage throttled).
+for name in RAG_DATABASE_URL VOYAGE_API_KEY; do
+    val=$(aws ssm get-parameter --name "/alpha-engine/$name" --with-decryption --query 'Parameter.Value' --output text --region "${AWS_REGION:-us-east-1}" 2>/dev/null || echo "")
+    if [ -z "$val" ]; then
+        echo "ERROR: could not fetch /alpha-engine/$name from SSM — required for RAG corpus ingest (alpha-engine-config#6063)" >> "$LOG"
+        exit 1
+    fi
+    export "$name=$val"
+    unset val
+done
+echo "RAG secrets fetched: RAG_DATABASE_URL, VOYAGE_API_KEY" >> "$LOG"
+
+# ── Preflight: prove the venv can import the run's real closure BEFORE
+# running (mirrors install-metron-intraday.sh — the 2026-07-29 incident class:
+# a missing import degrades silently for days). The RAG chain's lazy imports
+# sit inside daily_news.py's fail-soft try/except, so a missing dependency
+# would otherwise be swallowed into rag_status=error with no page.
+.venv/bin/python -c 'import collectors.daily_news; from rag.pipelines._watermarks import WatermarkStore; from rag.pipelines.ingest_news import ingest_articles; from rag.pipelines.run_news_pipeline import NEWS_DOC_TYPE, NEWS_SOURCE, _load_ticker_sector_map' >> "$LOG" 2>&1 || {
+    echo "ERROR: preflight import failed — the slim venv is missing a dependency of the daily-news chain (see traceback above)" >> "$LOG"
+    exit 1
+}
 
 # --require-digest: this box runner feeds the morning-signal podcast, whose
 # consumer treats the digest as a hard prerequisite. Exit non-zero if the

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -9,8 +9,15 @@ Derives, from a FAILED ``ne-weekly-freshness-pipeline`` execution, the exact
   stamped from Execution.StartTime and writes to different artifact prefixes,
   orphaning the prior partial run);
 - the derived ``skip_*`` flag set for every stage the failed execution
-  completed (re-running a succeeded side-effecting stage duplicates its
-  effects — 2026-07-11: duplicate model-zoo promotion emails, config#2252);
+  completed CLEANLY (re-running a succeeded side-effecting stage duplicates
+  its effects — 2026-07-11: duplicate model-zoo promotion emails,
+  config#2252). A stage that DEGRADED — ran, failed, and was absorbed by a
+  ``Publish*Degraded`` route so the pipeline could continue (alpha-engine-
+  config-I6055: observed 2026-08-01 when the Director hard-failed on
+  ``No module named 'openai'`` but the run kept going) — is recorded as
+  degraded and NEVER skipped: it is exactly the thing a mechanical rerun
+  exists to retry, and skipping it would make the rerun's green
+  indistinguishable from a real one;
 - ``pipeline_role="watch-rerun"`` (see ROLE GATING below);
 - ``sns_topic_arn`` / ``ec2_instance_id`` passthrough (the emitted input
   starts from the failed execution's own input, so both carry over).
@@ -107,7 +114,12 @@ RERUNNABLE_SOURCE_STATUSES = frozenset({"FAILED", "TIMED_OUT", "ABORTED"})
 # by tests/test_weekly_sf_rerun.py (witness = the state the SF enters iff the
 # stage completed successfully OR was skipped; either way the rerun must not
 # re-run it, and originally-skipped stages carry their flag from the
-# preserved original input anyway).
+# preserved original input anyway). degraded_witness = a *Degraded /
+# Publish*Degraded state entered iff the stage ran but FAILED and was
+# absorbed fail-open so the pipeline could continue (weekly-sf-policy §2.3);
+# entering one OVERRIDES witness: the stage is re-run, never skipped — the
+# whole point of a mechanical rerun is to retry exactly what degraded
+# (alpha-engine-config-I6055).
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
@@ -117,6 +129,10 @@ class Stage:
     gate: str                      # the CheckSkip* Choice state
     work: str                      # the stage's first work state
     witness: frozenset             # entered => completed-or-skipped
+    degraded_witness: frozenset = frozenset()   # a *Degraded / Publish*Degraded
+                                    # state entered => the stage RAN BUT FAILED
+                                    # and was absorbed fail-open — it must
+                                    # RE-RUN, overriding witness (I6055)
     emit_skip: bool = True         # False => never emit the flag (see notes)
     detect_failure: bool = True    # False => another Stage row already owns
                                     # this `work` state's failure detection
@@ -131,6 +147,17 @@ STAGES: tuple[Stage, ...] = (
         "lib_pin_drift_check", "skip_lib_pin_drift_check",
         "CheckSkipLibPinDriftCheck", "LibPinDriftCheck",
         frozenset({"CheckMutexRole"}),
+        # the whole pre-workload gate chain (lib-pin / pipeline-contract /
+        # evaluator / evaluator-director drift gates, config#2278 +
+        # config#2348) degrades fail-open through these Pass+Publish pairs —
+        # no skip flag is emitted either way (emit_skip=False), but the
+        # summary must say "degraded", not "completed", when one was hit.
+        degraded_witness=frozenset({
+            "LibPinGateDegraded", "PublishLibPinGateDegraded",
+            "PipelineContractGateDegraded", "PublishPipelineContractGateDegraded",
+            "EvaluatorGateDegraded", "PublishEvaluatorGateDegraded",
+            "EvaluatorDirectorGateDegraded", "PublishEvaluatorDirectorGateDegraded",
+        }),
         emit_skip=False,
         note=(
             "deliberately NEVER skipped on a rerun: the lib-pin drift +"
@@ -198,6 +225,10 @@ STAGES: tuple[Stage, ...] = (
         "thinktank_coverage", "skip_thinktank_coverage",
         "CheckSkipThinkTankCoverage", "ThinkTankCoverage",
         frozenset({"CheckSkipRegimeRetrospectiveEval"}),
+        # ThinkTankDegraded (alpha-engine-config-I5758) sets the visible
+        # thinktank_degraded flag and converges into this stage's witness —
+        # a degraded ThinkTank must re-run, not be skipped as completed.
+        degraded_witness=frozenset({"ThinkTankDegraded"}),
     ),
     Stage(
         "regime_retrospective_eval", "skip_regime_retrospective_eval",
@@ -305,6 +336,15 @@ STAGES: tuple[Stage, ...] = (
         "post_eval", "skip_post_eval",
         "CheckSkipPostEval", "SaturdayHealthCheck",
         frozenset({"CheckShellRunNotify"}),
+        # Every degraded route in the tail (config#2276 health checks +
+        # config#2302 ReportCard/Director) — entering ANY of them means the
+        # tail ran but something inside it failed and was absorbed; the
+        # tail must re-run, never be skipped as complete (I6055: the
+        # 2026-08-01 Director hard-fail that the next rerun skipped).
+        degraded_witness=frozenset({
+            "SaturdayHealthCheckDegraded", "SubstrateHealthCheckDegraded",
+            "PublishReportCardDegraded", "PublishDirectorDegraded",
+        }),
         note=(
             "skip_post_eval covers the whole health-check/report-card/"
             "director tail; a failure inside it re-runs the whole tail"
@@ -391,6 +431,7 @@ class RerunPlan:
     run_date_provenance: str
     original_input: dict
     completed: list = field(default_factory=list)   # stage names
+    degraded: list = field(default_factory=list)    # stage names (re-run!)
     failed: list = field(default_factory=list)      # stage names
     skip_flags: dict = field(default_factory=dict)  # flag -> True
     warnings: list = field(default_factory=list)
@@ -446,7 +487,19 @@ def derive_plan(events: list[dict], start_time: datetime | None = None) -> Rerun
                      original_input=original_input)
 
     for stage in STAGES:
-        if entered & stage.witness:
+        if entered & stage.degraded_witness:
+            # Ran, failed, absorbed fail-open (Publish*Degraded route): the
+            # stage must RE-RUN. Degraded overrides witness — the pipeline
+            # continuing past a degradation is NOT evidence of completion
+            # (I6055: the 2026-08-01 Director hard-fail recorded as
+            # "post_eval complete", then skipped by the next rerun).
+            plan.degraded.append(stage.name)
+            plan.notes.append(
+                f"{stage.name}: DEGRADED (entered "
+                f"{sorted(entered & stage.degraded_witness)}) — NOT skipped; "
+                "the rerun re-runs it to retry the absorbed failure"
+            )
+        elif entered & stage.witness:
             plan.completed.append(stage.name)
             if stage.emit_skip:
                 plan.skip_flags[stage.flag] = True
@@ -455,11 +508,12 @@ def derive_plan(events: list[dict], start_time: datetime | None = None) -> Rerun
         elif stage.detect_failure and stage.work in entered:
             plan.failed.append(stage.name)
 
-    if not plan.failed:
+    if not plan.failed and not plan.degraded:
         plan.warnings.append(
-            "no failed WORK stage identified — the failure was pre-workload "
-            "(gate / mutex / notifier). Fix the root cause first; this rerun "
-            "input re-runs everything not witnessed complete."
+            "no failed or degraded WORK stage identified — the failure was "
+            "pre-workload (gate / mutex / notifier). Fix the root cause "
+            "first; this rerun input re-runs everything not witnessed "
+            "complete."
         )
 
     # Anti-swallow / reachability guard: every failed stage's work must
@@ -744,6 +798,7 @@ def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str,
     print(f"rerun name       : {name}")
     print(f"pipeline_role    : {EMITTED_ROLE}")
     print(f"completed stages : {', '.join(plan.completed) or '(none)'}")
+    print(f"degraded stages  : {', '.join(plan.degraded) or '(none)'}")
     print(f"failed stages    : {', '.join(plan.failed) or '(none identified)'}")
     print(f"derived skips    : {', '.join(sorted(plan.skip_flags)) or '(none)'}")
     for n in plan.notes:

--- a/tests/fixtures/weekly_sf_rerun/director_degraded.json
+++ b/tests/fixtures/weekly_sf_rerun/director_degraded.json
@@ -1,0 +1,2400 @@
+{
+ "events": [
+  {
+   "timestamp": "2026-08-01T22:17:53.378000+00:00",
+   "type": "ExecutionStarted",
+   "id": 1,
+   "previousEventId": 0,
+   "executionStartedEventDetails": {
+    "input": "{\"pipeline_role\": \"watch-rerun\", \"run_date\": \"2026-08-01\", \"skip_aggregate_costs\": true, \"skip_backtester_stage_only\": true, \"skip_challenger_shadow\": true, \"skip_counterfactual\": true, \"skip_data_phase1\": true, \"skip_data_phase2\": true, \"skip_eval_judge\": true, \"skip_morning_enrich\": true, \"skip_portfolio_optimizer_backtest\": true, \"skip_predictor_backtest\": true, \"skip_predictor_training\": true, \"skip_rag_ingestion\": true, \"skip_rationale_clustering\": true, \"skip_regime_retrospective_eval\": true, \"skip_regime_substrate\": true, \"skip_replay_concordance\": true, \"skip_scanner\": true, \"skip_signals_envelope\": true, \"skip_thinktank_coverage\": true, \"sns_topic_arn\": \"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}",
+    "inputDetails": {
+     "truncated": false
+    },
+    "roleArn": "arn:aws:iam::711398986525:role/alpha-engine-step-functions-role"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 2,
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "InitializeInput"
+   }
+  },
+  {
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "type": "PassStateExited",
+   "id": 3,
+   "previousEventId": 2,
+   "stateExitedEventDetails": {
+    "name": "InitializeInput",
+    "output": "{\"research_dry\":false,\"data_phase2_dry\":false,\"skip_backtester_stage_only\":true,\"skip_rationale_clustering\":true,\"skip_eval_judge\":true,\"pipeline_label\":\"\",\"skip_challenger_shadow\":true,\"skip_rag_ingestion\":true,\"skip_scanner\":true,\"skip_replay_concordance\":true,\"preflight_args\":\"\",\"skip_predictor_backtest\":true,\"skip_counterfactual\":true,\"skip_morning_enrich\":true,\"pipeline_role\":\"watch-rerun\",\"skip_thinktank_coverage\":true,\"skip_predictor_training\":true,\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\",\"regime_action\":\"produce\",\"skip_portfolio_optimizer_backtest\":true,\"skip_data_phase2\":true,\"skip_regime_retrospective_eval\":true,\"skip_data_phase1\":true,\"skip_weekly_run_day_gate\":false,\"skip_signals_envelope\":true,\"skip_regime_substrate\":true,\"skip_aggregate_costs\":true,\"run_date\":\"2026-08-01\"}",
+    "outputDetails": {
+     "truncated": false
+    }
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 4,
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckWeeklyRunDayGate"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 6,
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckRunMode"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 8,
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipLibPinDriftCheck"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 10,
+   "timestamp": "2026-08-01T22:17:53.394000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "LibPinDriftCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 15,
+   "timestamp": "2026-08-01T22:17:56.475000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "LibPinDriftGate"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 17,
+   "timestamp": "2026-08-01T22:17:56.475000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "PipelineContractCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 22,
+   "timestamp": "2026-08-01T22:17:56.724000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "PipelineContractGate"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 24,
+   "timestamp": "2026-08-01T22:17:56.724000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorDeployDriftCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 29,
+   "timestamp": "2026-08-01T22:17:59.296000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorDeployDriftGate"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 31,
+   "timestamp": "2026-08-01T22:17:59.296000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorDirectorDeployDriftCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 36,
+   "timestamp": "2026-08-01T22:18:01.691000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorDirectorDeployDriftGate"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 38,
+   "timestamp": "2026-08-01T22:18:01.691000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckMutexRole"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 40,
+   "timestamp": "2026-08-01T22:18:01.691000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSpotDispatchNeeded"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 42,
+   "timestamp": "2026-08-01T22:18:01.691000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "DispatchWeeklyFreshnessSpot"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 47,
+   "timestamp": "2026-08-01T22:18:22.243000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "MergeWeeklyFreshnessSpotInstanceId"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 49,
+   "timestamp": "2026-08-01T22:18:22.243000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklyFreshnessSpotBootstrap"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 54,
+   "timestamp": "2026-08-01T22:18:22.382000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckWeeklyFreshnessSpotBootstrapStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 56,
+   "timestamp": "2026-08-01T22:18:22.382000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WeeklyFreshnessSpotBootstrapWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 58,
+   "timestamp": "2026-08-01T22:18:52.444000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklyFreshnessSpotBootstrap"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 63,
+   "timestamp": "2026-08-01T22:18:52.587000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckWeeklyFreshnessSpotBootstrapStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 65,
+   "timestamp": "2026-08-01T22:18:52.587000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WeeklyFreshnessSpotBootstrapWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 67,
+   "timestamp": "2026-08-01T22:19:22.652000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklyFreshnessSpotBootstrap"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 72,
+   "timestamp": "2026-08-01T22:19:22.783000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckWeeklyFreshnessSpotBootstrapStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 74,
+   "timestamp": "2026-08-01T22:19:22.783000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WeeklyFreshnessSpotBootstrapWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 76,
+   "timestamp": "2026-08-01T22:19:52.852000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklyFreshnessSpotBootstrap"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 81,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckWeeklyFreshnessSpotBootstrapStatus"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 83,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckShellRun"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 85,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipMorningEnrich"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 87,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipDataPhase1"
+   }
+  },
+  {
+   "type": "ParallelStateEntered",
+   "id": 89,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ResearchPredictorParallel"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 91,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipScanner"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 93,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipPredictorTraining"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 95,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipRegimeSubstrate"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 97,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ValidatePredictorSkipWeightsFresh"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 99,
+   "timestamp": "2026-08-01T22:19:53.010000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipSignalsEnvelope"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 102,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipChallengerShadow"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 104,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipRAGIngestion"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 106,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipThinkTankCoverage"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 108,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipRegimeRetrospectiveEval"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 110,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipDataPhase2"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 112,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipEvalJudge"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 114,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipRationaleClustering"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 116,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipReplayConcordance"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 118,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipCounterfactual"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 120,
+   "timestamp": "2026-08-01T22:19:53.090000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipAggregateCosts"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 124,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "BranchAComplete"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 126,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckPredictorSkipWeightsFresh"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 128,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "PredictorTrainingSkipped"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 132,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "AggregateBranchOutcomes"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 134,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckBranchOutcomes"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 136,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipBacktester"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 138,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipBacktesterStageOnly"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 140,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipPredictorBacktest"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 142,
+   "timestamp": "2026-08-01T22:19:53.185000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipPortfolioOptimizerBacktest"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 144,
+   "timestamp": "2026-08-01T22:19:53.266000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipParity"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 146,
+   "timestamp": "2026-08-01T22:19:53.266000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "Parity"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 151,
+   "timestamp": "2026-08-01T22:19:53.470000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 156,
+   "timestamp": "2026-08-01T22:19:53.601000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 158,
+   "timestamp": "2026-08-01T22:19:53.601000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 160,
+   "timestamp": "2026-08-01T22:20:53.662000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 165,
+   "timestamp": "2026-08-01T22:20:53.805000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 167,
+   "timestamp": "2026-08-01T22:20:53.805000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 169,
+   "timestamp": "2026-08-01T22:21:53.868000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 174,
+   "timestamp": "2026-08-01T22:21:54.011000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 176,
+   "timestamp": "2026-08-01T22:21:54.011000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 178,
+   "timestamp": "2026-08-01T22:22:54.062000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 183,
+   "timestamp": "2026-08-01T22:22:54.217000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 185,
+   "timestamp": "2026-08-01T22:22:54.217000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 187,
+   "timestamp": "2026-08-01T22:23:54.282000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 192,
+   "timestamp": "2026-08-01T22:23:54.408000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 194,
+   "timestamp": "2026-08-01T22:23:54.408000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 196,
+   "timestamp": "2026-08-01T22:24:54.474000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 201,
+   "timestamp": "2026-08-01T22:24:54.609000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 203,
+   "timestamp": "2026-08-01T22:24:54.609000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 205,
+   "timestamp": "2026-08-01T22:25:54.671000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 210,
+   "timestamp": "2026-08-01T22:25:54.772000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 212,
+   "timestamp": "2026-08-01T22:25:54.772000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 214,
+   "timestamp": "2026-08-01T22:26:54.845000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 219,
+   "timestamp": "2026-08-01T22:26:54.986000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 221,
+   "timestamp": "2026-08-01T22:26:54.986000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 223,
+   "timestamp": "2026-08-01T22:27:55.053000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 228,
+   "timestamp": "2026-08-01T22:27:55.181000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 230,
+   "timestamp": "2026-08-01T22:27:55.181000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 232,
+   "timestamp": "2026-08-01T22:28:55.240000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 237,
+   "timestamp": "2026-08-01T22:28:55.388000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 239,
+   "timestamp": "2026-08-01T22:28:55.388000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 241,
+   "timestamp": "2026-08-01T22:29:55.444000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 246,
+   "timestamp": "2026-08-01T22:29:55.587000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 248,
+   "timestamp": "2026-08-01T22:29:55.587000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 250,
+   "timestamp": "2026-08-01T22:30:55.647000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 255,
+   "timestamp": "2026-08-01T22:30:55.774000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 257,
+   "timestamp": "2026-08-01T22:30:55.774000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 259,
+   "timestamp": "2026-08-01T22:31:55.828000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 264,
+   "timestamp": "2026-08-01T22:31:55.963000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 266,
+   "timestamp": "2026-08-01T22:31:55.963000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 268,
+   "timestamp": "2026-08-01T22:32:56.015000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 273,
+   "timestamp": "2026-08-01T22:32:56.146000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 275,
+   "timestamp": "2026-08-01T22:32:56.146000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 277,
+   "timestamp": "2026-08-01T22:33:56.207000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 282,
+   "timestamp": "2026-08-01T22:33:56.342000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 284,
+   "timestamp": "2026-08-01T22:33:56.342000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 286,
+   "timestamp": "2026-08-01T22:34:56.410000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 291,
+   "timestamp": "2026-08-01T22:34:56.566000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 293,
+   "timestamp": "2026-08-01T22:34:56.566000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 295,
+   "timestamp": "2026-08-01T22:35:56.621000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 300,
+   "timestamp": "2026-08-01T22:35:56.777000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 302,
+   "timestamp": "2026-08-01T22:35:56.777000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 304,
+   "timestamp": "2026-08-01T22:36:56.836000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 309,
+   "timestamp": "2026-08-01T22:36:56.997000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 311,
+   "timestamp": "2026-08-01T22:36:56.997000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 313,
+   "timestamp": "2026-08-01T22:37:57.071000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 318,
+   "timestamp": "2026-08-01T22:37:57.200000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 320,
+   "timestamp": "2026-08-01T22:37:57.200000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 322,
+   "timestamp": "2026-08-01T22:38:57.254000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 327,
+   "timestamp": "2026-08-01T22:38:57.382000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 329,
+   "timestamp": "2026-08-01T22:38:57.382000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 331,
+   "timestamp": "2026-08-01T22:39:57.437000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 336,
+   "timestamp": "2026-08-01T22:39:57.571000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 338,
+   "timestamp": "2026-08-01T22:39:57.571000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 340,
+   "timestamp": "2026-08-01T22:40:57.629000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 345,
+   "timestamp": "2026-08-01T22:40:57.763000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 347,
+   "timestamp": "2026-08-01T22:40:57.763000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 349,
+   "timestamp": "2026-08-01T22:41:57.831000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 354,
+   "timestamp": "2026-08-01T22:41:57.967000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 356,
+   "timestamp": "2026-08-01T22:41:57.967000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 358,
+   "timestamp": "2026-08-01T22:42:58.027000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 363,
+   "timestamp": "2026-08-01T22:42:58.162000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 365,
+   "timestamp": "2026-08-01T22:42:58.162000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 367,
+   "timestamp": "2026-08-01T22:43:58.219000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 372,
+   "timestamp": "2026-08-01T22:43:58.351000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 374,
+   "timestamp": "2026-08-01T22:43:58.351000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 376,
+   "timestamp": "2026-08-01T22:44:58.410000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 381,
+   "timestamp": "2026-08-01T22:44:58.551000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 383,
+   "timestamp": "2026-08-01T22:44:58.551000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 385,
+   "timestamp": "2026-08-01T22:45:58.616000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 390,
+   "timestamp": "2026-08-01T22:45:58.746000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 392,
+   "timestamp": "2026-08-01T22:45:58.746000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 394,
+   "timestamp": "2026-08-01T22:46:58.822000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 399,
+   "timestamp": "2026-08-01T22:46:58.966000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 401,
+   "timestamp": "2026-08-01T22:46:58.966000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 403,
+   "timestamp": "2026-08-01T22:47:59.027000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 408,
+   "timestamp": "2026-08-01T22:47:59.211000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 410,
+   "timestamp": "2026-08-01T22:47:59.211000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 412,
+   "timestamp": "2026-08-01T22:48:59.266000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 417,
+   "timestamp": "2026-08-01T22:48:59.403000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 419,
+   "timestamp": "2026-08-01T22:48:59.403000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 421,
+   "timestamp": "2026-08-01T22:49:59.467000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 426,
+   "timestamp": "2026-08-01T22:49:59.604000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 428,
+   "timestamp": "2026-08-01T22:49:59.604000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 430,
+   "timestamp": "2026-08-01T22:50:59.664000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 435,
+   "timestamp": "2026-08-01T22:50:59.808000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 437,
+   "timestamp": "2026-08-01T22:50:59.808000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 439,
+   "timestamp": "2026-08-01T22:51:59.888000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 444,
+   "timestamp": "2026-08-01T22:52:00.029000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 446,
+   "timestamp": "2026-08-01T22:52:00.029000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 448,
+   "timestamp": "2026-08-01T22:53:00.088000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 453,
+   "timestamp": "2026-08-01T22:53:00.216000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 455,
+   "timestamp": "2026-08-01T22:53:00.216000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 457,
+   "timestamp": "2026-08-01T22:54:00.269000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 462,
+   "timestamp": "2026-08-01T22:54:00.403000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 464,
+   "timestamp": "2026-08-01T22:54:00.403000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 466,
+   "timestamp": "2026-08-01T22:55:00.471000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 471,
+   "timestamp": "2026-08-01T22:55:00.619000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 473,
+   "timestamp": "2026-08-01T22:55:00.619000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 475,
+   "timestamp": "2026-08-01T22:56:00.689000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 480,
+   "timestamp": "2026-08-01T22:56:00.822000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 482,
+   "timestamp": "2026-08-01T22:56:00.822000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 484,
+   "timestamp": "2026-08-01T22:57:00.874000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 489,
+   "timestamp": "2026-08-01T22:57:01.011000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 491,
+   "timestamp": "2026-08-01T22:57:01.011000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 493,
+   "timestamp": "2026-08-01T22:58:01.074000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 498,
+   "timestamp": "2026-08-01T22:58:01.219000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 500,
+   "timestamp": "2026-08-01T22:58:01.219000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 502,
+   "timestamp": "2026-08-01T22:59:01.287000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 507,
+   "timestamp": "2026-08-01T22:59:01.447000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 509,
+   "timestamp": "2026-08-01T22:59:01.447000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 511,
+   "timestamp": "2026-08-01T23:00:01.520000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 516,
+   "timestamp": "2026-08-01T23:00:01.692000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 518,
+   "timestamp": "2026-08-01T23:00:01.692000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 520,
+   "timestamp": "2026-08-01T23:01:01.750000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 525,
+   "timestamp": "2026-08-01T23:01:01.891000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 527,
+   "timestamp": "2026-08-01T23:01:01.891000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 529,
+   "timestamp": "2026-08-01T23:02:01.958000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 534,
+   "timestamp": "2026-08-01T23:02:02.081000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 536,
+   "timestamp": "2026-08-01T23:02:02.081000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 538,
+   "timestamp": "2026-08-01T23:03:02.146000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 543,
+   "timestamp": "2026-08-01T23:03:02.280000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 545,
+   "timestamp": "2026-08-01T23:03:02.280000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 547,
+   "timestamp": "2026-08-01T23:04:02.343000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 552,
+   "timestamp": "2026-08-01T23:04:02.495000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 554,
+   "timestamp": "2026-08-01T23:04:02.495000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 556,
+   "timestamp": "2026-08-01T23:05:02.559000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 561,
+   "timestamp": "2026-08-01T23:05:02.687000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 563,
+   "timestamp": "2026-08-01T23:05:02.687000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 565,
+   "timestamp": "2026-08-01T23:06:02.745000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 570,
+   "timestamp": "2026-08-01T23:06:02.893000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 572,
+   "timestamp": "2026-08-01T23:06:02.893000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 574,
+   "timestamp": "2026-08-01T23:07:02.954000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 579,
+   "timestamp": "2026-08-01T23:07:03.080000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 581,
+   "timestamp": "2026-08-01T23:07:03.080000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 583,
+   "timestamp": "2026-08-01T23:08:03.147000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 588,
+   "timestamp": "2026-08-01T23:08:03.570000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 590,
+   "timestamp": "2026-08-01T23:08:03.570000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 592,
+   "timestamp": "2026-08-01T23:09:03.631000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 597,
+   "timestamp": "2026-08-01T23:09:03.773000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 599,
+   "timestamp": "2026-08-01T23:09:03.773000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 601,
+   "timestamp": "2026-08-01T23:10:03.836000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 606,
+   "timestamp": "2026-08-01T23:10:03.961000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 608,
+   "timestamp": "2026-08-01T23:10:03.961000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 610,
+   "timestamp": "2026-08-01T23:11:04.026000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 615,
+   "timestamp": "2026-08-01T23:11:04.163000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 617,
+   "timestamp": "2026-08-01T23:11:04.163000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 619,
+   "timestamp": "2026-08-01T23:12:04.247000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 624,
+   "timestamp": "2026-08-01T23:12:04.387000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 626,
+   "timestamp": "2026-08-01T23:12:04.387000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 628,
+   "timestamp": "2026-08-01T23:13:04.446000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 633,
+   "timestamp": "2026-08-01T23:13:04.586000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 635,
+   "timestamp": "2026-08-01T23:13:04.586000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 637,
+   "timestamp": "2026-08-01T23:14:04.617000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 642,
+   "timestamp": "2026-08-01T23:14:04.753000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 644,
+   "timestamp": "2026-08-01T23:14:04.753000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 646,
+   "timestamp": "2026-08-01T23:15:04.817000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 651,
+   "timestamp": "2026-08-01T23:15:04.952000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 653,
+   "timestamp": "2026-08-01T23:15:04.952000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 655,
+   "timestamp": "2026-08-01T23:16:05.028000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 660,
+   "timestamp": "2026-08-01T23:16:05.164000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 662,
+   "timestamp": "2026-08-01T23:16:05.164000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 664,
+   "timestamp": "2026-08-01T23:17:05.223000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 669,
+   "timestamp": "2026-08-01T23:17:05.370000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 671,
+   "timestamp": "2026-08-01T23:17:05.370000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 673,
+   "timestamp": "2026-08-01T23:18:05.432000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 678,
+   "timestamp": "2026-08-01T23:18:05.571000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 680,
+   "timestamp": "2026-08-01T23:18:05.571000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 682,
+   "timestamp": "2026-08-01T23:19:05.635000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 687,
+   "timestamp": "2026-08-01T23:19:05.774000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 689,
+   "timestamp": "2026-08-01T23:19:05.774000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 691,
+   "timestamp": "2026-08-01T23:20:05.833000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 696,
+   "timestamp": "2026-08-01T23:20:05.962000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 698,
+   "timestamp": "2026-08-01T23:20:05.962000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 700,
+   "timestamp": "2026-08-01T23:21:06.038000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 705,
+   "timestamp": "2026-08-01T23:21:06.181000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 707,
+   "timestamp": "2026-08-01T23:21:06.181000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 709,
+   "timestamp": "2026-08-01T23:22:06.249000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 714,
+   "timestamp": "2026-08-01T23:22:06.378000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 716,
+   "timestamp": "2026-08-01T23:22:06.378000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ParityWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 718,
+   "timestamp": "2026-08-01T23:23:06.447000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForParity"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 723,
+   "timestamp": "2026-08-01T23:23:06.657000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckParityStatus"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 725,
+   "timestamp": "2026-08-01T23:23:06.657000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipEvaluator"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 727,
+   "timestamp": "2026-08-01T23:23:06.657000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "Evaluator"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 732,
+   "timestamp": "2026-08-01T23:23:06.897000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 737,
+   "timestamp": "2026-08-01T23:23:07.042000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 739,
+   "timestamp": "2026-08-01T23:23:07.042000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 741,
+   "timestamp": "2026-08-01T23:24:07.101000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 746,
+   "timestamp": "2026-08-01T23:24:07.244000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 748,
+   "timestamp": "2026-08-01T23:24:07.244000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 750,
+   "timestamp": "2026-08-01T23:25:07.301000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 755,
+   "timestamp": "2026-08-01T23:25:07.424000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 757,
+   "timestamp": "2026-08-01T23:25:07.424000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 759,
+   "timestamp": "2026-08-01T23:26:07.494000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 764,
+   "timestamp": "2026-08-01T23:26:07.626000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 766,
+   "timestamp": "2026-08-01T23:26:07.626000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 768,
+   "timestamp": "2026-08-01T23:27:07.683000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 773,
+   "timestamp": "2026-08-01T23:27:07.808000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 775,
+   "timestamp": "2026-08-01T23:27:07.808000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 777,
+   "timestamp": "2026-08-01T23:28:07.871000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 782,
+   "timestamp": "2026-08-01T23:28:08.045000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 784,
+   "timestamp": "2026-08-01T23:28:08.045000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 786,
+   "timestamp": "2026-08-01T23:29:08.116000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 791,
+   "timestamp": "2026-08-01T23:29:08.252000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 793,
+   "timestamp": "2026-08-01T23:29:08.252000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "EvaluatorWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 795,
+   "timestamp": "2026-08-01T23:30:08.360000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForEvaluator"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 800,
+   "timestamp": "2026-08-01T23:30:08.574000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckEvaluatorStatus"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 802,
+   "timestamp": "2026-08-01T23:30:08.574000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSkipPostEval"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 804,
+   "timestamp": "2026-08-01T23:30:08.574000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "SaturdayHealthCheck"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 809,
+   "timestamp": "2026-08-01T23:30:08.774000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForSaturdayHealthCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 814,
+   "timestamp": "2026-08-01T23:30:08.936000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSaturdayHealthCheckStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 816,
+   "timestamp": "2026-08-01T23:30:08.936000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "SaturdayHealthCheckPollWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 818,
+   "timestamp": "2026-08-01T23:30:38.997000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForSaturdayHealthCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 823,
+   "timestamp": "2026-08-01T23:30:39.190000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSaturdayHealthCheckStatus"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 825,
+   "timestamp": "2026-08-01T23:30:39.190000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "SaturdayHealthCheckDegraded"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 827,
+   "timestamp": "2026-08-01T23:30:39.190000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WeeklySubstrateHealthCheck"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 832,
+   "timestamp": "2026-08-01T23:30:39.362000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklySubstrateHealthCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 837,
+   "timestamp": "2026-08-01T23:30:39.522000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSubstrateHealthCheckStatus"
+   }
+  },
+  {
+   "type": "WaitStateEntered",
+   "id": 839,
+   "timestamp": "2026-08-01T23:30:39.522000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "SubstrateHealthCheckPollWait"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 841,
+   "timestamp": "2026-08-01T23:31:09.598000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WaitForWeeklySubstrateHealthCheck"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 846,
+   "timestamp": "2026-08-01T23:31:09.811000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckSubstrateHealthCheckStatus"
+   }
+  },
+  {
+   "type": "PassStateEntered",
+   "id": 848,
+   "timestamp": "2026-08-01T23:31:09.811000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "SubstrateHealthCheckDegraded"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 850,
+   "timestamp": "2026-08-01T23:31:09.811000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "ReportCard"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 855,
+   "timestamp": "2026-08-01T23:31:41.930000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "Director"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 860,
+   "timestamp": "2026-08-01T23:31:48.524000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "PublishDirectorDegraded"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 865,
+   "timestamp": "2026-08-01T23:31:48.697000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckShellRunNotify"
+   }
+  },
+  {
+   "type": "ChoiceStateEntered",
+   "id": 867,
+   "timestamp": "2026-08-01T23:31:48.697000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "CheckGateDegradedNotify"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 869,
+   "timestamp": "2026-08-01T23:31:48.697000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "NotifyCompleteHealthDegraded"
+   }
+  },
+  {
+   "type": "TaskStateEntered",
+   "id": 874,
+   "timestamp": "2026-08-01T23:31:48.838000+00:00",
+   "stateEnteredEventDetails": {
+    "name": "WriteCompletionMarker"
+   }
+  },
+  {
+   "timestamp": "2026-08-01T23:32:03.639000+00:00",
+   "type": "ExecutionFailed",
+   "id": 887,
+   "previousEventId": 886,
+   "executionFailedEventDetails": {
+    "error": "S3.AccessDeniedException",
+    "cause": "... (S3.AccessDeniedException writing _sf_completion marker)"
+   }
+  }
+ ]
+}

--- a/tests/test_install_daily_news_preflight.py
+++ b/tests/test_install_daily_news_preflight.py
@@ -1,0 +1,87 @@
+"""install-daily-news.sh + run_daily_news_standalone.sh must provision a
+python3.12 venv and prove it can import the run's real closure BEFORE enabling
+the timer / invoking the collector (alpha-engine-config#6063).
+
+WHY
+---
+The dashboard box's shared .venv was created with AL2023's default python3.9.
+requirements-daily-news.txt pins boto3>=1.43.59 (Python 3.10+) and
+numpy>=2.4.6 (Python 3.11+), so `pip install` failed on EVERY run and the venv
+could never advance — the RAG-ingest deps config-I5702 added
+(psycopg2-binary/pgvector via the lib's [rag] extra, voyageai for embeddings)
+never landed, and every daily run silently skipped corpus warming with only a
+WARN in the log. daily_news.py's RAG ingest is fail-soft by design, so the
+missing-import failure mode was invisible for days.
+
+The venv fix is two-layer: the RUNNER self-heals (rebuild-on-stale-interpreter)
+on every run, and the INSTALLER provisions + preflights at install time.
+
+Source-text assertions: both scripts run on an EC2 box (the runner as
+ec2-user via systemd; the installer as root via SSM), so executing them in CI
+is not meaningful. What these pin is that the rebuild-on-stale-interpreter
+exists, the RAG secrets SSM fetch exists and fails loud, and the preflight
+runs before the thing it guards.
+"""
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+
+_RUNNER = (_REPO / "scripts" / "run_daily_news_standalone.sh").read_text()
+_INSTALLER = (_REPO / "infrastructure" / "install-daily-news.sh").read_text()
+_REQS = (_REPO / "requirements-daily-news.txt").read_text()
+
+
+def test_requirements_carry_the_rag_ingest_deps():
+    """The daily_news RAG ingest chain (config-I5702) imports nousergon_lib.rag
+    (psycopg2-binary/pgvector via the lib's [rag] extra) and uses voyageai at
+    embed time. Without them the lazy import inside daily_news.py's fail-soft
+    try/except degrades silently — the exact #6063 failure."""
+    assert "nousergon-lib[rag,flow_doctor]" in _REQS, (
+        "the slim venv must ride the lib's [rag] extra so psycopg2-binary/"
+        "pgvector stay in lockstep with the lib pin"
+    )
+    assert "voyageai>=0.5.0" in _REQS, (
+        "voyageai has no lib extra; it mirrors requirements.txt's own pin"
+    )
+
+
+def test_runner_rebuilds_a_stale_interpreter_venv():
+    """The box's venv is python3.9; the requirements need Python 3.10+/3.11+.
+    'Provision if missing' alone would leave the stale 3.9 venv in place
+    forever — the runner must detect the stale interpreter and rebuild on
+    python3.12 (the interpreter install-metron-intraday.sh provisions on the
+    same box)."""
+    assert "python3.12 -m venv" in _RUNNER
+    assert "version_info >= (3, 11)" in _RUNNER
+    assert "rm -rf" in _RUNNER
+
+
+def test_runner_fetches_rag_secrets_from_ssm_fail_loud():
+    """RAG_DATABASE_URL + VOYAGE_API_KEY come from SSM Parameter Store (the
+    SCP'd .env lacks them — spot_data_weekly.sh's Phase-2 SSM migration).
+    A missing secret is an environment error that fails EVERY run; fail loud
+    rather than re-entering the silent-degradation loop #6063 closed."""
+    assert "aws ssm get-parameter" in _RUNNER
+    assert "/alpha-engine/$name" in _RUNNER
+    for name in ("RAG_DATABASE_URL", "VOYAGE_API_KEY"):
+        assert name in _RUNNER
+
+
+def test_runner_preflight_runs_before_the_collector():
+    """The preflight proves the venv can import the run's real closure
+    (including the RAG chain's lazy imports) BEFORE the collector runs —
+    a check after the fact proves nothing."""
+    assert "preflight import failed" in _RUNNER
+    assert _RUNNER.index("preflight import failed") < _RUNNER.index(
+        "--require-digest"
+    )
+
+
+def test_installer_preflight_runs_before_the_timer_is_enabled():
+    """Order is the whole point: a passing check after `enable --now` proves
+    nothing (metron-intraday 2026-07-29 incident class)."""
+    assert "preflight import failed" in _INSTALLER
+    assert _INSTALLER.index("preflight import failed") < _INSTALLER.index(
+        "systemctl enable --now daily-news.timer"
+    )

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -10,7 +10,15 @@ history's event vocabulary):
 - ``tail_stage_failure``: Parity fails with everything through the
   portfolio-optimizer backtest completed — exercises the skip_backtester
   OVERSHOOT drop (its skip route jumps the failed stage's gate);
-- ``early_failure``: DataPhase1 fails with only MorningEnrich completed.
+- ``early_failure``: DataPhase1 fails with only MorningEnrich completed;
+- ``director_degraded``: the REAL watch-rerun-2026-08-01-4 history (the
+  "permanent fixture" for alpha-engine-config-I6055 — see its test) — the
+  Director hard-failed (ModuleNotFoundError: openai, event 858),
+  PublishDirectorDegraded absorbed it, the tail's health checks degraded
+  too, and the run only failed terminally at WriteCompletionMarker
+  (S3.AccessDeniedException). Its tail states are real events, filtered
+  from the live Step Functions history to the event types this script
+  consumes.
 
 Plus the config#2280 mutex-steal decision matrix and the role-gating
 verification (config#2277 deliverable 2).
@@ -188,6 +196,50 @@ class TestDerivePlan:
         started["executionStartedEventDetails"]["input"] = json.dumps(inp)
         with pytest.raises(SystemExit, match="unreachable"):
             mod.derive_plan(events)
+
+    def test_degraded_tail_is_rerun_not_skipped(self, mod):
+        """alpha-engine-config-I6055: a stage that DEGRADED (ran, failed,
+        and was absorbed by a Publish*Degraded route so the pipeline could
+        continue) must NEVER be treated as complete — skipping it is what
+        made watch-rerun-2026-08-01-5 go green while doing nothing about
+        the Director hard-fail its rerun was started for. This fixture IS
+        the real watch-rerun-2026-08-01-4 history: Director failed with
+        'No module named openai' (event 858), PublishDirectorDegraded
+        absorbed it, the health checks degraded too, and the run only
+        failed terminally at WriteCompletionMarker."""
+        plan = mod.derive_plan(_events("director_degraded"))
+        # the degraded tail must re-run — never skipped, never "completed"
+        assert "post_eval" in plan.degraded
+        assert "post_eval" not in plan.completed
+        assert "skip_post_eval" not in plan.skip_flags
+        # the degradation must be surfaced in the derivation notes
+        assert any("DEGRADED" in n and "PublishDirectorDegraded" in n for n in plan.notes)
+        # stages that genuinely completed cleanly keep their skip flags
+        # (evaluator and parity really ran to completion on this execution)
+        assert plan.skip_flags.get("skip_evaluator") is True
+        assert plan.skip_flags.get("skip_parity") is True
+        assert "evaluator" in plan.completed and "parity" in plan.completed
+        # and the rerun input must not bypass the tail
+        assert "skip_post_eval" not in plan.rerun_input()
+
+    def test_degraded_branch_a_stage_is_rerun_not_skipped(self, mod):
+        """The same degraded-overrides-witness rule holds for branch A:
+        ThinkTankDegraded (alpha-engine-config-I5758) must drop
+        skip_thinktank_coverage even when the stage's witness was also
+        entered — degraded beats completed."""
+        events = _events("tail_stage_failure")  # thinktank_coverage completed
+        events = list(events) + [
+            {
+                "type": "PassStateEntered",
+                "id": 99999,
+                "timestamp": "2026-07-11T09:00:00Z",
+                "stateEnteredEventDetails": {"name": "ThinkTankDegraded"},
+            }
+        ]
+        plan = mod.derive_plan(events)
+        assert "thinktank_coverage" in plan.degraded
+        assert "thinktank_coverage" not in plan.completed
+        assert "skip_thinktank_coverage" not in plan.skip_flags
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +463,35 @@ class TestStageTableLockstep:
         # Backtester, rather than landing on Backtester directly.
         assert all_states["CheckSkipBacktester"]["Default"] == "CheckSkipBacktesterStageOnly"
         assert all_states["CheckSkipBacktesterStageOnly"]["Default"] == "Backtester"
+
+    def test_every_degraded_state_is_mapped(self, mod, all_states):
+        """Completeness (alpha-engine-config-I6055): a NEW *Degraded /
+        Publish*Degraded route in the SF without a STAGES degraded_witness
+        row means the helper would silently treat a degraded stage as
+        completed and skip it on the rerun — the exact 2026-08-01 defect.
+        The Notify*Degraded family is the terminal degraded-completion
+        EMAIL surface, not a stage degrading, so it is deliberately
+        unmapped."""
+        mapped: dict = {}
+        for stage in mod.STAGES:
+            for d in stage.degraded_witness:
+                assert d in all_states, (
+                    f"{stage.name}: degraded witness {d} is not a state in "
+                    f"infrastructure/step_function.json — update STAGES"
+                )
+                assert d not in mapped, (
+                    f"degraded state {d} is mapped to both {mapped[d]} and "
+                    f"{stage.name} — each degraded route must own exactly "
+                    f"one stage"
+                )
+                mapped[d] = stage.name
+        for name in all_states:
+            if name.endswith("Degraded") and not name.startswith("Notify"):
+                assert name in mapped, (
+                    f"degraded route {name} is not covered by any STAGES "
+                    f"degraded_witness — a degraded {name} stage would be "
+                    f"skipped as complete on a rerun; add it to STAGES"
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

**Deploy-mechanism:** N/A — `deploy.sh` is bootstrap-only (`--bootstrap`); the authoritative assignment change alters no applied artifact (the policy name it declares IS the name the script already applies). The live role/policy is untouched.

## What

`nous-ergon-ops/infrastructure/iam/check-drift.py --lambdas-root` (the consolidated IAM drift checker, config#2340 surface 3 / config#4925) maps each lambda's `iam-policy.json` to a live policy through the **top-level `ROLE_NAME=`/`POLICY_NAME=` assignments** in its `deploy.sh`. `thinktank-spot-dispatcher` applied its policy under the computed name `${ROLE_NAME}-policy` with no `POLICY_NAME` assignment — so its policy file could never be mapped, and the checker's coverage-gap guard failed the IAM drift sweep on **every scheduled and push run** since the lambda's creation (alpha-engine-config#6061; the same untracked-policy → outage class the epic targets).

## Fix

Declare the authoritative `POLICY_NAME="alpha-engine-thinktank-spot-dispatcher-role-policy"` (the exact name the script already applies) as a top-level assignment and use `$POLICY_NAME` in the `put-role-policy` call — mirroring the fleet convention (e.g. `sf-watch-spot-dispatcher`, `spot-orphan-reaper`).

## Validation

- `check-drift.py --lambdas-root infrastructure/lambdas` (current checker, live AWS): the `deploy.sh does not define POLICY_NAME` coverage-gap finding **disappears** with this change; the role is discovered and checked like the other 37. (Remaining live-run findings on my local identity are the expected AccessDenied on the lambda roles — the CI identity's `ReadCodifiedRoles` allowlist is `role/*` and covers them.)

Closes nousergon/alpha-engine-config#6061

---
Groom-Run: 129badd66caa4067b74db3d5de2886c8
