### PR TITLE
fix(groom): reclaim-aware concurrent guard so a spot-reclaimed relaunch proceeds

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1953,8 +1953,41 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
     # concurrent box racing the identical GitHub queue. config#2201: sweep
     # boxes guard on the distinct 'sweep' lane (see _tier_tag) so the
     # end-of-SF sweep never collides with a live mid-only groom box.
+    #
+    # Reclaim-aware bypass (2026-08-02 spot-reclaim race): the guard sees a
+    # spot-reclaimed instance as "live" for ~2 min after the interruption
+    # notice — AWS retains it `running` while the on-box watcher has already
+    # fired send_task_failure(SpotInterrupted) and the SF has already decided
+    # to relaunch. Without this leg the relaunch suppresses itself as a
+    # "duplicate" and the lane dies unworked (measured 2026-08-02 20:00 UTC:
+    # low-only reclaimed, relaunch attempt 1 skipped, lane lost). On a relaunch
+    # (attempt > 0 — ONLY the SF's bounded-retry ladder sets this), re-probe
+    # the "live" instances: any that are termination-imminent (terminal state
+    # OR a spot request marked-for-termination) are the dying prior attempt,
+    # not a competing workload — proceed past the guard for those. A genuinely
+    # healthy prior box (attempt 0, or a real duplicate on attempt > 0) still
+    # suppresses, preserving config#1979's intent. The probe is fail-safe: an
+    # API error returns an empty set and the guard suppresses as before, never
+    # risking a duplicate launch on a broken read.
     tier_tag = _tier_tag(run_mode, issue_filter)
     existing = _running_tier_instance_ids(tier_tag)
+    if existing and attempt > 0:
+        dying = spot_dispatch.termination_imminent(existing, region=REGION)
+        if dying:
+            live = [i for i in existing if i not in dying]
+            if not live:
+                logger.info(
+                    "relaunch attempt %d for lane %s: prior instance(s) %s are "
+                    "termination-imminent (spot reclaim / terminal state) — "
+                    "proceeding with the replacement, NOT a duplicate",
+                    attempt, tier_tag, existing)
+                existing = []  # fall through to launch
+            else:
+                logger.warning(
+                    "relaunch attempt %d for lane %s: mixed live (%s) + dying "
+                    "(%s) prior boxes — suppressing on the genuinely-live one(s)",
+                    attempt, tier_tag, live, [i for i in existing if i in dying])
+                existing = live
     if existing:
         logger.warning(
             "lane %s already has a live groom box (%s) — skipping launch to avoid "

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -54,5 +54,12 @@ boto3>=1.34.0
 # and CI green throughout. A floor is not an exemption; root >= floor satisfies it.
 # The exemption is removed and the tier-model floor is asserted explicitly in
 # tests/test_lib_pin_lockstep.py::test_groom_dispatcher_pin_can_express_the_policy_tier_table.
+# v0.124.33 (nousergon-lib, 2026-08-02) adds spot_dispatch.termination_imminent —
+# the reclaim-aware leg of the concurrent guard (config#1979). A spot-reclaimed
+# instance is observably `running` for ~2 min after the interruption notice, so
+# the relaunch ladder (attempt > 0) must see past State.Name via the spot
+# request's Status.Code or it suppresses its own replacement and the lane dies
+# unworked (measured 2026-08-02 20:00 UTC). This Lambda's _launch_groom_spot
+# calls it directly; pin must stay >= v0.124.33.
 # Bump this in lockstep with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -131,7 +131,7 @@ class _FakeWaiter:
 
 
 class _FakeEc2:
-    def __init__(self, running_tier_instances=None):
+    def __init__(self, running_tier_instances=None, spot_reclaimed=None):
         self.terminated = []
         # config#1979: (issue_filter -> [instance_ids]) already "live" for the
         # concurrent-tier guard's describe_instances check to find.
@@ -139,6 +139,13 @@ class _FakeEc2:
         # config-I5229: instance_id -> state name for the reconciler's
         # InstanceIds-based describe_instances.
         self._instance_states: dict[str, str] = {}
+        # 2026-08-02 spot-reclaim race: instance_ids whose spot request is
+        # marked-for-termination / closed (Status.Code) while the instance is
+        # still `running`. termination_imminent() probes these via
+        # describe_spot_instance_requests to see past State.Name during the
+        # 2-min interruption-notice window. Each id maps to the fake spot
+        # request record the paginator returns.
+        self._spot_reclaimed: dict[str, dict] = dict(spot_reclaimed or {})
 
     def get_waiter(self, name):
         return _FakeWaiter()
@@ -156,11 +163,18 @@ class _FakeEc2:
         # InstanceIds (batch lookup). The concurrent-tier guard uses Filters
         # (tag-based lookup). Support BOTH call shapes.
         if InstanceIds:
-            # Reconciler path — return the stubbed states for these ids.
+            # Reconciler / termination_imminent path — return the stubbed states
+            # for these ids, plus a SpotInstanceRequestId when one is registered
+            # (so the reclaim probe can look it up). Default state is `terminated`
+            # (a dead lane's instance) — tests exercising the reclaim race set
+            # `running` explicitly via _instance_states.
             instances = []
             for iid in InstanceIds:
                 state = self._instance_states.get(iid, "terminated")
-                instances.append({"InstanceId": iid, "State": {"Name": state}})
+                inst = {"InstanceId": iid, "State": {"Name": state}}
+                if iid in self._spot_reclaimed:
+                    inst["SpotInstanceRequestId"] = f"sir-{iid}"
+                instances.append(inst)
             return {"Reservations": [{"Instances": instances}]} if instances else {"Reservations": []}
         if Filters:
             by_name = {f["Name"]: f["Values"] for f in Filters}
@@ -168,6 +182,26 @@ class _FakeEc2:
             ids = self._running_tier_instances.get(issue_filter, [])
             return {"Reservations": [{"Instances": [{"InstanceId": i} for i in ids]}]} if ids else {"Reservations": []}
         return {"Reservations": []}
+
+    def get_paginator(self, name):
+        # 2026-08-02: termination_imminent paginates describe_spot_instance_requests
+        # to read Status.Code for instances still `running` but spot-reclaimed.
+        if name == "describe_spot_instance_requests":
+            requests = list(self._spot_reclaimed.values())
+            return _FakeSpotRequestPaginator(requests)
+        raise AssertionError(f"unexpected EC2 paginator in hermetic tests: {name!r}")
+
+
+class _FakeSpotRequestPaginator:
+    """Yields the stubbed spot-instance-request records for termination_imminent."""
+
+    def __init__(self, requests: list[dict]):
+        self._requests = requests
+
+    def paginate(self, SpotInstanceRequestIds=None):  # noqa: N803 — boto3 kwarg name
+        wanted = set(SpotInstanceRequestIds or [])
+        page = [r for r in self._requests if r.get("SpotInstanceRequestId") in wanted]
+        yield {"SpotInstanceRequests": page}
 
 
 class _FakeSsm:
@@ -247,11 +281,13 @@ class _FakeS3:
 
 
 def _load(monkeypatch, *, launch_impl=None, env=None, s3_objects=None, ssm_parameters=None,
-         running_tier_instances=None, sfn_executions=None, sfn_error=None):
+         running_tier_instances=None, sfn_executions=None, sfn_error=None,
+         spot_reclaimed=None):
     for k, v in (env or {}).items():
         monkeypatch.setenv(k, v)
     ssm = _FakeSsm(ssm_parameters)
