### PR TITLE
fix(schedule): remove the standalone sweep cadence — 6 dispatches/day → 3

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -142,6 +142,8 @@ SCHED_INPUTS=(
 )
 # Prefix used to discover live rules for prune reconciliation (see step 2f).
 SCHED_PREFIX="alpha-engine-scheduled-groom-"
+# Sweep rules are named outside SCHED_PREFIX (see 2e); they get their own prune.
+SWEEP_SCHED_PREFIX="alpha-engine-groom-sweep-"
 
 # DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
 # flag below, so DRY_RUN=1/true from a caller's shell actually no-ops
@@ -524,21 +526,42 @@ EOF
   # SCHED_NAMES entries target the STEP FUNCTION (a full groom cycle). These
   # target the LAMBDA with run_mode=sweep, so a shared prefix would have them
   # deleted on the next deploy.
-  SWEEP_SCHED_NAMES=(
-    "alpha-engine-groom-sweep-0000-daily"
-    "alpha-engine-groom-sweep-0800-daily"
-    "alpha-engine-groom-sweep-1600-daily"
-  )
-  SWEEP_SCHED_CRONS=(
-    "cron(0 0 * * ? *)"
-    "cron(0 8 * * ? *)"
-    "cron(0 16 * * ? *)"
-  )
+  # EMPTIED 2026-08-03 (Brian: "it seems to launch at all hours of the day...
+  # a clear schedule, minimal collisions"). These fired at 00/08/16 UTC —
+  # 17:00 / 01:00 / 09:00 local — interleaved exactly 4h between the groom
+  # slots, turning a chosen 3x/day cadence into a dispatch every four hours
+  # around the clock, including one at 01:00 nobody could respond to.
+  #
+  # Nothing is lost, and this is verified against the state machine rather
+  # than assumed. EVERY route through step_function_groom.json lands on
+  # DispatchEndOfSfSweep:
+  #
+  #   CheckAnyLaunches   --default--> AllSkipped             --> DispatchEndOfSfSweep
+  #   CheckMapLaneOutcomes --default-->                          DispatchEndOfSfSweep
+  #   SetMapFailureFromLanes -->                                 DispatchEndOfSfSweep
+  #   RecordMapLaunchFailure -->                                 DispatchEndOfSfSweep
+  #
+  # These rules were added 2026-07-30 because the sweep was then hostage to
+  # groom health — two of three cycles ended in `concurrent_cycle_skip` and
+  # the sweep ran on neither. config#2201 fixed that by rerouting the
+  # zero-launches path (it is no longer a terminal Succeed), so the standalone
+  # cadence has been buying coverage the SF already provides. The only route
+  # that skips the sweep is DecideLaunches failing outright — the dispatcher
+  # Lambda is down, and a standalone sweep invoking that same Lambda would not
+  # have run either.
+  #
+  # Guarded directly now by test_every_sf_path_reaches_the_tail_sweep, which
+  # asserts the routing rather than the existence of three rule names.
+  #
+  # Result: 3 dispatch windows/day (04/12/20 UTC = 21:00/05:00/13:00 local),
+  # each grooming and then sweeping. Same coverage, half the dispatches.
+  SWEEP_SCHED_NAMES=()
+  SWEEP_SCHED_CRONS=()
   # Mirrors the DispatchEndOfSfSweep payload in step_function_groom.json:
   # a literal launch_decided sweep event. `issue_filter` is inert for
   # run_mode=sweep but the launch path validates it, so it is passed
   # explicitly rather than defaulted.
-  for i in "${!SWEEP_SCHED_NAMES[@]}"; do
+  for i in "${!SWEEP_SCHED_NAMES[@]+${!SWEEP_SCHED_NAMES[@]}}"; do
     sname="${SWEEP_SCHED_NAMES[$i]}"
     scron="${SWEEP_SCHED_CRONS[$i]}"
     sweep_target=$(python3 -c 'import json,sys; print(json.dumps({"Arn": sys.argv[1], "RoleArn": sys.argv[2], "Input": json.dumps({"run_mode": "sweep", "launch_decided": True, "model": "deepseek-v4-flash", "issue_filter": "mid-only", "schedule": sys.argv[3]})}))' "${FN_ARN}" "${SCHED_ROLE_ARN}" "${sname}")
@@ -560,6 +583,35 @@ EOF
       aws scheduler get-schedule --name "${sname}" --region "${REGION}" \
         --query 'Name' --output text >/dev/null \
         || { echo "ERROR: sweep rule ${sname} not found after create/update" >&2; exit 1; }
