### PR TITLE
[P1/mid] fix(infra): derive every EventBridge --state from the pause manifest (I6619 + I6620)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -18,6 +18,13 @@
     "non-eventbridge": "DLM policy-0047cfbfb7070a3b7 (nightly dashboard-box snapshot, 14d) and the two SSM associations (ae-patch-scan-only, ae-software-inventory, rate(1 day)) are kept: they are read-only or protective hygiene for the 24/7 box, not autonomous processes."
   },
 
+  "pending": {
+    "_why": "Triggers that do not exist live yet but MUST be created DISABLED when they first appear. Brian's ruling covers 'everything else', which includes automation that lands after 2026-08-07 — but automation_pause.py --check requires every `paused` entry to exist live, so a not-yet-created name cannot go there without turning the check red. pause_state() reads BOTH blocks; --check requires existence only for `paused`. Move an entry up to `paused` once it exists live. Found by alpha-engine-config-I6620: nousergon-data#1207 declares three schedules that its (currently broken) deploy would have created ENABLED mid-pause.",
+    "alpha-engine-expense-collector-reconcile-monthly": "nousergon-data#1207; codified in expense-collector/deploy.sh, never created live",
+    "alpha-engine-sf-watch-reclaim-sweep-0645-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live",
+    "alpha-engine-sf-watch-reclaim-sweep-1445-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live"
+  },
+
   "paused": {
     "events_rules": {
       "alpha-engine-canary-replay-liveness-probe-tick": "overseer canary-replay liveness probe",

--- a/infrastructure/lambdas/_shared/pause.sh
+++ b/infrastructure/lambdas/_shared/pause.sh
@@ -1,0 +1,68 @@
+# shellcheck shell=bash
+#
+# pause.sh — resolve a trigger's intended state from the automation-pause manifest.
+#
+# Source this from any deploy.sh that creates or updates an EventBridge rule or
+# an EventBridge Scheduler schedule, and pass the result as --state:
+#
+#   source "${SCRIPT_DIR}/../_shared/pause.sh"
+#   aws events put-rule --name "${RULE}" --state "$(pause_state "${RULE}")" ...
+#
+# WHY (alpha-engine-config-I6619). Brian's 2026-08-07 ruling paused 40 scheduled
+# triggers; infrastructure/automation_pause.json records which. Neither
+# `aws events put-rule` nor `aws scheduler create-schedule|update-schedule`
+# accepts a "leave the state alone" option — both DEFAULT TO ENABLED when
+# --state is omitted, and update-schedule is a full replace. So every deploy.sh
+# that reconciles its own triggers silently un-paused them on the next redeploy.
+# The pause survived only by detection: automation_pause.py --check goes red the
+# next morning. This closes it at the write site instead.
+#
+# Fail-OPEN on purpose. If the manifest is missing or unreadable this returns
+# ENABLED — the pre-pause behaviour — rather than disabling a trigger nobody
+# asked to disable. The asymmetry is deliberate: a pause that silently SPREADS
+# would stop the weekly SF with no signal that a config file was the cause,
+# while a pause that silently LIFTS is caught by automation_pause.py --check the
+# next morning. One failure mode has a detector; the other does not.
+
+# Absolute path to the manifest, resolved from THIS file's location so a
+# deploy.sh may be invoked from any cwd (they are, by CI and by operators).
+_PAUSE_MANIFEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/automation_pause.json"
+
+# pause_state <trigger-name> -> "DISABLED" if the manifest pauses it, else "ENABLED".
+#
+# Matches on the trigger NAME across both surfaces. EventBridge rules and
+# Scheduler schedules are different APIs but share one namespace here, and
+# tests/test_automation_pause.py asserts no name appears on both, so a single
+# lookup is unambiguous.
+pause_state() {
+  local name="${1:?pause_state: trigger name required}"
+
+  if [ ! -r "${_PAUSE_MANIFEST}" ]; then
+    echo "ENABLED"
+    return 0
+  fi
+
+  # python3 rather than jq: every deploy.sh in this repo already depends on
+  # python3, none depends on jq, and adding a dependency to 26 scripts to read
+  # one JSON file is not worth it.
+  python3 - "${_PAUSE_MANIFEST}" "${name}" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    paused = manifest["paused"]
+    names = set(paused["events_rules"]) | set(paused["scheduler_schedules"])
+    # `pending` = paused, but not created live yet. Same write-time behaviour;
+    # it exists as a separate block only because automation_pause.py --check
+    # requires every `paused` entry to exist live. Keys prefixed `_` are notes.
+    names |= {k for k in manifest.get("pending", {}) if not k.startswith("_")}
+except Exception:
+    # Unreadable or malformed manifest -> pre-pause behaviour. See the
+    # fail-open note at the top of this file.
+    print("ENABLED")
+else:
+    print("DISABLED" if sys.argv[2] in names else "ENABLED")
+PY
+}

--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -38,6 +38,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-alert-drain-liveness-probe"
 ROLE_NAME="alpha-engine-alert-drain-liveness-probe-role"
@@ -144,7 +149,7 @@ if $BOOTSTRAP; then
     rule="${RECLAIM_RULE_NAMES[$i]}"
     echo "  Creating/updating EventBridge rule: ${rule}"
     run aws events put-rule \
-      --name "${rule}" \
+      --name "${rule}" --state "$(pause_state "${rule}")" \
       --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
       --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
       --region "${REGION}" \

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -36,6 +36,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-canary-replay-dispatcher"
@@ -177,8 +182,8 @@ if $BOOTSTRAP; then
   run aws events put-rule \
     --name "${RULE_NAME}" \
     --schedule-expression 'cron(0 9 ? * THU *)' \
-    --state DISABLED \
-    --description "Saturday-replay canary (config#2246) weekly trigger, 09:00 UTC Thursday. DISABLED until canary-replay-liveness-probe is deployed and verified live." \
+    --state "$(pause_state "${RULE_NAME}")" \
+    --description "Saturday-replay canary (config#2246) weekly trigger, 09:00 UTC Thursday. State is derived from infrastructure/automation_pause.json, not pinned here (I6619)." \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -26,6 +26,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-canary-replay-liveness-probe"
@@ -160,7 +165,7 @@ if $BOOTSTRAP; then
   run aws events put-rule \
     --name "${RULE_NAME}" \
     --schedule-expression 'rate(15 minutes)' \
-    --state ENABLED \
+    --state "$(pause_state "${RULE_NAME}")" \
     --description "Saturday-replay canary liveness probe tick (config#2246) - self-gates on its own check window + the dispatcher rule's live State." \
     --region "${REGION}" \
     --query 'RuleArn' --output text

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -44,6 +44,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-ci-watch-dispatcher"
@@ -208,13 +213,13 @@ if $BOOTSTRAP; then
   CANARY_TARGET="{\"Arn\":\"${OVERSEER_ROUTER_ARN}\",\"RoleArn\":\"${OVERSEER_SCHED_ROLE_ARN}\",\"Input\":\"{\\\"playbook\\\":\\\"ci-watch\\\",\\\"payload\\\":{\\\"is_drill\\\":\\\"true\\\"}}\",\"RetryPolicy\":{\"MaximumRetryAttempts\":0,\"MaximumEventAgeInSeconds\":60}}"
   if aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
     echo "  Updating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
-    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" \
+    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" --state "$(pause_state "${CANARY_SCHED_NAME}")" \
       --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
       --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
       --region "${REGION}" --query 'ScheduleArn' --output text
   else
     echo "  Creating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
-    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" \
+    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" --state "$(pause_state "${CANARY_SCHED_NAME}")" \
       --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
       --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
       --region "${REGION}" --query 'ScheduleArn' --output text

--- a/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
@@ -37,6 +37,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-ci-watch-liveness-probe"
 ROLE_NAME="alpha-engine-ci-watch-liveness-probe-role"
@@ -148,7 +153,7 @@ if $BOOTSTRAP; then
     rule="${RECLAIM_RULE_NAMES[$i]}"
     echo "  Creating/updating EventBridge rule: ${rule}"
     run aws events put-rule \
-      --name "${rule}" \
+      --name "${rule}" --state "$(pause_state "${rule}")" \
       --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
       --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
       --region "${REGION}" \

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -20,6 +20,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
@@ -159,12 +164,12 @@ if $BOOTSTRAP; then
   TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
   if aws scheduler get-schedule --name "${SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
     echo "  Updating Scheduler rule: ${SCHED_NAME} → ${SCHED_CRON}"
-    run aws scheduler update-schedule --name "${SCHED_NAME}" \
+    run aws scheduler update-schedule --name "${SCHED_NAME}" --state "$(pause_state "${SCHED_NAME}")" \
       --schedule-expression "${SCHED_CRON}" --flexible-time-window '{"Mode":"OFF"}' \
       --target "${TARGET}" --region "${REGION}" --query 'ScheduleArn' --output text
   else
     echo "  Creating Scheduler rule: ${SCHED_NAME} → ${SCHED_CRON}"
-    run aws scheduler create-schedule --name "${SCHED_NAME}" \
+    run aws scheduler create-schedule --name "${SCHED_NAME}" --state "$(pause_state "${SCHED_NAME}")" \
       --schedule-expression "${SCHED_CRON}" --flexible-time-window '{"Mode":"OFF"}' \
       --target "${TARGET}" --region "${REGION}" --query 'ScheduleArn' --output text
   fi

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -30,6 +30,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-eod-backstop"
@@ -162,8 +167,8 @@ if $BOOTSTRAP; then
   run aws events put-rule \
     --name "${RULE_NAME}" \
     --schedule-expression 'cron(30 22 ? * MON-FRI *)' \
-    --state DISABLED \
-    --description "EOD-pipeline backstop fire at 22:30 UTC MON-FRI (Lambda gates on trading-day + box-running + no-EOD-today). DISABLED until soak-reviewed." \
+    --state "$(pause_state "${RULE_NAME}")" \
+    --description "EOD-pipeline backstop fire at 22:30 UTC MON-FRI (Lambda gates on trading-day + box-running + no-EOD-today). State is derived from infrastructure/automation_pause.json, not pinned here (I6619); the soak this text referred to completed and the rule has been ENABLED since." \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -28,6 +28,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-eod-success-friday-shell-trigger"
@@ -168,7 +173,7 @@ if $BOOTSTRAP; then
 EOF
 )
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --event-pattern "${EVENT_PATTERN}" \
     --description "Trigger Saturday SF shell-run on Friday EOD SUCCEEDED (Lambda day-of-week-guards)" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/expense-collector/deploy.sh
+++ b/infrastructure/lambdas/expense-collector/deploy.sh
@@ -59,6 +59,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-expense-collector"
@@ -106,6 +111,19 @@ BOOTSTRAP_IAM=false
 RECONCILE_SCHEDULES=false
 APPLY_IAM=false
 SMOKE=false
+# alpha-engine-config-I6620. DRY_RUN was the ONE flag here with no default-init,
+# so `run()` below died 'DRY_RUN: unbound variable' under `set -u` on every
+# zero-flag invocation — which is every CI deploy. Observed 2026-08-07: the
+# Deploy expense-collector job failed AFTER packaging, so it looked like it had
+# got far enough to have worked, and the Lambda code was never updated.
+#
+# Same ambient-env idiom as every sibling deploy.sh, established by the I2752
+# incident (2026-07-16): DRY_RUN=1 from a caller's shell must actually no-op,
+# not silently run the real deploy path.
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
@@ -241,12 +259,12 @@ if $RECONCILE_SCHEDULES; then
       "${FN_ARN}" "${SCHED_ROLE_ARN}" "$(printf '%s' "${input_json}" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
     if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler update-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     else
       echo "  Creating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler create-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     fi

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -36,6 +36,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-freshness-monitor"
@@ -233,7 +238,7 @@ if $BOOTSTRAP; then
   # covered by the separate 30-min mini-rule below.
   echo "  Creating EventBridge cron: ${RULE_NAME}"
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --schedule-expression "cron(0 12 * * ? *)" \
     --description "Daily 12:00 UTC probe of the artifact freshness registry" \
     --region "${REGION}" \
@@ -261,7 +266,7 @@ if $BOOTSTRAP; then
   # Lookback defaults: 12 saturday + 30 weekday/eod cycles.
   echo "  Creating EventBridge historical cron: ${HISTORICAL_RULE_NAME}"
   run aws events put-rule \
-    --name "${HISTORICAL_RULE_NAME}" \
+    --name "${HISTORICAL_RULE_NAME}" --state "$(pause_state "${HISTORICAL_RULE_NAME}")" \
     --schedule-expression "cron(0 4 * * ? *)" \
     --description "Daily 04:00 UTC historical-cycle probe (mode=historical)" \
     --region "${REGION}" \
@@ -305,7 +310,7 @@ EOF
   # check_results/heartbeat/cycle_verdict surfaces the daily sweep owns.
   echo "  Creating EventBridge intraday cron: ${INTRADAY_RULE_NAME}"
   run aws events put-rule \
-    --name "${INTRADAY_RULE_NAME}" \
+    --name "${INTRADAY_RULE_NAME}" --state "$(pause_state "${INTRADAY_RULE_NAME}")" \
     --schedule-expression "cron(0/30 14-21 ? * MON-FRI *)" \
     --description "30-min weekday 14-21 UTC intraday probe (mode=intraday)" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -21,6 +21,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-friday-shell-run-report"
@@ -140,7 +145,7 @@ EVENT_PATTERN=$(cat <<EOF
 }
 EOF
 )
