### PR TITLE
feat(observability): SSM control-plane reachability probe + its own liveness alarm

### DIFF
--- a/.github/workflows/deploy-ssm-reachability-probe.yml
+++ b/.github/workflows/deploy-ssm-reachability-probe.yml
@@ -1,0 +1,89 @@
+name: Deploy ssm-reachability-probe
+
+# Auto-deploy the alpha-engine-ssm-reachability-probe Lambda CODE on merge to
+# main. Mirrors deploy-spot-orphan-reaper.yml exactly — same gap, same fix: a
+# merged code fix must not sit inert until someone remembers to run deploy.sh.
+#
+# CODE ONLY. deploy.sh's flagless run is code-only; --bootstrap is what adds
+# IAM-role creation, function creation, the EventBridge rule and the two
+# CloudWatch alarms. The github-actions-lambda-deploy OIDC role deliberately
+# holds no iam:CreateRole / iam:PutRolePolicy (fleet-wide, after 4 IAM-clobber
+# incidents in 2 months; see nous-ergon-ops/infrastructure/iam/README.md), so
+# first-time creation requires an operator to run --bootstrap by hand. That is
+# pull-request-policy.md §4.2 form 3 — an operator-gated SECURITY boundary —
+# and the detector that stays red until it runs is the
+# alpha-engine-ssm-reachability-probe-dead alarm, which sits in ALARM on
+# missing heartbeat data from the moment the alarm exists until the probe is
+# actually running.
+#
+# IAM: no new grant needed — LambdaUpdate already covers
+# arn:...:function:alpha-engine-* , which includes this function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/ssm-reachability-probe/**'
+      - '.github/workflows/deploy-ssm-reachability-probe.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-ssm-reachability-probe-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy ssm-reachability-probe Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      # Alarms land on EVERY merge, before and independently of the function.
+      # This is what makes the operator gate non-circular: the -dead alarm is
+      # in ALARM (missing heartbeat, treat-missing-data=breaching) from this
+      # step until someone actually runs --bootstrap. `alpha-engine-*` alarms
+      # are within the deploy role's alpha-engine-box-alarm-as-code grant.
+      - name: Apply CloudWatch alarms (the detector for the operator gate)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --apply-alarms
+
+      # The function may not exist yet — bootstrap creates an IAM role, which
+      # this OIDC role deliberately cannot do. Skip rather than fail, so the
+      # first merge is not a red build; the -dead alarm carries the signal.
+      - name: Deploy ssm-reachability-probe (code-only -- no --bootstrap)
+        working-directory: alpha-engine-data
+        run: |
+          if aws lambda get-function --function-name alpha-engine-ssm-reachability-probe >/dev/null 2>&1; then
+            bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+          else
+            echo "::warning::alpha-engine-ssm-reachability-probe does not exist yet (alpha-engine-config-I6198). The alpha-engine-ssm-reachability-probe-dead alarm is RED until an operator runs, from a checkout of this repo: AWS_PROFILE=ne-admin bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --bootstrap"
+          fi
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-ssm-reachability-probe \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text || echo "(not yet bootstrapped)"

