### PR TITLE
[P1/mid] fix(security): unblock secret scanning — 8 consecutive main failures were one test-fixture false positive

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,11 +3,32 @@ name: Gitleaks scan
 # Thin caller — all scan behavior lives in the reusable workflow. Edit it
 # there, not here: nousergon/nousergon-lib/.github/workflows/gitleaks-scan.yml
 #
-# GATED on nousergon-lib PR#228 merging first (config-I3005) — until then,
-# `uses:` below resolves against nousergon-lib@main which doesn't have the
-# file yet, so this check will fail/error. That is EXPECTED and BY DESIGN
-# (gate:dependency). Once PR#228 merges, re-run this workflow (Actions tab
-# -> re-run failed jobs, or push a new commit) to pick it up and go green.
+# A RED RUN HERE IS NEVER EXPECTED. Read it.
+#
+# This block used to say the opposite. It carried a dependency-gate note
+# claiming a red run was normal until nousergon-lib PR#228 landed. The note
+# outlived the gate: PR#228 merged, `uses:` below was pinned to a real SHA,
+# and the note stayed. Between 2026-08-04 and 2026-08-07 the job
+# then failed on eight consecutive pushes to main, across six merges, for an
+# entirely different and real reason (alpha-engine-config-I6622), and nobody
+# looked. A stale "expected to be red" note attached to a security gate is
+# indistinguishable from the gate working, and it is the likeliest reason
+# three days of unscanned merges went unnoticed.
+#
+# If this job is red: the scan found something. The detect step's exit status
+# IS the findings signal. Download the `gitleaks-sarif` run artifact and read
+# it before assuming tooling.
+#
+# To accept a triaged false positive, APPEND its single record to
+# `.gitleaks-baseline.json` — never regenerate that file. Regeneration accepts
+# every finding present at that moment by fingerprint, so one housekeeping
+# commit can grandfather in a real secret nobody read. A one-record append is
+# reviewable in the diff; a regeneration is not.
+#
+# A repo-local `.gitleaks.toml` is NOT the mechanism here and will not work:
+# `.gitignore` excludes it (it is a local symlink for the pre-commit hook), so
+# it never reaches the CI checkout. `tests/test_gitleaks_config.py` pins that,
+# because the file looks like exactly the right place to put an allowlist.
 
 on:
   push:

--- a/.gitleaks-baseline.json
+++ b/.gitleaks-baseline.json
@@ -82,5 +82,26 @@
   "Message": "fix(daily_closes): scrub FRED api_key from error logs + retry FRED 5xx (#220)\n\nrequests.exceptions.HTTPError.str() embeds the full request URL —\nincluding ``api_key=\u003ccredential\u003e`` — in its message. The existing\n``_fetch_fred_closes`` except-block logged that raw via\n``logger.warning(\"FRED fetch failed for %s (%s): %s\", t, sid, e)`` so\nany FRED 5xx in production MorningEnrich / EOD dumped the credential\nto CloudWatch.\n\nSurfaced 2026-05-12 during the post-merge repair run for PR #219 — a\ntransient FRED 500 on VXVCLS during the operator step leaked the key\nto the conversation transcript. The FRED key is rotated separately;\nthis commit closes the leak class.\n\nChanges:\n- ``_scrub_api_key(msg) -\u003e str`` helper in ``collectors/daily_closes.py``\n  masks the ``api_key=...`` querystring fragment with ``api_key=***``\n- ``_fetch_fred_closes`` warn-log routes the exception through the\n  scrubber\n- Repair script's ``_fetch_fred_range`` already added retry+scrub in\n  the cherry-pick from the live-debug session; this commit consolidates\n  by importing the shared ``_scrub_api_key`` from ``daily_closes`` so\n  the regex doesn't drift across files\n\nTests (+7, suite 792 → 799):\n- ``_scrub_api_key`` masks URL-embedded keys, handles exception objects\n  directly, passthroughs when no key present, terminates at ``\u0026``\n- ``_fetch_fred_closes`` warn-log scrub regression\n- ``_fetch_fred_range`` retry-warn + final-error scrub regressions\n\nCo-authored-by: Claude Opus 4.7 (1M context) \u003cnoreply@anthropic.com\u003e",
   "Tags": [],
   "Fingerprint": "366c23265b90e06a43db4d74a8c79a0f09d8658c:tests/test_fred_api_key_scrub.py:generic-api-key:99"
