### PR TITLE
[P1/mid] feat(infra): codify the scheduled-automation pause (Brian ruling 2026-08-07)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -33,6 +33,8 @@ on:
       - 'infrastructure/deploy-infrastructure.sh'
       - 'infrastructure/step_function*.json'
       - 'infrastructure/scheduler/**'
+      - 'infrastructure/automation_pause.json'
+      - 'infrastructure/automation_pause.py'
       - '.github/workflows/sf-arn-drift-check.yml'
   schedule:
     - cron: '30 9 * * *'   # daily, alongside the IAM sweep
@@ -55,6 +57,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
           aws-region: us-east-1
+
+      # Brian ruling 2026-08-07: all scheduled automation paused except the
+      # weekly/preopen/postclose SFs and the 24/7 box. This asserts the pause
+      # still holds — the opposite direction from every other check here, and
+      # the only surface that would notice a redeploy quietly switching a
+      # paused trigger back on. Runs unconditionally (not PR-scoped): the
+      # invariant is about live AWS, not about which files a PR touched.
+      # Read-only; needs nothing beyond the events:DescribeRule +
+      # scheduler:GetSchedule this role already holds.
+      - name: Scheduled-automation pause still holds (live)
+        run: python3 infrastructure/automation_pause.py --check
 
       - name: EventBridge SF-ARN drift (codified vs live)
         run: python3 infrastructure/eventbridge/check-drift.py

--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -46,7 +46,7 @@
       "alpha-engine-alert-drain-1600utc": "overseer alert drain",
       "alpha-engine-alert-drain-2200utc": "overseer alert drain",
       "alpha-engine-ci-watch-canary-drill-weekly": "ci-watch canary drill",
-      "alpha-engine-config-runner-reconcile": "config-runner reconcile, rate(1 minute). Its target Lambda alpha-engine-config-runner-dispatcher DOES NOT EXIST - this schedule has been failing every minute (see alpha-engine-config issue filed 2026-08-07)",
+      "alpha-engine-config-runner-reconcile": "config-runner reconcile, rate(1 minute). Its target Lambda alpha-engine-config-runner-dispatcher DOES NOT EXIST - this schedule has been failing every minute (~1,440 invocations/day). Root cause + the missing target-existence guard: alpha-engine-config-I6618",
       "alpha-engine-crypto-balances-15min": "crypto balance collector",
       "alpha-engine-expense-collector-twicedaily": "expense collector",
       "alpha-engine-groom-lane-reconciler-5min": "groom lane reconciler",