--- a/infrastructure/lambdas/ssm-reachability-probe/README.md
+++ b/infrastructure/lambdas/ssm-reachability-probe/README.md
@@ -1,0 +1,85 @@
+# alpha-engine-ssm-reachability-probe
+
+Answers one question every five minutes: **is every running fleet instance
+reachable over the SSM control plane?**
+
+`alpha-engine-config-I6198`.
+
+## Why
+
+SSM is the single transport by which every unattended workload receives its
+work — the backlog groom and sweep, sf-watch, ci-watch, alert-drain,
+think-tank, data-spot and the weekly Step Functions pipeline all dispatch by
+launching a spot box and sending it an SSM command. It had no health check.
+
+On 2026-08-03T01:50:11Z an interface VPC endpoint for
+`com.amazonaws.us-east-1.ssm` was created in `vpc-566f002e` with private DNS
+enabled, on a security group allowing inbound 443 only from the Cloudflare
+prefix lists. Private DNS overrides `ssm.us-east-1.amazonaws.com` for **every**
+instance in the VPC, so the whole fleet resolved the control plane to an ENI
+that dropped its packets.
+
+- The always-on dashboard box sat `ConnectionLost` for **2h31m**. Nothing
+  alarmed.
+- Eleven spot boxes failed to register and were terminated by their
+  dispatchers. The only human-visible signal was three lane-DEATH pages naming
+  the wrong cause (`alpha-engine-config-I6199`).
+
+## Design decisions worth knowing
+
+**Ground truth is `ec2:DescribeInstances`, not `ssm:DescribeInstanceInformation`.**
+The latter lists only instances that have *ever* registered, so a box that
+never registers — the actual 2026-08-03 failure mode — is invisible to it.
+
+**A healthy fleet publishes an explicit `0`.** Without that datapoint,
+"everything is fine" and "the probe is dead" are the same shape on the metric.
+
+**The probe is itself observed.** `ssm_probe_heartbeat` is published on every
+invocation, and the `-dead` alarm treats missing data as breaching.
+
+**Nothing is swallowed.** Every AWS call may raise. A probe that catches its
+own errors and returns cleanly would publish `0 unreachable` from a failed
+scan — a false green, which is worse than no probe at all.
+
+## Metrics — namespace `AlphaEngine/Infra`
+
+| Metric | Shape | Meaning |
+|---|---|---|
+| `ssm_unreachable_instances` | aggregate, always emitted | count of running fleet instances not `Online` in SSM |
+| `ssm_unreachable_instances` | dimension `name=<Name tag>` | one datapoint per affected box |
+| `ssm_probe_heartbeat` | always emitted, value 1 | the probe ran |
+
+## Alarms
+
+- `alpha-engine-ssm-reachability-probe-unreachable` — `> 0` for two
+  consecutive 5-minute periods, missing data **breaching**.
+- `alpha-engine-ssm-reachability-probe-dead` — heartbeat `< 1` over three
+  consecutive periods (15 minutes), missing data **breaching**.
+
+## Deploy
+
+Both **alarms** are applied on every merge by
+`.github/workflows/deploy-ssm-reachability-probe.yml` (`--apply-alarms`), and
+**code** deploys on every merge once the function exists.
+
+First-time creation of the IAM role, function and EventBridge rule is
+operator-gated, because the deploy OIDC role deliberately holds no
+`iam:CreateRole` / `iam:PutRolePolicy` (fleet-wide, after four IAM-clobber
+incidents). This is `pull-request-policy.md` §4.2 **form 3**: the merge emits
+the exact command, and `alpha-engine-ssm-reachability-probe-dead` sits RED from
+the moment the alarms land until the command has actually run. Alarm creation
+is deliberately NOT part of `--bootstrap` — that would make the detector for
+"bootstrap has not run" not exist until bootstrap ran.
+
+```
+AWS_PROFILE=ne-admin bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --bootstrap
+```
+
+Preview it first with `--dry-run`, and confirm afterwards with `--smoke`.
+
+## Tuning
+
+| Env var | Default | Notes |
+|---|---|---|
+| `GRACE_SECONDS` | `300` | must stay above the groom dispatcher's 180s SSM-online budget, or normal boot reads as an outage |
+| `NAME_PREFIX` | `alpha-engine-` | scopes the probe to fleet boxes so an unrelated instance cannot page |

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-ssm-reachability-probe Lambda,
+# wire its 5-minute EventBridge trigger, and create its two CloudWatch alarms.
+#
+# alpha-engine-config-I6198. SSM is the single transport by which every
+# unattended workload in this fleet receives work, and it had no health check:
+# on 2026-08-03 it was unreachable VPC-wide for 2h31m and emitted nothing.
+#
+# Zero third-party dependencies, so packaging is a plain `zip index.py` rather
+# than the Docker lambda_pip_install.sh path the reaper needs for pydantic.
+# That is deliberate: the detector for the fleet's transport must not be able to
+# fail because of a package build.
+#
+# Usage:
+#   bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh             # update code only
+#   bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --bootstrap # first-time create + wire EventBridge + alarms
+#   bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --apply-iam # re-apply iam-policy.json only
+#   bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --smoke     # invoke once and print the scan result
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
+FUNCTION_NAME="alpha-engine-ssm-reachability-probe"
+ROLE_NAME="alpha-engine-ssm-reachability-probe-role"
+POLICY_NAME="alpha-engine-ssm-reachability-probe-policy"
+RULE_NAME="alpha-engine-ssm-reachability-probe-5min"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+# Canonical function env — defined ONCE so create / update can never drift.
+# GRACE_SECONDS sits above the groom dispatcher's own 180s SSM-online budget so
+# a normally-booting box is never counted as unreachable.
+PROD_ENV='Variables={GRACE_SECONDS=300,NAME_PREFIX=alpha-engine-}'
+
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+APPLY_IAM=false
+APPLY_ALARMS=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --apply-iam) APPLY_IAM=true ;;
+    --apply-alarms) APPLY_ALARMS=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+PKG="$(mktemp -d)"
+trap 'rm -rf "${PKG}"' EXIT
+
+package() {
+  cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+  (cd "${PKG}" && zip -q "function.zip" index.py)
+  echo "  Packaged ${PKG}/function.zip ($(wc -c < "${PKG}/function.zip") bytes)"
+}
+
+# Alarm creation is SEPARATE from --bootstrap on purpose (pull-request-policy
+# §4.2 form 3). Bootstrap creates an IAM role, which the deploy OIDC role may
+# not do, so it is operator-gated. Alarms are `alpha-engine-*`, which that role
+# CAN write — so the merge itself lands them, and the -dead alarm sits in ALARM
+# on missing heartbeat data from that moment until an operator actually runs
+# --bootstrap. That is the detector which stays red until the command runs;
+# folding alarm creation into --bootstrap would make it circular — the detector
+# for "bootstrap has not run" would not exist until bootstrap ran.
+apply_alarms() {
+  local sns="${SNS_TOPIC_ARN:-arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts}"
+
+  # ── Alarm 1: the fleet ────────────────────────────────────────────────────
+  # Two consecutive 5-minute periods, so one scan racing a legitimate boot does
+  # not page. treat-missing-data=breaching: no data means the probe is not
+  # running, and an unobserved transport is precisely what this exists to stop
+  # being rendered as green.
+  echo "  Applying CloudWatch alarm: ${FUNCTION_NAME}-unreachable"
+  run aws cloudwatch put-metric-alarm \
+    --alarm-name "${FUNCTION_NAME}-unreachable" \
+    --alarm-description "One or more running alpha-engine instances are not Online in SSM. SSM is the single transport by which every unattended workload receives its work — the groom, sweep, sf-watch, ci-watch, alert-drain, think-tank, data-spot and the weekly SF all dispatch over it. On 2026-08-03 this condition held VPC-wide for 2h31m and emitted nothing (alpha-engine-config-I6198). Check the VPC endpoint for com.amazonaws.us-east-1.ssm and its security group first." \
+    --namespace "AlphaEngine/Infra" \
+    --metric-name "ssm_unreachable_instances" \
+    --statistic Maximum --period 300 --evaluation-periods 2 --datapoints-to-alarm 2 \
+    --threshold 0 --comparison-operator GreaterThanThreshold \
+    --treat-missing-data breaching \
+    --alarm-actions "${sns}" --region "${REGION}"
+
+  # ── Alarm 2: the probe itself ─────────────────────────────────────────────
+  # A detector that stops running must not read as a healthy fleet. 15 minutes
+  # of missing heartbeat at a 5-minute cadence is three consecutive misses.
+  echo "  Applying CloudWatch alarm: ${FUNCTION_NAME}-dead"
+  run aws cloudwatch put-metric-alarm \
+    --alarm-name "${FUNCTION_NAME}-dead" \
+    --alarm-description "The SSM reachability probe has not reported in 15 minutes. Its silence is indistinguishable from a healthy fleet on the unreachable metric, which is why this alarm exists. Until alpha-engine-config-I6198's operator bootstrap has run, this alarm is EXPECTED to be red — it is the detector for that step (pull-request-policy §4.2 form 3). Clear it with: AWS_PROFILE=ne-admin bash infrastructure/lambdas/ssm-reachability-probe/deploy.sh --bootstrap" \
+    --namespace "AlphaEngine/Infra" \
+    --metric-name "ssm_probe_heartbeat" \
+    --statistic Sum --period 300 --evaluation-periods 3 --datapoints-to-alarm 3 \
+    --threshold 1 --comparison-operator LessThanThreshold \
+    --treat-missing-data breaching \
+    --alarm-actions "${sns}" --region "${REGION}"
+}
+
+# ----- Apply IAM only -------------------------------------------------------
+
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  echo "  ✓ IAM applied."
+  exit 0
+fi
+
+# ----- Apply alarms only (what the deploy workflow runs on every merge) ------
+
+if $APPLY_ALARMS; then
+  echo "Applying CloudWatch alarms for ${FUNCTION_NAME}..."
+  apply_alarms
+  echo "  ✓ Alarms applied."
+  exit 0
+fi
+
+# ----- 1. Bootstrap (operator-only: creates IAM, function, rule, alarms) -----
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  package
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${PKG}/function.zip" \
+      --timeout 60 \
+      --memory-size 128 \
+      --environment "${PROD_ENV}" \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  fi
+
+  echo "  Creating EventBridge rule: ${RULE_NAME}"
+  run aws events put-rule \
+    --name "${RULE_NAME}" \
+    --schedule-expression "rate(5 minutes)" \
+    --description "Probe whether every running alpha-engine instance is reachable via SSM (I6198)" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+
+  FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+  run aws events put-targets \
+    --rule "${RULE_NAME}" \
+    --targets "Id=1,Arn=${FN_ARN}" \
+    --region "${REGION}"
+
+  RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
+  run aws lambda add-permission \
+    --function-name "${FUNCTION_NAME}" \
+    --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction \
+    --principal events.amazonaws.com \
+    --source-arn "${RULE_ARN}" \
+    --region "${REGION}" 2>/dev/null || true
+
+  apply_alarms
+fi
+
+# ----- 2. Update function code (always, unless bootstrap already did) -------
+
+if ! $BOOTSTRAP; then
+  package
+  echo "Updating Lambda function code: ${FUNCTION_NAME}"
+  run aws lambda update-function-code \
+    --function-name "${FUNCTION_NAME}" \
+    --zip-file "fileb://${PKG}/function.zip" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text
+
+  if ! $DRY_RUN; then
+    aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  fi
+fi
+
+echo "✓ Code deployed."
+
+# Converge env on EVERY deploy — update-function-code does not touch it, so an
+# existing function would otherwise keep whatever env it had.
+if ! $DRY_RUN; then
+  aws lambda update-function-configuration \
+    --function-name "${FUNCTION_NAME}" \
+    --environment "${PROD_ENV}" \
+    --region "${REGION}" \
+    --query 'LastUpdateStatus' --output text > /dev/null
+  aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  echo "✓ Env converged: ${PROD_ENV}"
+fi
+
+# ----- 3. Smoke -------------------------------------------------------------
+
+if $SMOKE; then
+  echo ""
+  echo "Smoke-testing via direct invoke..."
+  RESP=$(mktemp)
+  trap 'rm -f "${RESP}"; rm -rf "${PKG}"' EXIT
+  aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --payload '{}' \
+    --region "${REGION}" \
+    "${RESP}" >/dev/null
+  cat "${RESP}"
+  echo ""
+fi

