### PR TITLE
Register check-systemd-unit-drift and boot-pull as alert classes

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -811,6 +811,22 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: check_systemd_unit_drift
+    # config-I3211 backstop registration (alpha-engine-config#5715): installed
+    # systemd units on a box diverge from what the repo expects. Alert
+    # payload's raw `Source:` field is the hyphenated `check-systemd-unit-drift`.
+    source: "alpha-engine-data/infrastructure/systemd/check-systemd-unit-drift.py"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+  - class: boot_pull
+    # config-I3211 backstop registration (alpha-engine-config#5714 / #4793):
+    # boot-time repo pull on a box failed, risking stale code at session start.
+    # Alert payload's raw `Source:` field is the hyphenated `boot-pull`.
+    source: "alpha-engine/infrastructure/boot-pull.sh"
+    severities: [error]
+    intake: bus
+    response: drain-queue
 
   # ── groom (alpha-engine-config emitter) ──
   - class: groom_lifecycle_bus_events


### PR DESCRIPTION
## Summary
- Adds `check_systemd_unit_drift` and `boot_pull` rows to `infrastructure/overseer/playbooks.yaml`'s `alert_classes` registry.
- Both alert sources were flagged UNREGISTERED (config-I3211 backstop) in `nousergon/alpha-engine-config#5714` and `#5715`, filed 2026-07-30, and re-confirmed absent by multiple groom passes since.

## Test plan
- [x] `pytest tests/test_overseer_playbook_registry.py` — 42/42 passed locally before opening this PR (schema validation caught an initial hyphenated class-id attempt; fixed to snake_case per the `^[a-z0-9_]{3,60}$` pattern).

Closes-when for the registry piece of alpha-engine-config#5714 and #5715 — the operator-action pieces of those issues (verify trading-box systemd/git state) are handled separately in this session.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)