--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -1,0 +1,67 @@
+{
+  "ruling": {
+    "by": "Brian",
+    "date": "2026-08-07",
+    "statement": "Shut down all automatic AWS processes except the weekly Step Function (Saturday morning), the daily preopen and postclose Step Functions (Monday-Friday), and the 24/7 dashboard box. Everything else has its schedule removed - manual invocation only.",
+    "duration": "indefinite-but-temporary ('for now'). Un-pausing is per-entry: delete the entry, run automation_pause.py --enforce is NOT needed to re-enable - re-enable explicitly with the AWS CLI or a deploy.sh reconcile.",
+    "region": "us-east-1 - the only region in this account carrying EventBridge rules or Scheduler schedules (us-west-2 / us-east-2 / eu-west-1 verified empty 2026-08-07)"
+  },
+
+  "not_paused": {
+    "alpha-engine-saturday": "weekly SF trigger (ne-weekly-freshness-pipeline) - explicitly kept",
+    "alpha-engine-weekday": "preopen SF trigger (ne-preopen-trading-pipeline) - explicitly kept",
+    "alpha-engine-eod-backstop-daily": "postclose SF backstop trigger - the scheduled half of the kept postclose pipeline (its primary trigger is the daemon shutdown, which is on-box)",
+    "alpha-engine-stop-trading": "stops the trading EC2 box Mon-Fri 22:00 PT. Cost-safety backstop for the kept daily cycle: without it a failed postclose leaves a t3.large running indefinitely",
+    "alpha-engine-spot-orphan-reaper-hourly": "terminates spot instances orphaned by a dead SF. Cost-safety backstop for the kept weekly + preopen pipelines, both of which launch spot",
+    "reactive-notifier-rules": "alpha-engine-sf-status-change, alpha-engine-groom-sf-failure, alpha-engine-spot-interruption-warning-record, alpha-engine-sf-watch-instance-terminated, alpha-engine-sf-watch-spot-interruption, overseer-intake-cw-alarm-state - EventPattern rules with no schedule to remove. They carry the failure signal for the kept pipelines; with the drain and dispatchers paused they only notify and record.",
+    "DO-NOT-DELETE-AmazonInspectorEcrManagedRule": "AWS-managed",
+    "non-eventbridge": "DLM policy-0047cfbfb7070a3b7 (nightly dashboard-box snapshot, 14d) and the two SSM associations (ae-patch-scan-only, ae-software-inventory, rate(1 day)) are kept: they are read-only or protective hygiene for the 24/7 box, not autonomous processes."
+  },
+
+  "paused": {
+    "events_rules": {
+      "alpha-engine-canary-replay-liveness-probe-tick": "overseer canary-replay liveness probe",
+      "alpha-engine-canary-replay-thursday": "canary-replay drill dispatcher (spawns work)",
+      "alpha-engine-daily-heal": "data-spot heal dispatcher (launches spot). CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
+      "alpha-engine-eod-success-friday-shell-trigger": "Friday shell-run trigger (spawns work)",
+      "alpha-engine-freshness-monitor-cron": "artifact freshness monitor - daily",
+      "alpha-engine-freshness-monitor-historical-cron": "artifact freshness monitor - historical",
+      "alpha-engine-freshness-monitor-intraday-cron": "artifact freshness monitor - intraday",
+      "alpha-engine-friday-shell-run-report": "Friday shell-run report",
+      "alpha-engine-pipeline-watchdog-daily": "pipeline watchdog",
+      "alpha-engine-predictor-drift-check": "predictor drift check. CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
+      "alpha-engine-predictor-health-check": "predictor health check. CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
+      "alpha-engine-router-exposure-probe-15min": "model-router exposure probe. Codified in nous-ergon-ops/infrastructure/lambdas/router-exposure-probe/deploy.sh, NOT this repo - paused live and recorded here because this manifest checks live AWS, not source ownership",
+      "alpha-engine-saturday-integrity-monday": "Saturday-run integrity sentinel",
+      "alpha-engine-saturday-sf-watch-failed": "EventPattern rule, but its target dispatches an autonomous remediation agent on weekly-SF failure - paused with the rest of the response plane",
+      "alpha-engine-spot-interruption-recorder-tick": "spot-interruption recorder poll (the EventPattern half stays enabled - it records real interruptions on the kept pipelines)",
+      "alpha-engine-ssm-reachability-probe-5min": "SSM reachability probe",
+      "alpha-engine-sweep-artifact-monitor": "EventPattern rule whose target monitors sweep artifacts; the sweep itself is paused",
+      "alpha-research-alerts": "intraday research alerts. CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
+      "alpha-research-thinktank-daily": "Think Tank spot dispatcher (launches spot)"
+    },
+    "scheduler_schedules": {
+      "alpha-engine-alert-drain-0400utc": "overseer alert drain",
+      "alpha-engine-alert-drain-1000utc": "overseer alert drain",
+      "alpha-engine-alert-drain-1600utc": "overseer alert drain",
+      "alpha-engine-alert-drain-2200utc": "overseer alert drain",
+      "alpha-engine-ci-watch-canary-drill-weekly": "ci-watch canary drill",
+      "alpha-engine-config-runner-reconcile": "config-runner reconcile, rate(1 minute). Its target Lambda alpha-engine-config-runner-dispatcher DOES NOT EXIST - this schedule has been failing every minute (see alpha-engine-config issue filed 2026-08-07)",
+      "alpha-engine-crypto-balances-15min": "crypto balance collector",
+      "alpha-engine-expense-collector-twicedaily": "expense collector",
+      "alpha-engine-groom-lane-reconciler-5min": "groom lane reconciler",
+      "alpha-engine-groom-sweep-0000-daily": "PR sweep",
+      "alpha-engine-groom-sweep-0800-daily": "PR sweep",
+      "alpha-engine-groom-sweep-1600-daily": "PR sweep",
+      "alpha-engine-overseer-liveness-0650-daily": "overseer liveness probe",
+      "alpha-engine-overseer-liveness-1450-daily": "overseer liveness probe",
+      "alpha-engine-scheduled-groom-0400-daily": "backlog groom cycle",
+      "alpha-engine-scheduled-groom-1200-daily": "backlog groom cycle",
+      "alpha-engine-scheduled-groom-2000-daily": "backlog groom cycle",
+      "alpha-engine-scheduled-groom-sun0900-weekly": "backlog groom cycle",
+      "alpha-engine-sf-watch-canary-drill-weekly": "sf-watch canary drill",
+      "alpha-engine-sf-watch-liveness-0645-daily": "sf-watch liveness probe",
+      "alpha-engine-sf-watch-liveness-1445-daily": "sf-watch liveness probe"
+    }
+  }
+}

