### PR TITLE
fix(groom-dispatcher): truncate run_token in alert bodies — it wedges the alert-drain

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1691,6 +1691,33 @@ def _reconcile_lane_death() -> dict:
         tier_tag = exp.get("tier_tag", "unknown")
         schedule_label = exp.get("schedule", "unknown")
         run_token = str(exp.get("run_token") or "")
+        # Human-readable RENDERING of the token, for the notification body only.
+        #
+        # A bare `run_token=<32 lowercase hex>` is, to gitleaks' stock
+        # `generic-api-key` rule, indistinguishable from a leaked credential: the
+        # keyword `token` adjacent to a high-entropy 32-char value is exactly what
+        # that rule looks for. It is not a credential — it is a correlation id this
+        # Lambda mints per lane — but the scanner cannot know that.
+        #
+        # It matters because of where these bodies travel. `_notify_cycle` publishes
+        # onto the Overseer intake bus, alert-drain reads the queue into its LLM
+        # request, and the DLP egress proxy gitleaks-scans that outbound body. A
+        # match returns HTTP 400, the drain agent exits rc=1, and — because nothing
+        # is deleted from the queue without a ledger record (overseer-policy.md
+        # invariant 8) — the same message is re-read by the next run. One lane-death
+        # alert therefore wedges the entire response plane indefinitely.
+        #
+        # Measured 2026-08-03: 12 of 79 sampled intake messages carried this shape,
+        # every one from this emitter and this field; four consecutive drain runs
+        # died on it, and the retry ladder pushed the queue's other messages toward
+        # the DLQ five receives at a time.
+        #
+        # 12 hex chars keeps the prefix long enough to correlate a body against the
+        # dispatch ledger by eye, and short enough that no entropy rule fires. The
+        # FULL token is unchanged everywhere it is machine-read — `dedup_key` below,
+        # the `context` payload, and every log line — so nothing that consumes it
+        # programmatically is affected.
+        run_token_display = f"{run_token[:12]}…" if len(run_token) > 12 else run_token
 
         # alpha-engine-config-I5914: instance state is not a proxy for run
         # completion. A lane that finished its work and was reclaimed during
