### PR TITLE
feat(thinktank-spot): hand the box its router addressing (config-I6373)

### DIFF
--- a/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/index.py
@@ -125,6 +125,44 @@ WATCHDOG_SECONDS = int(os.environ.get("THINKTANK_SPOT_WATCHDOG_SECONDS", "9000")
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("THINKTANK_SPOT_SSM_ONLINE_BUDGET_SEC", "300"))
 CW_LOG_GROUP = os.environ.get("THINKTANK_SPOT_CW_LOG_GROUP", "/alpha-engine/thinktank-spot")
 
+# ── Router addressing (alpha-engine-config-I6367 / I6373) ──────────────────
+# Brian's ruling 2026-08-03: no agent may be directly linked to OpenRouter.
+# The Think Tank's tiers address model GROUPS, resolved through the
+# authenticated router edge. Three facts the box cannot derive for itself:
+#
+#   where it runs        — a stock-AMI spot box, so the dashboard box's local
+#                          egress proxy at 127.0.0.1:8990 does NOT answer here
+#                          and the edge is the only path;
+#   which URL             — model-router-policy §3.4a R27a: the router is
+#                          addressed by (url, credential) and reaching it may
+#                          not depend on host, VPC, subnet, SG or private IP;
+#   which credential     — the edge identifies a consumer BY its credential
+#                          VALUE, and krepis.secrets resolves SSM BEFORE
+#                          os.environ, so sharing the secret NAME
+#                          `LITELLM_MASTER_KEY` would collapse this box into
+#                          the director's identity however the environment is
+#                          set. `thinktank` is its own consumer in
+#                          nous-ergon-ops bin/render-router-secrets.sh.
+#
+# The registry itself comes from AppConfig: crucible-research is PUBLIC, so
+# private-docs/LLM_MODEL_REGISTRY.yaml is correctly absent from the clone.
+KREPIS_EXEC_CONTEXT = os.environ.get("THINKTANK_SPOT_EXEC_CONTEXT", "ec2")
+KREPIS_LITELLM_PROXY_URL = os.environ.get(
+    "THINKTANK_SPOT_ROUTER_URL", "https://router.nousergon.ai:8443"
+)
+KREPIS_ROUTER_CREDENTIAL_SECRET = os.environ.get(
+    "THINKTANK_SPOT_ROUTER_CREDENTIAL_SECRET", "ROUTER_CONSUMER_THINKTANK"
+)
+KREPIS_APPCONFIG_APPLICATION = os.environ.get(
+    "THINKTANK_SPOT_APPCONFIG_APPLICATION", "alpha-engine"
+)
+KREPIS_APPCONFIG_CONFIG_PROFILE = os.environ.get(
+    "THINKTANK_SPOT_APPCONFIG_CONFIG_PROFILE", "llm-model-registry"
+)
+KREPIS_APPCONFIG_ENVIRONMENT = os.environ.get(
+    "THINKTANK_SPOT_APPCONFIG_ENVIRONMENT", "production"
+)
+
 INSTANCE_TAG_NAME = "alpha-engine-thinktank-spot"
 
 
@@ -169,6 +207,12 @@ git clone --depth 1 --branch {RESEARCH_BRANCH} \\
 cd /home/ec2-user/crucible-research
 export THINKTANK_RUN_BUDGET_SECONDS={RUN_BUDGET_SECONDS}
 export THINKTANK_SPOT_RUN_TOKEN={run_token}