-run aws events put-rule --name "${RULE_NAME}" --event-pattern "${EVENT_PATTERN}" \
+run aws events put-rule --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" --event-pattern "${EVENT_PATTERN}" \
   --description "Consolidated Friday shell-run report on Saturday SF terminal (Lambda shell-run-guards)" \
   --region "${REGION}" --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -1,3 +1,8 @@
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-overseer-liveness-probe Lambda
 # and wire its EventBridge Scheduler rules.
@@ -201,12 +206,12 @@ if $BOOTSTRAP; then
     target="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
     if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler update-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     else
       echo "  Creating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler create-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     fi

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -28,6 +28,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-pipeline-watchdog"
@@ -166,7 +171,7 @@ if $BOOTSTRAP; then
   # rules at the EventBridge layer).
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --schedule-expression 'cron(0 14 * * ? *)' \
     --description "Daily pipeline-watchdog fire at 14:00 UTC (Lambda gates per-SF trading-day eligibility)" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -19,6 +19,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-saturday-integrity-sentinel"
@@ -109,7 +114,7 @@ if $BOOTSTRAP; then
   fi
 
   echo "  Creating EventBridge cron rule: ${RULE_NAME} (${SCHEDULE})"
-  run aws events put-rule --name "${RULE_NAME}" --schedule-expression "${SCHEDULE}" \
+  run aws events put-rule --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" --schedule-expression "${SCHEDULE}" \
     --description "Monday pre-open Saturday-integrity GO/NO-GO sentinel" --region "${REGION}" --query 'RuleArn' --output text
 
   FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -28,6 +28,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-saturday-sf-watch-dispatcher"
