### PR TITLE
[P1/mid] fix(rag): scope the corpus to the attractiveness top-60, not the momentum gate cut (config-I6630)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/collectors/daily_news.py
+++ b/collectors/daily_news.py
@@ -97,7 +97,7 @@ def assemble_universe(bucket: str, s3_client: Any) -> list[str]:
     """Union Metron held tickers ∪ the AE decision set.
 
     config-I5700: the AE slice now resolves through ``_rag_scope`` (the
-    scanner's ``cuts.scanner_candidates``) rather than ``signals.json``'s
+    scanner's ``cuts.attractiveness_top_60``) rather than ``signals.json``'s
     ``universe`` array — a 903-row SIZING envelope that was never a scope.
     The daily and weekly paths therefore resolve ONE identical set, which is
     what ``rag-corpus-policy.md`` §2.3's one-fetch-one-corpus corollary needs

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 krepis>=0.14.0

--- a/rag/pipelines/_rag_scope.py
+++ b/rag/pipelines/_rag_scope.py
@@ -20,9 +20,9 @@ account-wide 5 req/min (12.5 s/ticker), was roughly half of ``RAGIngestion``'s
 
 The decision set is already published, canonically, by the scanner:
 
-    universe_membership/{date}/membership.json :: cuts.scanner_candidates
-        {"basis": "scanner_gate", "size": 60, "tickers": [...],
-         "source": "candidates/{date}/candidates.json::scanner_tickers"}
+    universe_membership/{date}/membership.json :: cuts.attractiveness_top_60
+        {"basis": "attractiveness_rank", "size": 60, "tickers": [...],
+         "source": "scanner/universe/{date}/universe.json::attractiveness_score"}
 
 ``champion-challenger-policy.md`` §2 names that artifact as the universe-cut
 registry. Reading it here means the corpus scope is **arm-independent**: it
@@ -33,12 +33,44 @@ Held names are unioned in from Metron's holdings artifact — a position needs
 evidence whether or not it ranks this week, and an EXIT still needs a
 rationale (§2.1).
 
-WHY NOT THE TOP-20 PREDICTOR CUT. ``predictor_universe_cut`` resolves to
-``attractiveness_top_20`` today, but the Think Tank challenger arm consumes the
-**top 60** and outputs 20 — RAG evidence is that arm's input. Scoping the
-corpus to 20 would starve the challenger and make the champion/challenger
+WHICH 60 (alpha-engine-config-I6630)
+------------------------------------
+This module originally scoped to ``cuts.scanner_candidates`` and justified it
+with "the Think Tank challenger arm consumes the top 60." The **width** was
+right and the **ranking was wrong**, because the scanner publishes two 60-wide
+cuts from two different rankings:
+
+* ``scanner_candidates`` — the momentum **gate** cut: ``tech_score`` top-60
+  plus the most oversold-by-RSI names. No fundamentals.
+* ``attractiveness_top_60`` — the top 60 of the 6-pillar attractiveness rank
+  over the whole ~905-name board.
+
+Think Tank's window (``thinktank/run.py::GAP_FILL_TOP_N``) is computed over
+``scoring/universe_board.py``, which ranks by **attractiveness**. The predictor
+scores ``attractiveness_top_20``. So the corpus was scoped to a 60 that was the
+decision set of *neither* arm. Measured on the live 2026-08-07 membership
+artifact: the old scope cut and the predictor's 20 overlapped on **2 names**,
+and 55 of Think Tank's 60 were outside it — evidence paid for, at Polygon's
+account-wide 5 req/min, for names no arm decides on.
+
+``attractiveness_top_60`` makes the funnel nest by construction:
+
+    attractiveness rank over the full board
+      → attractiveness_top_60   this scope, and Think Tank's window
+        → attractiveness_top_20 the predictor's scored cut
+
+``scanner_candidates`` is still emitted by the producer — it remains the
+incumbent challenger arm and the week-over-week churn baseline
+(alpha-engine-config-I4983). Only its role as the *corpus scope* changed.
+
+WHY NOT THE TOP-20 PREDICTOR CUT. Scoping the corpus to 20 would starve the
+Think Tank challenger, whose input is the 60, and make the champion/challenger
 comparison unfair on breadth (``champion-challenger-policy.md`` §4). 60 is the
-correct width; Brian ruled the same on 2026-07-30.
+correct width; Brian ruled the same on 2026-07-30 and again on 2026-08-07.
+
+The width and the cut name come from ``nousergon_lib.decision_set``, which is
+the single definition ``rag-corpus-policy.md`` §2.1 refers to as
+``ATTRACTIVENESS_FEED_TOP_N``.
 
 FAIL LOUD. A missing or empty cut raises. There is deliberately NO fallback to
 ``signals.json::universe`` — that fallback IS the defect this module exists to
@@ -51,6 +83,13 @@ import json
 import logging
 import re
 from typing import Any
+
+from nousergon_lib.decision_set import (
+    FEED_CUT_NAME,
+    DecisionSetContractError,
+    assert_cut_nests,
+    predictor_cut_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,8 +119,10 @@ MEMBERSHIP_DATED_TPL = "universe_membership/{date}/membership.json"
 # (rag-corpus-policy.md §2.3, one fetch one corpus).
 HOLDINGS_UNIVERSE_KEY = "metron/holdings_universe.json"
 
-# The cut that defines the corpus width. See "WHY NOT THE TOP-20" above.
-SCOPE_CUT = "scanner_candidates"
+# The cut that defines the corpus scope. See "WHICH 60" above. Derived from
+# nousergon_lib so this repo does not carry a second literal 60 that can drift
+# from the one the policy names.
+SCOPE_CUT = FEED_CUT_NAME
 
 
 class RagScopeUnavailable(RuntimeError):
@@ -124,7 +165,7 @@ def _load_holdings(s3_client: Any, bucket: str) -> list[str]:
     if not data:
         logger.warning(
             "[rag_scope] holdings artifact s3://%s/%s unavailable — HELD NAMES "
-            "WILL NOT BE COVERED this run (scanner cut only). Not fatal, but "
+            "WILL NOT BE COVERED this run (feed cut only). Not fatal, but "
             "positions go without fresh evidence until it returns.",
             bucket, HOLDINGS_UNIVERSE_KEY,
         )
@@ -148,8 +189,9 @@ def load_rag_scope(
     pipeline run, so a corpus fill and the run it serves cannot disagree about
     which week they are in.
 
-    Raises :class:`RagScopeUnavailable` when the scanner cut is missing or
-    empty — never widens.
+    Raises :class:`RagScopeUnavailable` when the feed cut is missing or
+    empty, or when the predictor's scored cut is not nested inside it — never
+    widens, never fills the wrong 60.
     """
     if s3_client is None:
         import boto3