+    fi
+  done
+
+  # --- 2e-prune. Reconcile the SWEEP rules against SWEEP_SCHED_NAMES.
+  #
+  # These are named outside SCHED_PREFIX on purpose (see above), which means
+  # 2f's prune deliberately SKIPS them — so emptying SWEEP_SCHED_NAMES would
+  # otherwise leave three live rules firing forever with nothing in the tree
+  # declaring them. That is alpha-engine-config-I5805 in reverse:
+  # declared-removed, still live, invisible.
+  #
+  # Added 2026-08-03 alongside emptying the array, so the removal takes effect.
+  # Same contract as 2f: the array is the source of truth.
+  echo "  Pruning orphaned Scheduler rules under prefix ${SWEEP_SCHED_PREFIX}..."
+  LIVE_SWEEP=$(aws scheduler list-schedules --name-prefix "${SWEEP_SCHED_PREFIX}" \
+    --region "${REGION}" --query 'Schedules[].Name' --output text 2>/dev/null || echo "")
+  for live in ${LIVE_SWEEP}; do
+    keep=false
+    for want in "${SWEEP_SCHED_NAMES[@]+${SWEEP_SCHED_NAMES[@]}}"; do
+      [ "${live}" = "${want}" ] && { keep=true; break; }
+    done
+    if ! $keep; then
+      echo "    Deleting orphaned sweep Scheduler rule: ${live}"
+      run aws scheduler delete-schedule --name "${live}" --region "${REGION}"
+      if ! $DRY_RUN; then
+        aws scheduler get-schedule --name "${live}" --region "${REGION}" \
+          --query 'Name' --output text >/dev/null 2>&1 \
+          && { echo "ERROR: sweep Scheduler rule ${live} still present after delete" >&2; exit 1; }
+      fi
     fi
   done
 

--- a/tests/test_groom_cycle_notifications.py
+++ b/tests/test_groom_cycle_notifications.py
@@ -517,19 +517,65 @@ def _deploy_sh() -> str:
             / "scheduled-groom-dispatcher" / "deploy.sh").read_text(encoding="utf-8")
 
 
-def test_sweep_has_its_own_schedules_not_only_the_groom_tail():
-    """The sweep must not be hostage to groom health.
+def test_every_sf_path_reaches_the_tail_sweep():
+    """The sweep must not be hostage to groom health — asserted DIRECTLY.
 
