### PR TITLE
fix(data): correct misleading universe comment in alternative.py (config#6450)

### DIFF
--- a/collectors/alternative.py
+++ b/collectors/alternative.py
@@ -1079,7 +1079,27 @@ def _load_promoted_tickers(
         if t:
             tickers.add(t)
 
-    # Tracked universe (currently held + watchlist)
+    # Full board-width universe (~903 names), NOT "currently held + watchlist"
+    # as this comment previously (incorrectly) claimed — measured 2026-07-29,
+    # alpha-engine-config#5809. This function is DEPRECATED and reachable
+    # only via a direct/ad-hoc call that supplies no explicit `tickers` (see
+    # the module docstring above); the production path
+    # (`weekly_collector._run_phase2`) never reaches this loop.
+    #
+    # alpha-engine-config#6450 audited this site and its initial verdict was
+    # REPOINT to `nousergon_lib.decision_set` (a narrow ~60-name cut). That
+    # verdict does not hold for `alternative.collect`'s actual consumer: per
+    # `infrastructure/step_function.json`'s DataPhase2 state comment and
+    # PR #1186 (merged 2026-07-31), this collector's per-ticker output feeds
+    # 7 registered `alternative`-family feature-store columns
+    # (`features/registry.py::CATALOG`, consumers='predictor') for the WHOLE
+    # ArcticDB universe — a ticker with no alt data reads as 0.0, which is
+    # indistinguishable from a real zero. Narrowing this loop's source to a
+    # decision_set cut would silently zero those 7 columns for the ~843
+    # names outside the cut. That is why the production resolver
+    # (`weekly_collector._run_phase2`) passes the FULL constituent universe
+    # explicitly via `tickers=`, sourced from `constituents.json`, not a
+    # narrower decision_set cut — see #6450 for the corrected verdict.
     for entry in signals.get("universe", []):
         t = entry.get("ticker") or entry.get("symbol")
         if t:


### PR DESCRIPTION
## What

Implements the deliverable-5 comment fix for site 1 of `alpha-engine-config#6450`'s audit (part of epic `alpha-engine-config#5809`): the comment at `collectors/alternative.py`'s `_load_promoted_tickers` universe-read loop claimed "Tracked universe (currently held + watchlist)" — wrong, the universe is board-width (~903 names).

## Why no functional repoint

The audit's site-1 verdict called for repointing this read to `nousergon_lib.decision_set` @ `scanner_candidates` (width 60). That verdict does not survive contact with live code:

- `nousergon-data` PR#1186 (merged 2026-07-31) already established, on the record in `infrastructure/step_function.json`'s `DataPhase2` state comment, that this collector's per-ticker output feeds 7 registered `alternative`-family feature-store columns (`features/registry.py::CATALOG`, `consumers='predictor'`) for the **whole** ArcticDB universe. Narrowing the source to a 60-name cut would silently zero those 7 columns for ~843 tickers (a missing value reads as `0.0`, indistinguishable from a real zero).
- Production (`weekly_collector.py::_run_phase2`) already resolves the full board from `constituents.json` and passes it explicitly via `tickers=` — it never reaches this function. `_load_promoted_tickers`'s own docstring already marks it DEPRECATED as the production resolver, reachable only via a direct/ad-hoc call.

Applying the literal repoint would have shipped a feature-coverage regression on top of a comment fix. Deviation documented in full, plus the one residual live gap it surfaces (a still-CI-deployed but SF-orphaned `alpha-engine-data-collector` Lambda whose handler would still hit this deprecated path if manually invoked), in `alpha-engine-config#6508` — filed as tracked follow-up, out of this issue's scope.

**SOTA:** the audit's own stated target — repoint every per-ticker-external-work reader off `signals.json::universe` onto `nousergon_lib.decision_set`. **Delta:** this site is the one audited exception where applying that target verbatim would regress a load-bearing feature family; the delta is recorded above and in #6508, not silently absorbed.

## Test plan

- `python3 -m pytest tests/test_alt_data_scope_resolution.py tests/test_alternative_*.py -q` — 2 failures in `test_alt_data_scope_resolution.py` are pre-existing (`ModuleNotFoundError: yfinance`, an environment gap in this sandbox — confirmed identical on unmodified `main` via `git stash`), not caused by this change.
- Full suite (`python3 -m pytest -q --continue-on-collection-errors`, excluding the yfinance-blocked modules): **133 failed, 3755 passed, 9 skipped, 46 errors** — byte-identical counts with and without this diff (verified via `git stash`/`git stash pop` A-B comparison). All pre-existing, all attributable to sandbox dependency gaps, none touching `collectors/alternative.py` or this comment.

## Deploy-mechanism

N/A — comment-only change, no runtime behavior change, nothing to deploy.

## Cross-repo

Part of the same `alpha-engine-config#6450` implementation arc as:
- `nousergon/crucible-research` — comment-only fixes for sites 2 and 7: [PR #586](https://github.com/nousergon/crucible-research/pull/586).
- `nousergon/crucible-executor` — annotates the executor sizing/exit exception sites: [PR #462](https://github.com/nousergon/crucible-executor/pull/462) (7 of the audited 6-file list; the 8th named sub-site, `signal_reader.py::filter_buy_candidates_to_universe`, was found NOT to read `signals.json::universe` at all — see that PR body for the correction).

No functional dependency between the three — none blocks any other; no merge order required. None of the three PRs alone closes `alpha-engine-config#6450` (sites 2-7 land in the other two); this PR addresses site 1 only. Deliberately no `Closes` keyword here — the issue closes when all three PRs (plus the already-recorded no-action sites) land; see the issue's own tracking comment.

Related: alpha-engine-config#6450, alpha-engine-config#6508 (correction + residual-gap tracking issue this PR's deviation created), alpha-engine-config#5809 (parent epic).

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
