### PR TITLE
fix(groom): page the dispatcher's real termination reason, not the EC2 state

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1611,12 +1611,21 @@ def _reconcile_lane_death() -> dict:
     instance_ids = [e["instance_id"] for e in open_expectations
                     if e.get("instance_id")]
     instance_states: dict[str, str] = {}
+    # I6199: the reason THIS dispatcher terminated a box, tagged by
+    # spot_dispatch.terminate_on_failure at teardown. Tags survive on a
+    # terminated instance long enough for this reconciler (5-minute cadence) to
+    # read them. Without this, the page below can only restate EC2 state as if
+    # it were a diagnosis.
+    termination_reasons: dict[str, str] = {}
     if instance_ids:
         try:
             resp = ec2.describe_instances(InstanceIds=instance_ids)
             for reservation in resp.get("Reservations", []):
                 for inst in reservation.get("Instances", []):
                     instance_states[inst["InstanceId"]] = inst["State"]["Name"]
+                    for tag in inst.get("Tags", []):
+                        if tag.get("Key") == spot_dispatch.TERMINATION_REASON_TAG and tag.get("Value"):
+                            termination_reasons[inst["InstanceId"]] = tag["Value"]
         except Exception as exc:
             logger.warning("reconciler: describe-instances failed: %s", exc)
             # Fail-safe: treat ALL as unknown (not dead) — never page on a
@@ -1643,7 +1652,17 @@ def _reconcile_lane_death() -> dict:
             # Instance not found in describe-instances, or is in a terminal
             # state (stopped, terminated, shutting-down).
             page = True
-            reason = f"lane_died: instance {instance_id} is {state or 'absent'} — not in {sorted(_ALIVE_STATES)}"
+            # I6199: prefer the reason THIS dispatcher recorded when it tore the
+            # box down. EC2 state is a proxy — `is shutting-down` is true of a
+            # spot reclaim, a completed run winding down, and a dispatcher
+            # terminate after a failed bootstrap alike, and on 2026-08-03 it
+            # sent two cycles of investigation at the wrong subsystem.
+            dispatcher_reason = termination_reasons.get(instance_id, "")
+            if dispatcher_reason:
+                reason = (f"lane_died: dispatcher terminated instance {instance_id} "
+                          f"before bootstrap — {dispatcher_reason}")
+            else:
+                reason = f"lane_died: instance {instance_id} is {state or 'absent'} — not in {sorted(_ALIVE_STATES)}"
         elif exp.get("deadline_utc"):
             try:
                 deadline = datetime.fromisoformat(exp["deadline_utc"])