@@ -192,7 +197,7 @@ if $BOOTSTRAP; then
 EOF
 )
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --event-pattern "${EVENT_PATTERN}" \
     --description "Fleet SF (weekly/preopen/postclose) terminal failure -> sf-watch-dispatcher" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,3 +1,8 @@
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda,
 # the alpha-engine-groom-dispatch Step Function that wraps it, and wire the
@@ -428,7 +433,7 @@ EOF
         --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating Scheduler rule: ${name} → ${cron}"
       run aws scheduler update-schedule \
-        --name "${name}" \
+        --name "${name}" --state "$(pause_state "${name}")" \
         --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" \
         --flexible-time-window '{"Mode":"OFF"}' \
@@ -438,7 +443,7 @@ EOF
     else
       echo "  Creating Scheduler rule: ${name} → ${cron}"
       run aws scheduler create-schedule \
-        --name "${name}" \
+        --name "${name}" --state "$(pause_state "${name}")" \
         --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" \
         --flexible-time-window '{"Mode":"OFF"}' \
@@ -483,7 +488,7 @@ EOF
       --query 'Name' --output text >/dev/null 2>&1; then
     echo "  Updating reconciler rule: ${RECON_SCHED_NAME} → ${RECON_SCHED_CRON}"
     run aws scheduler update-schedule \
