### PR TITLE
feat(sf): weekday Scanner on preopen pipeline (alpha-engine-config-I6494)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,12 +1,12 @@
 {
-  "Comment": "Alpha Engine Weekday Pipeline \u2014 morning polygon enrichment, predictor inference, executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). MorningEnrich (added 2026-04-24) overwrites the prior trading day's ArcticDB row with polygon's authoritative OHLCV+VWAP before predictor inference reads it \u2014 fixes the 2026-04-17\u21922026-04-23 silent VWAP outage where the EOD yfinance pass was the only source. EOD yfinance collection runs via the post-close EOD SF on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only. alpha-engine-config-I2717/I2722 (2026-07-16): the universe-gap + chronic-polygon-gap self-heal (formerly ChronicGapSelfHeal) and the PredictorHealthCheck/PredictorDriftCheck observability producers were REMOVED from this SF entirely \u2014 the heal now runs standalone (weekly_collector.py --daily-heal, EventBridge 09:00 UTC weekdays) and the two health checks now fire on their own direct EventBridge triggers (13:40 UTC weekdays), both off this critical path. See infrastructure/cloudformation/alpha-engine-orchestration.yaml.",
+  "Comment": "Alpha Engine Weekday Pipeline \u2014 morning polygon enrichment, predictor inference, executor start. Runs Mon-Fri 6:05 AM PT (13:05 UTC). MorningEnrich (added 2026-04-24) overwrites the prior trading day's ArcticDB row with polygon's authoritative OHLCV+VWAP before predictor inference reads it \u2014 fixes the 2026-04-17\u21922026-04-23 silent VWAP outage where the EOD yfinance pass was the only source. EOD yfinance collection runs via the post-close EOD SF on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only. alpha-engine-config-I2717/I2722 (2026-07-16): the universe-gap + chronic-polygon-gap self-heal (formerly ChronicGapSelfHeal) and the PredictorHealthCheck/PredictorDriftCheck observability producers were REMOVED from this SF entirely \u2014 the heal now runs standalone (weekly_collector.py --daily-heal, EventBridge 09:00 UTC weekdays) and the two health checks now fire on their own direct EventBridge triggers (13:40 UTC weekdays), both off this critical path. See infrastructure/cloudformation/alpha-engine-orchestration.yaml. alpha-engine-config-I6494: after MorningArcticAppend, CheckSkipScanner \u2192 Scanner invokes alpha-engine-research-scanner:live (same entrypoint as the Saturday weekly SF) before PredictorInference so weekday universe_membership/{date} + factor profiles stay fresh without running the full Saturday pipeline (distinct from I5489 weekday weekly-SF exercise).",
   "StartAt": "InitializeInput",
   "States": {
     "InitializeInput": {
       "Type": "Pass",
-      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + trading_instance_id explicitly; manual reruns (which happened multiple times 2026-04-23) often omit sns_topic_arn, which caused HandleFailure to error on missing $.sns_topic_arn JSONPath. Mirrors the Saturday SF InitializeInput pattern \u2014 States.JsonMerge with user-input as the second arg lets explicit values win.",
+      "Comment": "Layer defaults under the execution input so manual invocations don't have to pass every field. Scheduled EventBridge runs pass sns_topic_arn + trading_instance_id explicitly; manual reruns often omit sns_topic_arn. Mirrors the Saturday SF InitializeInput pattern \u2014 States.JsonMerge with user-input as the second arg lets explicit values win. | alpha-engine-config-I6494: also stamps run_date = date($$.Execution.StartTime) so the weekday Scanner state (same alpha-engine-research-scanner:live entrypoint as the Saturday SF) keys universe_membership/{date} + factor profiles off ONE date. User-passed run_date still wins. Preopen always starts after UTC midnight for its trading day (America/Los_Angeles cron(15 5) MON-FRI), so the StartTime date IS the trading day; Scanner additionally normalizes via trading_calendar.",
       "Parameters": {
-        "merged.$": "States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'), $$.Execution.Input, false)"
+        "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
       "Next": "CheckMutexRole"
@@ -975,7 +975,7 @@
     },
     "WriteCompletionMarker": {
       "Type": "Task",
-      "Comment": "config#2857: SF-envelope completion marker — an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Reached only via RunDaemon/CheckSkipRunDaemon's success Next (including RunDaemon's own best-effort daemon-restart-failure Catch, which is still an overall pipeline SUCCESS) — NotifyHolidaySkip (NYSE closed, no run occurred) and TradingDayGateFailed/HandleFailure are NOT redirected here, so a holiday skip or a real failure never satisfies the SLA. cycle_key is the execution-start date (no run_date is threaded through this SF today, unlike the Saturday SF) — safe because this pipeline always starts well after UTC midnight for its trading day. Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_preopen_trading_pipeline (cadence weekday_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable — exactly the ambiguity this feature exists to surface, not mask.",
+      "Comment": "config#2857: SF-envelope completion marker \u2014 an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Reached only via RunDaemon/CheckSkipRunDaemon's success Next (including RunDaemon's own best-effort daemon-restart-failure Catch, which is still an overall pipeline SUCCESS) \u2014 NotifyHolidaySkip (NYSE closed, no run occurred) and TradingDayGateFailed/HandleFailure are NOT redirected here, so a holiday skip or a real failure never satisfies the SLA. cycle_key is the execution-start date (no run_date is threaded through this SF today, unlike the Saturday SF) \u2014 safe because this pipeline always starts well after UTC midnight for its trading day. Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_preopen_trading_pipeline (cadence weekday_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable \u2014 exactly the ambiguity this feature exists to surface, not mask.",
       "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
       "Parameters": {
         "Bucket": "alpha-engine-research",
@@ -991,14 +991,14 @@
           "MaxAttempts": 3,
           "IntervalSeconds": 2,
           "BackoffRate": 2.0,
-          "Comment": "Transient S3 fault coverage — mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
+          "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
         }
       ],
       "Next": "PipelineComplete"
     },
     "CheckSkipMorningEnrich": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate. Input {\"skip_morning_enrich\": true} routes past the entire data phase (enrich + Arctic append, now on the ephemeral spot box per config#1767) straight to CheckSkipPredictorInference; missing flag = run as normal. The old on-trading MorningEnrich/MorningArcticAppend SSM states were relocated to the data spot (LaunchMorningEnrichSpot ...) so the always-on ae-trading box no longer does the ~30-50 min data fetch + ArcticDB append (config#1767).",
+      "Comment": "Per-task rerun gate. Input {\"skip_morning_enrich\": true} routes past the entire data phase (enrich + Arctic append, now on the ephemeral spot box per config#1767) straight to CheckSkipScanner (alpha-engine-config-I6494 \u2014 Scanner still runs on ArcticDB/carried fundamentals when the spot data phase is skipped); missing flag = run as normal. The old on-trading MorningEnrich/MorningArcticAppend SSM states were relocated to the data spot (LaunchMorningEnrichSpot ...) so the always-on ae-trading box no longer does the ~30-50 min data fetch + ArcticDB append (config#1767).",
       "Choices": [
         {
           "And": [
@@ -1011,7 +1011,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckSkipPredictorInference"
+          "Next": "CheckSkipScanner"
         }
       ],
       "Default": "InitMorningEnrichRetryCounter"
@@ -1025,6 +1025,62 @@
       },
       "ResultPath": "$.morning_enrich_retry",
       "Next": "LaunchMorningEnrichSpot"
+    },
+    "CheckSkipScanner": {
+      "Type": "Choice",
+      "Comment": "Skip-gate (alpha-engine-config-I6494). {\"skip_scanner\": true} bypasses the weekday Scanner Lambda and jumps straight to CheckSkipPredictorInference \u2014 Scanner's own success and Catch edges converge there, so skipping it is behaviorally identical to a Scanner run that did nothing. Defaults to running (Default: Scanner) so scheduled Mon\u2013Fri preopen runs and any rerun that has not explicitly set the flag are unaffected. Same entrypoint as the Saturday SF Scanner state (alpha-engine-research-scanner:live); this is the daily cadence of ONE Scanner, not a second implementation. Distinct from I5489 (weekday exercise of the FULL weekly SF).",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_scanner",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_scanner",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckSkipPredictorInference"
+        }
+      ],
+      "Default": "Scanner"
+    },
+    "Scanner": {
+      "Type": "Task",
+      "Comment": "Weekday invoke of the SAME standalone scanner Lambda the Saturday SF runs (alpha-engine-research-scanner:live \u2014 ROADMAP L1995 / alpha-engine-config-I6494). Placed AFTER MorningArcticAppend so ArcticDB technicals for the trading day are present, and BEFORE PredictorInference so universe_membership/{date} + factor profiles (+ provenance) are fresh for the membership consumer (I6495). Features are daily-capable (I5360 / research-PR545; SCANNER_FEATURE_SOURCE default arcticdb). Status contract OK / ERROR \u2014 Catch is non-blocking at the SF layer (mirrors Saturday): Catch and Next converge on CheckSkipPredictorInference; a missing/stale membership surfaces at the predictor's own age gate rather than hard-failing preopen. dry_run_llm omitted \u2014 weekday cadence has no Friday-Preflight research_dry shell path.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-scanner:live",
+        "Payload": {
+          "run_date.$": "$.run_date"
+        }
+      },
+      "TimeoutSeconds": 600,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Scanner failure must NOT halt the weekday pipeline at the SF layer (mirrors Saturday Catch \u2192 CheckSkipRegimeSubstrate). Catch and Next converge on CheckSkipPredictorInference so daemon start still happens; membership freshness is an independent consumer concern.",
+          "Next": "CheckSkipPredictorInference",
+          "ResultPath": "$.scanner_error"
+        }
+      ],
+      "ResultPath": "$.scanner_result",
+      "Next": "CheckSkipPredictorInference"
     },
     "CheckSkipPredictorInference": {
       "Type": "Choice",
@@ -1169,7 +1225,7 @@
           "Next": "ExtractDataSpotError"
         }
       ],