-    ec2 = _FakeEc2(running_tier_instances=running_tier_instances)
+    ec2 = _FakeEc2(running_tier_instances=running_tier_instances,
+                   spot_reclaimed=spot_reclaimed)
     s3 = _FakeS3(s3_objects)
     sfn = _FakeSfn(executions=sfn_executions, error=sfn_error)
     clients = {"ec2": ec2, "ssm": ssm, "s3": s3, "stepfunctions": sfn}
@@ -734,6 +770,162 @@ def test_concurrent_tier_check_fails_safe_and_still_launches(monkeypatch):
     # A broken check must never block a launch — it's an optimization, not a
     # correctness gate (mirrors the demand gate fail-safe posture).
     assert out["groom"]["launched"] is True
+
+
+# ── 2026-08-02: spot-reclaim race — reclaim-aware relaunch (attempt > 0) ──────
+# The on-box watcher fires send_task_failure(SpotInterrupted) on the IMDS notice
+# ~2 min before AWS terminates the box, so the SF's relaunch runs while the prior
+# instance is still `running` and the concurrent guard (config#1979) would
+# suppress the replacement as a "duplicate" — the lane dies unworked. A relaunch
+# (attempt > 0) re-probes the "live" instances and proceeds past any that are
+# termination-imminent (the dying prior attempt, not a competing workload).
+
+def _reclaimed_sir(instance_id, status_code="marked-for-termination", state="active"):
+    """A spot-instance-request record the fake paginator returns for a
+    spot-reclaimed instance still in `running` state."""
+    return {"SpotInstanceRequestId": f"sir-{instance_id}",
+            "State": state, "Status": {"Code": status_code}}
+
+
+def test_relaunch_proceeds_when_prior_instance_is_spot_reclaimed(monkeypatch):
+    """The race case (2026-08-02 20:00 UTC low-only): attempt 1 finds the prior
+    box still `running` but its spot request is marked-for-termination. The
+    replacement MUST launch — suppressing here loses the lane."""
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-replacement"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"low-only": ["i-dying"]},
+        spot_reclaimed={"i-dying": _reclaimed_sir("i-dying")},
+    )
+    # The concurrent guard (Filters) returns i-dying as "live"; the reclaim
+    # probe (InstanceIds) must see it as `running` (not the default terminated)
+    # so the spot-request lookup is the thing that flags it imminent.
+    idx._test_ec2._instance_states["i-dying"] = "running"
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "low-only", "schedule": "0 20 * * *",
+         "launch_decided": True, "attempt": 1, "Token": "tok-1"},
+        None,
+    )
+    assert out["groom"]["launched"] is True
+    assert out["groom"]["instance_id"] == "i-replacement"
+    assert launched == [True]
+
+
+def test_relaunch_proceeds_when_prior_instance_is_already_terminated(monkeypatch):
+    """The reconciler-late case: by the time the relaunch fires, the prior box
+    has flipped to `terminated` (describe-instances still returns it for ~1h).
+    State alone is enough to see this one — no spot-request lookup needed."""
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-replacement"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"low-only": ["i-dead"]},
+    )
+    idx._test_ec2._instance_states["i-dead"] = "terminated"
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "low-only", "schedule": "0 20 * * *",
+         "launch_decided": True, "attempt": 1, "Token": "tok-1"},
+        None,
+    )
+    assert out["groom"]["launched"] is True
+    assert launched == [True]
+
+
+def test_relaunch_still_skips_when_prior_instance_is_genuinely_live(monkeypatch):
+    """A real duplicate (attempt > 0 but the prior box is healthy) still
+    suppresses — config#1979's intent is preserved for the genuine case."""
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        # Prior box running, no spot-reclaim entry -> healthy.
+        running_tier_instances={"mid-only": ["i-healthy"]},
+    )
+    idx._test_ec2._instance_states["i-healthy"] = "running"
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "mid-only", "schedule": "0 20 * * *",
+         "launch_decided": True, "attempt": 1, "Token": "tok-1"},
+        None,
+    )
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "concurrent_tier_skip"
+    assert out["groom"]["existing_instance_ids"] == ["i-healthy"]
+    assert launched == []
+
+
+def test_first_launch_attempt_zero_still_skips_on_live_box(monkeypatch):
+    """attempt 0 (a first launch, not a relaunch) with a live box is a genuine
+    duplicate — the reclaim bypass is scoped to attempt > 0 only."""
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-should-not-launch"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"low-only": ["i-existing"]},
+        # Even with a reclaim signal, attempt 0 must NOT bypass — a first launch
+        # has no prior attempt to be "dying," so this would be a true duplicate.
+        spot_reclaimed={"i-existing": _reclaimed_sir("i-existing")},
+    )
+    idx._test_ec2._instance_states["i-existing"] = "running"
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "low-only", "schedule": "0 20 * * *",
+         "launch_decided": True, "attempt": 0, "Token": "tok-0"},
+        None,
+    )
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "concurrent_tier_skip"
+    assert launched == []
+
+
+def test_reclaim_probe_failure_fails_safe_to_skip(monkeypatch):
+    """A broken spot-request probe must never risk a duplicate — degrade to the
+    original guard suppression. The lane is lost for this cycle (the reconciler
+    pages), but a duplicate-launch is the worse failure."""
+    launched = []
+
+    def _launch(types_, subnets, **kw):
+        launched.append(True)
+        return "i-maybe"
+
+    idx = _load(
+        monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"low-only": ["i-maybe"]},
+    )
+    # The concurrent probe (running_instance_ids) succeeds and returns the id;
+    # the reclaim probe (termination_imminent) calls describe_instances with
+    # InstanceIds and we make THAT raise.
+    original_describe = idx._test_ec2.describe_instances
+
+    def _describe(Filters=None, InstanceIds=None):  # noqa: N803 — boto3 kwarg names
+        if InstanceIds:
+            raise RuntimeError("EC2 API hiccup on reclaim probe")
+        return original_describe(Filters=Filters)
+
+    idx._test_ec2.describe_instances = _describe
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "low-only", "schedule": "0 20 * * *",
+         "launch_decided": True, "attempt": 1, "Token": "tok-1"},
+        None,
+    )
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "concurrent_tier_skip"
+    assert launched == []
 
 
 # ── config#1933: demand-driven dispatch (enumerate-then-decide) ──────────────

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,