+ },
+ {
+  "RuleID": "generic-api-key",
+  "Description": "Detected a Generic API Key, potentially exposing access to various services and sensitive operations.",
+  "StartLine": 3392,
+  "EndLine": 3392,
+  "StartColumn": 2,
+  "EndColumn": 50,
+  "Match": "_HEX32_TOKEN = \"REDACTED\"",
+  "Secret": "REDACTED",
+  "File": "infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py",
+  "SymlinkFile": "",
+  "Commit": "7f5b49880ac3de419b271a236a097e88e404e2c5",
+  "Link": "https://github.com/nousergon/nousergon-data/blob/7f5b49880ac3de419b271a236a097e88e404e2c5/infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py#L3392",
+  "Entropy": 3.9528196,
+  "Author": "Brian McMahon",
+  "Email": "brian@nousergon.ai",
+  "Date": "2026-08-03T18:14:38Z",
+  "Message": "fix(groom-dispatcher): truncate run_token in alert bodies \u2014 it wedges the alert-drain (#1216)\n\nA bare `run_token=<32 lowercase hex>` in a lane-death / lane-reclaimed\nnotification body matches gitleaks' stock `generic-api-key` rule: the keyword\n`token` adjacent to a high-entropy 32-char value is exactly that rule's shape.\nIt is not a credential \u2014 it is a correlation id this Lambda mints per lane.\n\nWhere it hurts is downstream. `_notify_cycle` publishes onto the Overseer intake\nbus; alert-drain reads the queue into its LLM request; the DLP egress proxy\ngitleaks-scans that outbound body and returns HTTP 400. The drain agent exits\nrc=1, and because nothing is deleted from the queue without a ledger record\n(overseer-policy.md invariant 8) the same message is re-read by the next run.\n\nOne lane-death alert therefore wedges the entire response plane indefinitely \u2014\nand the SQS retry ladder (`maxReceiveCount: 5`) drags the queue's *other*\nmessages into the DLQ five receives at a time while it does.\n\nMeasured 2026-08-03, reproduced locally against the fleet's own\n`gitleaks-egress.toml` at gitleaks 8.30.1:\n\n  - 12 of 79 sampled intake messages matched `generic-api-key`\n  - every one of them from `flow-doctor:scheduled-groom-dispatcher`\n  - every one of them on the `run_token=` field, in `detail.body`\n  - four consecutive drain runs dead (alpha-engine-config-I6191, occurrence 4)\n  - truncating the body token clears the match; scanning the post-fix message\n    yields zero findings\n\n12 hex chars stays long enough to correlate a body against the dispatch ledger\nby eye. The FULL token is unchanged everywhere it is machine-read \u2014 `dedup_key`,\nthe `context` payload, and every log line \u2014 so truncation is a rendering change\nand nothing programmatic is affected.\n\nGuard observed failing (overseer-policy.md invariant 13): restoring the full\ntoken to the body turns `test_lane_death_body_truncates_the_run_token` red.\n\nDoes NOT clear the messages already queued \u2014 those are immutable. See\nalpha-engine-config-I6294 for the structural half.",
+  "Tags": [],
+  "Fingerprint": "7f5b49880ac3de419b271a236a097e88e404e2c5:infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py:generic-api-key:3392"
  }
 ]

