### PR TITLE
fix(groom): raise the lane bound above the box wall — the ladder was inverted

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -294,6 +294,22 @@ GROOM_GH_PAT_SSM = os.environ.get("GROOM_GH_PAT_SSM", "/alpha-engine/saturday_sf
 #                                                        -> the reconciler's deadline_utc
 #   groom_spot_bootstrap.sh watchdog   21600s (360 min)  -> the box's own kill
 #
+# RE-ALIGNED 2026-08-03, and the same class recurred in the other direction.
+# Brian's 3.5h ruling moved the bootstrap watchdog to 12600 and its dead-man to
+# 13500 (alpha-engine-config-PR6356), leaving this constant and the SF lane at
+# 10800 — so the SSM command and the SF would abandon a lane at 3h while the
+# box worked on until 3.5h and was killed at 3.75h. The invariant's own words,
+# "the box must never outlive the lane the SF is waiting on", were violated by
+# a layer the binding test CANNOT SEE: it reads this constant, and the real box
+# bound lives in another repo.
+#
+# The ladder is now monotonic, each layer above the one it waits on:
+#   box soft budget      10800 (3.0h)   alpha-engine-config groom_run.sh
+#   box watchdog         12600 (3.5h)   alpha-engine-config bootstrap
+#   box dead-man         13500 (3.75h)  alpha-engine-config bootstrap
+#   this constant + lane 13800 (3.83h)  SSM timeout / reconciler / SF lane
+#   SF ceiling           14400 (4.0h)   step_function_groom.json
+#
 # The comment above this line claimed it "matches the bootstrap watchdog" — it
 # did, and both were wrong, because the SF had been tightened to 180 min
 # without them. The consequence is not cosmetic: the SF gives up on the lane at
@@ -309,7 +325,7 @@ GROOM_GH_PAT_SSM = os.environ.get("GROOM_GH_PAT_SSM", "/alpha-engine/saturday_sf
 # 10800 is therefore the value, and it is BOUND to the SF definition by
 # test_runtime_bound_is_single_and_authoritative — both files live in this
 # repo, so the binding is enforceable rather than aspirational.
-MAX_RUNTIME_SECONDS = int(os.environ.get("GROOM_MAX_RUNTIME_SECONDS", "10800"))
+MAX_RUNTIME_SECONDS = int(os.environ.get("GROOM_MAX_RUNTIME_SECONDS", "13800"))
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("GROOM_SSM_ONLINE_BUDGET_SEC", "180"))
 CW_LOG_GROUP = os.environ.get("GROOM_CW_LOG_GROUP", "/alpha-engine/groom-spot")
 

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -108,7 +108,7 @@
               "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
               "Payload.$": "States.JsonMerge(States.JsonMerge(States.JsonMerge($.schedInput, $.launchDecision, false), $.fod, false), $$.Task, false)"
             },
-            "TimeoutSeconds": 10800,
+            "TimeoutSeconds": 13800,
             "Retry": [
               {
                 "ErrorEquals": [
@@ -634,5 +634,5 @@
       "Cause": "Backlog groom dispatch failed during the decide phase — see the SNS alert / Lambda logs for detail."
     }
   },
-  "TimeoutSeconds": 14400
+  "TimeoutSeconds": 15000
 }

--- a/tests/test_groom_cycle_notifications.py
+++ b/tests/test_groom_cycle_notifications.py
@@ -584,10 +584,11 @@ def test_sf_timeout_sits_above_the_box_budget_hierarchy():
     Brian's ruling 2026-08-03 caps the spot box at 3.5h. The layers nest, and
     each must sit above the one it backstops:
 
-        soft budget 180m (3.0h)   alpha-engine-config scripts/groom_run.sh
-        MAX_RUNTIME 12600 (3.5h)  alpha-engine-config groom_spot_bootstrap.sh
-        DEADMAN     13500 (3.75h) alpha-engine-config groom_spot_bootstrap.sh
-        SF timeout  14400 (4.0h)  THIS FILE
+        soft budget 10800 (3.00h)  alpha-engine-config scripts/groom_run.sh
+        box watchdog 12600 (3.50h) alpha-engine-config groom_spot_bootstrap.sh
+        box dead-man 13500 (3.75h) alpha-engine-config groom_spot_bootstrap.sh
+        lane + SSM   13800 (3.83h) step_function_groom.json + dispatcher index.py
+        SF ceiling   15000 (4.17h) THIS FILE
 
     Why 4h and not 3.5h: if the SF timed out at the same instant the box does,
     it would abandon the execution while the box is still writing its final
@@ -603,8 +604,9 @@ def test_sf_timeout_sits_above_the_box_budget_hierarchy():
 
     sf = json.loads((REPO_ROOT / "infrastructure" / "step_function_groom.json").read_text())
     timeout = sf.get("TimeoutSeconds")