### PR DESCRIPTION
## What

Makes the groom concurrent-tier guard (`config#1979`) **reclaim-aware on the relaunch path** so a spot-reclaimed prior attempt no longer suppresses its own replacement.

## Why (verified against live AWS, 2026-08-02 20:00 UTC)

The `low-only` lane launched on `t4g.medium`, was spot-reclaimed (`instance-terminated-no-capacity`), and the SF correctly caught `SpotInterrupted` and fired the relaunch ladder (the 7/31 catch-default inversion **worked** — `CheckCompletionMarkerTaskToken` → `CheckRetryBudget` → `PrepRelaunch` → `LaunchGroomSpot`, attempt=1). But the relaunch Lambda found the prior instance still `running` (AWS retains a spot-reclaimed instance as `running` for ~2 min after the interruption notice) and the concurrent guard skipped the launch as a duplicate (`concurrent_tier_skip`). The lane died silently — no replacement ever launched — and the reconciler paged a 🔴 DEATH ~7 min later. Prior dispatch executions TIMED_OUT at exactly 7h on the same shape.

Root cause: the guard's contract is "skip if a *live, healthy* box exists." A box with a pending spot termination is neither. This is a recovery path that fires but produces no recovery — §6.4's "untested assumption with a comforting name."

## How

In `_launch_groom_spot`, after the existing `existing = _running_tier_instance_ids(tier_tag)` hit, when `attempt > 0`:
- Re-probe the "live" instances with `spot_dispatch.termination_imminent` (new in nousergon-lib v0.124.33): any terminal (`shutting-down`/`terminated`/`stopping`/`stopped`) OR spot-reclaimed (spot request `Status.Code` = `marked-for-termination` / `instance-terminated-no-capacity` / `closed`) are the dying prior attempt — proceed past the guard for those.
- A genuinely healthy prior box still suppresses, preserving `config#1979`.
- Scoped to `attempt > 0` only — a first launch (`attempt 0`) with a live box is a genuine duplicate and stays suppressed. The SF's relaunch ladder is the only path that sets `attempt > 0`.
- Fail-safe: a probe error returns an empty set → guard suppresses as before (never risks a duplicate on a broken read).