-      "Default": "CheckSkipPredictorInference"
+      "Default": "CheckSkipScanner"
     },
     "PollMorningEnrichSpot": {
       "Type": "Task",
@@ -1344,7 +1400,7 @@
           "Next": "ExtractDataSpotError"
         }
       ],
-      "Default": "CheckSkipPredictorInference"
+      "Default": "CheckSkipScanner"
     },
     "PollMorningArcticAppendSpot": {
       "Type": "Task",
@@ -1399,7 +1455,7 @@
         {
           "Variable": "$.arctic_append_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipPredictorInference"
+          "Next": "CheckSkipScanner"
         },
         {
           "Variable": "$.arctic_append_poll.Status",
@@ -1472,10 +1528,10 @@
             "States.ALL"
           ],
           "ResultPath": null,
-          "Next": "CheckSkipPredictorInference"
+          "Next": "CheckSkipScanner"
         }
       ],
-      "Next": "CheckSkipPredictorInference"
+      "Next": "CheckSkipScanner"
     }
   }
 }

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -17,8 +17,9 @@ liveness-poll quintet (``InitChronicGapPoll``/``WaitForChronicGap``/
 ``CheckChronicGapStatus``/``ChronicGapWait``/``StampChronicGapUnresponsive``),
 and its skip-gate (``CheckSkipChronicGapHeal``) are now DELETED from
 ``step_function_daily.json`` — 7 states removed in total. The 5 states that