--- a/tests/test_gitleaks_config.py
+++ b/tests/test_gitleaks_config.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""The gitleaks baseline must narrow the scanner, never blind it.
+
+alpha-engine-config-I6622. Secret scanning on this repo failed on every push to
+main from 2026-08-04 to 2026-08-07 — eight consecutive runs, six merges, no
+alert — on a single false positive: the `_HEX32_TOKEN` fixture in
+`infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py`, which is a
+run_token correlation id, not a credential. The finding is nonetheless real in
+gitleaks' terms and permanent: the scan walks full history at `fetch-depth: 0`,
+so the value cannot be edited out of commit 7f5b4988.
+
+A secret-scanner allowlist is the most dangerous file in the repo, because every
+way it can be wrong makes the scan look GREENER and nothing downstream reports
+the damage. These tests pin the properties that keep it honest.
+
+Two design traps were found by experiment while fixing I6622, both of which read
+as obviously correct:
+
+  * A repo-local `.gitleaks.toml` is the natural place for an allowlist, and it
+    silently does nothing: `.gitignore` excludes it (it is a local symlink for
+    the pre-commit hook), so it never reaches the CI checkout. Verified by
+    committing one and watching it not stage.
+  * Inside such a config, a `paths` allowlist excludes the whole file from
+    scanning BEFORE any regex runs, and `matchCondition = "AND"` does not
+    restrain it — measured against gitleaks 8.30.1, the pinned version. A path
+    scope there would have blinded the scanner to every future secret in a
+    3,900-line test file while appearing to forgive one line.
+
+Both are why the accepted finding lives in `.gitleaks-baseline.json` as a single
+appended record instead.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE = REPO_ROOT / ".gitleaks-baseline.json"
+CALLER = REPO_ROOT / ".github" / "workflows" / "gitleaks.yml"
+
+
+@pytest.fixture(scope="module")
+def baseline() -> list[dict]:
+    return json.loads(BASELINE.read_text(encoding="utf-8"))
+
+
+def test_baseline_parses_and_is_non_empty(baseline):
+    assert isinstance(baseline, list) and baseline
+
+
+def test_no_baseline_entry_carries_an_unredacted_secret(baseline):
+    """The baseline is committed. A real value in it is a leak by definition."""
+    for entry in baseline:
+        assert entry.get("Secret") == "REDACTED", (
+            f"{entry.get('File')}:{entry.get('StartLine')} has Secret="
+            f"{entry.get('Secret')!r}. The baseline must be generated with "
+            "--redact; committing the value turns the accept-list into the leak."
+        )
+        assert "REDACTED" in entry.get("Match", ""), (
+            f"{entry.get('File')}:{entry.get('StartLine')} has an unredacted Match"
+        )
+
+
+def test_every_baseline_entry_is_traceable(baseline):
+    """An accepted finding nobody can trace back is an unexplained hole."""
+    for entry in baseline:
+        for field in ("RuleID", "File", "Commit", "Fingerprint"):
+            assert entry.get(field), f"baseline entry missing {field}: {entry!r}"
+
+
+def test_baseline_fingerprints_are_unique(baseline):
+    fps = [e["Fingerprint"] for e in baseline]
+    dupes = {f for f in fps if fps.count(f) > 1}
+    assert not dupes, (
+        f"duplicate fingerprints {sorted(dupes)} — a sign the baseline was "
+        "regenerated and merged rather than appended to"
+    )
+
+
+def test_gitleaks_toml_stays_gitignored():
+    """The trap: it looks like the right place for an allowlist and never ships.
+
+    If this ever becomes tracked, the allowlist mechanism has changed and the
+    guidance in the caller workflow and in this file is wrong. Fail loudly
+    rather than let a config that CI cannot see look authoritative.
+    """
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", ".gitleaks.toml"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (
+        ".gitleaks.toml is no longer gitignored. Either it is now genuinely "
+        "shipped to CI — in which case update the caller workflow's guidance "
+        "and this test — or an allowlist has been put somewhere the CI "
+        "checkout will never see it."
+    )
+
+
+def test_caller_workflow_does_not_claim_red_is_expected():
+    """The stale gate note that made eight consecutive failures invisible."""
+    lowered = CALLER.read_text(encoding="utf-8").lower()
+    for phrase in ("expected and by design", "gate:dependency"):
+        assert phrase not in lowered, (
+            f"the caller workflow says {phrase!r}. A security gate documented "
+            "as expected-to-be-red is indistinguishable from one that works; "
+            "that note is why I6622 went unread for three days."
+        )
+
+
+def test_caller_workflow_says_where_findings_land(baseline):
+    src = CALLER.read_text(encoding="utf-8")
+    assert "gitleaks-sarif" in src, (
+        "the caller must tell a reader where the findings detail is, or a red "
+        "run has no next step"
+    )
+    assert "never regenerate" in src.lower(), (
+        "the caller must warn against regenerating the baseline — the one "
+        "action that clears a red run while hiding whatever else it accepts"
+    )


