### PR TITLE
feat(groom-dispatch): atomic per-lane singleton dispatch lease (I6460, §5.9)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.15.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -129,6 +129,29 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/groom/_control/*"
     },
     {
+      "Sid": "ListGroomDispatchLeases",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": "locks/*"
+        }
+      }
+    },
+    {
+      "Sid": "GroomDispatchLeaseRW",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/locks/groom-*"
+    },
+    {
       "Sid": "FlowDoctorDedupStore",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -94,6 +94,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -104,6 +105,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+from nousergon_lib import dispatch_lease
 from nousergon_lib import groom_eligibility as ge
 from nousergon_lib import spot_dispatch
 from nousergon_lib.flow_doctor_fleet import FleetTelegramTopic
@@ -721,6 +723,64 @@ def _launch_instance(force_on_demand: bool = False,
     )
 
 
+def _launch_instance_serialized(*, force_on_demand: bool = False, tier_tag: str = "",
+                                attempt: int = 0, run_token: str = "") -> tuple[str, str]:
+    """``_launch_instance`` wrapped in the shared spot-launch lease
+    (alpha-engine-config-I6460, groom-sweep-policy.md §5.9.3: "lanes that
+    share a resource share a lease, not one per lane").
+
+    The 2026-07-28 incident was three concurrently-dispatching tiers
+    (high/mid/low, MaxConcurrency=3 on the dispatch SF's Map state) issuing
+    RunInstances in the same instant against the same underlying spot-
+    capacity pool — all three reclaimed together. This wraps ONLY the
+    RunInstances call itself (a few seconds), not the lane's multi-hour
+    life, so concurrently-dispatching tiers serialize their capacity claim
+    by seconds rather than colliding in the same instant — without
+    reducing how many tiers launch per cycle (see the module-level comment
+    on ``_SPOT_LAUNCH_LEASE_KEY`` for why a full per-lane merge was
+    rejected).
+
+    A short bounded retry (``_SPOT_LAUNCH_LEASE_MAX_ATTEMPTS``, a few
+    seconds total) covers the case where a sibling lane's launch is
+    mid-flight — this is a sub-second mutual exclusion around ONE atomic
+    AWS API call, not a queued dispatch cycle, so it does not violate
+    §5.9's "does not queue behind the holder" (that rule bounds a whole
+    per-lane reconciliation cycle, not a millisecond-scale critical
+    section around a single AWS call already inherent to the lease's own
+    conditional-PUT retry). If every attempt is exhausted, this raises
+    rather than launching un-serialized — fail-loud, matching this
+    function's existing fail-loud posture (a silent bypass here would
+    reopen exactly the race this exists to close).
+    """
+    owner_id = f"spot-launch:{tier_tag}:attempt{attempt}:{run_token or uuid.uuid4().hex[:12]}"
+    acquired = False
+    last_holder = None
+    for i in range(_SPOT_LAUNCH_LEASE_MAX_ATTEMPTS):
+        result = dispatch_lease.acquire_lease(
+            _SPOT_LAUNCH_LEASE_KEY, owner_id=owner_id,
+            ttl_seconds=_SPOT_LAUNCH_LEASE_TTL_SECONDS, bucket=_RESEARCH_BUCKET,
+        )
+        if result.acquired:
+            acquired = True
+            break
+        last_holder = result.holder
+        logger.info(
+            "spot-launch lease busy (held by %s) — retry %d/%d for lane %s",
+            result.holder.owner_id, i + 1, _SPOT_LAUNCH_LEASE_MAX_ATTEMPTS, tier_tag)
+        time.sleep(_SPOT_LAUNCH_LEASE_RETRY_SLEEP_SECONDS)
+    if not acquired:
+        raise RuntimeError(
+            f"could not acquire spot-launch lease for lane {tier_tag!r} after "
+            f"{_SPOT_LAUNCH_LEASE_MAX_ATTEMPTS} attempts — last held by "
+            f"{last_holder.owner_id if last_holder else '?'}"
+        )
+    try:
+        return _launch_instance(force_on_demand=force_on_demand, tier_tag=tier_tag,
+                                attempt=attempt)
+    finally:
+        dispatch_lease.release_lease(_SPOT_LAUNCH_LEASE_KEY, bucket=_RESEARCH_BUCKET)
+
+
 def _wait_ssm_online(instance_id: str) -> None:
     """Block until the instance is running AND its SSM agent registers Online."""
     spot_dispatch.wait_ssm_online(
@@ -766,6 +826,67 @@ def _tier_tag(run_mode: str, issue_filter: str) -> str:
     groom boxes guard per issue_filter tier; sweep boxes guard as one
     distinct 'sweep' lane regardless of the (inert) issue_filter they carry."""
     return _SWEEP_TIER_TAG if run_mode == "sweep" else issue_filter
+
+
+# ── Per-lane singleton dispatch lease (alpha-engine-config-I6460, groom-
+# sweep-policy.md §5.9) ─────────────────────────────────────────────────────
+# §5.9: "The loop holds a singleton lease per lane. A dispatch that cannot
+# take the lease exits, recording that it yielded; it does not queue behind
+# the holder and it does not run beside it." Closes two gaps the existing
+# config#1979 `_running_tier_instance_ids` guard cannot: (1) it is fail-OPEN
+# by its own docstring ("an optimization, not a correctness gate") — a
+# DescribeInstances error lets a duplicate launch through rather than
+# blocking it; (2) it is a scan-then-launch TOCTOU race — two invocations
+# can both observe an empty tag set and both launch, since nothing makes the
+# observe-and-claim step atomic. `dispatch_lease.acquire_lease` (nousergon-
+# lib) is an S3 `PutObject(IfNoneMatch="*")` compare-and-swap, so the SAME
+# lane cannot be claimed twice regardless of API propagation delay or a
+# probe failure.
+#
+# Deliberately does NOT replace `_running_tier_instance_ids` — that check
+# stays exactly as-is, including its reclaim-aware bounded-relaunch bypass
+# (spot_dispatch.termination_imminent), because only live EC2 state can
+# distinguish "a box is genuinely still working this lane" from "a box is
+# mid-reclaim and about to die"; a lease token alone cannot see that. The
+# lease is the ADDITIONAL atomic-exclusion layer around the same decision:
+# acquired only once the EC2-state check has already concluded the lane
+# looks free, so it closes exactly the residual TOCTOU/fail-open window
+# rather than re-deciding something the EC2 check already answered.
+#
+# TTL = MAX_RUNTIME_SECONDS (the one authoritative runtime bound the box
+# ladder is built against, see that constant's own comment) — a live box can
+# never legitimately outlive it, so the lease can never expire out from
+# under a genuinely still-running lane, and a killed box (the normal case on
+# interruptible compute) releases the lane without an actor once the TTL
+# elapses.
+_LANE_LEASE_TTL_SECONDS = MAX_RUNTIME_SECONDS
+
+
+def _lane_lease_key(tier_tag: str) -> str:
+    return f"locks/groom-lane-{tier_tag}.lock"
+
+
+# Shared-resource lease (§5.9.3: "lanes that share a resource share a
+# lease, not one per lane"). The 2026-07-28 incident (three lanes reclaimed
+# `instance-terminated-no-capacity` at the SAME SECOND) was three
+# concurrently-dispatching tiers (high/mid/low, MaxConcurrency=3 on the
+# dispatch SF's Map state) landing their RunInstances calls in the same
+# instant against the same underlying spot-capacity pool. This lease
+# serializes only that brief moment — the RunInstances call inside
+# `_launch_instance`, held for a short TTL and released immediately after —
+# not the lane's multi-hour life. A full per-lane merge onto one shared
+# lease (only one of the three tiers ever launching per cycle) was
+# considered and rejected: it would cut daily groom throughput 3x, directly
+# regressing the deliberately-ratified "every tier launches independently"
+# design (config#1933/#5, this file's module README). Bounded retry here
+# (a few seconds, NOT a queued dispatch) is a sub-second mutual exclusion
+# around one atomic AWS API call — categorically different from queuing an
+# entire multi-hour reconciliation cycle behind another, which is what
+# §5.9's "does not queue" forbids.
+_SPOT_LAUNCH_LEASE_KEY = "locks/groom-spot-capacity-pool.lock"
+_SPOT_LAUNCH_LEASE_TTL_SECONDS = 180
+_SPOT_LAUNCH_LEASE_MAX_ATTEMPTS = 5
+_SPOT_LAUNCH_LEASE_RETRY_SLEEP_SECONDS = 2
 
 
 class ConcurrentCycleError(RuntimeError):
@@ -1262,6 +1383,38 @@ def _notify_concurrent_skip(tier_tag: str, existing_ids: list[str], schedule_lab
         )
     except Exception as exc:  # noqa: BLE001 — secondary observability
         logger.warning("concurrent-lane skip Telegram failed (non-fatal): %s", exc)
+
+
+def _notify_lane_lease_yielded(tier_tag: str, holder_owner_id: str, schedule_label: str) -> None:
+    """Best-effort loud ping for a §5.9 lane-lease yield — never raises.
+
+    Distinct from ``_notify_concurrent_skip``: that one fires off a live EC2
+    tag scan (a box is confirmed running); this one fires when the ATOMIC
+    lease itself could not be taken — the TOCTOU/fail-open window the EC2
+    scan alone cannot close. Both are recorded, non-launch dispositions
+    (groom-sweep-policy §5.9.2: "yielding is a recorded disposition, not a
+    silent no-op") — this record is what ``_reconcile_lane_yield_starvation``
+    later reads to decide whether a lane yielded all day."""
+    text = (
+        "⚪ Backlog groom slot YIELDED — could not take the per-lane dispatch "
+        f"lease (alpha-engine-config-I6460). lane={tier_tag}, lease held by "
+        f"owner_id={holder_owner_id}. schedule={schedule_label}. Zero spot/WET "
+        "spend; this slot's queue rides the next trigger once the lease "
+        "expires or the holder releases it."
+    )
+    try:
+        notify_via_flow_doctor(
+            text, silent=True, severity="info",
+            dedup_key=f"{_FLOW_NAME}:lane_lease_yielded:{tier_tag}",
+            flow_name=_FLOW_NAME, topics=_GROOM_LIFECYCLE_TOPICS,
+            db_basename=_DB_BASENAME,
+            context={"schedule": schedule_label, "tier_tag": tier_tag,
+                     "lease_holder_owner_id": holder_owner_id},
+            silent_topic=FleetTelegramTopic.GROOM,
+            source="flow-doctor:scheduled-groom-dispatcher",
+        )
+    except Exception as exc:  # noqa: BLE001 — secondary observability
+        logger.warning("lane-lease-yielded Telegram failed (non-fatal): %s", exc)
 
 
 # config#3173 — dedicated ceiling ledger, deliberately SEPARATE from the
@@ -1986,6 +2139,112 @@ def _reconcile_trigger_health() -> dict:
     return {"checked": checked, "missing": missing, "paged": paged}
 
 
+# alpha-engine-config-I6460 (§5.9.2): "yielding is a recorded disposition,
+# not a silent no-op. A cycle that yielded every time for a day is a
+# stalled lane wearing the appearance of a quiet backlog — the §6.2 failure
+# applied to dispatch." Only evaluated after this UTC hour: the three known
+# daily groom slots (0400/1200/2000 UTC) have all had their chance by then
+# with margin, so a lane that shows ONLY yields (zero launches) in today's
+# decision records by this point is trustworthy regardless of how many
+# triggers actually fired — deliberately NOT a hardcoded trigger COUNT,
+# since the weekly-schedule-adjuster (I6177) can move slot times and this
+# leg must not assume a fixed slot calendar.
+_LANE_YIELD_STARVATION_EVAL_HOUR_UTC = 22
+
+
+def _reconcile_lane_yield_starvation() -> dict:
+    """Page when a lane yielded its per-lane dispatch lease (I6460) on
+    EVERY decision recorded for it today, with zero successful launches.
+
+    Reads the SAME ``groom/decisions/{date}/*.json`` records every other
+    dispatch path already writes (``_write_trigger_record``/``_write_skip_
+    record``/``_write_sweep_decision_record``/``_write_fallback_decision_
+    record``) — no new record schema. A lane's per-decision entry carries
+    ``tier_tag``, ``launch``, and (for a non-launch) ``reason``; a yield is
+    ``launch: false, reason: "lane_lease_yielded"`` (see ``_launch_groom_
+    spot``'s return on lease-acquire failure).
+
+    Fail-safe: an S3 listing error skips the tick (never page on a broken
+    API); the next 5-min tick retries.
+    """
+    now = datetime.now(ZoneInfo("UTC"))
+    if now.hour < _LANE_YIELD_STARVATION_EVAL_HOUR_UTC:
+        return {"evaluated": False, "reason": "before_eval_hour", "paged": 0}
+
+    date = now.strftime("%Y-%m-%d")
+    s3 = boto3.client("s3", region_name=REGION)
+    prefix = f"groom/decisions/{date}/"
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        keys = [
+            obj["Key"]
+            for page in paginator.paginate(Bucket=_RESEARCH_BUCKET, Prefix=prefix)
+            for obj in page.get("Contents", [])
+        ]
+    except Exception as exc:  # noqa: BLE001 — fail-safe, never page on a broken API
+        logger.warning(
+            "lane-yield-starvation: decision-record listing failed (%s) — "
+            "skipping this tick (fail-safe; the next 5-min tick retries)", exc)
+        return {"evaluated": False, "error": str(exc), "paged": 0}
+
+    # tier_tag -> {"launched": bool, "yielded": int, "other": int}
+    tallies: dict[str, dict] = {}
+    for key in keys:
+        try:
+            body = json.loads(s3.get_object(Bucket=_RESEARCH_BUCKET, Key=key)["Body"].read())
+        except Exception as exc:  # noqa: BLE001 — one bad record must not sink the whole tick
+            logger.warning("lane-yield-starvation: could not read %s (skipping record): %s", key, exc)
+            continue
+        for d in body.get("decisions") or []:
+            tier_tag = str(d.get("tier_tag") or "")
+            if not tier_tag:
+                continue
+            t = tallies.setdefault(tier_tag, {"launched": False, "yielded": 0, "other": 0})
+            if d.get("launch"):
+                t["launched"] = True
+            elif d.get("reason") == "lane_lease_yielded":
+                t["yielded"] += 1
+            else:
+                t["other"] += 1
+
+    paged = 0
+    starved: list[str] = []
+    actioned_key = f"groom/_control/reconciled-lane-yield-starvation/{date}.json"
+    if _s3_key_exists(s3, actioned_key):
+        return {"evaluated": True, "already_actioned": True, "paged": 0}
+
+    for tier_tag, t in tallies.items():
+        if t["launched"] or t["yielded"] == 0:
+            continue
+        starved.append(tier_tag)
+        paged += 1
+        _notify_cycle(
+            f"🔴 Groom lane STARVED — {tier_tag} yielded its dispatch lease "
+            f"{t['yielded']} time(s) today with ZERO successful launches "
+            f"(alpha-engine-config-I6460). The lane's per-lane lease has "
+            "been contended (or held stale) for the whole scheduled day — "
+            "manual triage needed.",
+            severity="error",
+            dedup_key=f"{_CYCLE_FLOW_NAME}:lane_yield_starvation:{date}:{tier_tag}",
+            context={"tier_tag": tier_tag, "date": date, "tally": t},
+        )
+
+    if starved:
+        try:
+            s3.put_object(
+                Bucket=_RESEARCH_BUCKET, Key=actioned_key,
+                Body=json.dumps({
+                    "outcome": "lane_yield_starvation", "date": date,
+                    "starved_lanes": starved, "tallies": tallies,
+                    "actioned_at": now.isoformat(),
+                }).encode(),
+                ContentType="application/json")
+        except Exception as exc:  # noqa: BLE001 — a marker-write failure re-pages next tick, bounded by the dedup_key above
+            logger.warning("lane-yield-starvation: actioned-marker write failed (will re-check next tick): %s", exc)
+
+    return {"evaluated": True, "starved_lanes": starved, "paged": paged, "tallies": tallies}
+
+
 def _s3_key_exists(s3, key: str) -> bool:
     """True iff ``key`` exists. head_object on a missing key raises
     ClientError/404 — the same shape the lane-death leg relies on."""
@@ -2258,6 +2517,33 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
                 "issue_filter": issue_filter, "tier_tag": tier_tag,
                 "existing_instance_ids": existing}
 
+    # alpha-engine-config-I6460 (§5.9): the EC2-state check above has just
+    # concluded the lane LOOKS free — but that check is fail-open and a
+    # scan-then-launch TOCTOU race (see the module comment above
+    # `_LANE_LEASE_TTL_SECONDS`). Atomically claim the lane before doing
+    # anything else. `force=True` only when `attempt > 0` AND the guard
+    # above already independently confirmed (via live EC2 state, never
+    # inferred here) that any prior holder is dying/gone — the exact same
+    # condition that let `existing` fall through to empty above. A genuine
+    # concurrent duplicate (a fresh trigger, attempt=0, racing an existing
+    # live lane) always goes through the normal, non-forced path and is
+    # excluded by construction.
+    lane_lease_owner_id = f"{schedule_label}:{tier_tag}:attempt{attempt}:{uuid.uuid4().hex[:12]}"
+    lane_lease = dispatch_lease.acquire_lease(
+        _lane_lease_key(tier_tag), owner_id=lane_lease_owner_id,
+        ttl_seconds=_LANE_LEASE_TTL_SECONDS, bucket=_RESEARCH_BUCKET,
+        force=(attempt > 0),
+    )
+    if not lane_lease.acquired:
+        logger.warning(
+            "lane %s lease could not be acquired (held by owner_id=%s, "
+            "ttl_epoch=%d) — yielding, NOT queuing or launching", tier_tag,
+            lane_lease.holder.owner_id, lane_lease.holder.ttl_epoch)
+        _notify_lane_lease_yielded(tier_tag, lane_lease.holder.owner_id, schedule_label)
+        return {"launched": False, "reason": "lane_lease_yielded",
+                "issue_filter": issue_filter, "tier_tag": tier_tag,
+                "lease_holder_owner_id": lane_lease.holder.owner_id}
+
     # config#3173: outermost runaway backstop — checked LAST, after every
     # other suppression, so it fires even when a caller bypasses the demand
     # gate (queue_manifest_key / launch_decided relaunches). Counts every
@@ -2271,6 +2557,10 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
             GROOM_MAX_DISPATCHES_DAILY, tier_tag)
         _notify_dispatch_ceiling_exhausted(
             prior_dispatches, GROOM_MAX_DISPATCHES_DAILY, tier_tag, schedule_label)
+        # We hold the lane lease but are NOT going to launch — release it
+        # immediately rather than leaving the lane needlessly blocked for
+        # the full TTL. Best-effort: release() never raises.
+        dispatch_lease.release_lease(_lane_lease_key(tier_tag), bucket=_RESEARCH_BUCKET)
         return {"launched": False, "reason": "dispatch_ceiling_exhausted",
                 "issue_filter": issue_filter, "tier_tag": tier_tag,
                 "prior_dispatch_count": prior_dispatches,
@@ -2290,9 +2580,20 @@ def _launch_groom_spot(run_mode: str, schedule_label: str, model: str, issue_fil
     except Exception as exc:
         logger.warning("dispatch ledger pre-launch write failed (non-fatal): %s", exc)
 
-    instance_id, market = _launch_instance(force_on_demand=force_on_demand,
-                                           tier_tag=tier_tag,
-                                           attempt=attempt)
+    try:
+        instance_id, market = _launch_instance_serialized(
+            force_on_demand=force_on_demand, tier_tag=tier_tag, attempt=attempt,
+            run_token=run_token,
+        )
+    except Exception:
+        # No instance exists — the lane was never actually used. Release the
+        # lane lease so a launch failure (e.g. spot-launch lease contention
+        # exhausted, or ec2_spot itself raising) does not additionally block
+        # the lane for the full TTL on top of whatever caused the failure.
+        # Best-effort: release() never raises, and the raise below is
+        # unconditional either way (fail-loud, unchanged from prior behavior).
+        dispatch_lease.release_lease(_lane_lease_key(tier_tag), bucket=_RESEARCH_BUCKET)
+        raise
     logger.info("launched groom box %s (%s)", instance_id, market)
 
     # config#5303: the load-bearing groom-issue-filter tag is now passed as
@@ -3092,7 +3393,17 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         lane = _reconcile_lane_death()
         trigger = _reconcile_trigger_health()
         lane_start = _reconcile_lane_start_health()
-        return {**lane, "trigger_health": trigger, "lane_start_health": lane_start}
+        # alpha-engine-config-I6460 (§5.9.4): same 5-min cadence, additive
+        # leg — pages once per day per lane that yielded its dispatch lease
+        # every time with zero launches (see _LANE_YIELD_STARVATION_EVAL_
+        # HOUR_UTC for why this is time-gated rather than trigger-counted).
+        yield_starvation = _reconcile_lane_yield_starvation()
+        return {
+            **lane,
+            "trigger_health": trigger,
+            "lane_start_health": lane_start,
+            "lane_yield_starvation": yield_starvation,
+        }
     run_mode = _resolve_run_mode(event)
     model = _resolve_model(event)
     issue_filter = _resolve_issue_filter(event)

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -63,10 +63,10 @@ boto3>=1.34.0
 # calls it directly; pin must stay >= v0.124.34. (The branch was authored against
 # a predicted v0.124.33; main autobumped past it twice before this merged, so the
 # version this symbol actually shipped in is .34 — see PR286.)
-# v0.124.35 (PREDICTED — nousergon-lib PR#290, alpha-engine-config-I6460) adds
+# v0.124.36 (PREDICTED — nousergon-lib PR#290, alpha-engine-config-I6460) adds
 # nousergon_lib.dispatch_lease.acquire_lease/release_lease, the per-lane
 # singleton dispatch lease this Lambda's _launch_groom_spot/_launch_instance_
-# serialized now import and call directly. main was at v0.124.35 when PR#290
+# serialized now import and call directly. main was at v0.124.36 when PR#290
 # was opened, so .36 is the predicted post-merge auto-bump tag — mirrors the
 # PR286 precedent above (a predicted version, corrected if main autobumps past
 # it before merge). THIS PIN CANNOT RESOLVE until nousergon-lib PR#290 merges
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -63,5 +63,17 @@ boto3>=1.34.0
 # calls it directly; pin must stay >= v0.124.34. (The branch was authored against
 # a predicted v0.124.33; main autobumped past it twice before this merged, so the
 # version this symbol actually shipped in is .34 — see PR286.)
-# Bump this in lockstep with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+# v0.124.36 (PREDICTED — nousergon-lib PR#290, alpha-engine-config-I6460) adds
+# nousergon_lib.dispatch_lease.acquire_lease/release_lease, the per-lane
+# singleton dispatch lease this Lambda's _launch_groom_spot/_launch_instance_
+# serialized now import and call directly. main was at v0.124.35 when PR#290
+# was opened, so .36 is the predicted post-merge auto-bump tag — mirrors the
+# PR286 precedent above (a predicted version, corrected if main autobumps past
+# it before merge). THIS PIN CANNOT RESOLVE until nousergon-lib PR#290 merges
+# and its version auto-bump tags the resulting release — see that PR for
+# status. If CI on THIS PR is red on a `pip install` / `ModuleNotFoundError:
+# nousergon_lib.dispatch_lease` failure, that is why; re-verify the actual
+# post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
+# and correct this line if it drifted from .36, then bump this in lockstep
+# with the root pin.
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -63,7 +63,7 @@ boto3>=1.34.0
 # calls it directly; pin must stay >= v0.124.34. (The branch was authored against
 # a predicted v0.124.33; main autobumped past it twice before this merged, so the
 # version this symbol actually shipped in is .34 — see PR286.)
-# v0.124.36 (PREDICTED — nousergon-lib PR#290, alpha-engine-config-I6460) adds
+# v0.124.35 (PREDICTED — nousergon-lib PR#290, alpha-engine-config-I6460) adds
 # nousergon_lib.dispatch_lease.acquire_lease/release_lease, the per-lane
 # singleton dispatch lease this Lambda's _launch_groom_spot/_launch_instance_
 # serialized now import and call directly. main was at v0.124.35 when PR#290
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -1744,7 +1744,13 @@ def test_dispatch_ledger_write_failure_terminates_box_and_raises(monkeypatch):
     monkeypatch.setattr(idx, "_prior_launch_count_today", lambda: 0)
 
     def _boom(**kw):
-        raise RuntimeError("S3 down")
+        # I6460: the per-lane dispatch lease also writes via put_object
+        # (a different key, locks/groom-lane-*.lock) BEFORE the ledger —
+        # only the ledger key must fail here, so the lease acquire still
+        # succeeds and the launch proceeds far enough to need terminating.
+        if "dispatch-ledger" in kw.get("Key", ""):
+            raise RuntimeError("S3 down")
+        return idx._test_s3.__class__.put_object(idx._test_s3, **kw)
 
     monkeypatch.setattr(idx._test_s3, "put_object", _boom)
     with pytest.raises(RuntimeError, match="S3 down"):
@@ -3621,3 +3627,273 @@ def test_short_token_is_rendered_whole(monkeypatch):
     assert "run_token=tok-short " in text or "run_token=tok-short\n" in text, (
         f"a short token must render verbatim, got: {text}"
     )
+
+
+# ── alpha-engine-config-I6460 (§5.9): per-lane singleton dispatch lease ──────
+# groom-sweep-policy.md §5.9: "The loop holds a singleton lease per lane. A
+# dispatch that cannot take the lease exits, recording that it yielded; it
+# does not queue behind the holder and it does not run beside it." The lease
+# PRIMITIVE itself (acquire/TTL-self-recovery/force-override) is unit-tested
+# directly in nousergon-lib's own test_dispatch_lease.py — these tests pin
+# the DISPATCHER's behavior around that primitive: what it does when the
+# lease can/cannot be acquired, and that it never bypasses the mechanism.
+#
+# `idx.dispatch_lease` is the real `nousergon_lib.dispatch_lease` module
+# (not stubbed — only ec2_spot/boto3/github_app are hermetic stubs here), so
+# these tests monkeypatch its `acquire_lease`/`release_lease` functions
+# directly per groom-sweep-conformance's own "mock the lease backend"
+# guidance rather than relying on `_FakeS3`, which does not implement S3's
+# `IfNoneMatch` conditional-PUT semantics at all (every `put_object` call
+# unconditionally succeeds) and so cannot exercise a real acquire conflict.
+
+def test_lane_lease_yield_when_held_by_another(monkeypatch):
+    """The core §5.9 property applied to the actual dispatch path: when the
+    per-lane lease cannot be acquired, the dispatcher yields IMMEDIATELY —
+    it never queues, never launches, and records why."""
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-should-never-launch",
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+    )
+    holder = idx.dispatch_lease.LeaseHolder(
+        owner_id="other-cycle", started_at="2026-08-04T00:00:00Z",
+        ttl_epoch=9_999_999_999, hostname="box-y", pid=2,
+    )
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        return idx.dispatch_lease.LeaseAcquireResult(acquired=False, holder=holder)
+
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    g = out["groom"]
+    assert g["launched"] is False
+    assert g["reason"] == "lane_lease_yielded"
+    assert g["lease_holder_owner_id"] == "other-cycle"
+    assert launched == []  # never attempted a spot launch — zero spend
+
+
+def test_lane_lease_acquired_allows_normal_launch(monkeypatch):
+    """A successfully-acquired lease does not block or alter a normal
+    launch — the happy path is unchanged."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"})
+    calls = []
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        calls.append({"lock_key": lock_key, "force": force})
+        holder = idx.dispatch_lease.LeaseHolder(
+            owner_id=owner_id, started_at="x", ttl_epoch=1, hostname="h", pid=1)
+        return idx.dispatch_lease.LeaseAcquireResult(acquired=True, holder=holder)
+
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+    monkeypatch.setattr(idx.dispatch_lease, "release_lease", lambda *a, **kw: None)
+
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    assert out["groom"]["launched"] is True
+    # Both leases were taken: the lane lease, and the shared spot-launch
+    # lease wrapping the RunInstances call.
+    lock_keys = {c["lock_key"] for c in calls}
+    assert "locks/groom-lane-mid-only.lock" in lock_keys
+    assert "locks/groom-spot-capacity-pool.lock" in lock_keys
+    # attempt=0 (no live-EC2 proof of a dead holder) — never forces.
+    assert all(c["force"] is False for c in calls)
+
+
+def test_lane_lease_relaunch_attempt_forces_override(monkeypatch):
+    """A bounded SF relaunch (attempt > 0) whose prior box was confirmed
+    termination-imminent must pass force=True for the LANE lease — it has
+    independent, live proof the recorded holder is dead."""
+    idx = _load(
+        monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true"},
+        running_tier_instances={"low-only": ["i-dying"]},
+        spot_reclaimed={"i-dying": _reclaimed_sir("i-dying")},
+    )
+    lane_calls = []
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        if lock_key == "locks/groom-lane-low-only.lock":
+            lane_calls.append(force)
+        holder = idx.dispatch_lease.LeaseHolder(
+            owner_id=owner_id, started_at="x", ttl_epoch=1, hostname="h", pid=1)
+        return idx.dispatch_lease.LeaseAcquireResult(acquired=True, holder=holder)
+
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+    monkeypatch.setattr(idx.dispatch_lease, "release_lease", lambda *a, **kw: None)
+
+    out = idx.handler(
+        {"run_mode": "full", "issue_filter": "low-only", "schedule": "x", "attempt": 1}, None)
+    assert out["groom"]["launched"] is True
+    assert lane_calls == [True]
+
+
+def test_lane_lease_released_on_dispatch_ceiling_skip(monkeypatch):
+    """A lease acquired but then not used (daily ceiling exhausted) must be
+    released immediately rather than blocking the lane for the full TTL."""
+    idx = _load(monkeypatch, env={"GROOM_DISPATCH_ENABLED": "true", "GROOM_MAX_DISPATCHES_DAILY": "0"})
+    released = []
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        holder = idx.dispatch_lease.LeaseHolder(
+            owner_id=owner_id, started_at="x", ttl_epoch=1, hostname="h", pid=1)
+        return idx.dispatch_lease.LeaseAcquireResult(acquired=True, holder=holder)
+
+    def _release(lock_key, *, bucket, s3_client=None):
+        released.append(lock_key)
+
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+    monkeypatch.setattr(idx.dispatch_lease, "release_lease", _release)
+    monkeypatch.setattr(idx, "_prior_launch_count_today", lambda: 0)
+
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    assert out["groom"]["launched"] is False
+    assert out["groom"]["reason"] == "dispatch_ceiling_exhausted"
+    assert "locks/groom-lane-mid-only.lock" in released
+
+
+def test_spot_launch_lease_exhausted_retries_raises_without_launching(monkeypatch):
+    """§5.9.3 shared-resource lease: if the brief RunInstances critical
+    section can never be claimed (bounded retries exhausted), the dispatch
+    fails loud rather than launching un-serialized — a silent bypass would
+    reopen the exact 2026-07-28 race this lease exists to close."""
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-should-never-launch",
+        env={"GROOM_DISPATCH_ENABLED": "true"},
+    )
+    monkeypatch.setattr(idx.time, "sleep", lambda *_a, **_kw: None)  # no real waiting in tests
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        holder = idx.dispatch_lease.LeaseHolder(
+            owner_id="rival", started_at="x", ttl_epoch=1, hostname="h", pid=1)
+        if lock_key == "locks/groom-spot-capacity-pool.lock":
+            return idx.dispatch_lease.LeaseAcquireResult(acquired=False, holder=holder)
+        return idx.dispatch_lease.LeaseAcquireResult(
+            acquired=True,
+            holder=idx.dispatch_lease.LeaseHolder(
+                owner_id=owner_id, started_at="x", ttl_epoch=1, hostname="h", pid=1),
+        )
+
+    released = []
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+    monkeypatch.setattr(idx.dispatch_lease, "release_lease",
+                        lambda lock_key, **kw: released.append(lock_key))
+
+    with pytest.raises(RuntimeError, match="spot-launch lease"):
+        idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    assert launched == []  # never reached RunInstances
+    # The LANE lease (acquired successfully) was released on the failure path.
+    assert "locks/groom-lane-mid-only.lock" in released
+
+
+def test_spot_launch_lease_wraps_and_releases_around_launch_instance(monkeypatch):
+    """The shared spot-launch lease is acquired immediately before, and
+    released immediately after, the RunInstances call — never held across
+    the lane's subsequent SSM/bootstrap steps."""
+    order = []
+
+    def _launch(types_, subnets, **kw):
+        order.append("run_instances")
+        return "i-stub"
+
+    idx = _load(monkeypatch, launch_impl=_launch, env={"GROOM_DISPATCH_ENABLED": "true"})
+
+    def _acquire(lock_key, *, owner_id, ttl_seconds, bucket, s3_client=None, force=False):
+        if lock_key == "locks/groom-spot-capacity-pool.lock":
+            order.append("acquire_spot_launch")
+        holder = idx.dispatch_lease.LeaseHolder(
+            owner_id=owner_id, started_at="x", ttl_epoch=1, hostname="h", pid=1)
+        return idx.dispatch_lease.LeaseAcquireResult(acquired=True, holder=holder)
+
+    def _release(lock_key, *, bucket, s3_client=None):
+        if lock_key == "locks/groom-spot-capacity-pool.lock":
+            order.append("release_spot_launch")
+
+    monkeypatch.setattr(idx.dispatch_lease, "acquire_lease", _acquire)
+    monkeypatch.setattr(idx.dispatch_lease, "release_lease", _release)
+
+    out = idx.handler({"run_mode": "full", "issue_filter": "mid-only", "schedule": "x"}, None)
+    assert out["groom"]["launched"] is True
+    assert order == ["acquire_spot_launch", "run_instances", "release_spot_launch"]
+
+
+# ── §5.9.4: yielded-dispatch paging when a lane starves for a whole day ──────
+
+class _FixedNow(datetime):
+    """Subclasses stdlib datetime so `index.py`'s `datetime.now(tz)` calls
+    resolve to a fixed instant — only `.now()` is overridden, every other
+    classmethod (`.fromisoformat`, the constructor, etc.) is unchanged."""
+    _fixed = datetime(2026, 8, 4, 23, 0, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._fixed if tz is not None else cls._fixed.replace(tzinfo=None)
+
+
+def _decision_record(*entries):
+    return json.dumps({"schema_version": 2, "decisions": list(entries)}).encode()
+
+
+def test_lane_yield_starvation_pages_when_all_yielded(monkeypatch):
+    idx = _load(monkeypatch, s3_objects={
+        "groom/decisions/2026-08-04/trigger-0400.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": False, "reason": "lane_lease_yielded"}),
+        "groom/decisions/2026-08-04/trigger-1200.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": False, "reason": "lane_lease_yielded"}),
+    })
+    monkeypatch.setattr(idx, "datetime", _FixedNow)
+    result = idx.handler({"mode": "reconcile"}, None)
+    ys = result["lane_yield_starvation"]
+    assert ys["evaluated"] is True
+    assert ys["starved_lanes"] == ["mid-only"]
+    assert ys["paged"] == 1
+    assert "groom/_control/reconciled-lane-yield-starvation/2026-08-04.json" in idx._test_s3._objects
+
+
+def test_lane_yield_starvation_no_page_when_a_launch_occurred(monkeypatch):
+    idx = _load(monkeypatch, s3_objects={
+        "groom/decisions/2026-08-04/trigger-0400.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": False, "reason": "lane_lease_yielded"}),
+        "groom/decisions/2026-08-04/trigger-1200.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": True}),
+    })
+    monkeypatch.setattr(idx, "datetime", _FixedNow)
+    result = idx.handler({"mode": "reconcile"}, None)
+    ys = result["lane_yield_starvation"]
+    assert ys["starved_lanes"] == []
+    assert ys["paged"] == 0
+
+
+def test_lane_yield_starvation_skipped_before_eval_hour(monkeypatch):
+    class _EarlyNow(datetime):
+        _fixed = datetime(2026, 8, 4, 13, 0, tzinfo=timezone.utc)
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls._fixed if tz is not None else cls._fixed.replace(tzinfo=None)
+
+    idx = _load(monkeypatch, s3_objects={
+        "groom/decisions/2026-08-04/trigger-0400.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": False, "reason": "lane_lease_yielded"}),
+    })
+    monkeypatch.setattr(idx, "datetime", _EarlyNow)
+    result = idx.handler({"mode": "reconcile"}, None)
+    ys = result["lane_yield_starvation"]
+    assert ys["evaluated"] is False
+    assert ys["paged"] == 0
+
+
+def test_lane_yield_starvation_ignores_non_yield_skip_reasons(monkeypatch):
+    """A lane that was skipped for an unrelated reason (e.g. the ceiling)
+    every time is not a lease-starvation condition — only lane_lease_yielded
+    counts toward this specific page."""
+    idx = _load(monkeypatch, s3_objects={
+        "groom/decisions/2026-08-04/trigger-0400.json": _decision_record(
+            {"tier_tag": "mid-only", "launch": False, "reason": "dispatch_ceiling_exhausted"}),
+    })
+    monkeypatch.setattr(idx, "datetime", _FixedNow)
+    result = idx.handler({"mode": "reconcile"}, None)
+    ys = result["lane_yield_starvation"]
+    assert ys["starved_lanes"] == []
+    assert ys["paged"] == 0

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 krepis>=0.14.0

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 krepis>=0.14.0

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.35
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.34
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_severity_taxonomy_chokepoint.py
+++ b/tests/test_severity_taxonomy_chokepoint.py
@@ -126,6 +126,14 @@ _REGISTRY: dict[str, dict[str, list[dict]]] = {
                 "citation": "severity_taxonomy.md row: index.py:418-430",
             },
         ],
+        "_notify_lane_lease_yielded": [
+            {
+                "event_class": "Per-lane dispatch lease yield — atomic lease could not be taken (groom-sweep-policy §5.9)",
+                "severity": "info",
+                "silent": True,
+                "citation": "reconciled from live code 2026-08-04 — pending taxonomy entry; added with alpha-engine-config-I6460",
+            },
+        ],
         "_notify_dispatch_ceiling_exhausted": [
             {
                 "event_class": "Daily dispatch ceiling exhausted",


### PR DESCRIPTION
## Summary

Parent: `alpha-engine-config-I6306`. Implements `alpha-engine-config-I6460` (groom-sweep-policy.md §5.9). Companion: **`nousergon-lib-PR290`** (adds `nousergon_lib.dispatch_lease`) — **merge order: PR290 first**, this PR second (see "Blocked on" below). Tracked follow-up: **`alpha-engine-config-I6481`** (operator IAM step, see below).

§5.9: "The loop holds a singleton lease per lane, TTL-bounded. A dispatch that cannot take it exits and records that it yielded, never queuing behind or running beside the holder." Not implemented today: mutual exclusion rests on EventBridge Scheduler slot spacing (an assumption — the module's own docs note "a cycle running longer than its interval is normal") plus `_running_tier_instance_ids`, a fail-open ("an optimization, not a correctness gate", its own docstring) EC2-tag scan-then-launch with a TOCTOU race. The shared-resource half already fired live 2026-07-28: three lanes lost to one spot-capacity error because nothing serialized their claim on the shared pool.

## What changed (`scheduled-groom-dispatcher/index.py`)

- **Per-lane lease** (deliverables 1+2): `_launch_groom_spot` acquires an atomic lease (`nousergon_lib.dispatch_lease`, S3 conditional-PUT + soft-TTL, `locks/groom-lane-{tier_tag}.lock`, TTL=`MAX_RUNTIME_SECONDS`) right after the existing EC2-state check concludes the lane looks free. Conflict → `{"launched": false, "reason": "lane_lease_yielded"}`, notified, zero spend, no queue. The existing reclaim-aware EC2 guard is unchanged (only live EC2 state distinguishes "still working" from "mid-reclaim") — the lease closes the residual TOCTOU/fail-open gap around that decision.
- A bounded SF relaunch (`attempt > 0`) with independently-confirmed EC2 evidence the prior box is dying passes `force=True` to override a stale hold.
- **Shared-resource lease** (deliverable 3): `_launch_instance_serialized` wraps ONLY the `RunInstances` call in a short-TTL (180s) shared lease (`locks/groom-spot-capacity-pool.lock`) so concurrently-dispatching tiers serialize their capacity claim by seconds instead of colliding in the same instant (the literal 2026-07-28 mechanism), without cutting daily throughput by merging all three tiers onto one full-lane lease. **Design-fork ruling** (see Gotchas): narrow short-TTL lease around the RunInstances call, not full 3-tier serialization.
- **Yield-starvation paging** (deliverable 4): new `_reconcile_lane_yield_starvation` leg on the existing `mode=reconcile` 5-min cadence, pages once/day per lane whose every recorded decision today was a yield with zero launches. Time-gated (22:00 UTC) rather than trigger-counted, since the weekly-schedule-adjuster can move slot times. Reuses the existing `groom/decisions/{date}/*.json` shape — no new schema.
- Lease released on every non-launch path after acquisition (ceiling-skip, launch failure) so an unused lease never blocks the lane for the full TTL.

## `iam-policy.json` change — needs an operator action before merge

The lease needs S3 access under `locks/groom-*` — a prefix nothing in the existing policy covered. Added `GroomDispatchLeaseRW` (Put/Get/DeleteObject) + `ListGroomDispatchLeases` (ListBucket, required so a genuinely-absent lock 404s rather than 403s — `_shared/check_iam_getobject_listbucket.py` enforces this pairing and now passes).

Per this Lambda's own README, an IAM change has **zero live effect** until an operator runs `deploy.sh --apply-iam`/`--bootstrap` (the GHA auto-deploy OIDC role deliberately lacks `iam:PutRolePolicy`). This repo's `iam-policy-change-guard` (required check) stays red until one of: the policy is already-live (verified against the account), `deploy.sh` was also touched, or the PR carries `gate:operator` — **`gate:operator` is NOT used here**: this repo's own `gate-label-guard` (also required) rejects any `gate:*` label, so the two guards deadlock on that path (documented in `iam-policy-change-guard.yml`'s own history, alpha-engine-config-I5309). Filed **`alpha-engine-config-I6481`** naming the exact command and closes-when.

**Ask — Brian, before merging this PR:** run `bash infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh --apply-iam` from a checkout of this branch (needs a privileged AWS identity — `AWS_PROFILE=ne-admin` or equivalent; `ne-laptop-agent` is blanket-denied `iam:Put*`, which is why I couldn't do this myself). Once applied, `iam-policy-change-guard`'s already-live branch verifies it against the account automatically and the check goes green — no further edit needed here.

## Blocked on
**`nousergon-lib-PR290`** must merge and auto-tag first. `requirements.txt` (root + `Dockerfile` + `requirements-daily-news.txt` + `.github/workflows/deploy-infrastructure.yml` + every lambda's own `requirements.txt` — all lockstep-guarded by `tests/test_lib_pin_lockstep.py`) is bumped `v0.124.34` → `v0.124.36`, a **predicted** post-merge tag (main was at `.35` when PR290 opened). If CI here is red on `pip install`/`ModuleNotFoundError: nousergon_lib.dispatch_lease`, that's why — re-verify the actual tag once PR290 merges and correct the pin if it drifted from `.36` (precedented: PR286 predicted `.33`, shipped as `.34`).

**Staying draft** until PR290 merges, the pin is confirmed, the IAM policy is applied, and CI here is green.

## Test plan
- [x] 10 new unit tests in `test_handler.py`, no live AWS. The lease PRIMITIVE (acquire/TTL-recovery/force) is tested in nousergon-lib itself; these mock `dispatch_lease.acquire_lease`/`release_lease` per groom-sweep-conformance's "mock the lease backend" guidance — the existing hermetic `_FakeS3` doesn't implement `IfNoneMatch` conditional-PUT at all, so it can't exercise a real conflict. Covers: yield-without-launch on conflict, happy-path acquisition (both lease keys, `force=False`), relaunch `force=True`, release-on-ceiling-skip, spot-launch retry exhaustion (raises, never launches), acquire/launch/release ordering, and all four yield-starvation cases.
- [x] Ran locally against a local checkout of the nousergon-lib branch (PYTHONPATH override, since the tagged pin doesn't exist yet): `pytest test_handler.py -q` — **195 passed** (185 pre-existing + 10 new).
- [x] `pytest tests/test_lib_pin_lockstep.py -q` — **4 passed** (root/Dockerfile/daily-news/deploy-infra lockstep + every lambda's pin equality, post-bump).
- [x] `python3 infrastructure/lambdas/_shared/check_iam_getobject_listbucket.py` — clean (was failing before the `ListGroomDispatchLeases` addition; fixed before push).
- [x] `ruff check index.py` — clean. `ruff check test_handler.py` — no new findings in the added range (13 pre-existing findings elsewhere, unrelated, ruff not wired into this repo's CI).
- [x] Fixed one pre-existing test (`test_dispatch_ledger_write_failure_terminates_box_and_raises`) whose blanket S3 `put_object` failure simulation now also caught the new, earlier lease-acquire write — narrowed to the ledger key it was actually testing.

## Gotchas / stated assumptions
- **Design fork, ruled**: full 3-tier serialization onto one shared lease (only 1 of 3 tiers ever launches per cycle) vs. a narrow short-TTL lease around just the `RunInstances` call. Ruled: narrow lease — targets the measured failure mode without regressing the ratified independent-tier-launch throughput design.
- Not conflated with `alpha-engine-config-I6318` (§6.4b work-dispatch stop rule) — that lease is per-**item**; this is per-**lane** (the dispatch process itself). Both use the same TTL-lease primitive shape but gate different things.
- Does not assume a fixed slot calendar (weekly-schedule-adjuster, `I6177`) — the yield-starvation page is time-gated, not trigger-count-gated.

Closes-when (I6460, full arc — spans both PRs + the operator step): a deliberate double-fire of the same lane's schedule results in exactly one active dispatch and one recorded yield, verified against live dispatcher logs; the three-lanes-lost-to-one-capacity-error failure mode from 2026-07-28 cannot recur. Live verification is a post-merge, post-deploy, post-IAM-apply step — not claimed by this PR alone.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)