**SOTA:** reclaim-aware concurrency guard — the pattern every spot-aware autoscaler uses (consult the instance's own termination signal, not just EC2 state). **Delta:** one extra `describe-spot-instance-requests` call per relaunch that hits a "live" prior instance (~1 call/reclaim, negligible).

## Tests (suite passed locally before opening)

9 new tests in `test_handler.py`:
- `test_relaunch_proceeds_when_prior_instance_is_spot_reclaimed` — the race case (the 2026-08-02 incident)
- `test_relaunch_proceeds_when_prior_instance_is_already_terminated` — reconciler-late case
- `test_relaunch_still_skips_when_prior_instance_is_genuinely_live` — config#1979 preserved
- `test_first_launch_attempt_zero_still_skips_on_live_box` — bypass scoped to attempt > 0
- `test_reclaim_probe_failure_fails_safe_to_skip` — never duplicates on a broken probe
- 4 lib-side tests in nousergon-lib `test_spot_dispatch.py`

Full dispatcher suite: **178 passed**. Lockstep + SF-relaunch-wiring + cycle-notification tests: **all green**. Full `nousergon-data` suite: 3772 passed / 135 failed / 31 errors — **identical baseline on clean `main`** (the 135/31 are pre-existing missing-optional-dep collection errors in this local Python 3.14 env: `tenacity`, `pyarrow`, `arcticdb`; CI has the full dep set). Zero regressions from this change.

## Cross-repo dependency

- **Depends on:** nousergon-lib-PR286 (`feat(spot_dispatch): termination_imminent`) — adds `spot_dispatch.termination_imminent`, tags `v0.124.33`.
- **Merge order:** lib-PR286 first (tags `v0.124.33`), then this PR (its pin resolves to the tag).
- The reconciler's redundant `send_task_failure` (fails `TaskTimedOut` because the on-box watcher already consumed the token) is left as-is — harmless defense-in-depth, and correct if the watcher didn't fire. No code change; the fix removes the *consequence* (the lane now relaunches), so the late page becomes informational.

## Deployability

Mergeable by the merge button alone. The fix takes effect on the next `deploy.sh --bootstrap` of the dispatcher Lambda (operator-gated); no live action required this session. The currently-running 20:00 execution (mid-only still working) is unaffected; `low-only` is already lost for this cycle and will be picked up by the next trigger.

**Prepared by:** _ultra_ via [Claude Code](https://claude.com/claude-code)