### PR DESCRIPTION
## What & why

**Secret scanning on this repo has been effectively off for three days.** `Gitleaks scan` concluded `failure` on every push to `main` from 2026-08-04 21:26 UTC to 2026-08-07 16:55 UTC — **eight consecutive runs, six merges, no alert.** Found while verifying the post-merge state of #1238; filed as alpha-engine-config-I6622.

I classified it by reading the run's SARIF artifact, not by re-running the job. There is exactly **one** finding and it is **not a credential**:

| | |
|---|---|
| rule | `generic-api-key` |
| location | `infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py:3392` |
| commit | `7f5b4988` (2026-08-03, #1216) |
| content | `_HEX32_TOKEN = "<32 lowercase hex>"` |

That is the test fixture proving #1216's `run_token` truncation. `run_token` is a correlation id the dispatcher mints per lane — the keyword `token` next to a high-entropy 32-char value is exactly `generic-api-key`'s shape. **No exposure, nothing to rotate.**

The same value class already wedged the DLP egress proxy (alpha-engine-config-I6191 — four consecutive dead drain runs). This is the **second independent gitleaks surface** it has broken; they read different configs, so convergence is tracked separately as alpha-engine-config-I6624.

## Why an append, not a regeneration

The scan walks full history at `fetch-depth: 0`, so editing the fixture today cannot remove it from `7f5b4988`. Accepting it is the only durable fix short of rewriting history.

The reusable workflow documents "regenerate the baseline after triaging and accepting a real finding." **I deliberately did not do that.** Regeneration accepts, by fingerprint, every finding present at that moment — and this baseline dates from 2026-07-22. Clearing one understood false positive is not a reason to grandfather in three weeks of findings nobody has read. The diff here is **21 lines, all additions, one record**, and reviewable as such.

## Two traps worth recording

Both read as obviously correct and both are wrong. Both are now pinned by tests.

1. **A repo-local `.gitleaks.toml` silently does nothing.** It is the natural place for an allowlist. `.gitignore` excludes it — it is a local symlink for the pre-commit hook — so it never reaches the CI checkout. I wrote one, committed it, and watched it not stage.
2. **Inside such a config, a `paths` allowlist excludes the whole file from scanning before any regex is evaluated**, and `matchCondition = "AND"` does not restrain it. My first draft would have blinded the scanner to every future secret in a 3,900-line test file while appearing to forgive one line. Measured against gitleaks 8.30.1 — the version the workflow pins:

   | config | `_HEX32_TOKEN` line | unrelated `api_token` line in the same file |
   |---|---|---|
   | none | reported | reported |
   | `paths` + `regexes`, AND | **not reported** | **not reported** |

   (A third, milder one: allowlist `regexes` match the captured *secret*, not the line, unless `regexTarget = "line"` — so an assignment-anchored pattern is inert.)

## The stale note that made this invisible

The caller workflow carried a dependency-gate note saying a red run here was normal until `nousergon-lib` PR#228 landed. PR#228 merged, `uses:` was pinned to a real SHA, and **the note stayed.** A security gate documented as expected-to-be-red is indistinguishable from one that is working, and it is the likeliest reason eight failures went unread. Replaced with what to actually do when the job is red, and where findings live.

## Test plan

Run locally with gitleaks **8.30.1**, checksum-verified, the version the reusable workflow pins.

- `pytest tests/test_gitleaks_config.py` → **7 passed**
- `pytest tests/test_gitleaks_config.py tests/test_automation_pause.py` → **20 passed**
- `gitleaks detect --source . --baseline-path .gitleaks-baseline.json` on full history → **no leaks found** (before this change: `leaks found: 1`, same file/line/commit as CI)
- **Negative control** — an AWS-key shape planted in the very file the baseline forgives is **still reported**, so the accept is fingerprint-scoped, not file-scoped
- **Ruleset control** — the default ruleset is untouched; this change adds no config, only a baseline record

## Scope

Does not touch the reusable workflow in `nousergon-lib`. Whether the fleet's two gitleaks configs should converge is I6624, and whether a security gate failing repeatedly on a default branch should page is deliverable 3 of I6622 — neither belongs in a fix whose job is to get scanning working again.

Refs alpha-engine-config-I6622

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