-    assert timeout == 14400, (
-        f"SF TimeoutSeconds is {timeout}, expected 14400 (4.0h). It must remain "
-        "ABOVE the box's 3.75h dead-man, or the SF abandons runs that are still "
-        "winding down and records a failure for a clean wall-hit."
+    assert timeout == 15000, (
+        f"SF TimeoutSeconds is {timeout}, expected 15000 (4h10m). It must clear "
+        "the 13800s lane bound by the 900s wind-down headroom, which itself "
+        "clears the box's 3.75h dead-man — otherwise the SF abandons a run that "
+        "is still winding down and records a failure for a clean wall-hit."
     )

--- a/tests/test_sf_groom_end_of_sf_sweep_wiring.py
+++ b/tests/test_sf_groom_end_of_sf_sweep_wiring.py
@@ -218,7 +218,11 @@ def test_launch_groom_spot_uses_wait_for_task_token(states):
     """
     lg = states["MapLaunches"]["ItemProcessor"]["States"]["LaunchGroomSpot"]
     assert lg["Resource"] == "arn:aws:states:::lambda:invoke.waitForTaskToken"
-    assert lg["TimeoutSeconds"] == 10800
+    # 13800 (3h50m) since 2026-08-03. The lane bound must clear the box's 3.75h
+    # dead-man (alpha-engine-config groom_spot_bootstrap.sh) so the SF waits for a
+    # box that is winding down rather than abandoning it. Full ladder:
+    # tests/test_groom_cycle_notifications.py::test_sf_timeout_sits_above_the_box_budget_hierarchy
+    assert lg["TimeoutSeconds"] == 13800
     assert "TaskToken.$" not in lg["Parameters"]
     assert "TaskToken" not in lg["Parameters"]
     assert "$$.Task" in lg["Parameters"]["Payload.$"]

--- a/tests/test_sf_groom_relaunch_wiring.py
+++ b/tests/test_sf_groom_relaunch_wiring.py
@@ -188,7 +188,7 @@ def test_lane_timeout_is_the_sole_bound_no_unemitted_heartbeat(states):
     heartbeat sat beside a 21600s timeout with no emitter anywhere in the fleet,
     and every lane died at 3606s."""
     launch = states["LaunchGroomSpot"]
-    assert launch["TimeoutSeconds"] == 10800
+    assert launch["TimeoutSeconds"] == 13800
     assert "HeartbeatSeconds" not in launch, (
         "no SendTaskHeartbeat emitter exists on the groom box — a heartbeat here "
         "would become the real lane timeout"
@@ -398,6 +398,19 @@ def test_runtime_bound_is_single_and_authoritative():
     reconciler was mis-armed identically: deadline_utc was now + 360 min, so a
     lane the SF had already given up on stayed 'not overdue' for three hours.
     """
+    # 2026-08-03: this test reads the DISPATCHER constant, which is the SSM
+    # command timeout — NOT the box's own watchdog, which lives in
+    # alpha-engine-config and is invisible from here. That blind spot let the
+    # same class recur in the opposite direction: Brian's 3.5h ruling moved the
+    # bootstrap watchdog to 12600 while this constant and the lane sat at
+    # 10800, so both would have abandoned a lane at 3h while the box worked to
+    # 3.5h — and this assertion still passed, because the layer that changed
+    # was not one it can see.
+    #
+    # The cross-repo half is asserted from the other side by
+    # alpha-engine-config scripts/test_groom_run_telemetry.py
+    # (test_budget_layers_nest_in_the_right_order). Neither repo can check the
+    # whole ladder alone; both halves are named so a reader knows to look.
     lane_timeout = _lane_state()["TimeoutSeconds"]
     box_bound = _dispatcher_max_runtime()
     assert box_bound <= lane_timeout, (


### PR DESCRIPTION
Follow-through on `nousergon-data-PR1218` and `alpha-engine-config-PR6356`, both merged an hour ago. **I introduced this and caught it on the deployed-artifact check.**

## What was wrong

Brian's 3.5h ruling moved the box watchdog to 12600 and its dead-man to 13500. The **SSM command timeout and the SF lane bound stayed at 10800 (3h)** — so both would abandon a lane at 3h while the box worked on until 3.5h and was killed at 3.75h.

That is the same defect the dispatcher's own comment documents from 2026-07-30 — *"three copies that did NOT agree"* — recurring in the opposite direction.

## Why nothing caught it

`test_runtime_bound_is_single_and_authoritative` exists precisely for this, and it **still passed**. It reads the *dispatcher constant*; the layer that actually changed is the bootstrap watchdog, which lives in `alpha-engine-config` and is invisible from this repo.

A guard that cannot see the layer most likely to move is a guard whose silence means nothing. The blind spot is now written into its docstring, with the counterpart assertion named on the other side (`alpha-engine-config scripts/test_groom_run_telemetry.py::test_budget_layers_nest_in_the_right_order`). Neither repo can check the whole ladder alone; both halves now say so.

## The ladder, now monotonic

| Layer | Seconds | Where |
|---|---|---|
| box soft budget | 10800 (3.00h) | `alpha-engine-config` `groom_run.sh` |
| box watchdog | 12600 (3.50h) | `alpha-engine-config` bootstrap |
| box dead-man | 13500 (3.75h) | `alpha-engine-config` bootstrap |
| **lane + SSM + reconciler deadline** | **13800 (3.83h)** | here + dispatcher `index.py` |
| **SF ceiling** | **15000 (4.17h)** | `step_function_groom.json` |

Each layer sits above the one it waits on, so the SF and SSM now wait for a box that is winding down rather than abandoning it — which matters directly, because abandoning it is what would lose the `end_reason` that makes the new telemetry able to tell a wall-hit from a dying spot.

## The ceiling moved too, and a guard forced it

`14400 → 15000`, because the wind-down headroom rule I added in `PR1218` (`ceiling ≥ lane + 900s`) **failed once the lane rose**. That is the guard doing its job on its author.

## Three pins, three files

The lane bound was hardcoded at 10800 in three separate tests. All three updated, and each now points at the single ladder rather than restating it — so the next change breaks one assertion with a pointer, not three with three stories.

## Test plan

`test_sf_groom_relaunch_wiring.py` + `test_groom_cycle_notifications.py` → 46 passed. Full suite failure set **byte-identical to `origin/main`** (138 = 138) via `comm` in both directions.

Refs `alpha-engine-config-I6343`.

---

**Prepared by:** _Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)