@@ -1917,13 +1936,20 @@ def _notify_dispatch_ceiling_exhausted(prior: int, ceiling: int, tier_tag: str,
         logger.warning("dispatch-ceiling-exhausted Telegram failed (non-fatal): %s", exc)
 
 
-def _terminate_instance(instance_id: str) -> None:
+def _terminate_instance(instance_id: str, reason: str = "") -> None:
     """Best-effort terminate of a just-launched box whose post-launch steps
     failed. Without this the box orphans: it received no bootstrap, so neither
     the in-script watchdog nor the EXIT trap (both armed BY the bootstrap) is
     running to tear it down — it idles until manually killed. Never masks the
-    original error (logged, not raised)."""
-    spot_dispatch.terminate_on_failure(instance_id, region=REGION, label="groom")
+    original error (logged, not raised).
+
+    ``reason`` (I6199) is tagged onto the instance so the lane reconciler can
+    page the cause instead of restating EC2 state. Callers pass the exception
+    that triggered the teardown; omitting it degrades the page to the old
+    state-only wording rather than failing."""
+    spot_dispatch.terminate_on_failure(
+        instance_id, region=REGION, label="groom", reason=reason
+    )
 
 
 def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_filter: str,
@@ -2022,9 +2048,9 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             task_token=task_token,
             instance_type=_describe_instance_type(instance_id), market=market,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception(_LEDGER_WRITE_FAILED_MSG)
-        _terminate_instance(instance_id)
+        _terminate_instance(instance_id, reason=f"{type(exc).__name__}: {exc}")
         raise
     # Once the box is up, ANY failure before the bootstrap command is delivered
     # would orphan it (no watchdog/trap yet). Terminate-on-error so a slow
@@ -2045,8 +2071,8 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             instance_id, run_mode, run_url, model, issue_filter, run_token, soft_limit_min, pr_budget,
             queue_manifest_key, backend, task_token,
         )
-    except Exception:
-        _terminate_instance(instance_id)
+    except Exception as exc:
+        _terminate_instance(instance_id, reason=f"{type(exc).__name__}: {exc}")
         raise
     logger.info(
         "groom dispatched: instance=%s market=%s command=%s run_mode=%s model=%s issue_filter=%s "

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -55,4 +55,4 @@ boto3>=1.34.0
 # The exemption is removed and the tier-model floor is asserted explicitly in
 # tests/test_lib_pin_lockstep.py::test_groom_dispatcher_pin_can_express_the_policy_tier_table.
 # Bump this in lockstep with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -133,12 +133,19 @@ class _FakeWaiter:
 class _FakeEc2:
     def __init__(self, running_tier_instances=None):
         self.terminated = []
+        # `create_tags` appended to this list without it ever being initialised
+        # — an AttributeError waiting for the first test to exercise the tag
+        # path. I6199 is that first test.
+        self.tags_created: list[tuple[list[str], list[dict]]] = []
         # config#1979: (issue_filter -> [instance_ids]) already "live" for the
         # concurrent-tier guard's describe_instances check to find.
         self._running_tier_instances = dict(running_tier_instances or {})
         # config-I5229: instance_id -> state name for the reconciler's
         # InstanceIds-based describe_instances.
         self._instance_states: dict[str, str] = {}
+        # I6199: instance_id -> tags the reconciler reads to recover WHY the
+        # dispatcher tore a box down.
+        self._instance_tags: dict[str, list[dict]] = {}
 
     def get_waiter(self, name):
         return _FakeWaiter()
@@ -160,7 +167,10 @@ class _FakeEc2:
             instances = []
             for iid in InstanceIds:
                 state = self._instance_states.get(iid, "terminated")
-                instances.append({"InstanceId": iid, "State": {"Name": state}})
+                inst = {"InstanceId": iid, "State": {"Name": state}}
+                if iid in self._instance_tags:
+                    inst["Tags"] = self._instance_tags[iid]
+                instances.append(inst)
             return {"Reservations": [{"Instances": instances}]} if instances else {"Reservations": []}
         if Filters:
             by_name = {f["Name"]: f["Values"] for f in Filters}
@@ -3086,3 +3096,89 @@ def test_retry_marker_fails_soft_when_the_ledger_is_unreadable(monkeypatch):
     out = idx.handler({"retryMarker": True, "run_mode": "full",
                        "launchDecision": {"issue_filter": "mid-only"}}, None)
     assert out["lane_completed"] is False
+
+
+# ── The page must name the dispatcher's reason, not the EC2 state (I6199) ─────
+#
+# On 2026-08-03 eleven boxes were terminated by THIS Lambda after
+# `RuntimeError: SSM agent not Online after 180s`, and every page read
+# `instance is shutting-down — not in ('pending', 'running')`. EC2 state is a
+# proxy: `shutting-down` is equally true of a spot reclaim, a completed run
+# winding down, and a dispatcher terminate after a failed bootstrap. Two groom
+# cycles were spent looking for a groom defect that did not exist.
+
+_SSM_TIMEOUT_REASON = "RuntimeError: SSM agent not Online after 180s for i-dead"
+
+
+def _tag_dead_lane(idx, reason: str = _SSM_TIMEOUT_REASON) -> None:
+    idx._test_ec2._instance_tags["i-dead"] = [
+        {"Key": "Name", "Value": "alpha-engine-groom-spot"},
+        {"Key": "termination-reason", "Value": reason},
+        {"Key": "termination-source", "Value": "dispatcher"},
+    ]
+
+
+def test_lane_death_page_names_the_dispatcher_reason_not_the_instance_state(monkeypatch):
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects("tok-ssm"))
+    _tag_dead_lane(idx)
+    notifications = _spy_notify(monkeypatch, idx)
+
+    out = idx.handler({"mode": "reconcile"}, None)
+
+    assert out["deaths"] == 1
+    text, kw = notifications[0]
+    assert kw["severity"] == "error"
+    assert "SSM agent not Online after 180s" in text, (
+        f"page must carry the reason the dispatcher recorded, got: {text}"
+    )
+    assert "not in ['pending', 'running']" not in text, (
+        "page must not restate the EC2 state as if it were a diagnosis"
+    )
+
+
+def test_lane_death_page_records_the_dispatcher_reason_on_the_actioned_marker(monkeypatch):
+    """Every downstream consumer of the marker reads `reason` too."""
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects("tok-ssm2"))
+    _tag_dead_lane(idx)
+    _spy_notify(monkeypatch, idx)
+
+    idx.handler({"mode": "reconcile"}, None)
+
+    marker = json.loads(
+        idx._test_s3._objects["groom/_control/reconciled/tok-ssm2.json"].decode()
+    )
+    assert marker["outcome"] == "lane_died"
+    assert "SSM agent not Online" in marker["reason"]
+
+
+def test_lane_death_falls_back_to_instance_state_when_untagged(monkeypatch):
+    """A spot reclaim carries no dispatcher tag — behaviour must be unchanged."""
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects("tok-reclaim"))
+    notifications = _spy_notify(monkeypatch, idx)
+
+    out = idx.handler({"mode": "reconcile"}, None)
+
+    assert out["deaths"] == 1
+    text, _ = notifications[0]
+    assert "is terminated" in text
+    assert "dispatcher terminated" not in text
+
+
+def test_launch_failure_tags_the_instance_with_the_real_exception(monkeypatch):
+    """The producer half: the reason must reach EC2 before the terminate."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    monkeypatch.setattr(
+        idx, "_wait_ssm_online",
+        lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("SSM agent not Online after 180s for i-test")
+        ),
+    )
+
+    with pytest.raises(RuntimeError):
+        idx.handler({"run_mode": "full", "schedule": "0 4 * * *"}, None)
+
+    assert idx._test_ec2.terminated, "a box whose bootstrap never landed must be torn down"
+    tagged = {t["Key"]: t["Value"]
+              for _, tags in idx._test_ec2.tags_created for t in tags}
+    assert "SSM agent not Online after 180s" in tagged.get("termination-reason", "")
+    assert tagged.get("termination-source") == "dispatcher"

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 krepis>=0.14.0

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.27
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.33
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,