-    It ran only as DispatchEndOfSfSweep — the last state of the groom cycle —
-    so when two of three cycles ended in `concurrent_cycle_skip` on 2026-07-30,
-    the sweep did not run on either. It has no dependency on groom OUTPUT, so
-    the coupling bought nothing.
+    Was: `test_sweep_has_its_own_schedules_not_only_the_groom_tail`, which
+    asserted three named standalone schedules exist. That was a PROXY for the
+    property, adopted 2026-07-30 after two of three cycles ended in
+    `concurrent_cycle_skip` and the sweep ran on neither.
+
+    config#2201 then fixed the actual defect by rerouting: the zero-launches
+    path is no longer a terminal Succeed. Verified against the state machine
+    2026-08-03 — every route lands on DispatchEndOfSfSweep:
+
+        CheckAnyLaunches   --default-->  AllSkipped --> DispatchEndOfSfSweep
+        CheckMapLaneOutcomes --default-->             DispatchEndOfSfSweep
+        SetMapFailureFromLanes -->                    DispatchEndOfSfSweep
+        RecordMapLaunchFailure -->                    DispatchEndOfSfSweep
+
+    So the standalone schedules were buying coverage the SF already provided,
+    at the price of a second cadence interleaved 4h between the groom slots —
+    a dispatch every four hours around the clock, including 01:00 local. They
+    were emptied 2026-08-03 (Brian: "it seems to launch at all hours of the
+    day... a clear schedule, minimal collisions").
+
+    This test asserts the property the proxy stood for, which also makes it a
+    real regression guard: re-terminating any of those paths breaks it.
     """
-    sh = _deploy_sh()
-    assert "SWEEP_SCHED_NAMES=(" in sh, "no independent sweep schedules defined"
-    for hhmm in ("0000", "0800", "1600"):
-        assert f"alpha-engine-groom-sweep-{hhmm}-daily" in sh, (
-            f"missing the {hhmm} UTC sweep rule")
+    import json
+    sf = json.loads((REPO_ROOT / "infrastructure" / "step_function_groom.json").read_text())
+    states = sf["States"]
+    assert "DispatchEndOfSfSweep" in states, "the tail sweep state is gone"
+
+    def _successors(state):
+        out = []
+        if state.get("Next"):
+            out.append(state["Next"])
+        out += [c["Next"] for c in state.get("Choices", []) if c.get("Next")]
+        if state.get("Default"):
+            out.append(state["Default"])
+        out += [c["Next"] for c in state.get("Catch", []) if c.get("Next")]
+        return out
+
+    # Every terminal-ish route out of the decide/launch phases must funnel to
+    # the sweep. The one legitimate exception is DecideLaunches failing
+    # outright — the dispatcher Lambda is down, and a standalone sweep
+    # invoking that same Lambda would not have run either.
+    for name in (
+        "AllSkipped",
+        "CheckMapLaneOutcomes",
+        "SetMapFailureFromLanes",
+        "RecordMapLaunchFailure",
+    ):
+        assert name in states, f"{name} missing from the state machine"
+        succ = _successors(states[name])
+        assert "DispatchEndOfSfSweep" in succ, (
+            f"{name} no longer routes to DispatchEndOfSfSweep (successors: {succ}). "
+            "The sweep is hostage to groom health again — this is the 2026-07-30 "
+            "failure, and the standalone sweep schedules that used to mask it "
+            "were removed 2026-08-03."
+        )
 
 
 def test_sweep_rules_sit_outside_the_pruned_prefix():
@@ -550,29 +596,51 @@ def test_sweep_rules_sit_outside_the_pruned_prefix():
         )
 
 
-def test_sweep_schedule_interleaves_with_the_groom():
-    """Each sweep must land between grooms, not on top of one.
+def test_no_dispatch_lands_in_the_quiet_hours():
+    """The declared cadence must not fire while nobody is awake to respond.
 
-    groom 04/12/20 UTC daily, sweep 00/08/16 UTC — every daily groom is swept
-    4h later. The Sun 09:00 UTC weekly slot is an extra and is excluded: it is
-    not part of the daily interleave.
+    Was: `test_sweep_schedule_interleaves_with_the_groom`, which asserted the
+    sweep landed exactly 4h AFTER each groom — i.e. it enforced the very
+    interleave that produced a dispatch every four hours around the clock.
+    The standalone sweeps were emptied 2026-08-03 and the interleave with them;
+    what should have been guarded all along is the property below.
+
+    groom-sweep-policy.md §4.8: irreversible work is confined to an attended
+    window, because a merge at 01:00 has the longest possible time-to-human
+    detection and F4 will not surface it for up to seven days.
+
+    Local time is UTC-7 (PDT). The current declared cadence is 04/12/20 UTC =
+    21:00 / 05:00 / 13:00 local. 21:00 and 05:00 are deliberately kept — Brian
+    chose that 3x/day cadence on 2026-07-30 — so the guarded window is the
+    genuinely dead hours, 01:00-04:00 local, which nothing may occupy.
     """
     import re
     sh = _deploy_sh()
 
-    def hours(block_name: str) -> list[int]:
+    def daily_hours(block_name: str) -> list[int]:
+        if block_name not in sh:
+            return []
         block = sh.split(block_name, 1)[1].split(")\n", 1)[0]
-        # Daily rules only: `cron(0 H * * ? *)`. The weekly is `? * SUN *`.
         return sorted(int(h) for h in
                       re.findall(r'cron\(0 (\d+) \* \* \? \*\)', block))
 
-    groom = hours("SCHED_CRONS=(")
-    sweep = hours("SWEEP_SCHED_CRONS=(")
-    assert groom and sweep, f"could not parse schedules: groom={groom} sweep={sweep}"
-    assert not (set(groom) & set(sweep)), (
-        f"a sweep fires at the same hour as a groom: {sorted(set(groom) & set(sweep))}"
-    )
-    for g in groom:
-        assert any((s - g) % 24 == 4 for s in sweep), (
-            f"groom at {g:02d}:00 UTC has no sweep 4h later; sweeps={sweep}"
+    groom = daily_hours("SCHED_CRONS=(")
+    sweep = daily_hours("SWEEP_SCHED_CRONS=(")
+    assert groom, "no daily groom cadence declared"
+
+    UTC_OFFSET = 7  # PDT
+    DEAD_LOCAL = {1, 2, 3}
+    for utc_h in groom + sweep:
+        local = (utc_h - UTC_OFFSET) % 24
+        assert local not in DEAD_LOCAL, (
+            f"cron(0 {utc_h} * * ? *) fires at {local:02d}:00 local, inside the "
+            f"dead window {sorted(DEAD_LOCAL)}. groom-sweep-policy.md §4.8 — a "
+            "dispatch nobody can respond to maximises time-to-detection."
         )
+
+    # And no two declared cadences may fire in the same hour: that is a
+    # collision, not a schedule (§5.9 — one lease per lane).
+    overlap = set(groom) & set(sweep)
+    assert not overlap, f"groom and sweep both fire at {sorted(overlap)} UTC"
+
+

--- a/tests/test_scheduler_reconcile_is_ci_runnable.py
+++ b/tests/test_scheduler_reconcile_is_ci_runnable.py
@@ -100,15 +100,29 @@ class TestReconcileBlockIsIamFree:
             "Offending lines:\n  " + "\n  ".join(offenders)
         )
 
-    def test_reconcile_block_still_creates_the_sweep_rules(self):
-        """The three rules I5805 exists because of."""
+    def test_reconcile_block_reconciles_the_sweep_array_including_empty(self):
+        """The reconcile block owns the sweep rules — whatever the array says.
+
+        Was: asserted three specific rule names exist. That pinned a *cadence*
+        rather than the *mechanism*, so emptying the array (2026-08-03, Brian:
+        "it seems to launch at all hours of the day") failed a test that was
+        never about those three names. Same class as a version test asserting a
+        hardcoded literal: the check blocks the change it should have allowed.
+
+        What must hold is that the block both CREATES what is declared and
+        PRUNES what is not — the sweep rules are named outside SCHED_PREFIX, so
+        2f's prune skips them and removal is otherwise silently ineffective.
+        """
         block = _reconcile_block()
-        for name in (
-            "alpha-engine-groom-sweep-0000-daily",
-            "alpha-engine-groom-sweep-0800-daily",
-            "alpha-engine-groom-sweep-1600-daily",
-        ):
-            assert name in block, f"{name} is not created in the reconcile block"
+        assert "SWEEP_SCHED_NAMES" in block, "the sweep array is not reconciled here"
+        assert "SWEEP_SCHED_PREFIX" in block, (
+            "no prune over the sweep prefix — removing an entry from "
+            "SWEEP_SCHED_NAMES would orphan a still-firing live rule, which is "
+            "alpha-engine-config-I5805 in reverse"
+        )
+        assert "aws scheduler delete-schedule" in block, (
+            "the sweep prune must actually delete, not just enumerate"
+        )
 
     def test_bootstrap_still_implies_both_halves(self):
         """`--bootstrap` predates the split and must keep its old meaning."""
@@ -145,23 +159,26 @@ class TestDeployWorkflowRunsIt:
 
 
 class TestDriftCheckerSeesEveryDeclaredRule:
-    def test_discovery_finds_the_sweep_rules(self):
+    def test_discovery_finds_indented_arrays(self):
         """Indented arrays included — they live inside an `if` block.
 
         The first draft of the checker anchored its array regex at column 0 and
-        found 11 of 14 rules, missing exactly the sweep ones. Zero findings on an
-        invisible rule reads as "no drift", which is the same class of bug the
-        checker is for.
+        found 11 of 14 rules, missing exactly the ones nested in the reconcile
+        block. Zero findings on an invisible rule reads as "no drift", which is
+        the same class of bug the checker exists for.
+
+        Named rules here are the ones that must always be discoverable; the
+        standalone sweep cadence was emptied 2026-08-03 and deliberately is not
+        among them (end-of-SF sweep covers it every cycle).
         """
         checker = _load_checker()
         rules, errors, _ = checker.discover_codified_rules()
         assert not errors, f"source errors in deploy scripts: {errors}"
         names = {r["name"] for r in rules}
         for expected in (
-            "alpha-engine-groom-sweep-0000-daily",
-            "alpha-engine-groom-sweep-0800-daily",
-            "alpha-engine-groom-sweep-1600-daily",
             "alpha-engine-scheduled-groom-0400-daily",
+            "alpha-engine-scheduled-groom-1200-daily",
+            "alpha-engine-scheduled-groom-2000-daily",
             "alpha-engine-groom-lane-reconciler-5min",
         ):
             assert expected in names, (
@@ -287,9 +304,14 @@ class TestDeployAssertionIsScopedToItsOwnDispatcher:
             "it owned all of them, scoping would be a no-op and this test would "
             "prove nothing"
         )
-        # 4 groom cadences + 3 sweep cadences + 1 lane reconciler.
-        assert len(scoped) == 8, (
-            f"expected 8 rules for the groom dispatcher, found {len(scoped)}: "
+        # 4 groom cadences (3 daily + 1 weekly) + 1 lane reconciler.
+        # Was 8: the 3 standalone sweep cadences were emptied 2026-08-03 —
+        # DispatchEndOfSfSweep already sweeps at the end of every groom cycle,
+        # so they were a second sweep cadence layered on a design that already
+        # swept, and their 00/08/16 UTC slots interleaved 4h between the groom
+        # slots to produce a dispatch every four hours around the clock.
+        assert len(scoped) == 5, (
+            f"expected 5 rules for the groom dispatcher, found {len(scoped)}: "
             f"{sorted(r['name'] for r in scoped)}"
         )
 


### PR DESCRIPTION
Brian, 2026-08-03: *"it seems to launch at all hours of the day and breaks constantly… a clear schedule, minimal collisions."*

## The cause: two cadences, not one

| | UTC | Local (PDT) |
|---|---|---|
| groom | 04 / 12 / 20 | 21:00 / 05:00 / 13:00 — **chosen 2026-07-30** |
| sweep | 00 / 08 / 16 | 17:00 / **01:00** / 09:00 — added 2026-07-30 |

The sweeps interleave **exactly 4h between the groom slots**. That is what turns a deliberately chosen 3×/day cadence into a dispatch every four hours with no quiet period — and puts a spot box at 01:00 local that nobody can respond to.

## Removing them costs no coverage — verified, not assumed

Every route through `step_function_groom.json` lands on `DispatchEndOfSfSweep`:

```
CheckAnyLaunches      --default--> AllSkipped --> DispatchEndOfSfSweep
CheckMapLaneOutcomes  --default-->               DispatchEndOfSfSweep
SetMapFailureFromLanes -->                       DispatchEndOfSfSweep
RecordMapLaunchFailure -->                       DispatchEndOfSfSweep
```

The standalone rules were added for a real reason: the sweep was then hostage to groom health — two of three cycles hit `concurrent_cycle_skip` and the sweep ran on neither. **`config#2201` fixed that defect properly**, by rerouting the zero-launches path off a terminal `Succeed`. The second cadence has since been buying coverage the SF already provides.

The only route that skips the sweep is `DecideLaunches` failing outright — the dispatcher Lambda is down, in which case a standalone sweep invoking that same Lambda would not have run either.

## The trap in removing it

These rules are named **outside `SCHED_PREFIX` on purpose**, so `2f`'s prune deliberately skips them. Emptying the array alone would have left three schedules firing forever with nothing in the tree declaring them — `alpha-engine-config-I5805` in reverse: declared-removed, still live, invisible.

This adds a matching prune over `SWEEP_SCHED_PREFIX`, so removal actually lands. Deploys on merge via `deploy-scheduled-groom-dispatcher.yml --reconcile-schedules`; no operator step.

## Two guards replaced, not deleted

Both asserted proxies for properties, and both blocked the change they should have allowed — the same class as a version test pinned to a hardcoded literal.

| Was | Now |
|---|---|
| `test_sweep_has_its_own_schedules_not_only_the_groom_tail` — three named rules exist | **`test_every_sf_path_reaches_the_tail_sweep`** — asserts the routing those names stood for. A genuine regression guard: re-terminating any of those paths fails it |
| `test_sweep_schedule_interleaves_with_the_groom` — sweep lands 4h after groom | **`test_no_dispatch_lands_in_the_quiet_hours`** — guards `groom-sweep-policy.md` §4.8 instead of enforcing the interleave that caused this. **Verified to fail** against the removed 08:00 UTC rule |

21:00 and 05:00 local are deliberately kept — that is the cadence you chose on 2026-07-30. Only the un-chosen second cadence goes.

## Test plan

Full suite: **138 failed / 3770 passed**, byte-identical to `origin/main` measured on the same interpreter. The 138 are pre-existing local dependency gaps (`bs4`, `tenacity`, `yfinance`), present on `main` and installed in CI. Targeted: `test_groom_cycle_notifications.py` + `test_scheduler_reconcile_is_ci_runnable.py` → 39 passed. `bash -n` clean.

Related: `nous-ergon-ops-PR457` (§2.9 cadence derived, §4.8 attended window, §5.9 singleton lease) — policy, merges independently.

---

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)