-      --name "${RECON_SCHED_NAME}" \
+      --name "${RECON_SCHED_NAME}" --state "$(pause_state "${RECON_SCHED_NAME}")" \
       --schedule-expression "${RECON_SCHED_CRON}" \
       --flexible-time-window '{"Mode":"OFF"}' \
       --target "${recon_target}" \
@@ -492,7 +497,7 @@ EOF
   else
     echo "  Creating reconciler rule: ${RECON_SCHED_NAME} → ${RECON_SCHED_CRON}"
     run aws scheduler create-schedule \
-      --name "${RECON_SCHED_NAME}" \
+      --name "${RECON_SCHED_NAME}" --state "$(pause_state "${RECON_SCHED_NAME}")" \
       --schedule-expression "${RECON_SCHED_CRON}" \
       --flexible-time-window '{"Mode":"OFF"}' \
       --target "${recon_target}" \
@@ -555,13 +560,13 @@ EOF
     if aws scheduler get-schedule --name "${sname}" --region "${REGION}" \
         --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating sweep rule: ${sname} → ${scron}"
-      run aws scheduler update-schedule --name "${sname}" \
+      run aws scheduler update-schedule --name "${sname}" --state "$(pause_state "${sname}")" \
         --schedule-expression "${scron}" --schedule-expression-timezone "UTC" \
         --flexible-time-window '{"Mode":"OFF"}' --target "${sweep_target}" \
         --region "${REGION}" --query 'ScheduleArn' --output text
     else
       echo "  Creating sweep rule: ${sname} → ${scron}"
-      run aws scheduler create-schedule --name "${sname}" \
+      run aws scheduler create-schedule --name "${sname}" --state "$(pause_state "${sname}")" \
         --schedule-expression "${scron}" --schedule-expression-timezone "UTC" \
         --flexible-time-window '{"Mode":"OFF"}' --target "${sweep_target}" \
         --region "${REGION}" --query 'ScheduleArn' --output text

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -21,6 +21,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-sf-telegram-notifier"
@@ -178,7 +183,7 @@ EVENT_PATTERN=$(cat <<EOF
 EOF
 )
 run aws events put-rule \
-  --name "${RULE_NAME}" \
+  --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
   --event-pattern "${EVENT_PATTERN}" \
   --description "Fan SF status changes to alpha-engine-sf-telegram-notifier" \
   --region "${REGION}" \
@@ -234,7 +239,7 @@ GROOM_EVENT_PATTERN=$(cat <<EOF
 EOF
 )
 run aws events put-rule \
-  --name "${GROOM_RULE_NAME}" \
+  --name "${GROOM_RULE_NAME}" --state "$(pause_state "${GROOM_RULE_NAME}")" \
   --event-pattern "${GROOM_EVENT_PATTERN}" \
   --description "Fan groom-dispatch SF FAILURE transitions to alpha-engine-sf-telegram-notifier (successes are reported by the SF's own cycle roll-up)" \
   --region "${REGION}" \

--- a/infrastructure/lambdas/sf-watch-market-hours-toggler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-market-hours-toggler/deploy.sh
@@ -31,6 +31,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FUNCTION_NAME="alpha-engine-sf-watch-market-hours-toggler"
 ROLE_NAME="alpha-engine-sf-watch-market-hours-toggler-role"
@@ -127,7 +132,7 @@ if $BOOTSTRAP; then
   fi
 
   echo "  Creating EventBridge rule: ${RULE_NAME} (${SCHEDULE})"
-  run aws events put-rule --name "${RULE_NAME}" --schedule-expression "${SCHEDULE}" \
+  run aws events put-rule --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" --schedule-expression "${SCHEDULE}" \
     --description "Poll NYSE market-hours state, toggle sf-watch-executor-role's trading-pipeline StartExecution grant (config#2932)" \
     --region "${REGION}" --query 'RuleArn' --output text
 

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
@@ -1,3 +1,8 @@
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-sf-watch-reclaim-sweep-handler Lambda
 # and wire its EventBridge Scheduler rules.
@@ -247,7 +252,7 @@ if $BOOTSTRAP_IAM; then
     rule="${RECLAIM_RULE_NAMES[$i]}"
     echo "  Creating/updating EventBridge rule: ${rule}"
     run aws events put-rule \
-      --name "${rule}" \
+      --name "${rule}" --state "$(pause_state "${rule}")" \
       --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
       --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
       --region "${REGION}" \
@@ -277,12 +282,12 @@ if $RECONCILE_SCHEDULES; then
     target="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
     if aws scheduler get-schedule --name "${name}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
       echo "  Updating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler update-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler update-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     else
       echo "  Creating Scheduler rule: ${name} → ${cron}"