+export KREPIS_EXEC_CONTEXT={KREPIS_EXEC_CONTEXT}
+export KREPIS_LITELLM_PROXY_URL={KREPIS_LITELLM_PROXY_URL}
+export KREPIS_ROUTER_CREDENTIAL_SECRET={KREPIS_ROUTER_CREDENTIAL_SECRET}
+export KREPIS_APPCONFIG_APPLICATION={KREPIS_APPCONFIG_APPLICATION}
+export KREPIS_APPCONFIG_CONFIG_PROFILE={KREPIS_APPCONFIG_CONFIG_PROFILE}
+export KREPIS_APPCONFIG_ENVIRONMENT={KREPIS_APPCONFIG_ENVIRONMENT}
 exec bash infrastructure/thinktank_spot_bootstrap.sh
 """
 

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/test_handler.py
@@ -277,3 +277,61 @@ class TestDiscriminatorTags:
         hours_to_midnight = 24 - dispatch_hour_utc
         assert mod.RUN_TIMEOUT_SECONDS / 3600 < hours_to_midnight
         assert mod.WATCHDOG_SECONDS / 3600 < hours_to_midnight
+
+
+# ── Router addressing (alpha-engine-config-I6367 / I6373) ────────────────
+
+
+class TestRouterEnvReachesTheBox:
+    """Brian's ruling 2026-08-03: no agent directly linked to OpenRouter. The
+    Think Tank's tiers address model groups through the authenticated router
+    edge, and the box cannot derive any of what that needs for itself."""
+
+    def _prelude(self):
+        return _load()._bootstrap_command("tok123")
+
+    def test_every_router_var_is_exported(self):
+        prelude = self._prelude()
+        for var in (
+            "KREPIS_EXEC_CONTEXT",
+            "KREPIS_LITELLM_PROXY_URL",
+            "KREPIS_ROUTER_CREDENTIAL_SECRET",
+            "KREPIS_APPCONFIG_APPLICATION",
+            "KREPIS_APPCONFIG_CONFIG_PROFILE",
+            "KREPIS_APPCONFIG_ENVIRONMENT",
+        ):
+            assert f"export {var}=" in prelude, (
+                f"{var} never reaches the box — krepis' AppConfig path is "
+                "opt-in on all three APPCONFIG vars and SWALLOWS its errors, "
+                "so a missing one surfaces later as "
+                "'LLM_MODEL_REGISTRY.yaml not found', naming neither"
+            )
+
+    def test_exec_context_is_ec2_not_lambda(self):
+        """It names WHERE CODE RUNS (R28), never how it is attached, and never
+        which routes are wanted. Declaring `lambda` from an EC2 box to force a
+        route would be a lie the registry then acts on."""
+        assert "export KREPIS_EXEC_CONTEXT=ec2" in self._prelude()
+
+    def test_credential_secret_is_the_boxs_own_not_the_shared_one(self):
+        """The edge identifies a consumer BY its credential VALUE, and
+        krepis.secrets resolves SSM BEFORE os.environ — so naming
+        LITELLM_MASTER_KEY here would collapse this box into the director's
+        identity at the edge no matter what the environment says."""
+        prelude = self._prelude()
+        assert (
+            "export KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_THINKTANK"
+            in prelude
+        )
+        assert "KREPIS_ROUTER_CREDENTIAL_SECRET=LITELLM_MASTER_KEY" not in prelude
+
+    def test_router_url_is_the_edge_not_a_loopback(self):
+        """This is a stock-AMI spot box: the dashboard box's local egress
+        proxy at 127.0.0.1:8990 does not answer here. A loopback URL would
+        make every call fail connect and read as the router being down."""
+        prelude = self._prelude()
+        assert "export KREPIS_LITELLM_PROXY_URL=https://router.nousergon.ai:8443" in prelude
+        assert "KREPIS_LITELLM_PROXY_URL=http://127.0.0.1" not in prelude
+
+    def test_no_openrouter_credential_is_handed_to_the_box(self):
+        assert "OPENROUTER" not in self._prelude()


### PR DESCRIPTION
## Why

Brian's ruling, 2026-08-03 (`alpha-engine-config-I6367`): **no agent may be directly linked to OpenRouter.** The Think Tank's four tiers now address model **groups** through the authenticated router edge (`crucible-research#571`, merged). The SSM prelude is the only place three of the six facts that needs can come from — the box cannot derive any of them.

Step 4 of `alpha-engine-config-I6373`.

## What

Six exports added to `_bootstrap_command`, every value env-overridable on the dispatcher (matching the existing convention for every other launch parameter here).

| variable | value | why it cannot be defaulted elsewhere |
|---|---|---|
| `KREPIS_EXEC_CONTEXT` | `ec2` | Names **where code runs** (R28) — never how it is attached, never which routes are wanted. |
| `KREPIS_LITELLM_PROXY_URL` | `https://router.nousergon.ai:8443` | This is a **stock-AMI spot box**: the dashboard box's local egress proxy at `127.0.0.1:8990` does not answer here, so the edge is the only path. |
| `KREPIS_ROUTER_CREDENTIAL_SECRET` | `ROUTER_CONSUMER_THINKTANK` | Its own, not the shared `LITELLM_MASTER_KEY` — see below. |
| `KREPIS_APPCONFIG_APPLICATION` / `_CONFIG_PROFILE` / `_ENVIRONMENT` | `alpha-engine` / `llm-model-registry` / `production` | `crucible-research` is PUBLIC, so `private-docs/LLM_MODEL_REGISTRY.yaml` is correctly absent from the clone. |

**On the URL:** `model-router-policy` §3.4a **R27a** is categorical — the router is addressed by `(url, credential)` and reaching it may not depend on host, VPC, subnet, SG or private IP. So this is config, never a network change. The opposite reading cost 2h20m of fleet-wide SSM loss on 2026-08-03 (`nous-ergon-ops-I417`).

**On the credential:** the edge identifies a consumer **by its credential VALUE** (`bin/render-router-secrets.sh` maps value → name; nginx sets `X-Router-Consumer` from it), and `krepis.secrets` resolves **SSM before `os.environ`**. A shared secret *name* would therefore collapse this box into the director's identity at the edge however the environment is set. `thinktank` is its own consumer as of `nous-ergon-ops-PR474` (merged).

**On AppConfig:** all three are required together, and the failure is silent — krepis' AppConfig path is opt-in on the application id and **swallows its own errors**, falling through to a filesystem walk that finds nothing on a fresh box. A missing one surfaces later as `FileNotFoundError: LLM_MODEL_REGISTRY.yaml not found`, naming neither AppConfig nor the cause. That is the error that reverted `crucible-evaluator-PR157`.

## Testing

`TestRouterEnvReachesTheBox` — all six exported; `exec_context` is `ec2` and not `lambda` (declaring the wrong context to force a route is a lie the registry then acts on); the credential secret is the box's own and not the shared one; the URL is the edge and not a loopback; and **no OpenRouter credential is handed to the box at all**.

**25 passed.**

## Already live underneath

`/alpha-engine/ROUTER_CONSUMER_THINKTANK` exists (SecureString, verified resolvable) · `thinktank` is in `CONSUMERS` (`nous-ergon-ops-PR474`) · `alpha-engine-executor-role` holds `alpha-engine-appconfig-registry-read`, confirmed applied live · AppConfig serves 29,895 bytes, 4 groups, 23 models.

## Blast radius

**Nothing changes until `alpha-engine-config`'s `research/thinktank.yaml` flips to `group:`** — I6373 step 6, deliberately last. Until then every tier parses in its pinned form and these variables are simply present and unread. Draft until the edge map is re-rendered on the box.

**Prepared by:** _Claude Opus 5 (1M context)_ via [Claude Code](https://claude.com/claude-code)