### PR TITLE
fix(notify): a partial run does not page as a cadence failure

### DIFF
--- a/infrastructure/lambdas/sf-telegram-notifier/index.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/index.py
@@ -117,15 +117,65 @@ def _describe_execution(execution_arn: str) -> dict | None:
         return None
 
 
-def _is_preflight_execution(describe_resp: dict | None) -> bool:
+def _execution_input(describe_resp: dict | None) -> dict:
+    """Parsed execution input, or ``{}`` when absent/unparseable."""
     if not describe_resp:
-        return False
+        return {}
     try:
         payload = json.loads(describe_resp.get("input") or "{}")
     except (ValueError, TypeError) as exc:
         logger.warning("could not parse execution input as JSON: %s", exc)
-        return False
-    return bool(payload.get("shell_run"))
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _is_preflight_execution(describe_resp: dict | None) -> bool:
+    return bool(_execution_input(describe_resp).get("shell_run"))
+
+
+# The canonical role each state machine's own EventBridge-scheduled cadence
+# trigger stamps into its execution input. Mirrors
+# alpha-engine-config/scripts/gate_sf_run_sweep.py::_CANONICAL_PIPELINE_ROLE —
+# the same distinction, applied to notification rather than to gate clearing.
+_CANONICAL_PIPELINE_ROLE = {
+    "ne-weekly-freshness-pipeline": "weekly",
+    "ne-preopen-trading-pipeline": "daily",
+    "ne-postclose-trading-pipeline": "eod",
+}
+
+
+def _skipped_stage_count(payload: dict) -> int:
+    return sum(1 for k, v in payload.items() if k.startswith("skip_") and v)
+
+
+def _is_partial_execution(sm_arn: str, describe_resp: dict | None) -> tuple[bool, int]:
+    """Is this a narrowed run rather than the pipeline's real cadence run?
+
+    Returns ``(is_partial, skipped_stage_count)``.
+
+    An execution carrying ``skip_*`` flags ran a deliberately narrowed subset of
+    the pipeline. Its failure is not the cadence cycle failing, and paging it at
+    the same shape is overseer-policy invariant 17 — severity is a property of
+    the invariant breached, not of the check that emitted it.
+
+    Live example this exists for: ``director-verify-20260804T003005Z`` on
+    ne-weekly-freshness-pipeline carried **24** ``skip_*: true`` flags and no
+    ``pipeline_role``. It ran one stage, failed in 0m, and paged as
+    "🔴 Weekly Freshness SF — FAILED / Duration: 0m / States: (no workload
+    states in history)" — a message carrying, in its own body, the evidence that
+    it was not a weekly run.
+
+    A canonical ``pipeline_role`` (weekly/daily/eod) always wins: a real cadence
+    run that legitimately skips a completed stage on a rerun is still the
+    cadence run.
+    """
+    payload = _execution_input(describe_resp)
+    name = sm_arn.rsplit(":", 1)[-1] if sm_arn else ""
+    skipped = _skipped_stage_count(payload)
+    role = payload.get("pipeline_role")
+    if role and role == _CANONICAL_PIPELINE_ROLE.get(name):
+        return False, skipped
+    return skipped > 0, skipped
 
 
 def _failure_cause_from(describe_resp: dict | None) -> str:
@@ -149,15 +199,19 @@ def _build_message(
     sf_client=None,
     s3_client=None,
 ) -> tuple[str, bool, bool]:
-    """Return ``(text, silent, hollow_suspect)``."""
+    """Return ``(text, silent, hollow_suspect, is_partial)``."""
     status = detail.get("status", "UNKNOWN")
     execution_arn = detail.get("executionArn", "")
     if describe_resp is None:
         describe_resp = _describe_execution(execution_arn)
     is_preflight = _is_preflight_execution(describe_resp)
-    label = _label_for_arn(
-        detail.get("stateMachineArn", ""), is_preflight=is_preflight
-    )
+    sm_arn = detail.get("stateMachineArn", "")
+    is_partial, skipped_stages = _is_partial_execution(sm_arn, describe_resp)
+    label = _label_for_arn(sm_arn, is_preflight=is_preflight)
+    if is_partial:
+        # Say what it actually was. A reader must not have to open the console
+        # to learn that "Weekly Freshness SF — FAILED" meant one stage of it.
+        label = f"{label} (partial run — {skipped_stages} stage(s) skipped)"
     emoji = _STATUS_EMOJI.get(status, "\U0001f4e8")
     exec_name = detail.get("name", "") or "(unknown execution)"
     hollow_suspect = False