@@ -179,6 +221,28 @@ def load_rag_scope(
             f"widen (rag-corpus-policy.md §2.1)."
         )
 
+    # The funnel invariant (alpha-engine-config-I6630). The corpus exists to
+    # give the scored names evidence, so a scope that does not contain the
+    # scored cut is filling the wrong 60 — the exact defect this cut change
+    # fixed, and it was invisible for weeks because nothing tied the two cuts
+    # together. FAIL LOUD rather than fill wrongly: ingestion is deliberately
+    # off every decision pipeline's critical path (rag-corpus-policy.md §2.3),
+    # so raising here costs a corpus fill, never a trading day.
+    #
+    # This also fires when an arm promotion moves ``predictor_universe_cut`` to
+    # a cut outside the attractiveness rank family. That is the correct
+    # outcome: a champion change that moves the decision set must move the
+    # corpus scope in the same change, and this is the coupling that was
+    # missing.
+    try:
+        assert_cut_nests(membership, inner=predictor_cut_name(membership), outer=SCOPE_CUT)
+    except DecisionSetContractError as exc:
+        raise RagScopeUnavailable(
+            f"membership artifact s3://{bucket}/{key} fails the funnel "
+            f"invariant: {exc} Refusing to fill a corpus that does not cover "
+            f"the cut the predictor scores (rag-corpus-policy.md §2.1)."
+        ) from exc
+
     held = _load_holdings(s3_client, bucket)
     candidates = sorted(set(cut_tickers) | set(held))
 
