### PR TITLE
fix(groom): batch lane-start-health pages into one digest, not N pages

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -2396,6 +2396,7 @@ def _reconcile_lane_start_health() -> dict:
     s3 = boto3.client("s3", region_name=REGION)
     checked = 0
     paged = 0
+    newly_found: list[dict] = []
     for delta_days in range(2):
         day = (now - timedelta(days=delta_days)).strftime("%Y-%m-%d")
         prefix = f"{_DISPATCH_LEDGER_PREFIX}/{day}/"
@@ -2443,19 +2444,10 @@ def _reconcile_lane_start_health() -> dict:
             if _s3_key_exists(s3, started_key) or _s3_key_exists(s3, completed_key):
                 continue  # the charter began (or the lane already reached a terminal outcome) — healthy
             paged += 1
-            _notify_cycle(
-                "🔴 Groom lane NEVER STARTED — dispatch-ledger entry "
-                f"run_token={run_token} instance={instance_id} decided "
-                f"{recorded_at} ({age_min:.0f}m ago), but no "
-                f"groom/_control/started/ or /completed/ marker exists. The "
-                "charter never ran (box likely reclaimed during/before "
-                "bootstrap — alpha-engine-config-I4987). Manual triage "
-                "needed (alpha-engine-config-I6325).",
-                severity="error",
-                dedup_key=f"{_CYCLE_FLOW_NAME}:lane_never_started:{run_token}",
-                context={"run_token": run_token, "instance_id": instance_id,
-                         "recorded_at": recorded_at, "age_min": round(age_min, 1)},
-            )
+            newly_found.append({
+                "run_token": run_token, "instance_id": instance_id,
+                "recorded_at": recorded_at, "age_min": age_min,
+            })
             try:
                 s3.put_object(
                     Bucket=_RESEARCH_BUCKET, Key=actioned_key,
@@ -2468,6 +2460,33 @@ def _reconcile_lane_start_health() -> dict:
                 logger.warning(
                     "lane-start health: actioned-marker write failed for %s "
                     "(will re-page next tick): %s", run_token, exc)
+
+    # ONE aggregate page per cycle, never one per lane (2026-08-04 incident:
+    # this leg's first-ever run discovered a 2-day backlog of 27 pre-existing
+    # I4987 failures — all already the SAME known, tracked gap — and paged
+    # each individually, flooding the operator channel and plausibly tripping
+    # Telegram's own rate limit (flow-doctor's "ALL notifiers failed" alert
+    # fired in the same window). A burst belongs in one digest; the per-token
+    # actioned-key above still gives idempotency across ticks.
+    if newly_found:
+        lines = "\n".join(
+            f"  • run_token={f['run_token']} instance={f['instance_id']} "
+            f"decided {f['recorded_at']} ({f['age_min']:.0f}m ago)"
+            for f in sorted(newly_found, key=lambda f: -f["age_min"])[:20]
+        )
+        more = f"\n  … and {len(newly_found) - 20} more" if len(newly_found) > 20 else ""
+        _notify_cycle(
+            f"🔴 {len(newly_found)} groom lane(s) NEVER STARTED — dispatch-ledger "
+            "entries decided, no groom/_control/started/ or /completed/ marker "
+            "exists. Charter never ran (box likely reclaimed during/before "
+            "bootstrap — alpha-engine-config-I4987, same known cause for all "
+            f"listed below). Manual triage needed (alpha-engine-config-I6325).\n"
+            f"{lines}{more}",
+            severity="error",
+            dedup_key=f"{_CYCLE_FLOW_NAME}:lane_never_started_batch:{now:%Y-%m-%dT%H:%M}",
+            context={"count": len(newly_found),
+                     "run_tokens": [f["run_token"] for f in newly_found]},
+        )
     return {"checked": checked, "paged": paged}
 
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py
@@ -2939,6 +2939,31 @@ def test_lane_start_health_listing_error_is_fail_safe(monkeypatch):
     assert result["paged"] == 0
 
 
+def test_lane_start_health_batches_multiple_lanes_into_one_page(monkeypatch):
+    """2026-08-04 incident: this leg's first-ever run found a 2-day backlog of
+    27 never-started lanes and paged each individually, flooding the operator
+    channel and plausibly tripping Telegram's own rate limit. N discoveries in
+    one cycle must produce exactly ONE notify call, not N."""
+    idx = _load(monkeypatch, s3_objects={
+        _ledger_key("tok1"): _mature_ledger_entry("tok1"),
+        _ledger_key("tok2"): _mature_ledger_entry("tok2"),
+        _ledger_key("tok3"): _mature_ledger_entry("tok3"),
+    })
+    notified = _spy_notify(monkeypatch, idx)
+    result = idx._reconcile_lane_start_health()
+    assert result["checked"] == 3
+    assert result["paged"] == 3
+    assert len(notified) == 1  # one digest, not three individual pages
+    text, kw = notified[0]
+    assert "3 groom lane(s) NEVER STARTED" in text
+    assert "tok1" in text and "tok2" in text and "tok3" in text
+    assert kw["context"]["count"] == 3
+    # Each lane is still individually actioned, so a later tick doesn't
+    # re-discover (and re-page) any of them.
+    for tok in ("tok1", "tok2", "tok3"):
+        assert f"groom/_control/reconciled-lane-start/{tok}.json" in idx._test_s3._objects
+
+
 def test_reconcile_sends_task_failure_for_dead_lane_with_token(monkeypatch):
     """Lane death with a task_token → send-task-failure collapses the hung SF
     execution immediately instead of waiting for the 6h timeout."""


### PR DESCRIPTION
## Summary
- `_reconcile_lane_start_health`'s first-ever run (2026-08-04 ~12:25 UTC) discovered a 2-day backlog of 27 pre-existing `I4987` failures and paged each **individually** — 27 separate `error`-severity Telegram sends in ~30 seconds. Live-confirmed via `s3 ls groom/_control/reconciled-lane-start/` — all 27 actioned-marker objects timestamped within the same ~30s window.
- Almost certainly the direct cause of the concurrent `flow-doctor: ALL notifier(s) failed` critical alert in the same window (Telegram rate limit).
- Fix: collect all newly-discovered never-started lanes during one reconcile tick, send exactly **one** aggregate digest (`_notify_cycle`, listing up to 20 with a truncation note) instead of N individual pages. Per-token `actioned-key` writes are unchanged — idempotency across ticks is preserved; this changes notification shape only.

## Deploy mechanism
Auto-deploys on merge via `deploy-scheduled-groom-dispatcher.yml` (existing mechanism, unchanged by this PR).

## Test plan
- [x] New test `test_lane_start_health_batches_multiple_lanes_into_one_page` — 3 simultaneous never-started lanes produce exactly 1 notify call, all 3 still individually actioned.
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py tests/test_severity_taxonomy_chokepoint.py` — 212/212 pass, run before opening this PR.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)