@@ -166,7 +220,7 @@ def _build_message(
 
     if status == "RUNNING":
         lines.append(f"Execution: {exec_name}")
-        return "\n".join(lines), True, False
+        return "\n".join(lines), True, False, is_partial
 
     duration = _format_duration(detail.get("startDate"), detail.get("stopDate"))
     if duration:
@@ -200,7 +254,12 @@ def _build_message(
     silent = False
     if status == "SUCCEEDED" and hollow_suspect:
         silent = False
-    return "\n".join(lines), silent, hollow_suspect
+    # A narrowed run is delivered without a push. It is still sent, still
+    # readable in the topic, and still recorded — it just does not buzz, because
+    # the cadence cycle it is named after did not fail.
+    if is_partial:
+        silent = True
+    return "\n".join(lines), silent, hollow_suspect, is_partial
 
 
 def handler(event: dict, context) -> dict:  # noqa: ARG001
@@ -209,11 +268,18 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001
     sm_name = (detail.get("stateMachineArn") or "").rsplit(":", 1)[-1]
     logger.info("SF status change: sf=%s status=%s", sm_name, status)
 
-    text, silent, hollow_suspect = _build_message(detail)
+    text, silent, hollow_suspect, is_partial = _build_message(detail)
     ok = notify_via_flow_doctor(
         text,
         silent=silent,
-        severity="warning" if hollow_suspect and status == "SUCCEEDED" else _severity_for_status(status),
+        # A partial run is recorded at info regardless of its terminal status:
+        # severity belongs to the invariant breached, and a narrowed
+        # verification run failing does not breach the cadence cycle's.
+        severity=(
+            "info" if is_partial
+            else "warning" if hollow_suspect and status == "SUCCEEDED"
+            else _severity_for_status(status)
+        ),
         dedup_key=_dedup_key(detail),
         flow_name=_FLOW_NAME,
         topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
@@ -222,6 +288,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001
             "state_machine": sm_name,
             "execution": detail.get("name"),
             "status": status,
+            "partial_run": is_partial,
         },
         silent_topic=FleetTelegramTopic.PIPELINE,
         # Matches playbooks.yaml's registered `sf_completion_telegram` class

--- a/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
@@ -7,6 +7,7 @@ the handler hands to the primitive, plus the return value shape.
 
 from __future__ import annotations
 
+import json
 import sys
 import types
 from pathlib import Path
@@ -362,3 +363,78 @@ def test_succeeded_hollow_predictor_training_flags_loud(reset_send_message):
     assert "⚠️" in text
     assert result["hollow_suspect"] is True
     assert result["silent"] is False
+
+
+class TestPartialRunsDoNotPageAsCadenceFailures:
+    """A narrowed run is labelled as one and does not buzz.
+
+    `director-verify-20260804T003005Z` on ne-weekly-freshness-pipeline carried
+    24 `skip_*: true` flags and no `pipeline_role`. It ran one stage, failed in
+    0m, and paged as "🔴 Weekly Freshness SF — FAILED / Duration: 0m / States:
+    (no workload states in history)" — a message carrying, in its own body, the
+    evidence that it was not a weekly run. overseer-policy invariant 17:
+    severity is a property of the invariant breached, not of the check that
+    emitted it.
+    """
+
+    _WEEKLY_ARN = (
+        "arn:aws:states:us-east-1:711398986525:stateMachine:"
+        "ne-weekly-freshness-pipeline"
+    )
+
+    def _detail(self, name="director-verify-20260804T003005Z"):
+        return {
+            "stateMachineArn": self._WEEKLY_ARN,
+            "executionArn": f"{self._WEEKLY_ARN}:{name}".replace(
+                ":stateMachine:", ":execution:"
+            ),
+            "name": name,
+            "status": "FAILED",
+            "startDate": 0,
+            "stopDate": 0,
+        }
+
+    def test_skip_flagged_run_is_labelled_partial_and_silent(self):
+        describe = {"input": json.dumps({
+            "run_date": "2026-08-03",
+            "skip_scanner": True,
+            "skip_evaluator": True,
+            "skip_post_eval": False,
+        })}
+        text, silent, _hollow, is_partial = index._build_message(
+            self._detail(), describe
+        )
+        assert is_partial is True
+        assert silent is True, "a narrowed run must not buzz"
+        assert "partial run — 2 stage(s) skipped" in text, text
+        assert "Weekly Freshness SF (partial run" in text, text
+
+    def test_canonical_cadence_role_wins_over_skip_flags(self):
+        """A real weekly rerun skipping completed stages is still the weekly run."""
+        describe = {"input": json.dumps({
+            "pipeline_role": "weekly",
+            "run_date": "2026-08-03",
+            "skip_data_phase1": True,
+        })}
+        text, silent, _hollow, is_partial = index._build_message(
+            self._detail("weekly-2026-08-03"), describe
+        )
+        assert is_partial is False
+        assert silent is False, "a cadence run failing must still page"
+        assert "partial run" not in text, text
+
+    def test_full_run_with_no_skips_is_not_partial(self):
+        describe = {"input": json.dumps({"run_date": "2026-08-03"})}
+        _text, silent, _hollow, is_partial = index._build_message(
+            self._detail("abc-123"), describe
+        )
+        assert is_partial is False
+        assert silent is False
+
+    def test_unparseable_input_is_not_treated_as_partial(self):
+        """Absence of evidence is never evidence of a narrowed run."""
+        _text, silent, _hollow, is_partial = index._build_message(
+            self._detail("abc-123"), {"input": "not json"}
+        )
+        assert is_partial is False
+        assert silent is False, "an unreadable input must fail toward paging"


### PR DESCRIPTION
## What & why

`director-verify-20260804T003005Z` on `ne-weekly-freshness-pipeline` carried **24** `skip_*: true` flags and no `pipeline_role`. It ran one stage, failed in 0m, and paged Brian as:

```
🔴 Weekly Freshness SF — FAILED
Duration: 0m
States: (no workload states in history)
Cause: States.Runtime: ... 'SaturdayHealthCheck' ...
Execution: director-verify-20260804T003005Z
```

The message carries, in its own body, the evidence that it was not a weekly run — `0m`, `(no workload states in history)` — and is delivered at the same shape and severity as a genuine weekly-pipeline failure.

`overseer-policy` invariant 17: *severity is a property of the invariant breached, not of the check that emitted it.* A merged severity makes the page rate track bookkeeping rather than health, and the correct operator response becomes to stop reading the class. That is the state this notifier had reached.

## What changed

The notifier already read the execution input to distinguish a `shell_run` preflight (`_is_preflight_execution`). This extends the same seam rather than adding a parallel one:

| | |
|---|---|
| `_is_partial_execution` | derives narrowing from the execution's own input. A canonical `pipeline_role` (`weekly`/`daily`/`eod`) **always wins**, so a real cadence rerun that skips already-completed stages is still the cadence run |
| label | `Weekly Freshness SF (partial run — N stage(s) skipped)` — the reader must not have to open the console to learn that "Weekly Freshness SF — FAILED" meant one stage of it |
| delivery | `silent=True`, recorded at `info`. Still sent, still readable in the topic, still recorded with `partial_run` in its context — it just does not buzz |
| unparseable input | **not** treated as partial. Absence of evidence is never evidence of a narrowed run, and fail-toward-paging is the safe direction |

The role map mirrors `alpha-engine-config/scripts/gate_sf_run_sweep.py::_CANONICAL_PIPELINE_ROLE` — the same cadence-vs-ad-hoc distinction that file already relies on, applied to notification rather than to gate clearing. Cross-referenced in a comment on both sides of the mirror.

## Test plan — run before opening

- `test_handler.py` `+4` guards. The load-bearing one **demonstrated failing with the gate reverted** (`return False, skipped`). The other three are controls: a canonical `weekly` role still pages despite a skip flag, a full run is not partial, and unparseable input is not partial.
- `31 passed` across `test_handler.py` + `test_execution_digest.py`; `test_flow_doctor_fleet_wiring.py` passes alone.
- The collection error when all three files run in one invocation is a **pre-existing** module-name collision, reproduced identically on clean `main`. Not introduced here.

## SOTA and delta

SOTA is that a notification's class and severity are derived from what actually broke, and that a channel's page rate tracks health rather than activity. **Delta:** this fixes the notifier's *reading* of the run. It does not stop `director-verify` executions from being launched against the weekly state machine in the first place — a verification harness reusing the production state machine is a separate question, and `alpha-engine-config#6408` covers whether the weekly pipeline reports honestly about the Director at all.

Related: `alpha-engine-config#6408` (weekly SF reports SUCCEEDED with the Director dead), `flow-doctor#75` (cascade reports recorded, not paged). Independent — no merge order.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)