### PR TITLE
fix(iam): grant scheduled-groom-dispatcher ec2:DescribeSpotInstanceRequests

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/iam-policy.json
@@ -18,7 +18,8 @@
         "ec2:RunInstances",
         "ec2:CreateTags",
         "ec2:DescribeInstances",
-        "ec2:DescribeInstanceStatus"
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeSpotInstanceRequests"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Summary
- Live root cause of `alpha-engine-config-I4987`'s continued failures 3+ days after the 2026-07-30 fixes landed, found while investigating Brian's 2026-08-04 "why is this still broken" question.
- The reclaim-aware concurrent-guard added 2026-08-02 (`nousergon_lib.spot_dispatch.termination_imminent`, `nousergon-lib-PR286` + `nousergon-data-PR1208`) calls `ec2:DescribeSpotInstanceRequests`, which `alpha-engine-scheduled-groom-dispatcher-role` was **never granted**. Every call has been silently degrading to the OLD blind concurrent-guard suppression since deployment — recreating the exact "relaunch structurally guaranteed to no-op against a dead box" defect I4987 already fixed once.
- Live-confirmed via Lambda logs (2026-08-03T23:00:38Z): `termination-imminent probe failed ... UnauthorizedOperation ... returning empty set (caller degrades to the original concurrent-guard suppression)` immediately followed by `lane mid-only already has a live groom box (...) — skipping launch`.
- **IAM grant already applied live** (`deploy.sh --apply-iam`, operator-authorized this session) — this PR is the paper trail catching the code up to what's already deployed.

## Deploy mechanism
Auto-deploys on merge via `deploy-scheduled-groom-dispatcher.yml`. IAM already applied live ahead of merge (operator step, per this repo's standing IAM-apply convention) — `iam-policy-change-guard` should read the policy as already-live and pass.

## Test plan
- [x] `pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py` — 206/206 pass (no code change, IAM-only; existing tests mock the EC2 client and could not have caught a live-account IAM gap)
- [x] Live-verified: `aws iam get-role-policy` now shows `ec2:DescribeSpotInstanceRequests` on the `LaunchGroomSpot` statement

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)