--- a/infrastructure/lambdas/ssm-reachability-probe/iam-policy.json
+++ b/infrastructure/lambdas/ssm-reachability-probe/iam-policy.json
@@ -1,0 +1,38 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DescribeAllInstances",
+      "Effect": "Allow",
+      "Action": "ec2:DescribeInstances",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadSsmRegistrationState",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeInstanceInformation",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EmitSsmReachabilityMetrics",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "cloudwatch:namespace": "AlphaEngine/Infra"
+        }
+      }
+    },
+    {
+      "Sid": "LambdaLogging",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:*"
+    }
+  ]
+}

--- a/infrastructure/lambdas/ssm-reachability-probe/index.py
+++ b/infrastructure/lambdas/ssm-reachability-probe/index.py
@@ -1,0 +1,182 @@
+"""alpha-engine-ssm-reachability-probe — is the SSM control plane reachable?
+
+alpha-engine-config-I6198.
+
+WHY THIS EXISTS. SSM is the single transport by which every unattended workload
+in this fleet receives its work: the backlog groom and sweep, sf-watch,
+ci-watch, alert-drain, think-tank, data-spot and the weekly Step Functions
+pipeline all dispatch by launching a spot box and sending it an SSM command. It
+had no health check of any kind.
+
+On 2026-08-03T01:50:11Z an interface VPC endpoint for
+``com.amazonaws.us-east-1.ssm`` was created in vpc-566f002e with private DNS
+enabled, attached to a security group allowing inbound 443 only from the
+Cloudflare prefix lists. Private DNS overrides ``ssm.us-east-1.amazonaws.com``
+for EVERY instance in the VPC, so the whole fleet began resolving the SSM
+control plane to an ENI that dropped its packets. Measured consequences:
+
+  - The always-on dashboard box sat at ``PingStatus=ConnectionLost`` for 2h31m.
+    Nothing alarmed, nothing paged, no surface showed it.
+  - Eleven spot boxes failed to register and were terminated by their
+    dispatchers. The only signal that reached a human was three lane-DEATH
+    pages naming the wrong cause (alpha-engine-config-I6199), and the outage
+    was diagnosed only because someone asked why they kept arriving.
+
+Per principles.md §2.7: a component emitting nothing is not healthy, it is
+unobserved — and *no data* is never rendered as green. This probe is what makes
+the fleet's most load-bearing dependency emit.
+
+DESIGN — start from DescribeInstances, not DescribeInstanceInformation.
+
+``ssm:DescribeInstanceInformation`` lists only instances that have EVER
+registered with SSM. A box that never registers — precisely the 2026-08-03
+failure mode — is invisible to it. The comparison therefore starts from
+``ec2:DescribeInstances`` (ground truth for what SHOULD be reachable) and
+subtracts what SSM reports as ``Online``.
+
+GRACE. A freshly launched box legitimately takes tens of seconds to register;
+the groom dispatcher's own budget is 180s. Instances younger than
+``GRACE_SECONDS`` (default 300) are excluded so normal boot is not reported as
+an outage.
+
+EMITTING ZERO IS THE POINT. ``ssm_unreachable_instances`` is published as an
+explicit ``0`` when everything is reachable. Without that datapoint, "healthy"
+and "the probe is dead" are the same shape on the metric — the failure this
+exists to prevent. ``ssm_probe_heartbeat`` is published on every invocation for
+the same reason one layer up: it makes the detector itself observable, so a
+dead probe alarms instead of reading as a quiet fleet.
+
+FAIL LOUD. Every AWS call here is allowed to raise. A probe that swallows its
+own errors and returns a clean result is worse than no probe: it would publish
+"0 unreachable" from a failed scan. The Lambda erroring is a visible, alarmable
+state; a false green is not.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+#: Seconds an instance may be running before its SSM registration is expected.
+#: The groom dispatcher waits 180s for `Online` before giving up, so anything at
+#: or below that would report normal boot as an outage.
+GRACE_SECONDS = int(os.environ.get("GRACE_SECONDS", "300"))
+
+#: Only instances whose Name tag carries this prefix are in scope — the fleet's
+#: own boxes. An unrelated instance in the account must not page this fleet.
+NAME_PREFIX = os.environ.get("NAME_PREFIX", "alpha-engine-")
+
+METRIC_NAMESPACE = "AlphaEngine/Infra"
+UNREACHABLE_METRIC = "ssm_unreachable_instances"
+HEARTBEAT_METRIC = "ssm_probe_heartbeat"
+
+#: PutMetricData rejects a call carrying more than 1000 MetricDatum.
+_PUT_METRIC_DATA_MAX = 1000
+
+
+def _name_tag(instance: dict) -> str:
+    for tag in instance.get("Tags", []):
+        if tag.get("Key") == "Name":
+            return tag.get("Value", "")
+    return ""
+
+
+def _expected_instances(ec2, now: datetime) -> dict[str, str]:
+    """Running fleet instances old enough to have registered: id -> Name tag."""
+    cutoff = now - timedelta(seconds=GRACE_SECONDS)
+    expected: dict[str, str] = {}
+    paginator = ec2.get_paginator("describe_instances")
+    for page in paginator.paginate(
+        Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
+    ):
+        for reservation in page.get("Reservations", []):
+            for inst in reservation.get("Instances", []):
+                name = _name_tag(inst)
+                if not name.startswith(NAME_PREFIX):
+                    continue
+                if inst["LaunchTime"] > cutoff:
+                    # Still inside its legitimate registration window.
+                    continue
+                expected[inst["InstanceId"]] = name
+    return expected
+
+
+def _online_instance_ids(ssm) -> set[str]:
+    online: set[str] = set()
+    paginator = ssm.get_paginator("describe_instance_information")
+    for page in paginator.paginate():
+        for info in page.get("InstanceInformationList", []):
+            if info.get("PingStatus") == "Online":
+                online.add(info["InstanceId"])
+    return online
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    now = datetime.now(timezone.utc)
+    ec2 = boto3.client("ec2", region_name=REGION)
+    ssm = boto3.client("ssm", region_name=REGION)
+    cloudwatch = boto3.client("cloudwatch", region_name=REGION)
+
+    expected = _expected_instances(ec2, now)
+    online = _online_instance_ids(ssm)
+    unreachable = {iid: name for iid, name in expected.items() if iid not in online}
+
+    # The aggregate datapoint (what the alarm evaluates) is published FIRST and
+    # unconditionally — including as 0. An absent datapoint must mean the probe
+    # is dead, never that the fleet is healthy. The per-box datapoints that
+    # follow tell an operator WHICH box without opening the logs, and are
+    # truncated rather than allowed to displace the aggregate.
+    metric_data: list[dict] = [
+        {
+            "MetricName": UNREACHABLE_METRIC,
+            "Value": float(len(unreachable)),
+            "Unit": "Count",
+            "Timestamp": now,
+        },
+        {
+            "MetricName": HEARTBEAT_METRIC,
+            "Value": 1.0,
+            "Unit": "Count",
+            "Timestamp": now,
+        },
+    ]
+    for iid, name in sorted(unreachable.items()):
+        metric_data.append({
+            "MetricName": UNREACHABLE_METRIC,
+            "Dimensions": [{"Name": "name", "Value": name}],
+            "Value": 1.0,
+            "Unit": "Count",
+            "Timestamp": now,
+        })
+        logger.error(
+            "SSM UNREACHABLE: %s (%s) is running but not Online in SSM after %ss",
+            iid, name, GRACE_SECONDS,
+        )
+
+    cloudwatch.put_metric_data(
+        Namespace=METRIC_NAMESPACE, MetricData=metric_data[:_PUT_METRIC_DATA_MAX]
+    )
+
+    if unreachable:
+        logger.error(
+            "%d of %d fleet instances unreachable via SSM", len(unreachable), len(expected)
+        )
+    else:
+        logger.info("all %d fleet instances reachable via SSM", len(expected))
+
+    return {
+        "checked_at": now.isoformat(),
+        "expected": len(expected),
+        "online": len(expected) - len(unreachable),
+        "unreachable": len(unreachable),
+        "unreachable_instances": sorted(unreachable),
+        "grace_seconds": GRACE_SECONDS,
+    }

--- a/infrastructure/lambdas/ssm-reachability-probe/requirements.txt
+++ b/infrastructure/lambdas/ssm-reachability-probe/requirements.txt
@@ -1,0 +1,5 @@
+# boto3 is provided by the Lambda python3.12 runtime; declared for local test
+# runs and reproducible builds. This Lambda deliberately has NO other
+# dependency — it is the detector for the transport every other workload rides
+# on, so it must not be able to fail because of a third-party package.
+boto3>=1.34.0

--- a/infrastructure/lambdas/ssm-reachability-probe/test_handler.py
+++ b/infrastructure/lambdas/ssm-reachability-probe/test_handler.py
@@ -1,0 +1,199 @@
+"""Tests for the SSM reachability probe (alpha-engine-config-I6198).
+
+The probe exists because SSM — the single transport by which every unattended
+workload in this fleet receives its work — went unreachable VPC-wide for 2h31m
+on 2026-08-03 and emitted nothing. So the load-bearing assertions here are not
+"does it count correctly" but:
+
+  - does a box that NEVER registered get counted (the actual failure mode, and
+    the one `DescribeInstanceInformation` alone cannot see)
+  - is a healthy fleet published as an explicit 0, so that missing data means a
+    dead probe rather than a quiet one
+  - does a failed scan RAISE instead of publishing a false green
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load(monkeypatch, *, instances, ssm_info, put_side_effect=None, env=None):
+    """Import index.py fresh with boto3 stubbed, return (module, put_calls)."""
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+
+    ec2 = mock.MagicMock()
+    ec2.get_paginator.return_value.paginate.return_value = [
+        {"Reservations": [{"Instances": instances}]}
+    ]
+    ssm = mock.MagicMock()
+    ssm.get_paginator.return_value.paginate.return_value = [
+        {"InstanceInformationList": ssm_info}
+    ]
+    cloudwatch = mock.MagicMock()
+    if put_side_effect is not None:
+        cloudwatch.put_metric_data.side_effect = put_side_effect
+
+    clients = {"ec2": ec2, "ssm": ssm, "cloudwatch": cloudwatch}
+
+    spec = importlib.util.spec_from_file_location("ssm_probe_index", _HERE / "index.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ssm_probe_index"] = module
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(
+        module.boto3, "client", lambda name, region_name=None: clients[name]
+    )
+    return module, cloudwatch
+
+
+def _instance(iid, name="alpha-engine-groom-spot", *, age_seconds=3600):
+    return {
+        "InstanceId": iid,
+        "LaunchTime": datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+        "Tags": [{"Key": "Name", "Value": name}],
+    }
+
+
+def _datapoints(cloudwatch):
+    return cloudwatch.put_metric_data.call_args.kwargs["MetricData"]
+
+
+def _aggregate(cloudwatch, metric):
+    return next(
+        d["Value"] for d in _datapoints(cloudwatch)
+        if d["MetricName"] == metric and "Dimensions" not in d
+    )
+
+
+def test_counts_an_instance_that_never_registered_with_ssm(monkeypatch):
+    """The 2026-08-03 failure mode.
+
+    A box that never registers is ABSENT from DescribeInstanceInformation, so a
+    probe built on that call alone reports a healthy fleet while the fleet is
+    down. Ground truth has to start from DescribeInstances.
+    """
+    module, cloudwatch = _load(
+        monkeypatch,
+        instances=[_instance("i-never-registered")],
+        ssm_info=[],  # SSM has never heard of it
+    )
+    result = module.handler({}, None)
+
+    assert result["unreachable"] == 1
+    assert result["unreachable_instances"] == ["i-never-registered"]
+    assert _aggregate(cloudwatch, module.UNREACHABLE_METRIC) == 1.0
+
+
+def test_counts_an_instance_whose_connection_was_lost(monkeypatch):
+    """The dashboard box's shape: registered once, now ConnectionLost."""
+    module, cloudwatch = _load(
+        monkeypatch,
+        instances=[_instance("i-dash", "alpha-engine-dashboard")],
+        ssm_info=[{"InstanceId": "i-dash", "PingStatus": "ConnectionLost"}],
+    )
+    result = module.handler({}, None)
+
+    assert result["unreachable"] == 1
+    per_box = [d for d in _datapoints(cloudwatch) if "Dimensions" in d]
+    assert per_box[0]["Dimensions"] == [{"Name": "name", "Value": "alpha-engine-dashboard"}]
+
+
+def test_healthy_fleet_publishes_an_explicit_zero(monkeypatch):
+    """`no data` must never be indistinguishable from `all reachable`."""
+    module, cloudwatch = _load(
+        monkeypatch,
+        instances=[_instance("i-ok")],
+        ssm_info=[{"InstanceId": "i-ok", "PingStatus": "Online"}],
+    )
+    result = module.handler({}, None)
+
+    assert result["unreachable"] == 0
+    assert _aggregate(cloudwatch, module.UNREACHABLE_METRIC) == 0.0, (
+        "a healthy scan must publish 0, not publish nothing"
+    )
+
+
+def test_heartbeat_is_published_on_every_invocation(monkeypatch):
+    """The detector has to be observable itself, healthy or not."""
+    module, cloudwatch = _load(
+        monkeypatch,
+        instances=[_instance("i-ok")],
+        ssm_info=[{"InstanceId": "i-ok", "PingStatus": "Online"}],
+    )
+    module.handler({}, None)
+
+    assert _aggregate(cloudwatch, module.HEARTBEAT_METRIC) == 1.0
+
+
+def test_a_freshly_launched_box_is_not_counted(monkeypatch):
+    """Registration takes tens of seconds — normal boot is not an outage."""
+    module, _ = _load(
+        monkeypatch,
+        instances=[_instance("i-booting", age_seconds=30)],
+        ssm_info=[],
+    )
+    result = module.handler({}, None)
+
+    assert result["expected"] == 0
+    assert result["unreachable"] == 0
+
+
+def test_a_box_older_than_grace_is_counted(monkeypatch):
+    """The boundary the previous test brackets — otherwise grace could be
+    infinite and the probe would never report anything."""
+    module, _ = _load(
+        monkeypatch,
+        instances=[_instance("i-stuck", age_seconds=301)],
+        ssm_info=[],
+    )
+    assert module.handler({}, None)["unreachable"] == 1
+
+
+def test_non_fleet_instances_are_ignored(monkeypatch):
+    """An unrelated instance in the account must not page this fleet."""
+    module, _ = _load(
+        monkeypatch,
+        instances=[_instance("i-other", "someone-elses-box")],
+        ssm_info=[],
+    )
+    result = module.handler({}, None)
+
+    assert result["expected"] == 0
+    assert result["unreachable"] == 0
+
+
+def test_the_aggregate_datapoint_survives_truncation(monkeypatch):
+    """PutMetricData caps at 1000 datapoints.
+
+    The aggregate is what the alarm evaluates; a large outage must not push it
+    out of the call and leave the alarm reading missing-data.
+    """
+    instances = [_instance(f"i-{n:04d}") for n in range(1200)]
+    module, cloudwatch = _load(monkeypatch, instances=instances, ssm_info=[])
+    module.handler({}, None)
+
+    sent = _datapoints(cloudwatch)
+    assert len(sent) == 1000
+    assert sent[0]["MetricName"] == module.UNREACHABLE_METRIC
+    assert "Dimensions" not in sent[0]
+    assert sent[0]["Value"] == 1200.0
+
+
+def test_a_failed_scan_raises_rather_than_publishing_a_false_green(monkeypatch):
+    """A probe that swallows its own errors is worse than no probe."""
+    module, _ = _load(
+        monkeypatch,
+        instances=[_instance("i-ok")],
+        ssm_info=[{"InstanceId": "i-ok", "PingStatus": "Online"}],
+        put_side_effect=RuntimeError("cloudwatch throttled"),
+    )
+    with pytest.raises(RuntimeError, match="cloudwatch throttled"):
+        module.handler({}, None)