@@ -196,7 +260,7 @@ def load_rag_scope(
         )
 
     logger.info(
-        "[rag_scope] resolved %d ticker(s) for run_date=%s — scanner cut %r %d "
+        "[rag_scope] resolved %d ticker(s) for run_date=%s — feed cut %r %d "
         "∪ held %d (source: %s)",
         len(tickers), membership.get("run_date"), SCOPE_CUT, len(set(cut_tickers)),
         len(set(held)), cut.get("source") or key,

--- a/rag/pipelines/ingest_8k_filings.py
+++ b/rag/pipelines/ingest_8k_filings.py
@@ -254,7 +254,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Ingest 8-K filings into RAG store")
     parser.add_argument("--tickers", type=str, help="Comma-separated ticker list")
-    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates)")
+    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60)")
     parser.add_argument("--lookback-days", type=int, default=365, help="Days of filings to backfill")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/rag/pipelines/ingest_earnings_finnhub.py
+++ b/rag/pipelines/ingest_earnings_finnhub.py
@@ -241,7 +241,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Ingest earnings transcripts from Finnhub into RAG")
     parser.add_argument("--tickers", type=str, help="Comma-separated ticker list")
-    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates)")
+    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60)")
     parser.add_argument("--max-per-ticker", type=int, default=8, help="Max transcripts per ticker")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()

--- a/rag/pipelines/ingest_form4.py
+++ b/rag/pipelines/ingest_form4.py
@@ -571,7 +571,7 @@ def main():
     )
     grp.add_argument(
         "--from-signals", action="store_true",
-        help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates).",
+        help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60).",
     )
     parser.add_argument(
         "--lookback-days", type=int, default=90,

--- a/rag/pipelines/ingest_sec_filings.py
+++ b/rag/pipelines/ingest_sec_filings.py
@@ -288,7 +288,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Ingest SEC filings into RAG store")
     parser.add_argument("--tickers", type=str, help="Comma-separated ticker list")
-    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates)")
+    parser.add_argument("--from-signals", action="store_true", help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60)")
     parser.add_argument("--lookback-years", type=int, default=2, help="Years of filings to backfill")
     parser.add_argument("--dry-run", action="store_true", help="Print what would be ingested without writing")
     args = parser.parse_args()