-used to route into ``CheckSkipChronicGapHeal`` now route directly to
-``CheckSkipPredictorInference`` instead: ``CheckSkipMorningEnrich``,
+used to route into ``CheckSkipChronicGapHeal`` now route to
+``CheckSkipScanner`` (alpha-engine-config-I6494 — weekday Scanner before
+PredictorInference): ``CheckSkipMorningEnrich``,
 ``CheckMorningEnrichSpotLaunched``, ``CheckMorningArcticAppendSpotLaunched``,
 ``CheckMorningArcticAppendSpotStatus`` (its "Success" choice), and
 ``PublishDataSpotFailureImmediate`` (both its plain ``Next`` and its Catch's
@@ -29,7 +30,7 @@ This test catches regressions like:
   to this SF instead of the standalone daily-heal job — reopening the exact
   preopen poll-budget risk I2717 exists to close.
 - Someone leaves a dangling reference to one of the removed state names.
-- The 5 rewired predecessors drifting off ``CheckSkipPredictorInference``.
+- The 5 rewired predecessors drifting off ``CheckSkipScanner``.
 - ``ForceStopUnresponsiveInstance`` (SHARED with the code-freshness-gate and
   morning-planner liveness loops) getting accidentally deleted along with the
   chronic-gap quintet it used to also serve.
@@ -108,23 +109,24 @@ class TestChronicGapHealQuintetRemoved:
                 )
 
 