-      run aws scheduler create-schedule --name "${name}" --schedule-expression "${cron}" \
+      run aws scheduler create-schedule --name "${name}" --state "$(pause_state "${name}")" --schedule-expression "${cron}" \
         --schedule-expression-timezone "UTC" --flexible-time-window '{"Mode":"OFF"}' \
         --target "${target}" --region "${REGION}" --query 'ScheduleArn' --output text
     fi

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -45,6 +45,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-sf-watch-spot-dispatcher"
@@ -277,13 +282,13 @@ PY
 )
   if aws scheduler get-schedule --name "${CANARY_SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
     echo "  Updating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
-    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" \
+    run aws scheduler update-schedule --name "${CANARY_SCHED_NAME}" --state "$(pause_state "${CANARY_SCHED_NAME}")" \
       --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
       --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
       --region "${REGION}" --query 'ScheduleArn' --output text
   else
     echo "  Creating Scheduler rule: ${CANARY_SCHED_NAME} → ${CANARY_CRON}"
-    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" \
+    run aws scheduler create-schedule --name "${CANARY_SCHED_NAME}" --state "$(pause_state "${CANARY_SCHED_NAME}")" \
       --schedule-expression "${CANARY_CRON}" --schedule-expression-timezone "UTC" \
       --flexible-time-window '{"Mode":"OFF"}' --target "${CANARY_TARGET}" \
       --region "${REGION}" --query 'ScheduleArn' --output text

--- a/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
+++ b/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
@@ -25,6 +25,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-spot-interruption-recorder"
@@ -147,7 +152,7 @@ if $BOOTSTRAP; then
 
   echo "  Creating EventBridge rule: ${TICK_RULE} (ENABLED, 5 min)"
   run aws events put-rule --name "${TICK_RULE}" \
-    --schedule-expression 'rate(5 minutes)' --state ENABLED \
+    --schedule-expression 'rate(5 minutes)' --state "$(pause_state "${TICK_RULE}")" \
     --description "Spot-interruption reconciler tick (alpha-engine-config-I5197) - sweeps CloudTrail BidEvictedEvent and records any eviction not already in overseer/interruptions/." \
     --region "${REGION}" --query 'RuleArn' --output text
   run aws events put-targets --rule "${TICK_RULE}" \
@@ -158,10 +163,10 @@ if $BOOTSTRAP; then
     --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${TICK_RULE}" \
     --region "${REGION}" 2>/dev/null || true
 
-  echo "  Creating EventBridge rule: ${WARN_RULE} (ENABLED)"
+  echo "  Creating EventBridge rule: ${WARN_RULE} ($(pause_state "${WARN_RULE}"))"
   run aws events put-rule --name "${WARN_RULE}" \
     --event-pattern '{"source":["aws.ec2"],"detail-type":["EC2 Spot Instance Interruption Warning"]}' \
-    --state ENABLED \
+    --state "$(pause_state "${WARN_RULE}")" \
     --description "Low-latency leg of the spot-interruption recorder (alpha-engine-config-I5197). NOT sufficient alone - AWS emits no warning for a box reclaimed during bootstrap, which is what the reconciler tick covers." \
     --region "${REGION}" --query 'RuleArn' --output text
   run aws events put-targets --rule "${WARN_RULE}" \

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -29,6 +29,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-spot-orphan-reaper"
@@ -160,7 +165,7 @@ if $BOOTSTRAP; then
   # EventBridge hourly trigger
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --schedule-expression "cron(15 * * * ? *)" \
     --description "Hourly scan for orphan alpha-engine spot instances" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -20,6 +20,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-ssm-reachability-probe"
@@ -177,7 +182,7 @@ if $BOOTSTRAP; then
 
   echo "  Creating EventBridge rule: ${RULE_NAME}"
   run aws events put-rule \
-    --name "${RULE_NAME}" \
+    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
     --schedule-expression "rate(5 minutes)" \
     --description "Probe whether every running alpha-engine instance is reachable via SSM (I6198)" \
     --region "${REGION}" \

--- a/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
+++ b/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
@@ -22,6 +22,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-sweep-artifact-monitor"
@@ -129,7 +134,7 @@ EVENT_PATTERN=$(cat <<EOF
 }
 EOF
 )
-run aws events put-rule --name "${RULE_NAME}" --event-pattern "${EVENT_PATTERN}" \
+run aws events put-rule --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" --event-pattern "${EVENT_PATTERN}" \
   --description "Post-SF sweep-artifact validation on groom-dispatch SUCCEEDED (config#2392)" \
   --region "${REGION}" --query 'RuleArn' --output text
 

--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -49,6 +49,11 @@
 
 set -euo pipefail
 
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
@@ -225,7 +230,7 @@ EOF
   fi
   echo "  scheduling auto re-enable: ${sched_name} → ${at_expr} UTC"
   run aws scheduler create-schedule \
-    --name "${sched_name}" \
+    --name "${sched_name}" --state "$(pause_state "${sched_name}")" \
     --schedule-expression "${at_expr}" \
     --schedule-expression-timezone "UTC" \
     --flexible-time-window '{"Mode":"OFF"}' \

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -238,3 +239,158 @@ def test_scheduler_disable_round_trips_the_full_spec():
     )
     for derived in ("Arn", "CreationDate", "LastModificationDate"):
         assert derived in src, f"{derived} is not stripped before update-schedule"
