### PR TITLE
feat(groom): F8 scheduled-cycle record + fast lane-start paging (I6325)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -1395,6 +1395,18 @@ def _write_dispatch_ledger_entry(run_token: str, tier_tag: str, schedule_label: 
 
 _RECONCILE_COMPLETED_PREFIX = "groom/_control/completed"
 
+# groom-sweep-policy §2.8/F8 (alpha-engine-config-I6325) — the on-box "the
+# charter actually began" marker, written by groom_run.sh (NOT this Lambda)
+# once a decided lane's box reaches its own Start-ping point. Distinct from
+# `_RECONCILE_COMPLETED_PREFIX` (terminal) and from a decision record
+# (proves only that THIS LAMBDA decided to launch, not that the box's agent
+# ever ran) — the gap between "decided" and "started" is exactly the
+# alpha-engine-config-I4987 failure mode (box reclaimed during/before
+# bootstrap). Date-prefixed (`{prefix}/{date}/{run_token}.json`), unlike
+# `_RECONCILE_COMPLETED_PREFIX`, so F8's daily emitter can bucket by day via
+# a plain prefix listing instead of parsing `aws s3 ls` modification times.
+_LANE_STARTED_PREFIX = "groom/_control/started"
+
 # Expectations this reconciler has already ACTIONED (paged + send-task-failure).
 # Without it the reconciler re-detects the same dead lane on every 5-minute
 # tick for as long as the ledger entry is in the scan window, and re-pages —
@@ -1865,6 +1877,15 @@ def _reconcile_trigger_health() -> dict:
 
     Fail-safe: a list-executions error skips the tick (never page on a broken
     SF API); the next 5-min tick retries.
+
+    **F8 side effect (alpha-engine-config-I6325):** every execution this tick
+    examines gets a `groom/_control/scheduled/{date}/{hhmm}.json` record
+    written (idempotent — see `_write_scheduled_cycle_record`), regardless of
+    whether its decision record is present. This is deliverable 1 of F8: "the
+    scheduler emits a scheduled-cycle record independently of the cycle" —
+    sourced from the SF's OWN execution history, which exists the instant
+    EventBridge Scheduler fires it, before any of this Lambda's own code has
+    had a chance to run (let alone fail).
     """
     now = datetime.now(ZoneInfo("UTC"))
     s3 = boto3.client("s3", region_name=REGION)
@@ -1901,6 +1922,13 @@ def _reconcile_trigger_health() -> dict:
         date = started.strftime("%Y-%m-%d")
         hhmm = started.strftime("%H%M")
         slot_id = f"{date}-{hhmm}"
+
+        # F8 deliverable 1 — written for EVERY examined execution, ahead of
+        # the "already actioned" (paging) short-circuit below: the scheduled
+        # record's existence must never depend on whether this slot has
+        # already been paged for a missing decision record.
+        _write_scheduled_cycle_record(s3, date, hhmm, started, ex)
+
         actioned_key = f"groom/_control/reconciled-trigger/{slot_id}.json"
         try:
             s3.head_object(Bucket=_RESEARCH_BUCKET, Key=actioned_key)
@@ -1966,6 +1994,152 @@ def _s3_key_exists(s3, key: str) -> bool:
         return True
     except Exception:  # noqa: BLE001 — any failure reads as "no receipt"
         return False
+
+
+# groom-sweep-policy §2.8/F8 (alpha-engine-config-I6325) ─────────────────────
+_SCHEDULED_CYCLE_PREFIX = "groom/_control/scheduled"
+
+
+def _write_scheduled_cycle_record(s3, date: str, hhmm: str, started, ex: dict) -> None:
+    """F8 deliverable 1 — the scheduled-cycle record, produced by the
+    SCHEDULER (this reconciler tick, reading the dispatch SF's own execution
+    history) independently of the cycle it describes. ``started-versus-
+    scheduled must be computable without trusting the thing that failed to
+    run``: an SF execution exists from the moment EventBridge Scheduler fires
+    it, regardless of whether the Lambda invocation that follows ever
+    completes — so this is strictly upstream of, and independent from, the
+    I4988 decision record and the on-box started marker.
+
+    Idempotent (head_object-gated): re-attempted on every tick that still
+    sees this slot in its lookback window, but only the first successful call
+    actually PUTs — cheap even at the 5-min cadence over a 30h window.
+    Best-effort: a write failure here must never affect trigger-health
+    paging, which reads live SF execution history directly and does not
+    depend on this record existing.
+    """
+    key = f"{_SCHEDULED_CYCLE_PREFIX}/{date}/{hhmm}.json"
+    if _s3_key_exists(s3, key):
+        return
+    try:
+        s3.put_object(
+            Bucket=_RESEARCH_BUCKET,
+            Key=key,
+            Body=json.dumps({
+                "execution_arn": ex.get("executionArn"),
+                "execution_name": ex.get("name"),
+                "started_at": started.isoformat(),
+            }).encode(),
+            ContentType="application/json")
+    except Exception as exc:  # noqa: BLE001 — best-effort, mirrors every other decision-record writer in this file
+        logger.warning("scheduled-cycle record write failed for %s (non-fatal): %s", key, exc)
+
+
+# F8 deliverable 3 — fast paging on "decided but never started" (alpha-
+# engine-config-I6325, I4987's exact failure mode: a box reclaimed during or
+# before bootstrap, so nothing on-box ever runs). Distinct from
+# `_reconcile_trigger_health` (I4988), which pages when the LAMBDA never
+# reached a decision at all — this leg pages when the Lambda DID decide and
+# launch (a dispatch-ledger entry reached EC2, i.e. carries an instance_id),
+# but the CHARTER never wrote its started marker. Mirrors the
+# SF_IS_DRILL/CI_IS_DRILL/DRAIN_IS_DRILL family's own distinction elsewhere in
+# this fleet: being dispatched and reaching the charter are different facts,
+# and only the second is "started" for F8's purposes.
+_LANE_START_MATURITY_MIN = 12  # SSM online budget (180s) + dnf/git-clone (~2-4min) + margin
+
+
+def _reconcile_lane_start_health() -> dict:
+    """Page a decided lane launch that never wrote its on-box started marker
+    within `_LANE_START_MATURITY_MIN` of being dispatched — instead of the 6h
+    SF timeout. Scans today's + yesterday's dispatch ledger (mirrors
+    `_reconcile_lane_death`'s own scan window) so a maturity check straddling
+    UTC midnight still finds its ledger entry.
+
+    A lane that already has a COMPLETED marker is not paged even absent a
+    started marker — it reached a terminal outcome by some other path (e.g. a
+    very fast classified failure) and is not silently stuck; that is a
+    diagnosability gap for a human to read off the two markers directly, not
+    a paging condition.
+
+    Fail-safe: an S3 listing/read error skips that day's scan; the next
+    5-min tick retries.
+    """
+    now = datetime.now(ZoneInfo("UTC"))
+    s3 = boto3.client("s3", region_name=REGION)
+    checked = 0
+    paged = 0
+    for delta_days in range(2):
+        day = (now - timedelta(days=delta_days)).strftime("%Y-%m-%d")
+        prefix = f"{_DISPATCH_LEDGER_PREFIX}/{day}/"
+        try:
+            keys: list[str] = []
+            paginator = s3.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=_RESEARCH_BUCKET, Prefix=prefix):
+                keys.extend(obj["Key"] for obj in page.get("Contents", []))
+        except Exception as exc:  # noqa: BLE001 — fail-safe, never page on a broken listing
+            logger.warning(
+                "lane-start health: listing %s failed (%s) — skipping this "
+                "day this tick (fail-safe; the next 5-min tick retries)",
+                prefix, exc)
+            continue
+        for key in keys:
+            try:
+                body = json.loads(
+                    s3.get_object(Bucket=_RESEARCH_BUCKET, Key=key)["Body"].read())
+            except Exception as exc:  # noqa: BLE001 — a single unreadable ledger entry must not stall the scan
+                logger.warning("lane-start health: could not read %s (%s) — skipping", key, exc)
+                continue
+            run_token = str(body.get("run_token") or "")
+            instance_id = str(body.get("instance_id") or "")
+            recorded_at = str(body.get("recorded_at") or "")
+            if not run_token or not instance_id or not recorded_at:
+                # The FIRST (pre-launch, config#3173) ledger write for this
+                # token, not yet the post-launch one — no EC2 request exists
+                # yet, so there is nothing to check a "started" marker
+                # against. The post-launch write (same key, overwritten) is
+                # what this leg evaluates.
+                continue
+            try:
+                recorded = datetime.fromisoformat(recorded_at)
+            except ValueError:
+                continue
+            age_min = (now - recorded).total_seconds() / 60.0
+            if age_min < _LANE_START_MATURITY_MIN:
+                continue
+            checked += 1
+            actioned_key = f"groom/_control/reconciled-lane-start/{run_token}.json"
+            if _s3_key_exists(s3, actioned_key):
+                continue  # already paged — one page per never-started lane
+            started_key = f"{_LANE_STARTED_PREFIX}/{day}/{run_token}.json"
+            completed_key = f"{_RECONCILE_COMPLETED_PREFIX}/{run_token}.json"
+            if _s3_key_exists(s3, started_key) or _s3_key_exists(s3, completed_key):
+                continue  # the charter began (or the lane already reached a terminal outcome) — healthy
+            paged += 1
+            _notify_cycle(
+                "🔴 Groom lane NEVER STARTED — dispatch-ledger entry "
+                f"run_token={run_token} instance={instance_id} decided "
+                f"{recorded_at} ({age_min:.0f}m ago), but no "
+                f"groom/_control/started/ or /completed/ marker exists. The "
+                "charter never ran (box likely reclaimed during/before "
+                "bootstrap — alpha-engine-config-I4987). Manual triage "
+                "needed (alpha-engine-config-I6325).",
+                severity="error",
+                dedup_key=f"{_CYCLE_FLOW_NAME}:lane_never_started:{run_token}",
+                context={"run_token": run_token, "instance_id": instance_id,
+                         "recorded_at": recorded_at, "age_min": round(age_min, 1)},
+            )
+            try:
+                s3.put_object(
+                    Bucket=_RESEARCH_BUCKET, Key=actioned_key,
+                    Body=json.dumps({
+                        "outcome": "lane_never_started", "run_token": run_token,
+                        "actioned_at": now.isoformat(),
+                    }).encode(),
+                    ContentType="application/json")
+            except Exception as exc:  # noqa: BLE001 — re-pages next tick, bounded by the flow-doctor dedup key above
+                logger.warning(
+                    "lane-start health: actioned-marker write failed for %s "
+                    "(will re-page next tick): %s", run_token, exc)
+    return {"checked": checked, "paged": paged}
 
 
 def _notify_dispatch_ceiling_exhausted(prior: int, ceiling: int, tier_tag: str,
@@ -2910,12 +3084,15 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         # cadence) invokes this mode to screen open expectations against
         # live EC2 state. config-I4988 (trigger-health leg, added with the
         # run_window retirement): the same tick also screens dispatch-SF
-        # executions for their decision-record receipts. No other caller
-        # sets a top-level `mode`, so this cannot collide with any other
-        # invocation shape.
+        # executions for their decision-record receipts. alpha-engine-
+        # config-I6325 (F8 lane-start-health leg): the same tick also
+        # screens decided lane launches for a charter that never started. No
+        # other caller sets a top-level `mode`, so this cannot collide with
+        # any other invocation shape.
         lane = _reconcile_lane_death()
         trigger = _reconcile_trigger_health()
-        return {**lane, "trigger_health": trigger}
+        lane_start = _reconcile_lane_start_health()
+        return {**lane, "trigger_health": trigger, "lane_start_health": lane_start}
     run_mode = _resolve_run_mode(event)
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2745,6 +2745,194 @@ def test_trigger_health_pages_running_execution_without_record(monkeypatch):
     assert th["missing"][0]["execution_status"] == "RUNNING"
 
 
+# ── F8 scheduled-cycle record (groom-sweep-policy §2.8, alpha-engine-config-
+# I6325) ─────────────────────────────────────────────────────────────────────
+# Deliverable 1: the scheduler emits a scheduled-cycle record independently
+# of the cycle — sourced from the dispatch SF's own execution history, the
+# same source the trigger-health leg already reads.
+
+
+def test_scheduled_cycle_record_written_for_mature_execution(monkeypatch):
+    """A mature execution gets a groom/_control/scheduled/{date}/{hhmm}.json
+    record, regardless of whether its decision record exists."""
+    exec_ = _sfn_exec(hours_ago=3)
+    idx = _load(monkeypatch, sfn_executions=[exec_], s3_objects={})
+    idx.handler({"mode": "reconcile"}, None)
+    from datetime import timezone
+    started = exec_["startDate"].astimezone(timezone.utc)
+    key = f"groom/_control/scheduled/{started:%Y-%m-%d}/{started:%H%M}.json"
+    assert key in idx._test_s3._objects
+    body = json.loads(idx._test_s3._objects[key])
+    assert body["execution_arn"] == exec_["executionArn"]
+
+
+def test_scheduled_cycle_record_written_even_when_decision_record_present(monkeypatch):
+    """A healthy execution (decision record present, no page) still gets its
+    scheduled record — F8's 'scheduled' count must not depend on the cycle's
+    own health."""
+    exec_ = _sfn_exec(hours_ago=3)
+    idx = _load(monkeypatch, sfn_executions=[exec_], s3_objects={
+        _decision_key_for_execution(exec_): b'{"trigger": "demand-all"}',
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    assert result["trigger_health"]["paged"] == 0
+    from datetime import timezone
+    started = exec_["startDate"].astimezone(timezone.utc)
+    key = f"groom/_control/scheduled/{started:%Y-%m-%d}/{started:%H%M}.json"
+    assert key in idx._test_s3._objects
+
+
+def test_scheduled_cycle_record_idempotent_across_ticks(monkeypatch):
+    """A slot already carrying a scheduled record is not overwritten on the
+    next tick — the write is a plain existence check, not a refresh."""
+    exec_ = _sfn_exec(hours_ago=3)
+    from datetime import timezone
+    started = exec_["startDate"].astimezone(timezone.utc)
+    key = f"groom/_control/scheduled/{started:%Y-%m-%d}/{started:%H%M}.json"
+    seeded = json.dumps({"execution_arn": "PRE-EXISTING", "sentinel": True}).encode()
+    idx = _load(monkeypatch, sfn_executions=[exec_], s3_objects={key: seeded})
+    idx.handler({"mode": "reconcile"}, None)
+    assert idx._test_s3._objects[key] == seeded
+
+
+def test_scheduled_cycle_record_not_written_within_maturity_window(monkeypatch):
+    """An execution still within its maturity window is not yet examined at
+    all, so no scheduled record is written for it prematurely — mirrors the
+    trigger-health leg's own 'checked == 0' behavior for the same input."""
+    exec_ = _sfn_exec(hours_ago=0.25)
+    idx = _load(monkeypatch, sfn_executions=[exec_], s3_objects={})
+    idx.handler({"mode": "reconcile"}, None)
+    assert not any(k.startswith("groom/_control/scheduled/") for k in idx._test_s3._objects)
+
+
+# ── F8 lane-start-health reconciler (alpha-engine-config-I6325) ─────────────
+# Deliverable 3 (fast paging leg): a decided lane launch (a dispatch-ledger
+# entry that reached EC2) that never wrote its on-box started marker within
+# the maturity window pages — the I4987 failure mode, caught in ~15 minutes
+# instead of the 6h SF timeout. Distinct population from the trigger-health
+# tests above: those cover "the Lambda never decided"; these cover "the
+# Lambda decided and launched, but the charter never ran."
+
+
+def _mature_ledger_entry(run_token: str = "tok1", *, minutes_ago: float = 20,
+                         schedule: str = "0 4 * * *") -> bytes:
+    from datetime import datetime, timedelta, timezone
+    recorded = (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+    return json.dumps({
+        "run_token": run_token, "tier_tag": "mid-only", "schedule": schedule,
+        "instance_id": "i-launched", "deadline_utc": _future_deadline(),
+        "recorded_at": recorded,
+    }).encode()
+
+
+def _started_key(run_token: str = "tok1", *, days_ago: int = 0) -> str:
+    from datetime import datetime, timedelta, timezone
+    day = (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+    return f"groom/_control/started/{day}/{run_token}.json"
+
+
+def test_lane_start_health_pages_when_never_started(monkeypatch):
+    """A mature, decided, launched lane with no started or completed marker
+    pages — the box never reached its charter."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): _mature_ledger_entry(),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 1
+    assert lsh["paged"] == 1
+    assert "groom/_control/reconciled-lane-start/tok1.json" in idx._test_s3._objects
+
+
+def test_lane_start_health_quiet_when_started_marker_present(monkeypatch):
+    """A started marker (the charter began) satisfies the check — no page."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): _mature_ledger_entry(),
+        _started_key(): json.dumps({"mode": "full", "started_at": "2026-08-04T00:00:00Z"}).encode(),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 1
+    assert lsh["paged"] == 0
+
+
+def test_lane_start_health_quiet_when_completed_marker_present(monkeypatch):
+    """A completed marker with no started marker still satisfies the check —
+    the lane reached SOME terminal outcome; it is not silently stuck."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): _mature_ledger_entry(),
+        "groom/_control/completed/tok1.json": json.dumps({"outcome": "failure", "rc": 1}).encode(),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 1
+    assert lsh["paged"] == 0
+
+
+def test_lane_start_health_not_yet_mature_is_not_checked(monkeypatch):
+    """A lane decided moments ago (well under the maturity window) is not yet
+    a miss — bootstrap (dnf install + git clone) legitimately takes minutes."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): _mature_ledger_entry(minutes_ago=2),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 0
+    assert lsh["paged"] == 0
+
+
+def test_lane_start_health_actioned_lane_is_not_repaged(monkeypatch):
+    """An already-actioned never-started lane is not re-paged on the next tick."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): _mature_ledger_entry(),
+        "groom/_control/reconciled-lane-start/tok1.json": json.dumps(
+            {"outcome": "lane_never_started"}).encode(),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 1
+    assert lsh["paged"] == 0
+
+
+def test_lane_start_health_ignores_pre_launch_only_ledger_entry(monkeypatch):
+    """config#3173's FIRST (pre-launch) ledger write carries no instance_id —
+    there is no EC2 request yet to check a started marker against, so it must
+    never be counted or paged."""
+    from datetime import datetime, timezone
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key(): json.dumps({
+            "run_token": "tok1", "tier_tag": "mid-only", "schedule": "0 4 * * *",
+            "instance_id": "", "deadline_utc": "",
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+        }).encode(),
+    })
+    result = idx.handler({"mode": "reconcile"}, None)
+    lsh = result["lane_start_health"]
+    assert lsh["checked"] == 0
+    assert lsh["paged"] == 0
+
+
+def test_lane_start_health_listing_error_is_fail_safe(monkeypatch):
+    """A broken S3 listing must never page — the tick is skipped and retried.
+
+    Calls the reconciler leg directly (not through handler({"mode":
+    "reconcile"})) because `_reconcile_lane_death` reads the SAME dispatch-
+    ledger prefix earlier in that dispatch chain and has no fail-safe wrapper
+    of its own around its listing call — patching `get_paginator` globally
+    would fail that unrelated, earlier leg instead of exercising this one.
+    """
+    idx = _load(monkeypatch, s3_objects={_ledger_key(): _mature_ledger_entry()})
+
+    class _RaisingPaginator:
+        def paginate(self, **kw):
+            raise RuntimeError("simulated S3 outage")
+
+    idx._test_s3.get_paginator = lambda name: _RaisingPaginator()
+    result = idx._reconcile_lane_start_health()
+    assert result["checked"] == 0
+    assert result["paged"] == 0
+
+
 def test_reconcile_sends_task_failure_for_dead_lane_with_token(monkeypatch):
     """Lane death with a task_token → send-task-failure collapses the hung SF
     execution immediately instead of waiting for the 6h timeout."""


### PR DESCRIPTION
## What & why

`alpha-engine-config-I6325` (groom-sweep-policy §2.8/F8 — cycle availability
is the first outcome). F1–F7 all assume the loop executes; that assumption
had been false for whole days with no term measuring it. This is the
**scheduler-side** half — see companion PR `alpha-engine-config-PR6477`
(same branch topic, `i6325-f8-cycle-availability`) for the on-box started
marker and the F8 computation/paging.

**Deliverable 1 (load-bearing design choice):** the scheduler emits a
scheduled-cycle record independently of the cycle. `_reconcile_trigger_health`
(config-I4988's own 5-min reconciler tick) now writes
`groom/_control/scheduled/{date}/{hhmm}.json` for every dispatch-SF execution
it examines — sourced from the SF's own execution history, which exists the
instant EventBridge Scheduler fires it, before any of this Lambda's own code
has had a chance to run (let alone fail).

**Deliverable 3 (fast paging, the second of F8's two paging conditions):** a
new `_reconcile_lane_start_health()`, wired into the same `"mode":
"reconcile"` tick, pages a decided lane launch (a dispatch-ledger entry that
reached EC2) with no on-box started marker within ~12 minutes —
`alpha-engine-config-I4987`'s exact failure mode (a box reclaimed
during/before bootstrap), caught in minutes instead of the existing 6h SF
timeout.

## Test plan / verification

`infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — 196
tests pass locally (`pip install --target <scratch> pytest -r
requirements.txt`, then `pytest test_handler.py`), including 12 new tests
covering: the scheduled-cycle record write (idempotent, written regardless
of decision-record health, not written before the maturity window) and the
lane-start-health leg (pages on never-started, quiet on started-marker
present, quiet on completed-marker present with no started marker, not-yet-
mature is not checked, actioned lanes are not re-paged, pre-launch-only
ledger entries are ignored, listing errors fail safe).

## Deploy-mechanism

Lambda code — deployed via this repo's existing
`deploy-scheduled-groom-dispatcher.yml` on merge to `main` (no IAM/schema
change, no operator step).

## Merge order

No dependency either direction — this PR is self-contained (it only adds a
new record-write and a new reconciler leg to the existing 5-min tick).
`alpha-engine-config-PR6477` (the companion PR) reads the
`groom/_control/scheduled/` and `groom/_control/started/` prefixes this PR's
code writes to; land in either order, but F8 in `flow_metrics.py` reads real
data only once BOTH are live.

Closes: alpha-engine-config-I6325 (jointly with the alpha-engine-config PR)

---

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