-class TestRewiredPredecessorsRouteToPredictorInferenceGate:
+class TestRewiredPredecessorsRouteToScannerGate:
     """The 5 states that used to enter CheckSkipChronicGapHeal now enter
-    CheckSkipPredictorInference directly."""
+    CheckSkipScanner (alpha-engine-config-I6494 — weekday Scanner sits
+    between the data-phase continue path and PredictorInference)."""
 
     def test_check_skip_morning_enrich_skip_edge(self, states):
         choices = states["CheckSkipMorningEnrich"]["Choices"]
         assert len(choices) == 1
-        assert choices[0]["Next"] == "CheckSkipPredictorInference"
+        assert choices[0]["Next"] == "CheckSkipScanner"
 
     def test_morning_enrich_spot_launched_default(self, states):
         assert states["CheckMorningEnrichSpotLaunched"]["Default"] == (
-            "CheckSkipPredictorInference"
+            "CheckSkipScanner"
         )
 
     def test_arctic_append_spot_launched_default(self, states):
         assert states["CheckMorningArcticAppendSpotLaunched"]["Default"] == (
-            "CheckSkipPredictorInference"
+            "CheckSkipScanner"
         )
 
     def test_arctic_append_spot_status_success_edge(self, states):
@@ -133,12 +135,12 @@ class TestRewiredPredecessorsRouteToPredictorInferenceGate:
             for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["CheckSkipPredictorInference"]
+        assert success == ["CheckSkipScanner"]
 
     def test_publish_data_spot_failure_immediate_routes_forward(self, states):
         st = states["PublishDataSpotFailureImmediate"]
-        assert st["Next"] == "CheckSkipPredictorInference"
-        assert st["Catch"][0]["Next"] == "CheckSkipPredictorInference"
+        assert st["Next"] == "CheckSkipScanner"
+        assert st["Catch"][0]["Next"] == "CheckSkipScanner"
 
 
 class TestPredictorInferenceGateUnchanged:

--- a/tests/test_sf_daily_scanner_wiring.py
+++ b/tests/test_sf_daily_scanner_wiring.py
@@ -1,0 +1,145 @@
+"""Pins the weekday Scanner wiring in ``step_function_daily.json``.
+
+alpha-engine-config-I6494 (Brian ruled option A, 2026-08-04): enable a daily
+Scanner schedule so ``universe_membership/{date}`` + factor profiles (+
+provenance) refresh on trading days without requiring the full Saturday
+weekly SF.
+
+SOTA: ONE Scanner entrypoint (``alpha-engine-research-scanner:live``), TWO
+cadences:
+
+  * Saturday — ``ne-weekly-freshness-pipeline`` Branch A ``Scanner`` state
+    (pinned by ``test_sf_scanner_wiring.py``)
+  * Weekday  — ``ne-preopen-trading-pipeline`` ``Scanner`` state (this file),
+    after MorningArcticAppend and before PredictorInference, riding the
+    existing America/Los_Angeles ``cron(15 5) MON-FRI`` preopen schedule
+    (TradingDayGate already skips NYSE holidays)
+
+Distinct from I5489 (weekday exercise of the FULL weekly SF).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
+_WEEKLY_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_SF_PATH.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def weekly_scanner() -> dict:
+    weekly = json.loads(_WEEKLY_SF_PATH.read_text())
+    flat: dict = dict(weekly["States"])
+    for st in weekly["States"].values():
+        if st.get("Type") == "Parallel":
+            for branch in st["Branches"]:
+                flat.update(branch["States"])
+    return flat["Scanner"]
+
+
+class TestStatesPresent:
+    def test_scanner_state_exists(self, states):
+        assert "Scanner" in states
+        assert states["Scanner"]["Type"] == "Task"
+
+    def test_skip_gate_defaults_to_running(self, states):
+        assert states["CheckSkipScanner"]["Type"] == "Choice"
+        assert states["CheckSkipScanner"]["Default"] == "Scanner"
+        skip = states["CheckSkipScanner"]["Choices"][0]
+        assert skip["Next"] == "CheckSkipPredictorInference"
+        variables = {c["Variable"] for c in skip["And"]}
+        assert variables == {"$.skip_scanner"}
+
+
+class TestSameEntrypointAsWeekly:
+    def test_lambda_function_matches_weekly(self, states, weekly_scanner):
+        assert (
+            states["Scanner"]["Parameters"]["FunctionName"]
+            == weekly_scanner["Parameters"]["FunctionName"]
+            == "alpha-engine-research-scanner:live"
+        )
+        assert states["Scanner"]["Resource"] == weekly_scanner["Resource"] == (
+            "arn:aws:states:::lambda:invoke"
+        )
+
+    def test_timeout_matches_weekly(self, states, weekly_scanner):
+        assert states["Scanner"]["TimeoutSeconds"] == weekly_scanner["TimeoutSeconds"] == 600
+
+
+class TestPayloadAndRunDate:
+    def test_payload_threads_run_date(self, states):
+        payload = states["Scanner"]["Parameters"]["Payload"]
+        assert payload["run_date.$"] == "$.run_date"
+
+    def test_initialize_input_seeds_run_date(self, states):
+        merged = states["InitializeInput"]["Parameters"]["merged.$"]
+        assert "run_date" in merged
+        assert "$$.Execution.StartTime" in merged
+        assert "States.Format" in merged
+
+
+class TestEdges:
+    def test_arctic_append_success_enters_scanner_gate(self, states):
+        success = [
+            c["Next"]
+            for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert success == ["CheckSkipScanner"]
+
+    def test_data_phase_continue_paths_enter_scanner_gate(self, states):
+        assert states["CheckSkipMorningEnrich"]["Choices"][0]["Next"] == (
+            "CheckSkipScanner"
+        )
+        assert states["CheckMorningEnrichSpotLaunched"]["Default"] == (
+            "CheckSkipScanner"
+        )
+        assert states["CheckMorningArcticAppendSpotLaunched"]["Default"] == (
+            "CheckSkipScanner"
+        )
+        pub = states["PublishDataSpotFailureImmediate"]
+        assert pub["Next"] == "CheckSkipScanner"
+        assert pub["Catch"][0]["Next"] == "CheckSkipScanner"
+
+    def test_scanner_success_and_catch_converge_on_predictor_gate(self, states):
+        assert states["Scanner"]["Next"] == "CheckSkipPredictorInference"
+        catches = states["Scanner"]["Catch"]
+        assert any(
+            c["Next"] == "CheckSkipPredictorInference"
+            and "States.ALL" in c["ErrorEquals"]
+            for c in catches
+        )
+
+    def test_no_direct_edge_from_arctic_to_predictor_bypassing_scanner(self, states):
+        """Regression: Arctic success must not skip the new Scanner gate."""
+        success = [
+            c["Next"]
+            for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
+            if c.get("StringEquals") == "Success"
+        ]
+        assert "CheckSkipPredictorInference" not in success
+
+
+class TestResultPaths:
+    def test_success_result_lands_under_scanner_result(self, states):
+        assert states["Scanner"]["ResultPath"] == "$.scanner_result"
+
+    def test_failure_result_lands_under_scanner_error(self, states):
+        catch_all = next(
+            c for c in states["Scanner"]["Catch"] if "States.ALL" in c["ErrorEquals"]
+        )
+        assert catch_all["ResultPath"] == "$.scanner_error"

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -148,9 +148,9 @@ class TestWeekdayFailureIsolation:
 
     # alpha-engine-config-I2717 (2026-07-16): the continue path used to be the
     # CheckSkipChronicGapHeal gate; that gate (and the heal behind it) was
-    # removed entirely — the continue path now rejoins directly at
-    # CheckSkipPredictorInference.
-    _CONTINUE = "CheckSkipPredictorInference"
+    # removed entirely. alpha-engine-config-I6494: the continue path now
+    # rejoins at CheckSkipScanner (weekday Scanner before PredictorInference).
+    _CONTINUE = "CheckSkipScanner"
 
     def test_launch_catch_is_fail_open(self, daily):
         for name in ("LaunchMorningEnrichSpot", "LaunchMorningArcticAppendSpot"):

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -195,6 +195,10 @@ _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # {data_spot:{launched,instance_id,...}}.
     "LaunchMorningEnrichSpot": frozenset({"workload", "force_on_demand.$"}),
     "LaunchMorningArcticAppendSpot": frozenset({"workload", "force_on_demand.$"}),
+    # alpha-engine-config-I6494: weekday Scanner — same Lambda as Saturday SF
+    # Scanner, payload is run_date only (no research_dry / dry_run_llm on the
+    # weekday cadence).
+    "Scanner": frozenset({"run_date.$"}),
 }
 
 

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -35,12 +35,13 @@ phase (CheckSkipMorningEnrich).
 alpha-engine-config-I2717/I2722 (2026-07-16): the CheckSkipChronicGapHeal gate
 + ChronicGapSelfHeal (and its liveness-poll quintet) were REMOVED entirely —
 the heal moved to a standalone EventBridge-triggered daily job, off this SF's