@@ -1707,7 +1734,7 @@ def _reconcile_lane_death() -> dict:
             _notify_cycle(
                 f"🟡 Groom lane reclaimed AFTER completing — {reason}\n"
                 f"tier={tier_tag}  schedule={schedule_label}\n"
-                f"run_token={run_token}  instance={instance_id}\n"
+                f"run_token={run_token_display}  instance={instance_id}\n"
                 f"work completed; evidence={evidence}",
                 # 2026-08-03 notification cleanup: SILENT — no work was lost,
                 # it is durably recorded in the reconcile ledger, and a
@@ -1734,7 +1761,7 @@ def _reconcile_lane_death() -> dict:
             _notify_cycle(
                 f"🔴 Groom lane DEATH — {reason}\n"
                 f"tier={tier_tag}  schedule={schedule_label}\n"
-                f"run_token={run_token}  instance={instance_id}",
+                f"run_token={run_token_display}  instance={instance_id}",
                 severity="error",
                 dedup_key=f"{_CYCLE_FLOW_NAME}:lane_death:{run_token}",
                 context={"expectation": {k: v for k, v in exp.items()

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -3186,3 +3186,59 @@ def test_launch_failure_tags_the_instance_with_the_real_exception(monkeypatch):
               for _, tags in idx._test_ec2.tags_created for t in tags}
     assert "SSM agent not Online after 180s" in tagged.get("termination-reason", "")
     assert tagged.get("termination-source") == "dispatcher"
+
+
+# ── Alert bodies must not carry a credential-shaped run token ────────────────
+#
+# A bare `run_token=<32 lowercase hex>` matches gitleaks' stock `generic-api-key`
+# rule. These bodies travel onto the Overseer intake bus, alert-drain reads the
+# queue into its LLM request, and the DLP egress proxy scans that outbound body —
+# so one lane-death alert returns HTTP 400, the drain exits rc=1, and because
+# nothing is deleted from the queue without a ledger record the SAME message
+# wedges every subsequent run. Measured 2026-08-03: 12 of 79 sampled intake
+# messages, all this emitter, all this field, four consecutive drain runs dead.
+
+_HEX32_TOKEN = "af87ec3d9b1e4c7a2f60d583be914c02"
+
+
+def _lane_death_body(monkeypatch, token):
+    idx = _load(monkeypatch, s3_objects=_dead_lane_objects(token))
+    _tag_dead_lane(idx)
+    notifications = _spy_notify(monkeypatch, idx)
+    idx.handler({"mode": "reconcile"}, None)
+    return notifications[0]
+
+
+def test_lane_death_body_truncates_the_run_token(monkeypatch):
+    """The rendered body must not contain the full 32-char token."""
+    text, _kw = _lane_death_body(monkeypatch, _HEX32_TOKEN)
+    assert _HEX32_TOKEN not in text, (
+        "the full run_token reached the notification body; gitleaks' "
+        "generic-api-key rule matches `run_token=<32 hex>` and the DLP egress "
+        "proxy will 400 every alert-drain run that reads this message"
+    )
+    assert _HEX32_TOKEN[:12] in text, (
+        "the truncated prefix must survive — it is what correlates a body "
+        "against the dispatch ledger by eye"
+    )
+
+
+def test_lane_death_dedup_key_keeps_the_full_token(monkeypatch):
+    """Truncation is a RENDERING change; machine-read fields are untouched.
+
+    The dedup key is what collapses repeated pages for one dead lane into one
+    alert. Truncating it there would widen the key and could collide two lanes
+    sharing a 12-char prefix.
+    """
+    _text, kw = _lane_death_body(monkeypatch, _HEX32_TOKEN)
+    assert kw["dedup_key"].endswith(_HEX32_TOKEN), (
+        f"dedup_key lost the full token: {kw['dedup_key']}"
+    )
+
+
+def test_short_token_is_rendered_whole(monkeypatch):
+    """No ellipsis on a token that was never long enough to look like a key."""
+    text, _kw = _lane_death_body(monkeypatch, "tok-short")
+    assert "run_token=tok-short " in text or "run_token=tok-short\n" in text, (
+        f"a short token must render verbatim, got: {text}"
+    )


### PR DESCRIPTION
## What and why

The alert-drain has been dead all day. Root cause, read out of the 1600Z run's SSM output:

```
API Error: 400 BLOCKED by LLM egress proxy (secret-content DLP):
gitleaks flagged outbound request body -- rules ['generic-api-key']
[alert-drain-run] claude exited rc=1 (run_id=drain-2026-08-03T1600Z)
```

A bare `run_token=<32 lowercase hex>` in this Lambda's lane-death / lane-reclaimed
notification bodies matches gitleaks' stock `generic-api-key` rule — the keyword `token`
adjacent to a high-entropy 32-char value is exactly that rule's shape. It is not a credential;
it is a correlation id this Lambda mints per lane. The scanner cannot know that.

Where it hurts is downstream: `_notify_cycle` publishes onto the Overseer intake bus,
alert-drain reads the queue into its LLM request, and the DLP egress proxy scans that outbound
body. A match returns 400, the agent exits rc=1, and because nothing is deleted from the queue
without a ledger record (`overseer-policy.md` invariant 8) the same message is re-read by the
next run. **One lane-death alert wedges the entire response plane indefinitely** — and the SQS
retry ladder (`maxReceiveCount: 5`) drags the queue's *other* messages into the DLQ while it does.

## Measurement

Reproduced locally against the fleet's own `gitleaks-egress.toml` at gitleaks 8.30.1:

| | |
|---|---|
| sampled intake messages matching `generic-api-key` | **12 of 79** |
| emitters responsible | `flow-doctor:scheduled-groom-dispatcher` — all 12 |
| field | `run_token=` in `detail.body` — all 12 |
| consecutive dead drain runs | 4 (`alpha-engine-config-I6191`) |
| post-fix scan of the same message | **0 findings** |

## The change

`run_token_display` — 12 hex chars plus an ellipsis — is used in the two notification bodies.
Long enough to correlate a body against the dispatch ledger by eye; short enough that no
entropy rule fires.

The **full** token is unchanged everywhere it is machine-read: `dedup_key` (truncating it would
widen the key and could collide two lanes sharing a prefix), the `context` payload, and every
log line. This is a rendering change.

## Guard observed failing

Per `overseer-policy.md` invariant 13 — restoring the full token to the body:

```
FAILED test_lane_death_body_truncates_the_run_token
1 failed, 3 passed
```

Three tests added, covering both directions: the body must truncate,
`dedup_key` must **not**, and a short token must render whole with no ellipsis.

## Testing

`180 passed` — the full `scheduled-groom-dispatcher` suite.

Run with `PYTHONPATH=~/Development/nousergon-lib/src`: the laptop's site-packages holds
`nousergon-lib` **0.124.21** against this Lambda's pinned **0.124.33**, and the stale copy
lacks `spot_dispatch.TERMINATION_REASON_TAG`, which fails ~10 pre-existing reconciler tests
including the lane-death ones this change sits beside. That is the local environment, not this
diff — the same tests pass against the pinned version.

## Scope

This stops the class being produced. It does **not** clear the ~17 poisoned messages already
queued — those are immutable. The structural half (sanitize at the request boundary, quarantine
what still fails, alarm DLQ growth) is `alpha-engine-config-I6298`, which carries the decision
on how to clear the existing backlog.

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)