+
+
+# ── deploy-time enforcement (alpha-engine-config-I6619) ──────────────────────
+#
+# The manifest records the pause and automation_pause.py --check verifies it,
+# but until 2026-08-07 nothing stopped a redeploy from lifting it: neither
+# `aws events put-rule` nor `aws scheduler create-schedule|update-schedule`
+# has a "leave the state alone" option, and BOTH default to ENABLED when
+# --state is omitted. Every deploy.sh reconciling its own triggers therefore
+# silently re-enabled whatever it owned.
+#
+# Two shapes had to be fixed, and the second is the one worth a test: an
+# OMITTED --state (defaults ENABLED) and a HARDCODED --state literal. The
+# hardcoded ones were worse — `eod-backstop/deploy.sh` pinned `--state
+# DISABLED` for a rule Brian explicitly KEPT, so redeploying it would have
+# silently turned off the postclose SF backstop.
+
+_WRITE_VERBS = (
+    "aws events put-rule",
+    "aws scheduler create-schedule",
+    "aws scheduler update-schedule",
+)
+PAUSE_LIB = INFRA / "lambdas" / "_shared" / "pause.sh"
+
+
+def _deploy_scripts() -> list[Path]:
+    return sorted(INFRA.glob("lambdas/*/deploy.sh")) + sorted(INFRA.glob("*.sh"))
+
+
+def _statements(text: str):
+    """Yield whole logical statements, backslash continuations joined.
+
+    Load-bearing: `--name` and `--state` routinely sit on different physical
+    lines, so a line-at-a-time check would pass a statement that omits --state.
+    """
+    lines = text.splitlines(keepends=True)
+    i = 0
+    while i < len(lines):
+        if any(v in lines[i] for v in _WRITE_VERBS) and not lines[i].lstrip().startswith("#"):
+            j = i
+            while lines[j].rstrip().endswith("\\") and j + 1 < len(lines):
+                j += 1
+            yield i + 1, "".join(lines[i:j + 1])
+            i = j + 1
+        else:
+            i += 1
+
+
+def test_pause_helper_exists():
+    assert PAUSE_LIB.is_file(), (
+        "infrastructure/lambdas/_shared/pause.sh is gone — every deploy.sh "
+        "sourcing it will fail at deploy time"
+    )
+
+
+def test_every_trigger_write_derives_state_from_the_manifest():
+    """No omitted --state (defaults ENABLED) and no hardcoded literal."""
+    offenders = []
+    for script in _deploy_scripts():
+        for lineno, stmt in _statements(script.read_text(encoding="utf-8")):
+            if "pause_state" in stmt:
+                continue
+            rel = script.relative_to(REPO_ROOT)
+            reason = "hardcoded --state" if "--state" in stmt else "no --state (defaults ENABLED)"
+            offenders.append(f"{rel}:{lineno} — {reason}")
+    assert not offenders, (
+        "these EventBridge writes do not derive --state from "
+        "automation_pause.json, so a redeploy silently changes a trigger's "
+        "state:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_script_that_calls_pause_state_also_sources_the_helper():
+    missing = []
+    for script in _deploy_scripts():
+        text = script.read_text(encoding="utf-8")
+        if "pause_state" in text and "_shared/pause.sh" not in text:
+            missing.append(str(script.relative_to(REPO_ROOT)))
+    assert not missing, (
+        f"{missing} call pause_state without sourcing the helper — the deploy "
+        "fails at runtime, after the Lambda code has already been pushed"
+    )
+
+
+def test_pause_helper_fails_open_not_closed():
+    """A missing manifest must yield ENABLED, never DISABLED.
+
+    The asymmetry is deliberate. A pause that silently SPREADS would stop the
+    weekly SF with no signal that a config file caused it; a pause that
+    silently LIFTS is caught by automation_pause.py --check the next morning.
+    Only one of those failure modes has a detector.
+    """
+    src = PAUSE_LIB.read_text(encoding="utf-8")
+    assert 'echo "ENABLED"' in src, "no fail-open branch for an unreadable manifest"
+    marker = src.index("if [ ! -r")
+    assert 'echo "ENABLED"' in src[marker:marker + 200], (
+        "the unreadable-manifest branch does not return ENABLED"
+    )
+
+
+def test_pause_helper_resolves_both_surfaces():
+    """Live behaviour, not just source inspection."""
+    manifest = json.loads((INFRA / "automation_pause.json").read_text(encoding="utf-8"))
+    paused_rule = sorted(manifest["paused"]["events_rules"])[0]
+    paused_sched = sorted(manifest["paused"]["scheduler_schedules"])[0]
+
+    def _state(name: str) -> str:
+        out = subprocess.run(
+            ["bash", "-c", f'source "{PAUSE_LIB}"; pause_state "{name}"'],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+
+    assert _state(paused_rule) == "DISABLED", paused_rule
+    assert _state(paused_sched) == "DISABLED", paused_sched
+    for kept in ("alpha-engine-saturday", "alpha-engine-weekday",
+                 "alpha-engine-eod-backstop-daily"):
+        assert _state(kept) == "ENABLED", f"{kept} is kept by the ruling"
+    assert _state("a-rule-nobody-has-heard-of") == "ENABLED"
+
+
+def test_pending_entries_are_paused_at_write_time_but_not_required_live(manifest, module):
+    """`pending` = paused, for triggers that do not exist live yet.
+
+    alpha-engine-config-I6620. nousergon-data#1207 declares three schedules its
+    deploy would create ENABLED mid-pause. They cannot go in `paused` — the
+    check requires those to exist live — but they must still be born DISABLED.
+    """
+    pending = {k for k in manifest.get("pending", {}) if not k.startswith("_")}
+    assert pending, "the pending block is empty; if #1207's schedules now exist live, move them to paused"
+
+    # --check must NOT require them to exist live.
+    assert not (pending & module.paused_names(manifest)), (
+        "a name is in BOTH pending and paused — --check would demand it exist "
+        "live while the pending block exists precisely because it does not"
+    )
+
+    def _state(name: str) -> str:
+        out = subprocess.run(
+            ["bash", "-c", f'source "{PAUSE_LIB}"; pause_state "{name}"'],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+
+    for name in sorted(pending):
+        assert _state(name) == "DISABLED", f"{name} would be created ENABLED"
+
+
+def test_pending_notes_are_not_treated_as_trigger_names():
+    """`_`-prefixed keys are prose, not triggers."""
+    out = subprocess.run(
+        ["bash", "-c", f'source "{PAUSE_LIB}"; pause_state "_why"'],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "ENABLED"

--- a/tests/test_shell_arg_parse_default_init.py
+++ b/tests/test_shell_arg_parse_default_init.py
@@ -35,12 +35,32 @@ from pathlib import Path
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_INFRA_SCRIPTS = sorted((_REPO_ROOT / "infrastructure").glob("*.sh"))
+# alpha-engine-config-I6620: the scope AND the loop shape below are both
+# widened. This guard existed, was correct, and caught nothing when
+# `expense-collector/deploy.sh` shipped the exact bug it exists for on
+# 2026-08-07 — because the bug was in a `lambdas/*/deploy.sh` (outside the
+# glob) using `for arg in "$@"` (outside the regex). Detection blindness
+# outranks the defect it hides: a guard that covers one directory and one
+# loop syntax is a guard that reads as green for every script it cannot see.
+_INFRA_SCRIPTS = sorted(
+    list((_REPO_ROOT / "infrastructure").glob("*.sh"))
+    + list((_REPO_ROOT / "infrastructure" / "lambdas").glob("*/deploy.sh"))
+    + list((_REPO_ROOT / "infrastructure" / "lambdas" / "_shared").glob("*.sh"))
+)
 
 _SET_U_RE = re.compile(r"^\s*set\s+-[a-z]*u[a-z]*\b", re.MULTILINE)
 _LOOP_RE = re.compile(
     r'while\s*\[\[?\s*\$#\s*-gt\s*0\s*\]\]?\s*;?\s*do\s*\n'
     r'\s*case\s+"\$1"\s+in\n(.*?)\n\s*esac\s*\ndone',
+    re.DOTALL,
+)
+# The second arg-parse idiom in this repo, and the one the I6620 bug used.
+# `for arg in "$@"` has the SAME zero-flag property as the while-shift form:
+# with no arguments the body never runs, so a variable assigned only in a case
+# arm is unbound at the first read under `set -u`.
+_FOR_LOOP_RE = re.compile(
+    r'for\s+\w+\s+in\s+"\$@"\s*;?\s*do\s*\n'
+    r'\s*case\s+"\$\w+"\s+in\n(.*?)\n\s*esac\s*\ndone',
     re.DOTALL,
 )
 _ARM_ASSIGN_RE = re.compile(r'\b([A-Z][A-Z0-9_]*)=')
@@ -51,7 +71,7 @@ def _find_unguarded_loop_vars(text: str) -> list[tuple[str, int]]:
     case-arm-only variable read after the loop with no prior default-init."""
     if not _SET_U_RE.search(text):
         return []
-    loop_m = _LOOP_RE.search(text)
+    loop_m = _LOOP_RE.search(text) or _FOR_LOOP_RE.search(text)
     if not loop_m:
         return []
     loop_start, loop_end = loop_m.start(), loop_m.end()
@@ -63,10 +83,30 @@ def _find_unguarded_loop_vars(text: str) -> list[tuple[str, int]]:
         read_m = re.search(rf'\$\{{?{var}\b', after)
         if not read_m:
             continue  # never read outside the loop -> not this bug class
-        default_re = re.compile(rf'^{var}=', re.MULTILINE)
-        already_defaulted = default_re.search(
-            text[:loop_start]
-        ) or default_re.search(after[: read_m.start()])
+        # Two accepted default-init forms. Recognising only the first was a
+        # 34-of-35 false-positive rate when this guard was widened to the
+        # lambda deploy scripts (I6620) — and a guard that cries wolf 34 times
+        # gets switched off, which is how coverage returns to zero.
+        #   1. column-0 assignment:  VAR="${VAR:-false}"
+        #   2. the fleet's ambient-env idiom, which assigns INSIDE case arms:
+        #        case "${VAR:-false}" in
+        #          true|1|yes) VAR=true ;;
+        #          *)          VAR=false ;;
+        #        esac
+        #      Established by the I2752 incident (2026-07-16) so DRY_RUN=1 from
+        #      a caller's shell actually no-ops. The `${VAR:-` expansion is what
+        #      makes it safe under `set -u`, wherever it sits.
+        # `^VAR=` alone misses `BOOTSTRAP=0; SMOKE=0; CUTOVER=0` — one line,
+        # three initialisers, two of them not at column 0. Accept a
+        # semicolon-separated assignment as top-level too.
+        default_re = re.compile(rf'(?:^|;\s*){var}=', re.MULTILINE)
+        expansion_re = re.compile(rf'\$\{{{var}:-')
+        already_defaulted = (
+            default_re.search(text[:loop_start])
+            or default_re.search(after[: read_m.start()])
+            or expansion_re.search(text[:loop_start])
+            or expansion_re.search(after[: read_m.start()])
+        )
         if already_defaulted:
             continue
         line_no = text.count("\n", 0, loop_end + read_m.start()) + 1


### PR DESCRIPTION
## What & why

Closes `alpha-engine-config-I6619` and `alpha-engine-config-I6620`.

The automation pause (`I6617`) survived only by **detection** — `automation_pause.py --check` went red the next morning if a redeploy lifted it. This closes it at the **write site**.

Neither `aws events put-rule` nor `aws scheduler create-schedule|update-schedule` has a "leave the state alone" option, and **both default to `ENABLED`** when `--state` is omitted. Two shapes were wrong:

| Shape | Count | Consequence |
|---|---|---|
| `--state` omitted | 36 | silently re-enabled on redeploy |
| `--state` hardcoded | 4 | **worse** — see below |

The hardcoded ones were the real find. **`eod-backstop/deploy.sh` pinned `--state DISABLED` for a rule Brian explicitly KEPT** — redeploying it would have turned off the postclose SF backstop. `canary-replay-liveness-probe` and `spot-interruption-recorder` pinned `ENABLED` for rules that are paused.

All 40 now resolve through `infrastructure/lambdas/_shared/pause.sh`. Placed in `_shared/` because that is where this repo already keeps sourced deploy helpers (`apply_iam_policy.sh`, `preserve_env_flags.sh`) — not a parallel `lib/`.

**`pause_state` fails OPEN.** A missing manifest yields `ENABLED`. Deliberate asymmetry: a pause that silently *spreads* would stop the weekly SF with no signal that a config file caused it; a pause that silently *lifts* is caught by `--check` the next morning. Only one failure mode has a detector.

## New `pending` manifest block

`I6620` noted a hole: a trigger that did not exist when the manifest was written has no entry, so it is **born ENABLED** mid-pause. #1207 declares three such schedules. They cannot go in `paused` — `--check` requires those to exist live — so `pending` holds them: same write-time behaviour, no liveness requirement. `pause_state` reads both.

## I6620's other half — the deploy broken since #1207 merged

```
infrastructure/lambdas/expense-collector/deploy.sh: line 133: DRY_RUN: unbound variable
```

`DRY_RUN` was the one flag with no default-init, so `run()` died under `set -u` on every zero-flag invocation — which is every CI deploy. It failed **after** packaging, so it looked like it had got far enough to have worked; the Lambda code was never updated. Reproduced locally, fixed with the same ambient-env idiom every sibling uses (`I2752`).

### The guard for this exact bug class existed and caught nothing

`tests/test_shell_arg_parse_default_init.py` (config#2949) exists for precisely this. It scanned only `infrastructure/*.sh` and matched only `while [[ $# -gt 0 ]]` loops. The bug was in a `lambdas/*/deploy.sh` using `for arg in "$@"`. **Widened to both** — detection blindness outranks the defect it hides.

Widening raised **35 findings, 34 of them false**: the guard demanded a column-0 `VAR=` and missed both the fleet's `case "${VAR:-false}"` idiom and `BOOTSTRAP=0; SMOKE=0; CUTOVER=0` on one line. Both taught to it. A guard that cries wolf 34 times gets switched off, and coverage returns to zero. After de-noising, **exactly one finding remained — the real bug.**

## Test plan

- **121 tests pass** across `test_automation_pause.py`, `test_shell_arg_parse_default_init.py`, `test_scheduler_reconcile_is_ci_runnable.py`, `test_eventbridge_check_drift.py`, `test_gitleaks_config.py`
- `shellcheck --severity=error infrastructure/*.sh` clean (the CI gate); every touched script passes `bash -n`
- Every `source` path verified to resolve from its own script dir, per file — not assumed from the relative depth
- **End-to-end with a stubbed `aws`**: `expense-collector --reconcile-schedules` now runs past line 133 and emits

  ```
  --name alpha-engine-expense-collector-twicedaily          --state DISABLED
  --name alpha-engine-expense-collector-reconcile-monthly   --state ENABLED
  ```

  That second line is *why* the `pending` block exists; it resolves `DISABLED` once the block was added.
- **Before/after on the real bug**: stashing this change reproduces `line 133: DRY_RUN: unbound variable` exactly as CI reported it
- Live pause unchanged: `automation_pause.py --check` → 40/40 `DISABLED`

## Post-merge

None required. Merging triggers the path-filtered deploy workflows for the touched Lambdas; they will now reconcile each trigger to its manifest state rather than to `ENABLED`. That is the intended effect and is self-verifying — `automation_pause.py --check` runs in the daily sweep.

## Related

- `alpha-engine-config-PR6631` — the gate-health sweep, independent, no merge order.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)