### PR DESCRIPTION
> **DRAFT — must not merge before `nousergon-lib-PR287`.** The `reason=` argument this PR passes does not exist in the currently pinned lib (`v0.124.27`), so merging out of order breaks every groom dispatch with a `TypeError`. The pin bump is the only remaining commit and lands as soon as PR287 merges and autobumps the version.

## What this fixes

The lane reconciler could only see EC2 instance state, so it restated that state as if it were a diagnosis:

```
🔴 Groom lane DEATH — lane-died: instance i-0f5c55a3e3b26f2ae is shutting-down
   — not in ('pending', 'running')
```

`shutting-down` is equally true of a spot reclaim, a completed run winding down, and this Lambda's own terminate after a failed bootstrap. On 2026-08-03 eleven boxes were torn down here after `RuntimeError: SSM agent not Online after 180s`, and every page carried the wording above. Two groom cycles were spent looking for a groom defect that did not exist — the real fault was a VPC endpoint with private DNS on a Cloudflare-only SG (alpha-engine-config-I6190).

## What it does

- **Producer half** — both `except` blocks in `_launch_groom_spot` pass the exception into `_terminate_instance`, which forwards it to `spot_dispatch.terminate_on_failure(reason=...)`.
- **Consumer half** — the reconciler's `describe_instances` reads the `termination-reason` tag and, when present, pages `dispatcher terminated instance <id> before bootstrap — <reason>`.
- **Unchanged for reclaims** — an untagged instance keeps the existing state-based wording exactly, so genuine spot-reclaim reporting is untouched.
- The tag key comes from `spot_dispatch.TERMINATION_REASON_TAG`, not a local literal, so producer and consumer cannot drift.
- `dedup_key` is deliberately untouched: it is keyed on `run_token`, not the message body, so enriching the text does not change dedup behaviour.

Also initialises `_FakeEc2.tags_created`, which `create_tags` appended to without it ever being defined — an `AttributeError` waiting for the first test to exercise the tag path. This PR is that first test.

## Test plan

`pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — **177 passed**, run against `nousergon-lib` installed from the PR287 branch. `pytest tests/test_lib_pin_lockstep.py` — 4 passed.

Four new tests, three of which fail against `origin/main` with `TypeError: terminate_on_failure() got an unexpected keyword argument 'reason'`:

- the page names the dispatcher's reason and does **not** restate the EC2 state
- the reason also reaches the `groom/_control/reconciled/<token>.json` marker every downstream consumer reads
- an untagged (reclaimed) instance keeps the old wording — the no-regression control
- the producer half: a failed `_wait_ssm_online` tags the instance with the real exception *and* still tears the box down

## Cross-repo

Part of **alpha-engine-config-I6199**. Merge order: **`nousergon-lib-PR287` first**, then this PR.

Closes #6199

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