-critical path. CheckSkipMorningEnrich's skip edge and the data-phase spot
-success edges now route straight to CheckSkipPredictorInference. Likewise
-PredictorHealthCheck + PredictorDriftCheck were REMOVED and re-homed onto
-their own direct EventBridge triggers — CoverageGapChoice and
-FinalCoverageGate (the coverage-gap Choice states that used to Default into
-PredictorHealthCheck) now Default straight to CheckSkipMorningPlanner.
+critical path. alpha-engine-config-I6494: CheckSkipMorningEnrich's skip edge
+and the data-phase spot success edges now route to CheckSkipScanner (weekday
+Scanner before PredictorInference). Likewise PredictorHealthCheck +
+PredictorDriftCheck were REMOVED and re-homed onto their own direct
+EventBridge triggers — CoverageGapChoice and FinalCoverageGate (the
+coverage-gap Choice states that used to Default into PredictorHealthCheck)
+now Default straight to CheckSkipMorningPlanner.
 
 Catches regressions like:
 - A skip-gate dropped, so an entry edge points straight at the task again.
@@ -66,10 +67,12 @@ _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
 
 # (gate, task, skip_flag, next_gate) in pipeline order.
 # alpha-engine-config-I2717: CheckSkipChronicGapHeal + ChronicGapSelfHeal