--- a/rag/pipelines/run_analyst_pipeline.py
+++ b/rag/pipelines/run_analyst_pipeline.py
@@ -47,7 +47,7 @@ def main() -> int:
     )
     grp.add_argument(
         "--from-signals", action="store_true",
-        help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates).",
+        help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60).",
     )
     parser.add_argument(
         "--snapshot-date", type=str, default=None,

--- a/rag/pipelines/run_news_pipeline.py
+++ b/rag/pipelines/run_news_pipeline.py
@@ -84,7 +84,7 @@ def main() -> int:
     )
     grp.add_argument(
         "--from-signals", action="store_true",
-        help="Load tickers from the scanner decision set (universe-membership cuts.scanner_candidates)",
+        help="Load tickers from the scanner decision set (universe-membership cuts.attractiveness_top_60)",
     )
     parser.add_argument(
         "--hours", type=int, default=168,

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.36
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_corpus_freshness_assertion.py
+++ b/tests/test_corpus_freshness_assertion.py
@@ -25,7 +25,12 @@ def _s3(marks: dict):
     payloads = {
         "universe_membership/latest.json": {
             "run_date": "2026-07-31",
-            "cuts": {"scanner_candidates": {"size": len(SCOPE), "tickers": SCOPE}},
+            "predictor_universe_cut": "attractiveness_top_20",
+            # config-I6630: the attractiveness RANK cut, not the gate cut.
+            "cuts": {
+                "attractiveness_top_60": {"size": len(SCOPE), "tickers": SCOPE},
+                "attractiveness_top_20": {"size": 1, "tickers": SCOPE[:1]},
+            },
         },
         "metron/holdings_universe.json": {"as_of": "2026-07-31", "tickers": []},
         "rag/watermarks/v1/news.json": {"marks": marks},

--- a/tests/test_daily_news.py
+++ b/tests/test_daily_news.py
@@ -48,11 +48,21 @@ def _mock_s3(holdings=None, signals_universe=None):
         if Key == "universe_membership/latest.json":
             return {"Body": BytesIO(json.dumps({
                 "run_date": "2026-07-29",
-                "cuts": {"scanner_candidates": {
-                    "basis": "scanner_gate",
-                    "size": len(signals_universe or []),
-                    "tickers": list(signals_universe or []),
-                }},
+                "predictor_universe_cut": "attractiveness_top_20",
+                "cuts": {
+                    # config-I6630: the attractiveness RANK cut, not the
+                    # tech_score momentum gate cut.
+                    "attractiveness_top_60": {
+                        "basis": "attractiveness_rank",
+                        "size": len(signals_universe or []),
+                        "tickers": list(signals_universe or []),
+                    },
+                    "attractiveness_top_20": {
+                        "basis": "attractiveness_rank",
+                        "size": len(signals_universe or []),
+                        "tickers": list(signals_universe or []),
+                    },
+                },
             }).encode())}
         raise RuntimeError(f"unexpected key {Key}")
 

--- a/tests/test_gate_a_orchestrators.py
+++ b/tests/test_gate_a_orchestrators.py
@@ -20,29 +20,46 @@ import pytest
 # ── _rag_scope ────────────────────────────────────────────────────────
 #
 # config-I5700: the corpus fetch set is the scanner DECISION SET, resolved
-# from universe_membership/{date}/membership.json::cuts.scanner_candidates —
-# NOT signals.json::universe, which is a 903-row sizing envelope. The old
-# TestLoadSignalsTickers class pinned the defective behaviour (including that
-# `sorted(prefixes)[-1]` list_objects_v2 scan, which silently returns the
-# 1000th-oldest date once the partition count crosses a page) and is replaced
-# wholesale rather than adapted.
+# from universe_membership/{date}/membership.json — NOT signals.json::universe,
+# which is a 903-row sizing envelope. The old TestLoadSignalsTickers class
+# pinned the defective behaviour (including that `sorted(prefixes)[-1]`
+# list_objects_v2 scan, which silently returns the 1000th-oldest date once the
+# partition count crosses a page) and is replaced wholesale rather than
+# adapted.
+#
+# config-I6630: the cut is ``attractiveness_top_60``, not
+# ``scanner_candidates``. Both are 60 wide, but the latter is a tech_score
+# momentum GATE and the former is the attractiveness RANK the predictor's
+# scored cut is the head of. Scoping to the gate cut meant the corpus covered
+# 2 of the predictor's 20 names (measured live 2026-08-07).
 
 
 class TestLoadRagScope:
-    def _s3(self, *, cuts=None, holdings=("HELD",), membership=True):
+    def _s3(self, *, cuts=None, holdings=("HELD",), membership=True,
+            predictor_cut="attractiveness_top_20"):
         s3 = MagicMock()
         payloads = {}
         if membership:
             payloads["universe_membership/latest.json"] = {
                 "run_date": "2026-07-29",
+                "predictor_universe_cut": predictor_cut,
                 "cuts": cuts if cuts is not None else {
-                    "scanner_candidates": {
-                        "basis": "scanner_gate", "size": 2,
+                    "attractiveness_top_60": {
+                        "basis": "attractiveness_rank", "size": 2,
                         "tickers": ["msft", "AAPL"],
+                        "source": "scanner/universe/2026-07-29/universe.json::attractiveness_score",
+                    },
+                    # The predictor's scored cut — nested, as the funnel requires.
+                    "attractiveness_top_20": {
+                        "basis": "attractiveness_rank", "size": 1,
+                        "tickers": ["AAPL"],
+                    },
+                    # The momentum GATE cut is present and must NOT be picked up.
+                    "scanner_candidates": {
+                        "basis": "scanner_gate", "size": 3,
+                        "tickers": ["A", "B", "C"],
                         "source": "candidates/2026-07-29/candidates.json::scanner_tickers",
                     },
-                    # A wider cut is present and must NOT be picked up.
-                    "attractiveness_top_60": {"size": 3, "tickers": ["A", "B", "C"]},
                 },
             }
         if holdings is not None:
@@ -58,7 +75,7 @@ class TestLoadRagScope:
         s3.get_object.side_effect = _get
         return s3
 
-    def test_resolves_scanner_cut_union_holdings_uppercased_and_sorted(self):
+    def test_resolves_feed_cut_union_holdings_uppercased_and_sorted(self):
         from rag.pipelines._rag_scope import load_rag_scope_tickers
 
         assert load_rag_scope_tickers(s3_client=self._s3()) == ["AAPL", "HELD", "MSFT"]
@@ -88,12 +105,57 @@ class TestLoadRagScope:
             for c in s3.get_object.call_args_list
         )
 
-    def test_takes_only_the_scanner_cut_not_a_wider_one(self):
+    def test_takes_the_attractiveness_feed_cut_not_the_momentum_gate_cut(self):
+        # config-I6630. Both cuts are present and both are "the 60"; only the
+        # attractiveness rank cut is the decision set.
         from rag.pipelines._rag_scope import load_rag_scope
 
         scope = load_rag_scope(s3_client=self._s3())
-        assert scope["counts"]["scanner_candidates"] == 2
-        assert "B" not in scope["tickers"]
+        assert scope["counts"]["attractiveness_top_60"] == 2
+        assert "scanner_candidates" not in scope["counts"]
+        assert not {"A", "B", "C"} & set(scope["tickers"])
+
+    def test_scope_contains_the_cut_the_predictor_scores(self):
+        # The funnel invariant, consumer side. The corpus exists to give the
+        # SCORED names evidence; a scope that does not contain them is filling
+        # the wrong 60.
+        from rag.pipelines._rag_scope import load_rag_scope
+
+        scope = load_rag_scope(s3_client=self._s3())
+        assert {"AAPL"} <= set(scope["tickers"])
+
+    def test_scope_not_covering_the_predictor_cut_raises(self):
+        # The exact live 2026-08-07 shape: scored cut and scope cut drawn from
+        # different rankings. Ingestion is off every decision pipeline's
+        # critical path, so raising costs a corpus fill, never a trading day.
+        from rag.pipelines._rag_scope import RagScopeUnavailable, load_rag_scope_tickers
+
+        s3 = self._s3(cuts={
+            "attractiveness_top_60": {"tickers": ["ANF", "SN"]},
+            "attractiveness_top_20": {"tickers": ["ANF", "LULU", "ROKU"]},
+        })
+        with pytest.raises(RagScopeUnavailable, match="funnel invariant"):
+            load_rag_scope_tickers(s3_client=s3)
+
+    def test_an_arm_promotion_to_an_uncovered_cut_raises(self):
+        # A champion change that moves the decision set must move the corpus
+        # scope in the same change. This is the coupling that was missing.
+        from rag.pipelines._rag_scope import RagScopeUnavailable, load_rag_scope_tickers
+
+        s3 = self._s3(predictor_cut="thinktank_top_20", cuts={
+            "attractiveness_top_60": {"tickers": ["AAPL", "MSFT"]},
+            "thinktank_top_20": {"tickers": ["NVDA"]},
+        })
+        with pytest.raises(RagScopeUnavailable, match="funnel invariant"):
+            load_rag_scope_tickers(s3_client=s3)
+
+    def test_membership_without_a_named_predictor_cut_raises(self):
+        # A consumer guessing which cut is scored is how a cut change becomes
+        # invisible to half the fleet.
+        from rag.pipelines._rag_scope import RagScopeUnavailable, load_rag_scope_tickers
+
+        with pytest.raises(RagScopeUnavailable, match="predictor_universe_cut"):
+            load_rag_scope_tickers(s3_client=self._s3(predictor_cut=None))
 
     def test_missing_membership_raises_never_widens(self):
         from rag.pipelines._rag_scope import RagScopeUnavailable, load_rag_scope_tickers
@@ -101,11 +163,11 @@ class TestLoadRagScope:
         with pytest.raises(RagScopeUnavailable, match="903-ticker"):
             load_rag_scope_tickers(s3_client=self._s3(membership=False))
 
-    def test_empty_scanner_cut_raises_and_names_the_available_cuts(self):
+    def test_empty_feed_cut_raises_and_names_the_available_cuts(self):
         from rag.pipelines._rag_scope import RagScopeUnavailable, load_rag_scope_tickers
 
-        s3 = self._s3(cuts={"attractiveness_top_20": {"tickers": ["X"]}})
-        with pytest.raises(RagScopeUnavailable, match="attractiveness_top_20"):
+        s3 = self._s3(cuts={"scanner_candidates": {"tickers": ["X"]}})
+        with pytest.raises(RagScopeUnavailable, match="scanner_candidates"):
             load_rag_scope_tickers(s3_client=s3)
 
     def test_missing_holdings_degrades_loudly_but_does_not_fail(self, caplog):


### PR DESCRIPTION
Closes alpha-engine-config-I6630 · Closes nousergon/alpha-engine-config#6630

## What

The corpus fetch set moves from `cuts.scanner_candidates` to `cuts.attractiveness_top_60`, and `load_rag_scope()` now enforces the funnel invariant it should always have had.

## Why

The scanner funnel was not a funnel. The corpus scoped to `scanner_candidates` while the predictor scores `attractiveness_top_20` — **two different rankings**, both 60 wide, which is why it read as correct:

| Cut | Ranking |
|---|---|
| `scanner_candidates` | `tech_score` momentum **gate** (RSI / MACD / MA50 / MA200 / 20d momentum, no fundamentals) |
| `attractiveness_top_60` | 6-pillar attractiveness **rank** over the whole ~905-name board |

Measured on the live `universe_membership/2026-08-07/membership.json`:

```
attractiveness_top_20 ∩ scanner_candidates ..  2 / 20
attractiveness_top_60 ∩ scanner_candidates ..  5 / 60
attractiveness_top_20 ⊂ attractiveness_top_60  True
```

**18 of the 20 names the predictor scores carried no fresh corpus evidence.** 55 of Think Tank's 60 (`thinktank/run.py::GAP_FILL_TOP_N`, computed over `scoring/universe_board.py` — which ranks by attractiveness, not `tech_score`) were outside the fetch set. Polygon / EDGAR / Finnhub requests, at an account-wide 5 req/min, were spent on names no arm decides on — the failure `rag-corpus-policy.md` §2.1 exists to prevent, re-entered through a different constant than the one config-I5700 removed.

The module's own docstring named the reason it was wrong: it justified `scanner_candidates` with *"the Think Tank challenger arm consumes the top 60."* True — but the **attractiveness** top 60. The width was right; the ranking was wrong.

## Changes

- `SCOPE_CUT = nousergon_lib.decision_set.FEED_CUT_NAME`. Width and cut name come from the lib, so this repo carries no second literal 60 to drift from the one `rag-corpus-policy.md` §2.1 names as `ATTRACTIVENESS_FEED_TOP_N`.
- **Funnel invariant, enforced at resolve time.** The cut the producer names in `predictor_universe_cut` must nest inside the scope cut, or `RagScopeUnavailable` is raised. Ingestion is deliberately off every decision pipeline's critical path (§2.3), so raising costs a corpus fill, never a trading day — and filling the wrong 60 silently is strictly worse. It also fires on an arm promotion that moves the decision set, which is exactly the coupling that was missing.
- Docstring rewritten to state *which* 60 and why, with the measured numbers.
- `--from-signals` help text across the six ingestion entry points and `collectors/daily_news.py` updated to name the cut they now resolve.

`scanner_candidates` is still emitted by the producer — it remains the incumbent challenger arm and the churn baseline (config-I4983). Only its role as the corpus scope changed.

## Test plan

Reworked the three membership fixtures onto the attractiveness cuts and added four guards: feed-cut-not-gate-cut · scope-covers-the-scored-cut · the live I6630 non-nesting shape raises · an arm promotion to an uncovered cut raises.

```
tests/test_gate_a_orchestrators.py
tests/test_daily_news.py
tests/test_corpus_freshness_assertion.py .......... 51 passed
tests/test_lib_pin_lockstep.py ..................... 4 passed
```

Run against this branch with `nousergon-lib` PR#294's `src/` on `PYTHONPATH`, since the pinned tag does not exist until that PR merges.

**Not run locally:** the collector / ArcticDB half of the suite does not collect on this laptop — `arcticdb` rejects the locally installed `protobuf` 7.35.1 (`We only support protobuf versions 3, 4, 5 & 6`). Those modules are untouched by this change; CI pins a compatible protobuf and covers them.

## Merge order

1. `nousergon-lib-PR294` — adds `nousergon_lib.decision_set`; merge-time autobump publishes the tag
2. **this PR** — pins `v0.124.37`, the version that autobump produces from PR294

⚠️ The pin is **predicted**. If any other `src/**` PR merges into `nousergon-lib` between PR294 and this one, the published tag will be `v0.124.38` and the pin needs one bump — CI will say so. All 27 pins across this repo were bumped in lockstep (`tests/test_lib_pin_lockstep.py` guards it).

3. `crucible-research-PR<N>` — producer-side nesting assertion, independent of both

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