### PR DESCRIPTION
## The gap

SSM is the single transport by which **every** unattended workload in this fleet receives its work — the backlog groom and sweep, sf-watch, ci-watch, alert-drain, think-tank, data-spot and the weekly Step Functions pipeline all dispatch by launching a spot box and sending it an SSM command.

It had no health check of any kind.

On 2026-08-03T01:50:11Z an interface VPC endpoint for `com.amazonaws.us-east-1.ssm` was created in `vpc-566f002e` with private DNS enabled, on a security group allowing inbound 443 only from the Cloudflare prefix lists. Private DNS overrides `ssm.us-east-1.amazonaws.com` for **every** instance in the VPC, so the whole fleet resolved the control plane to an ENI that dropped its packets.

- The always-on dashboard box sat `ConnectionLost` for **2h31m**. Nothing alarmed, nothing paged, no surface showed it.
- Eleven spot boxes failed to register and were terminated by their dispatchers. The only human-visible signal was three lane-DEATH pages naming the wrong cause (#6199), and the outage was diagnosed only because someone asked why they kept arriving.

Per `principles.md` §2.7 — a component emitting nothing is not healthy, it is unobserved, and *no data* is never rendered as green.

## Design decisions that carry the value

**Ground truth is `ec2:DescribeInstances`, not `ssm:DescribeInstanceInformation`.** The latter lists only instances that have *ever* registered, so a box that never registers — the actual 2026-08-03 failure mode — is invisible to it. This is the difference between a probe that would have caught the outage and one that would have reported a healthy fleet throughout.

**A healthy fleet publishes an explicit `0`.** Without that datapoint, "everything is fine" and "the probe is dead" are the same shape on the metric.

**The probe is itself observed.** `ssm_probe_heartbeat` on every invocation, with a `-dead` alarm treating missing data as breaching.

**Nothing is swallowed.** Every AWS call may raise. A probe that caught its own errors and returned cleanly would publish `0 unreachable` from a failed scan — a false green, which is worse than no probe.

**`GRACE_SECONDS=300`** sits above the groom dispatcher's own 180s SSM-online budget, so a normally-booting box never reads as an outage.

## Deploy shape — form 3, made non-circular

The workflow applies **both alarms on every merge** (`--apply-alarms`); `alpha-engine-*` alarms are inside the deploy role's existing `alpha-engine-box-alarm-as-code` grant. IAM-role creation stays operator-only — that role deliberately holds no `iam:CreateRole` after four IAM-clobber incidents.

So `pull-request-policy.md` §4.2 **form 3** is satisfied properly: the merge emits the exact command, and `alpha-engine-ssm-reachability-probe-dead` sits **RED from the moment the alarms land until the command has actually run**.

Alarm creation is deliberately **not** inside `--bootstrap`. That would make the detector for "bootstrap has not run" not exist until bootstrap ran — a gate with no detector, which is the `alpha-engine-config-I1906` anti-pattern.

## Test plan

`pytest infrastructure/lambdas/ssm-reachability-probe/test_handler.py` — **9 passed**.

- an instance that **never registered** is counted (the failure mode `DescribeInstanceInformation` alone cannot see)
- a `ConnectionLost` instance is counted, with its `name` dimension
- a healthy fleet publishes an explicit `0`
- the heartbeat is published on every invocation
- a box younger than grace is not counted; one at 301s is (the boundary bracketed from both sides)
- a non-fleet instance cannot page
- the aggregate datapoint survives `PutMetricData`'s 1000-datum truncation during a large outage
- a failed scan **raises** instead of publishing a false green

The explicit-zero and truncation guards were each shown to FAIL against a deliberately mutated `index.py` before being kept — a guard never observed failing is not a guard.

`bash -n` clean on `deploy.sh`; workflow YAML parses; `--bootstrap --dry-run` and `--apply-alarms --dry-run` both emit the expected command sequence.

Closes #6198

Related: #6190 (the outage), #6199 (the page that named the wrong cause), #6197.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