-# removed entirely — CheckSkipMorningEnrich's skip edge now routes straight to
-# CheckSkipPredictorInference.
+# removed entirely. alpha-engine-config-I6494: CheckSkipMorningEnrich's skip
+# edge now routes to CheckSkipScanner (weekday Scanner still runs when the
+# spot data phase is skipped); Scanner then joins CheckSkipPredictorInference.
 _CHAIN = [
-    ("CheckSkipMorningEnrich", "LaunchMorningEnrichSpot", "skip_morning_enrich", "CheckSkipPredictorInference"),
+    ("CheckSkipMorningEnrich", "LaunchMorningEnrichSpot", "skip_morning_enrich", "CheckSkipScanner"),
+    ("CheckSkipScanner", "Scanner", "skip_scanner", "CheckSkipPredictorInference"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
     # config#2857: the skip edge now routes through the SF-envelope
@@ -171,14 +174,14 @@ class TestEntryEdgesRouteThroughGates:
         assert success == ["InitMorningArcticAppendRetryCounter"]
         assert states["InitMorningArcticAppendRetryCounter"]["Next"] == "LaunchMorningArcticAppendSpot"
 
-    def test_arctic_append_spot_success_enters_predictor_gate(self, states):
+    def test_arctic_append_spot_success_enters_scanner_gate(self, states):
         # config#1767: the Arctic append also runs on its own spot; its Success
-        # rejoins the trading path at CheckSkipPredictorInference directly
-        # (alpha-engine-config-I2717: the intermediate CheckSkipChronicGapHeal
-        # gate was removed — the heal moved to the standalone daily-heal job).
+        # rejoins the trading path at CheckSkipScanner (alpha-engine-config-I6494:
+        # weekday Scanner runs before PredictorInference). I2717 removed the
+        # intermediate CheckSkipChronicGapHeal gate (heal moved standalone).
         success = [c["Next"] for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
                    if c.get("StringEquals") == "Success"]
-        assert success == ["CheckSkipPredictorInference"]
+        assert success == ["CheckSkipScanner"]
 
     def test_data_phase_no_longer_on_trading_box(self, states):
         # config#1767 deliverable #2: the trading path retains NO data-phase SSM
@@ -282,17 +285,17 @@ class TestPaths:
         # completion marker on its way to PipelineComplete.
         assert order == ["WriteCompletionMarker", "PipelineComplete"]
 
-    def test_skip_data_phase_resumes_at_predictor_inference(self, states):
+    def test_skip_data_phase_resumes_at_scanner_then_predictor(self, states):
         """config#1767: skip_morning_enrich skips the ENTIRE spot data phase
         (enrich + append both on independent spots) — the old separate
-        skip_morning_arctic_append gate is gone. alpha-engine-config-I2717
-        (2026-07-16): the intermediate chronic-gap-heal gate/state this test
-        used to resume at is ALSO gone (moved to the standalone --daily-heal
-        job), so the skip now resumes directly at PredictorInference."""
+        skip_morning_arctic_append gate is gone. alpha-engine-config-I6494:
+        the skip resumes at Scanner (still needed for weekday membership /
+        factor-profile freshness on ArcticDB), then PredictorInference."""
         order = self._walk(states, "CheckSkipMorningEnrich", skip_flags={"skip_morning_enrich"})
         assert "LaunchMorningEnrichSpot" not in order
         assert "LaunchMorningArcticAppendSpot" not in order
-        assert order[0] == "PredictorInference"
+        assert order[0] == "Scanner"
+        assert order.index("Scanner") < order.index("PredictorInference")
         assert order[-1] == "PipelineComplete"
 
     def test_happy_path_runs_data_phase_on_spot(self, states):
@@ -300,8 +303,8 @@ class TestPaths:
         order = self._walk(states, "CheckSkipMorningEnrich", skip_flags=set())
         assert "LaunchMorningEnrichSpot" in order
         assert "LaunchMorningArcticAppendSpot" in order
-        # Enrich spot precedes append spot precedes PredictorInference —
-        # alpha-engine-config-I2717 removed the intermediate chronic-gap-heal
-        # hop this test used to check for.
+        # Enrich spot precedes append spot precedes Scanner precedes
+        # PredictorInference (I6494); I2717 removed chronic-gap-heal hop.
         assert order.index("LaunchMorningEnrichSpot") < order.index("LaunchMorningArcticAppendSpot")
-        assert order.index("LaunchMorningArcticAppendSpot") < order.index("PredictorInference")
+        assert order.index("LaunchMorningArcticAppendSpot") < order.index("Scanner")
+        assert order.index("Scanner") < order.index("PredictorInference")


### PR DESCRIPTION
## Summary

Closes the invoke-path half of [alpha-engine-config-I6494](https://github.com/nousergon/alpha-engine-config/issues/6494) (Ruling A): enable weekday trading-day Scanner on the existing preopen Step Functions pipeline so `universe_membership` and factor profiles refresh Mon–Fri without running the full Saturday weekly SF.

**What:** Wire a Scanner state into `ne-preopen-trading-pipeline` (`infrastructure/step_function_daily.json`) that invokes the same `alpha-engine-research-scanner:live` entrypoint used by weekly SF.

**Why:** Universe membership and factor profiles need weekday freshness; Saturday weekly SF alone is too sparse for trading-day ops.

### SOTA justification

One Scanner entrypoint, two cadences: daily preopen (this PR) + Saturday weekly (existing). No parallel Lambda/rule/entrypoint — same live scanner task definition, scheduled via the pipeline that already owns weekday preopen work.

### Inventory evidence (current path before this PR)

- Weekly SF already has a Scanner state → `alpha-engine-research-scanner:live`
- `CheckEnableStandaloneScanner` was removed historically; there was no separate daily EventBridge rule / standalone daily scanner before this change
- Preopen SF had MorningArcticAppend → PredictorInference with no Scanner between them

### Schedule design

- Rides existing `America/Los_Angeles` `cron(15 5) MON-FRI` preopen pipeline
- Placement: after `MorningArcticAppend`, before `PredictorInference`
- `TradingDayGate` skips holidays / non-trading days

### Distinct from I5489

I5489 is a separate concern; this PR is specifically weekday Scanner on preopen for I6494 universe/factor refresh cadence — not that workstream.

### Cross-link / sibling dependency

Registry cadence flip for `factor_profiles_provenance` is owned by the sibling **alpha-engine-config** docs PR (I4921 / I6493 / I6494 cadence). This PR **DEPENDS** on that flip for `ARTIFACT_REGISTRY`; this PR is the **invoke-path half** only.

### IAM

No new grants — `alpha-engine-step-functions-role` already allows `alpha-engine-research-scanner*`.

## Deploy mechanism

**Deploy-mechanism:** merge deploys via `deploy-infrastructure.sh` updating `ne-preopen-trading-pipeline`. No operator post-merge command; merge button is the last action.

## Test plan

- [x] `tests/test_sf_daily_scanner_wiring.py`
- [x] `tests/test_sf_weekday_skipgate_wiring.py`
- [x] `tests/test_sf_chronic_gap_heal_wiring.py`
- [x] `tests/test_sf_data_spot_relocation_wiring.py`
- [x] `tests/test_sf_payload_uniqueness.py`
- [x] 177 pytest tests passed in the wiring suite run for this change

---

**Prepared by:** Cursor Grok 4.5 via Cursor

Made with [Cursor](https://cursor.com)