### PR TITLE
fix(groom-sf): max_retries 3 → 0, TimeoutSeconds 7h → 4h

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
 ## Deploy mechanism
 <!-- Required if this PR touches a path with an auto-deploy-on-merge mechanism. -->
 **Deploy-mechanism:** <name the workflow that will fire on merge, e.g. `deploy.yml` / `deploy-infrastructure.yml` / `deploy-on-merge.sh via SSM`, or write `N/A` if this PR does not touch a deploy-triggering path>
+
+---
+
+**Prepared by:** <!-- model name from the session prompt, e.g. claude-sonnet-5, deepseek-v4-flash, claude-haiku-4-5 — replaces the generic "Generated with Claude Code" footer -->

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -634,5 +634,5 @@
       "Cause": "Backlog groom dispatch failed during the decide phase — see the SNS alert / Lambda logs for detail."
     }
   },
-  "TimeoutSeconds": 25200
+  "TimeoutSeconds": 14400
 }

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -77,7 +77,7 @@
         "schedInput.$": "$.schedInput",
         "launchDecision.$": "$$.Map.Item.Value",
         "retry_count": 0,
-        "max_retries": 3,
+        "max_retries": 0,
         "fod": {
           "force_on_demand": false,
           "launch_decided": true,

--- a/tests/test_groom_cycle_notifications.py
+++ b/tests/test_groom_cycle_notifications.py
@@ -576,3 +576,35 @@ def test_sweep_schedule_interleaves_with_the_groom():
         assert any((s - g) % 24 == 4 for s in sweep), (
             f"groom at {g:02d}:00 UTC has no sweep 4h later; sweeps={sweep}"
         )
+
+
+def test_sf_timeout_sits_above_the_box_budget_hierarchy():
+    """The SF must outlive the box it is waiting on, or it reports a false failure.
+
+    Brian's ruling 2026-08-03 caps the spot box at 3.5h. The layers nest, and
+    each must sit above the one it backstops:
+
+        soft budget 180m (3.0h)   alpha-engine-config scripts/groom_run.sh
+        MAX_RUNTIME 12600 (3.5h)  alpha-engine-config groom_spot_bootstrap.sh
+        DEADMAN     13500 (3.75h) alpha-engine-config groom_spot_bootstrap.sh
+        SF timeout  14400 (4.0h)  THIS FILE
+
+    Why 4h and not 3.5h: if the SF timed out at the same instant the box does,
+    it would abandon the execution while the box is still writing its final
+    telemetry and firing its task-token callback — turning a clean 3.5h
+    wall-hit into a reported SF failure with no end_reason recorded. The
+    15-minute gap is what lets the box finish saying why it stopped.
+
+    The counterpart values live in another repo and cannot be asserted from
+    here; alpha-engine-config's scripts/test_groom_run_telemetry.py owns them.
+    This test owns the top of the hierarchy.
+    """
+    import json
+
+    sf = json.loads((REPO_ROOT / "infrastructure" / "step_function_groom.json").read_text())
+    timeout = sf.get("TimeoutSeconds")
+    assert timeout == 14400, (
+        f"SF TimeoutSeconds is {timeout}, expected 14400 (4.0h). It must remain "
+        "ABOVE the box's 3.75h dead-man, or the SF abandons runs that are still "
+        "winding down and records a failure for a clean wall-hit."
+    )

--- a/tests/test_groom_instance_type_rotation.py
+++ b/tests/test_groom_instance_type_rotation.py
@@ -49,20 +49,46 @@ def lane_states() -> dict:
 
 # ── The ladder has room for spot attempts before the on-demand rung ───────────
 
-def test_ladder_leaves_at_least_two_spot_retries_before_on_demand(item_selector):
-    """Brian ruling: at least two DIFFERENT types tried on spot first.
+def test_there_is_no_in_cycle_ladder(item_selector):
+    """SUPERSEDED RULING, recorded rather than deleted.
 
-    CheckForceOnDemand fires when retry_count == max_retries, so the number of
-    spot attempts is max_retries (attempt 0 plus retries 1..max_retries-1) and
-    the final retry is the on-demand rung. max_retries must therefore be >= 3
-    to give three spot attempts.
+    Was `test_ladder_leaves_at_least_two_spot_retries_before_on_demand`,
+    asserting `max_retries >= 3` — Brian's ruling of 2026-07-31 (I5923), which
+    existed so a reclaim would try two alternate spot pools before falling back
+    to on-demand during prime time.
+
+    **Superseded 2026-08-03**, by the same person: *"lets set max retry to 0...
+    so if a spot dies, it dies."* The two could not both hold. Each relaunch is
+    a NEW BOX with its own 3.5h wall (alpha-engine-config
+    groom_spot_bootstrap.sh MAX_RUNTIME_SECONDS=12600), so two attempts is ~7h
+    of wall-clock whatever the SF ceiling allows — a bounded cycle and a
+    multi-rung in-cycle ladder are arithmetically incompatible, and the 7h
+    cycles were the thing being fixed.
+
+    **What was given up:** the two alternate-spot-pool rungs and the on-demand
+    rung. A reclaimed lane now waits for the next cycle instead of relaunching
+    inside this one. Safe because the reconciler is level-triggered
+    (groom-sweep-policy.md §5.1) — the lane loses latency, never work.
+
+    **What replaced it:** the outcome rollup
+    (`alpha-engine-config scripts/groom_run_outcomes.py`), which reports the
+    got-through / died / hit-the-wall rates. That measurement was Brian's
+    stated condition for accepting max_retries=0, so a bad spot afternoon is
+    now visible as reduced throughput rather than hidden inside a cycle that
+    never ends.
+
+    The pool-rotation machinery below is deliberately LEFT INTACT: it costs
+    nothing while unused, and restoring a ladder should be a one-value change
+    rather than a rebuild.
     """
     max_retries = item_selector["max_retries"]
-    spot_attempts = max_retries  # attempt 0 .. max_retries-1
-    assert spot_attempts >= 3, (
-        f"max_retries={max_retries} yields only {spot_attempts} spot attempt(s) "
-        "before the forced on-demand rung. The ruling requires at least two "
-        "DIFFERENT instance types tried on spot first."
+    assert max_retries == 0, (
+        f"max_retries={max_retries}, expected 0 (Brian's ruling 2026-08-03). "
+        "Raising it re-opens the conflict with the 3.5h box wall: each retry is "
+        "a new box with its own full budget, so N attempts is N x 3.5h of "
+        "wall-clock. If a ladder is wanted again, the box wall and the SF "
+        "ceiling have to move with it — see "
+        "tests/test_sf_groom_relaunch_wiring.py::test_state_machine_declares_a_global_ceiling."
     )
 
 

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -237,9 +237,39 @@ def test_state_machine_declares_a_global_ceiling():
     ceiling = doc.get("TimeoutSeconds")
     assert ceiling, "the state machine must declare a top-level TimeoutSeconds"
     lane = doc["States"]["MapLaunches"]["ItemProcessor"]["States"]["LaunchGroomSpot"]
-    assert ceiling > lane["TimeoutSeconds"] * 2, (
-        "the global ceiling must leave room for one near-ceiling death plus one "
-        "full healthy retry"
+    # REVISED 2026-08-03 (Brian's ruling: max_retries -> 0, "if a spot dies, it
+    # dies"). The old bound was `ceiling > lane * 2` — room for one near-ceiling
+    # death PLUS one full healthy retry. That bound presumed in-cycle recovery.
+    #
+    # It is now unsatisfiable by construction and was never really about the SF:
+    # each relaunch is a NEW BOX with its own 3.5h wall
+    # (alpha-engine-config groom_spot_bootstrap.sh MAX_RUNTIME_SECONDS=12600),
+    # so two attempts is ~7h of wall-clock no matter what the ceiling permits.
+    # Holding both the 3.5h cap and a multi-rung ladder inside one cycle is
+    # arithmetically impossible.
+    #
+    # With max_retries=0 a lane gets exactly one attempt and a death waits for
+    # the next cycle — safe because the reconciler is level-triggered
+    # (groom-sweep-policy.md §5.1): the lane loses latency, never work.
+    #
+    # The bound that remains load-bearing: the ceiling must exceed ONE lane
+    # attempt with enough headroom for the box to wind down, write its final
+    # telemetry record and fire its task-token callback. Timing the SF out at
+    # the same moment the box stops would record a clean wall-hit as an SF
+    # failure with no end_reason — defeating the telemetry that makes this
+    # ruling safe.
+    retries = doc["States"]["MapLaunches"]["ItemSelector"]["max_retries"]
+    assert retries == 0, (
+        f"max_retries is {retries}, expected 0. Brian's ruling 2026-08-03: a "
+        "lane gets one attempt; a dead spot waits for the next cycle. Raising "
+        "it re-opens the conflict with the 3.5h box wall, because each retry is "
+        "a new box with its own full budget."
+    )
+    _WIND_DOWN_HEADROOM_S = 900  # 15 min: telemetry write + task-token callback
+    assert ceiling >= lane["TimeoutSeconds"] + _WIND_DOWN_HEADROOM_S, (
+        f"ceiling {ceiling}s leaves under {_WIND_DOWN_HEADROOM_S}s above the "
+        f"{lane['TimeoutSeconds']}s lane timeout — a box hitting its wall would "
+        "be abandoned mid-wind-down and its end_reason lost"
     )
     assert ceiling < _CYCLE_CADENCE_SECONDS, (
         "the global ceiling must stay under the 8h cycle cadence — an execution "


### PR DESCRIPTION
Counterpart to **`alpha-engine-config-PR6356`**, which caps the groom spot box at 3.5h (Brian's ruling 2026-08-03).

**Merge order: `alpha-engine-config-PR6356` FIRST, then this one.** Landing this alone would lower the SF's patience while the box still runs to 6h, converting working runs into reported failures.

Refs `alpha-engine-config-I6343`.

## The hierarchy

| Layer | Value | Where |
|---|---|---|
| soft budget (happy-path self-stop) | 180m (3.0h) | `alpha-engine-config` `scripts/groom_run.sh` |
| `MAX_RUNTIME_SECONDS` (hard watchdog) | 12600 (3.5h) | `alpha-engine-config` `groom_spot_bootstrap.sh` |
| `GROOM_DEADMAN_SECONDS` | 13500 (3.75h) | `alpha-engine-config` `groom_spot_bootstrap.sh` |
| **SF `TimeoutSeconds`** | **14400 (4.0h)** | **here** |

## Why 4h and not 3.5h

If the SF timed out at the same instant the box does, it would abandon the execution while the box is still writing its final telemetry record and firing its task-token callback — turning a **clean 3.5h wall-hit into a reported SF failure with no `end_reason` recorded**. That would defeat the point of the telemetry in the counterpart PR, which exists to distinguish "hit the wall" from "the spot died."

The 15-minute gap is what lets the box finish saying why it stopped.

## The cross-repo seam is stated, not assumed

The three counterpart values live in another repo and cannot be asserted from here. `alpha-engine-config`'s `scripts/test_groom_run_telemetry.py` owns the box-side nesting; this test owns the top of the hierarchy and says so in its docstring, so a future reader knows where the other half is rather than assuming this file is the whole contract.

## Test plan

`tests/test_groom_cycle_notifications.py` → **25 passed**. The new guard was verified to **fail** against the old `25200` value before passing against `14400`.

Full suite: **139 failed / 3770 passed** — failure set **byte-identical to baseline**, confirmed by a same-worktree stash comparison (`comm` reports zero difference in both directions). The 139 are pre-existing local dependency gaps (`bs4`, `tenacity`, `yfinance`), installed in CI.

---

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)