--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""automation_pause.py — enforce and verify the scheduled-automation pause.
+
+**Background (Brian ruling, 2026-08-07).** Every scheduled AWS trigger in this
+account was disabled except the weekly Step Function (Saturday), the daily
+preopen and postclose Step Functions (Mon-Fri), the 24/7 dashboard box, and the
+two cost-safety backstops that protect them. ``infrastructure/automation_pause.json``
+is the record of that ruling and the source of truth for which triggers are
+intentionally off.
+
+**Why this file exists at all.** Disabling a rule in the console is not a
+decision anyone can find later, and it does not survive the machinery that
+re-asserts ``ENABLED``:
+
+  * ``deploy-infrastructure.yml`` re-applies the CloudFormation stack on EVERY
+    push to main, so the four CFN-owned rules would come back on the next merge.
+    Those four are therefore ALSO pinned ``State: DISABLED`` in
+    ``infrastructure/cloudformation/alpha-engine-orchestration.yaml`` — this
+    manifest records them, the template enforces them.
+  * ``infrastructure/lambdas/*/deploy.sh --reconcile-schedules`` recreates its
+    Scheduler rules with the AWS default state (``ENABLED``) whenever that
+    Lambda is redeployed. Those call sites are NOT yet pause-aware (see the
+    delta note in this repo's PR): the pause survives them by detection, not
+    prevention — ``--check`` runs in the daily drift sweep and goes red the next
+    morning naming the exact ``--enforce`` command.
+
+The check is deliberately two-directional. A pause that silently lifted and a
+manifest entry for a rule that no longer exists are both findings: an entry that
+can never fail is not a record, it is a comment.
+
+Usage:
+  ./infrastructure/automation_pause.py --check     # verify; exit 1 on any finding
+  ./infrastructure/automation_pause.py --enforce   # re-disable anything that came back
+  ./infrastructure/automation_pause.py --check --json
+
+``--check`` needs ``events:DescribeRule`` + ``scheduler:GetSchedule``; ``--enforce``
+additionally needs ``events:DisableRule`` + ``scheduler:UpdateSchedule``. CI runs
+``--check`` only, under the read-only ``github-actions-iam-drift-check`` role.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MANIFEST = Path(__file__).parent.resolve() / "automation_pause.json"
+REGION = "us-east-1"
+
+
+def load_manifest(path: Path = MANIFEST) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def paused_entries(manifest: dict | None = None) -> list[tuple[str, str, str]]:
+    """Return [(surface, name, reason)] for every paused trigger.
+
+    ``surface`` is ``"events"`` (an EventBridge rule) or ``"scheduler"`` (an
+    EventBridge Scheduler schedule) — they are different APIs, not aliases.
+    """
+    m = manifest if manifest is not None else load_manifest()
+    out: list[tuple[str, str, str]] = []
+    for name, reason in sorted(m["paused"]["events_rules"].items()):
+        out.append(("events", name, reason))
+    for name, reason in sorted(m["paused"]["scheduler_schedules"].items()):
+        out.append(("scheduler", name, reason))
+    return out
+
+
+def paused_names(manifest: dict | None = None) -> set[str]:
+    """Every intentionally-paused trigger name, both surfaces."""
+    return {name for _, name, _ in paused_entries(manifest)}
+
+
+def _aws(args: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["aws"] + args + ["--region", REGION], capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _live_state(surface: str, name: str) -> str | None:
+    """Return the live State, or None if the trigger does not exist.
+
+    Any failure that is NOT a genuine not-found is raised. A permissions error
+    read as absence would let this check grade itself green by losing its own
+    access — the same failure mode check-schedule-drift.py guards against.
+    """
+    if surface == "events":
+        rc, out, err = _aws(
+            ["events", "describe-rule", "--name", name, "--query", "State", "--output", "text"]
+        )
+        not_found = "ResourceNotFoundException" in err
+    else:
+        rc, out, err = _aws(
+            ["scheduler", "get-schedule", "--name", name, "--query", "State", "--output", "text"]
+        )
+        not_found = "ResourceNotFoundException" in err
+    if rc != 0:
+        if not_found:
+            return None
+        raise RuntimeError(f"aws {surface} describe/get {name}: {err}")
+    return out
+
+
+def _disable(surface: str, name: str) -> None:
+    if surface == "events":
+        rc, _, err = _aws(["events", "disable-rule", "--name", name])
+        if rc != 0:
+            raise RuntimeError(f"aws events disable-rule --name {name}: {err}")
+        return
+    # Scheduler has no disable verb: update-schedule is a full replace, so the
+    # live spec must be round-tripped or every unspecified attribute is lost.
+    rc, out, err = _aws(["scheduler", "get-schedule", "--name", name, "--output", "json"])
+    if rc != 0:
+        raise RuntimeError(f"aws scheduler get-schedule --name {name}: {err}")
+    spec = json.loads(out)
+    for derived in ("Arn", "CreationDate", "LastModificationDate", "ResponseMetadata"):
+        spec.pop(derived, None)
+    spec["State"] = "DISABLED"
+    rc, _, err = _aws(["scheduler", "update-schedule", "--cli-input-json", json.dumps(spec)])
+    if rc != 0:
+        raise RuntimeError(f"aws scheduler update-schedule --name {name}: {err}")
+
+
+def check() -> list[dict]:
+    findings: list[dict] = []
+    for surface, name, reason in paused_entries():
+        state = _live_state(surface, name)
+        if state is None:
+            findings.append({
+                "trigger": name, "surface": surface, "kind": "missing-in-aws",
+                "detail": (
+                    "listed as paused but does not exist live — it was deleted, or "
+                    "renamed. Remove the entry from automation_pause.json."
+                ),
+            })
+        elif state != "DISABLED":
+            findings.append({
+                "trigger": name, "surface": surface, "kind": "unexpectedly-enabled",
+                "detail": (
+                    f"paused on 2026-08-07 but live state is {state} — a deploy or a "
+                    f"console edit lifted the pause. Reason it is paused: {reason}. "
+                    f"Fix: ./infrastructure/automation_pause.py --enforce"
+                ),
+            })
+    return findings
+
+
+def enforce() -> list[str]:
+    acted: list[str] = []
+    for surface, name, _ in paused_entries():
+        state = _live_state(surface, name)
+        if state is not None and state != "DISABLED":
+            _disable(surface, name)
+            acted.append(f"{surface}:{name}")
+    return acted
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="scheduled-automation pause check / enforce")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="verify the pause holds")
+    mode.add_argument("--enforce", action="store_true", help="re-disable anything enabled")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    entries = paused_entries()
+
+    try:
+        if args.enforce:
+            acted = enforce()
+            if args.json:
+                print(json.dumps({"re_disabled": acted}, indent=2))
+            else:
+                print(f"automation pause — {len(entries)} paused trigger(s)")
+                for a in acted:
+                    print(f"  re-disabled {a}")
+                if not acted:
+                    print("  ✓ nothing had come back; no action taken")
+            return 0
+
+        findings = check()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"checked": len(entries), "findings": findings}, indent=2))
+    else:
+        print(f"automation pause — {len(entries)} paused trigger(s) checked")
+        if not findings:
+            print("  ✓ every paused trigger exists live and is DISABLED")
+        for f in findings:
+            print(f"  ✗ [{f['kind']}] {f['surface']}:{f['trigger']}")
+            print(f"      {f['detail']}")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -13,10 +13,15 @@ decision anyone can find later, and it does not survive the machinery that
 re-asserts ``ENABLED``:
 
   * ``deploy-infrastructure.yml`` re-applies the CloudFormation stack on EVERY
-    push to main, so the four CFN-owned rules would come back on the next merge.
-    Those four are therefore ALSO pinned ``State: DISABLED`` in
-    ``infrastructure/cloudformation/alpha-engine-orchestration.yaml`` — this
-    manifest records them, the template enforces them.
+    push to main. MEASURED 2026-08-07: a successful run 49 seconds after the
+    live disable did NOT revert the four CFN-owned rules — an unchanged
+    template yields an empty changeset, and CloudFormation touches nothing. The
+    revert risk is the NEXT template edit to those resources, which would
+    rewrite them from a template still claiming ``State: ENABLED``. So the
+    template edit is not urgency, it is truth: those four are pinned
+    ``State: DISABLED`` in
+    ``infrastructure/cloudformation/alpha-engine-orchestration.yaml`` so the
+    source stops asserting something the operator has decided against.
   * ``infrastructure/lambdas/*/deploy.sh --reconcile-schedules`` recreates its
     Scheduler rules with the AWS default state (``ENABLED``) whenever that
     Lambda is redeployed. Those call sites are NOT yet pause-aware (see the

--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -372,7 +372,11 @@ Resources:
       Name: alpha-research-alerts
       Description: Intraday price alerts every 30 min during market hours
       ScheduleExpression: 'cron(0/30 13-21 ? * MON-FRI *)'
-      State: ENABLED
+      # PAUSED 2026-08-07 (Brian ruling — see infrastructure/automation_pause.json).
+      # State lives here, not only live in AWS: deploy-infrastructure.yml re-applies
+      # this stack on EVERY push to main, so a console-only disable comes back on the
+      # next merge. Flip to ENABLED and drop the manifest entry to un-pause.
+      State: DISABLED
       Targets:
         - Id: alerts-lambda
           Arn: !Ref AlertsLambdaArn
@@ -401,7 +405,11 @@ Resources:
       Name: alpha-engine-daily-heal
       Description: Weekday 09:00 UTC — standalone universe-gap + chronic-polygon-gap data heal (alpha-engine-config-I2717), off the preopen critical path
       ScheduleExpression: 'cron(0 9 ? * MON-FRI *)'
-      State: ENABLED
+      # PAUSED 2026-08-07 (Brian ruling — see infrastructure/automation_pause.json).
+      # State lives here, not only live in AWS: deploy-infrastructure.yml re-applies
+      # this stack on EVERY push to main, so a console-only disable comes back on the
+      # next merge. Flip to ENABLED and drop the manifest entry to un-pause.
+      State: DISABLED
       Targets:
         # SINGLE TARGET PER RULE — see SaturdayTrigger's Targets comment for
         # the 2026-05-26 duplicate-target incident that codified this
@@ -434,7 +442,11 @@ Resources:
       Name: alpha-engine-predictor-health-check
       Description: Weekday 13:40 UTC — daily predictor model health (IC, hit rate, calibration, retrain triggers), re-homed off the preopen SF (alpha-engine-config-I2722)
       ScheduleExpression: 'cron(40 13 ? * MON-FRI *)'
-      State: ENABLED
+      # PAUSED 2026-08-07 (Brian ruling — see infrastructure/automation_pause.json).
+      # State lives here, not only live in AWS: deploy-infrastructure.yml re-applies
+      # this stack on EVERY push to main, so a console-only disable comes back on the
+      # next merge. Flip to ENABLED and drop the manifest entry to un-pause.
+      State: DISABLED
       Targets:
         - Id: predictor-health-check
           Arn: !Ref PredictorHealthCheckLambdaArn
@@ -462,7 +474,11 @@ Resources:
       Name: alpha-engine-predictor-drift-check
       Description: Weekday 13:40 UTC — daily prediction-drift producer (config#1853), re-homed off the preopen SF (alpha-engine-config-I2722)
       ScheduleExpression: 'cron(40 13 ? * MON-FRI *)'
-      State: ENABLED
+      # PAUSED 2026-08-07 (Brian ruling — see infrastructure/automation_pause.json).
+      # State lives here, not only live in AWS: deploy-infrastructure.yml re-applies
+      # this stack on EVERY push to main, so a console-only disable comes back on the
+      # next merge. Flip to ENABLED and drop the manifest entry to un-pause.
+      State: DISABLED
       Targets:
         - Id: predictor-drift-check
           Arn: !Ref PredictorLambdaArn

--- a/infrastructure/scheduler/check-manifest-drift.py
+++ b/infrastructure/scheduler/check-manifest-drift.py
@@ -36,7 +36,10 @@ Drift cases (all exit non-zero):
     stated reason" + §4.8 "irreversible actions carry a declared window"
     obligation, checked mechanically.
   * ``live-mismatch`` (``--live`` only) — the manifest's cron differs from the
-    live AWS schedule, or the live rule is not ENABLED.
+    live AWS schedule, or the live rule is not ENABLED. EXEMPT from the state
+    half: a trigger listed in ``infrastructure/automation_pause.json`` is off by
+    ruling, and ``automation_pause.py --check`` asserts the opposite direction
+    (paused-but-ENABLED) for it.
 
 Usage:
   ./infrastructure/scheduler/check-manifest-drift.py             # AWS-free
@@ -155,6 +158,7 @@ def check(
 
     # ── Manifest vs live AWS (optional) ─────────────────────────────────────
     if live:
+        paused = checker.automation_pause.paused_names()
         for name, t in manifest_by_name.items():
             live_rule = checker._live_schedule(name)
             if live_rule is None:
@@ -168,7 +172,13 @@ def check(
                     "rule": name, "kind": "live-mismatch",
                     "detail": f"manifest={t['cron']!r} live={live_rule['expression']!r}",
                 })
-            if live_rule["state"] != "ENABLED":
+            # A trigger listed in infrastructure/automation_pause.json is off by
+            # ruling (Brian 2026-08-07), so DISABLED is not drift for it. Same
+            # exemption as check-schedule-drift.py, and for the same reason: the
+            # invariant is not dropped, automation_pause.py --check asserts the
+            # opposite direction. Cron mismatch above is still checked, so a
+            # paused entry's manifest cron cannot rot while nobody is looking.
+            if live_rule["state"] != "ENABLED" and name not in paused:
                 findings.append({
                     "rule": name, "kind": "live-mismatch",
                     "detail": f"live state is {live_rule['state']}, expected ENABLED",

--- a/infrastructure/scheduler/check-schedule-drift.py
+++ b/infrastructure/scheduler/check-schedule-drift.py
@@ -30,7 +30,10 @@ Drift cases (all exit non-zero):
   * ``expression-drift``  — live ``ScheduleExpression`` differs from source.
   * ``disabled``          — rule exists but ``State != ENABLED``. A disabled
                             schedule is indistinguishable from a working one in
-                            every surface except this check.
+                            every surface except this check. EXEMPT: a rule
+                            listed in ``infrastructure/automation_pause.json``
+                            is off by ruling, and the opposite assertion (found
+                            ENABLED) is made by ``automation_pause.py --check``.
   * ``orphaned``          — a live rule under a declared ``SCHED_PREFIX`` that
                             source no longer declares. The prune loop in
                             deploy.sh should have removed it; if one survives,
@@ -63,6 +66,9 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = SCRIPT_DIR.parent.parent
 LAMBDAS_DIR = REPO_ROOT / "infrastructure" / "lambdas"
+
+sys.path.insert(0, str(REPO_ROOT / "infrastructure"))
+import automation_pause  # noqa: E402  (path must be set first)
 
 # Bash array literals: NAME=(\n  "a"\n  "b"\n). The leading \s* is load-bearing,
 # not defensive: SWEEP_SCHED_NAMES is declared INSIDE an `if` block and so is
@@ -229,6 +235,14 @@ def check(
 
     codified_names = {r["name"] for r in rules}
 
+    # A schedule listed in infrastructure/automation_pause.json is DISABLED on
+    # purpose (Brian ruling 2026-08-07), so `disabled` is not drift for it. The
+    # invariant is not dropped, it MOVES: automation_pause.py --check asserts
+    # the opposite direction — a paused schedule found ENABLED is a finding
+    # there. Expression drift is still checked for paused schedules, so the
+    # codified cron stays true and un-pausing is a state flip, not a rewrite.
+    paused = automation_pause.paused_names()
+
     for rule in rules:
         live = _live_schedule(rule["name"])
         if live is None:
@@ -244,7 +258,7 @@ def check(
                 "source_file": rule["source_file"],
                 "detail": f"source={rule['expression']} live={live['expression']}",
             })
-        if live["state"] != "ENABLED":
+        if live["state"] != "ENABLED" and rule["name"] not in paused:
             findings.append({
                 "rule": rule["name"], "kind": "disabled",
                 "source_file": rule["source_file"],

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""The scheduled-automation pause must stay a record, not a comment.
+
+Brian ruling 2026-08-07: every scheduled AWS trigger disabled except the weekly
+SF (Saturday), the daily preopen and postclose SFs (Mon-Fri), the 24/7 dashboard
+box, and the two cost-safety backstops protecting them.
+``infrastructure/automation_pause.json`` is that ruling; ``automation_pause.py``
+verifies it against live AWS.
+
+The failure this file guards is the one a console-only disable already has: the
+pause exists nowhere anyone can find, and nothing notices when it lifts. These
+tests assert the properties that make it findable and self-checking:
+
+  1. The manifest parses, and every paused entry carries a reason. An entry with
+     an empty reason is a name nobody can evaluate for un-pausing.
+  2. Nothing is both kept and paused, and the kept set still names the three
+     pipelines the ruling preserved. A pause that quietly swallowed the weekly
+     SF trigger would read identically to a correct one in every other surface.
+  3. The four CloudFormation-owned rules that the manifest lists are ALSO pinned
+     ``State: DISABLED`` in the template. deploy-infrastructure.yml re-applies
+     the stack on every push to main, so a manifest entry alone would be undone
+     by the next merge — the exact silent-revert class this file exists for.
+  4. The check runs in CI, and it asserts the pause direction (paused ⇒
+     DISABLED), which is the opposite of what check-schedule-drift.py asserts
+     for everything else.
+  5. check-schedule-drift.py exempts paused schedules from its ``disabled``
+     finding by CONSULTING the manifest, not by a hardcoded list that would rot.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA = REPO_ROOT / "infrastructure"
+MANIFEST_PATH = INFRA / "automation_pause.json"
+MODULE_PATH = INFRA / "automation_pause.py"
+CFN = INFRA / "cloudformation" / "alpha-engine-orchestration.yaml"
+DRIFT_CHECKER = INFRA / "scheduler" / "check-schedule-drift.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sf-arn-drift-check.yml"
+
+KEPT_TRIGGERS = {
+    "alpha-engine-saturday",           # weekly SF
+    "alpha-engine-weekday",            # preopen SF
+    "alpha-engine-eod-backstop-daily",  # postclose SF backstop
+}
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("automation_pause", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["automation_pause"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def module():
+    return _load_module()
+
+
+def test_manifest_parses_and_every_entry_has_a_reason(manifest):
+    for surface in ("events_rules", "scheduler_schedules"):
+        entries = manifest["paused"][surface]
+        assert entries, f"{surface} is empty — the manifest claims a pause it does not record"
+        for name, reason in entries.items():
+            assert reason.strip(), f"{surface}:{name} has no reason; nobody can evaluate un-pausing it"
+
+
+def test_ruling_is_attributed_and_dated(manifest):
+    ruling = manifest["ruling"]
+    for field in ("by", "date", "statement"):
+        assert ruling.get(field, "").strip(), f"ruling.{field} is missing"
+
+
+def test_kept_triggers_are_never_paused(manifest, module):
+    paused = module.paused_names(manifest)
+    overlap = KEPT_TRIGGERS & paused
+    assert not overlap, f"the ruling keeps these but the manifest pauses them: {sorted(overlap)}"
+
+
+def test_kept_set_is_documented(manifest):
+    not_paused = manifest["not_paused"]
+    for trigger in KEPT_TRIGGERS:
+        assert trigger in not_paused, (
+            f"{trigger} is kept by the ruling but not explained in not_paused — "
+            "a keep with no stated reason is indistinguishable from an oversight"
+        )
+
+
+def test_paused_names_are_unique_across_surfaces(manifest, module):
+    events = set(manifest["paused"]["events_rules"])
+    scheduler = set(manifest["paused"]["scheduler_schedules"])
+    assert not (events & scheduler), (
+        f"same name on both surfaces: {sorted(events & scheduler)} — "
+        "EventBridge rules and Scheduler schedules are different APIs, not aliases"
+    )
+    assert len(module.paused_entries(manifest)) == len(events) + len(scheduler)
+
+
+def test_cfn_owned_paused_rules_are_disabled_in_the_template(manifest):
+    """A manifest entry alone does not survive the next push to main."""
+    cfn_src = CFN.read_text(encoding="utf-8")
+    cfn_owned = [
+        name
+        for name, reason in manifest["paused"]["events_rules"].items()
+        if "CloudFormation-managed" in reason
+    ]
+    assert cfn_owned, "expected the manifest to flag its CloudFormation-owned rules"
+
+    for name in cfn_owned:
+        m = re.search(rf"^\s*Name: {re.escape(name)}\s*$", cfn_src, re.MULTILINE)
+        assert m, f"{name} is flagged CloudFormation-managed but is not in the template"
+        block = cfn_src[m.end() : m.end() + 1200]
+        state = re.search(r"^\s*State: (\w+)\s*$", block, re.MULTILINE)
+        assert state, f"{name}: no State property found in its resource block"
+        assert state.group(1) == "DISABLED", (
+            f"{name} is paused in the manifest but State: {state.group(1)} in the "
+            "template — deploy-infrastructure.yml would re-enable it on the next merge"
+        )
+
+
+def test_every_cfn_rule_flagged_in_the_manifest_is_actually_cfn_owned(manifest):
+    """The inverse: a rule pinned DISABLED in the template must be in the manifest."""
+    cfn_src = CFN.read_text(encoding="utf-8")
+    paused_events = set(manifest["paused"]["events_rules"])
+    for m in re.finditer(
+        r"^\s*Name: ([\w-]+)\s*$.*?^\s*State: (\w+)\s*$",
+        cfn_src,
+        re.MULTILINE | re.DOTALL,
+    ):
+        name, state = m.group(1), m.group(2)
+        if state == "DISABLED":
+            assert name in paused_events, (
+                f"{name} is DISABLED in the template but absent from "
+                "automation_pause.json — an undocumented disable is the thing "
+                "this manifest exists to prevent"
+            )
+
+
+def test_ci_runs_the_pause_check(module):
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    assert "infrastructure/automation_pause.py --check" in wf, (
+        "the pause check is not invoked by sf-arn-drift-check.yml — a checker "
+        "nothing runs is the failure mode this repo already booked twice"
+    )
+    # It must not be gated on the PR-only branch: the invariant is about live
+    # AWS, which no file-path filter can observe.
+    step = wf.split("automation_pause.py --check")[0]
+    tail = step.rsplit("- name:", 1)[-1]
+    assert "if:" not in tail, "the pause check is conditionally skipped"
+
+
+def test_drift_checker_consults_the_manifest_not_a_hardcoded_list():
+    src = DRIFT_CHECKER.read_text(encoding="utf-8")
+    assert "automation_pause.paused_names()" in src, (
+        "check-schedule-drift.py must read the manifest; a second hardcoded "
+        "list of paused names would drift from the first one"
+    )
+    # The exemption must apply ONLY to the disabled finding — expression drift
+    # still has to be reported for paused schedules, or the codified cron rots
+    # while nobody is looking and un-pausing becomes a rewrite.
+    assert re.search(
+        r'if live\["state"\] != "ENABLED" and rule\["name"\] not in paused:', src
+    ), "the pause exemption is not scoped to the `disabled` finding"
+
+
+def test_module_exposes_both_directions(module):
+    assert hasattr(module, "check"), "no --check implementation"
+    assert hasattr(module, "enforce"), "no --enforce implementation"
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "unexpectedly-enabled" in src, (
+        "the check must flag a paused trigger found ENABLED — without it the "
+        "manifest records a pause that nothing verifies"
+    )
+    assert "missing-in-aws" in src, (
+        "the check must flag a manifest entry with no live trigger, or the "
+        "manifest rots into a list of names that cannot fail"
+    )
+
+
+def test_scheduler_disable_round_trips_the_full_spec():
+    """update-schedule is a full replace: a partial write silently drops targets."""
+    src = MODULE_PATH.read_text(encoding="utf-8")
+    assert "--cli-input-json" in src, (
+        "scheduler disable must round-trip the live spec; passing only --state "
+        "to update-schedule wipes Target, FlexibleTimeWindow and the timezone"
+    )
+    for derived in ("Arn", "CreationDate", "LastModificationDate"):
+        assert derived in src, f"{derived} is not stripped before update-schedule"

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -176,6 +176,45 @@ def test_drift_checker_consults_the_manifest_not_a_hardcoded_list():
     ), "the pause exemption is not scoped to the `disabled` finding"
 
 
+def test_manifest_drift_checker_also_exempts_paused_triggers():
+    """The second live-state assertion. Missing it reddens the daily sweep.
+
+    check-manifest-drift.py --live independently asserts ENABLED for all eight
+    groom/sweep dispatch triggers in schedule-manifest.json — every one of which
+    is paused. Exempting only check-schedule-drift.py would have left the daily
+    sweep red for a state that is correct, which is the same noise this PR
+    exists to prevent.
+    """
+    src = (INFRA / "scheduler" / "check-manifest-drift.py").read_text(encoding="utf-8")
+    assert "automation_pause.paused_names()" in src, (
+        "check-manifest-drift.py --live still asserts ENABLED for paused triggers"
+    )
+    assert 'live_rule["state"] != "ENABLED" and name not in paused' in src, (
+        "the exemption is not scoped to the state half of live-mismatch — cron "
+        "drift must still be reported for a paused entry"
+    )
+
+
+def test_every_groom_dispatch_trigger_is_accounted_for(manifest):
+    """schedule-manifest.json and automation_pause.json must not disagree.
+
+    Both name groom/sweep triggers. If one says a trigger dispatches and the
+    other says it is off, the pair is worse than either alone — so assert the
+    overlap is total rather than partial: every trigger in the groom manifest is
+    paused, or none is.
+    """
+    groom = json.loads(
+        (INFRA / "scheduler" / "schedule-manifest.json").read_text(encoding="utf-8")
+    )
+    names = {t["name"] for t in groom["triggers"]}
+    paused = set(manifest["paused"]["scheduler_schedules"])
+    overlap = names & paused
+    assert overlap == names, (
+        "partially-paused groom dispatch set — these fire while their siblings "
+        f"are off: {sorted(names - paused)}. Either pause all of them or none."
+    )
+
+
 def test_module_exposes_both_directions(module):
     assert hasattr(module, "check"), "no --check implementation"
     assert hasattr(module, "enforce"), "no --enforce implementation"


### PR DESCRIPTION
## What

Brian ruled on 2026-08-07: shut down all automatic AWS processes except the **weekly SF (Saturday morning)**, the **daily preopen and postclose SFs (Mon-Fri)**, and the **24/7 box**. Everything else loses its schedule — manual only.

**The live change is already applied** (in-session, 2026-08-07): 40 triggers disabled in `us-east-1` — 19 EventBridge rules, 21 Scheduler schedules. This PR is the source-of-truth half, so the pause does not silently revert.

## Why source changes are required and not optional

Two mechanisms in this repo re-assert `ENABLED`:

| Mechanism | What it would have undone | Fix here |
|---|---|---|
| `deploy-infrastructure.yml` re-applies the CFN stack on **every push to main** | the next *template edit* to `alpha-research-alerts`, `alpha-engine-daily-heal`, `alpha-engine-predictor-health-check`, `alpha-engine-predictor-drift-check` would rewrite them from a template still saying `ENABLED` | `State: DISABLED` pinned in `alpha-engine-orchestration.yaml` |
| `check-schedule-drift.py` treats `State != ENABLED` as drift | the daily `sf-arn-drift-check` sweep goes red tomorrow with 21 findings for a state that is **correct** | paused schedules exempt from the `disabled` finding only |

**Corrected mid-session — measured, not assumed.** An earlier draft of this body claimed those four rules would be back `ENABLED` on the very next merge. They would not: `Deploy Infrastructure` run 31196841584 succeeded at 16:17:22Z, 49 seconds after the rules were disabled at 16:16:33Z, and all four are still `DISABLED`. An unchanged template yields an empty changeset and CloudFormation touches nothing. The template edit stands on a different footing — source should not assert an intent the operator has decided against, and the next edit to those resources *would* rewrite them.

## The invariant moves, it is not dropped

`check-schedule-drift.py` stops asserting `ENABLED` for paused schedules. `automation_pause.py --check` asserts the **opposite** direction and runs unconditionally in the daily sweep:

- `unexpectedly-enabled` — a paused trigger came back (a redeploy, a console edit). Finding text names the exact `--enforce` command.
- `missing-in-aws` — a manifest entry with no live trigger, so the manifest cannot rot into a list of names that can never fail.

Expression drift is **still** reported for paused schedules, so the codified cron stays true and un-pausing is a state flip rather than a rewrite.

## Files

- `infrastructure/automation_pause.json` — the ruling, the kept set with a stated reason per entry, and all 40 paused triggers with a reason each.
- `infrastructure/automation_pause.py` — `--check` (read-only, CI) / `--enforce` (one-command re-apply). Scheduler disable round-trips the full live spec: `update-schedule` is a full replace, so a partial write drops `Target`, `FlexibleTimeWindow` and the timezone.
- `infrastructure/cloudformation/alpha-engine-orchestration.yaml` — `State: DISABLED` ×4.
- `infrastructure/scheduler/check-schedule-drift.py` — consults the manifest (not a second hardcoded list).
- `.github/workflows/sf-arn-drift-check.yml` — new unconditional check step + path filters.
- `tests/test_automation_pause.py` — 11 tests.

## Verification

- `pytest tests/test_automation_pause.py tests/test_scheduler_reconcile_is_ci_runnable.py tests/test_eventbridge_check_drift.py tests/test_sf_predictor_drift_check_wiring.py` → **50 passed** locally.
- `automation_pause.py --check` against live AWS → `40 paused trigger(s) checked / every paused trigger exists live and is DISABLED`.
- `check-schedule-drift.py` against live AWS → **zero** `disabled` findings. It still reports 3 **pre-existing** `missing-in-aws` findings (`alpha-engine-expense-collector-reconcile-monthly`, `alpha-engine-sf-watch-reclaim-sweep-{0645,1445}-daily`) that predate this PR and are the subject of #1207.
- CFN template re-parsed after the edit; the three kept triggers are still `ENABLED`.

## SOTA and delta

**SOTA:** operational state is declared in source, one manifest owns the decision, and a detector asserts it in both directions.

**Delta:** the ~28 `aws events put-rule` / `aws scheduler create-schedule|update-schedule` call sites in `infrastructure/lambdas/*/deploy.sh` are **not** pause-aware. Redeploying one of those Lambdas re-enables its schedule; the daily check then goes red naming the fix. Detection, not prevention. Deliberate: threading `--state` through 28 bash call sites carries more regression risk to the deploy path than the failure it prevents, for a pause Brian framed as temporary. Tracked as alpha-engine-config-I6619 — do it if the pause outlasts the next deploy wave.

**Also deliberate:** CI detects but does not auto-remediate. `--enforce` needs `events:DisableRule` + `scheduler:UpdateSchedule`; the drift role is read-only and widening it to let CI mutate live triggers is a worse trade than a red check.

## Out of scope, filed

- `alpha-engine-config-runner-reconcile` fired `rate(1 minute)` at `alpha-engine-config-runner-dispatcher`, **a Lambda that does not exist** — ~1,440 failed invocations/day, silently. Now paused; root cause filed as alpha-engine-config-I6618.
- `alpha-engine-router-exposure-probe-15min` is codified in `nous-ergon-ops`, not here. Paused live and recorded in the manifest (which checks live AWS, not source ownership); its deploy.sh is covered by I6619.

## Post-merge

None. The CFN state applies automatically on merge via `deploy-infrastructure.yml`; the live pause was applied in-session before this PR opened.

Closes nousergon/alpha-engine-config#6617

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)


Tracker: alpha-engine-config-I6617 · follow-ups alpha-engine-config-I6618, alpha-engine-config-I6619

