### PR TITLE
[P1/low] fix(infra): exempt `pending` triggers in the drift checkers too

### DIFF
--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -74,9 +74,32 @@ def paused_entries(manifest: dict | None = None) -> list[tuple[str, str, str]]:
     return out
 
 
+def pending_names(manifest: dict | None = None) -> set[str]:
+    """Triggers that must be BORN disabled but do not exist live yet.
+
+    Separate from ``paused`` because ``check()`` requires every paused entry to
+    exist live — a not-yet-created name there would be a permanent
+    ``missing-in-aws`` finding. Keys prefixed ``_`` are prose, not triggers.
+    """
+    m = manifest if manifest is not None else load_manifest()
+    return {k for k in m.get("pending", {}) if not k.startswith("_")}
+
+
 def paused_names(manifest: dict | None = None) -> set[str]:
-    """Every intentionally-paused trigger name, both surfaces."""
-    return {name for _, name, _ in paused_entries(manifest)}
+    """Every name for which DISABLED is the INTENDED live state.
+
+    Includes ``pending``. This is the question the drift checkers ask — "is a
+    DISABLED trigger drift, or deliberate?" — and the answer is the same for
+    both blocks. It is NOT the question ``check()`` asks, which is "does this
+    exist live and is it off"; that one iterates ``paused_entries()`` and so
+    still ignores ``pending``.
+
+    Getting this wrong cost a red deploy on 2026-08-07: the pending block was
+    wired into the bash helper but not here, so expense-collector correctly
+    created its schedule DISABLED and its own post-deploy assertion then failed
+    the deploy for the state it had just been told to write.
+    """
+    return {name for _, name, _ in paused_entries(manifest)} | pending_names(manifest)
 
 
 def _aws(args: list[str]) -> tuple[int, str, str]:

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -370,8 +370,12 @@ def test_pending_entries_are_paused_at_write_time_but_not_required_live(manifest
     pending = {k for k in manifest.get("pending", {}) if not k.startswith("_")}
     assert pending, "the pending block is empty; if #1207's schedules now exist live, move them to paused"
 
-    # --check must NOT require them to exist live.
-    assert not (pending & module.paused_names(manifest)), (
+    # --check must NOT require them to exist live. That obligation is carried
+    # by paused_entries(), NOT by paused_names() — the latter deliberately
+    # includes pending so the drift checkers do not flag a correctly-pending
+    # trigger. See test_paused_names_includes_pending_but_check_does_not.
+    entry_names = {name for _, name, _ in module.paused_entries(manifest)}
+    assert not (pending & entry_names), (
         "a name is in BOTH pending and paused — --check would demand it exist "
         "live while the pending block exists precisely because it does not"
     )
@@ -394,3 +398,34 @@ def test_pending_notes_are_not_treated_as_trigger_names():
         capture_output=True, text=True, check=True,
     )
     assert out.stdout.strip() == "ENABLED"
+
+
+def test_paused_names_includes_pending_but_check_does_not(manifest, module):
+    """The two questions differ, and conflating them failed a deploy.
+
+    2026-08-07: `pending` was wired into the bash helper but not here, so
+    expense-collector correctly created its schedule DISABLED and its own
+    post-deploy assertion (check-schedule-drift.py, which reads paused_names)
+    then failed the deploy for the state it had just been told to write.
+
+      paused_names()   -> "is DISABLED deliberate?"  MUST include pending
+      paused_entries() -> "does it exist live and is it off?"  MUST NOT
+    """
+    pending = module.pending_names(manifest)
+    assert pending, "pending is empty; this test guards a block that must exist"
+
+    names = module.paused_names(manifest)
+    assert pending <= names, (
+        "paused_names() excludes pending, so every drift checker will report a "
+        "correctly-pending trigger as drift and fail the deploy that created it"
+    )
+
+    entry_names = {name for _, name, _ in module.paused_entries(manifest)}
+    assert not (pending & entry_names), (
+        "paused_entries() includes a pending name — automation_pause.py --check "
+        "would demand it exist live, which is exactly why pending is separate"
+    )
+
+
+def test_pending_notes_are_not_returned_as_names(module, manifest):
+    assert not any(n.startswith("_") for n in module.pending_names(manifest))


### PR DESCRIPTION
## What & why

Follow-on to #1240, **found by the deploy that PR unblocked.**

`Deploy expense-collector` got all the way past the `DRY_RUN` bug to its post-deploy assertion, created `alpha-engine-expense-collector-reconcile-monthly` correctly `DISABLED` per the new `pending` block — and then failed the deploy on the state it had just been told to write:

```
scheduler drift — 2 codified rule(s) checked
  ✗ [disabled] alpha-engine-expense-collector-reconcile-monthly
      live state is DISABLED, expected ENABLED
```

`pending` was wired into the bash helper (`pause_state`) but not into `automation_pause.paused_names()`, which is what both drift checkers read.

## The fix

A separation the manifest already implied, now explicit:

| Function | Question it answers | `pending` |
|---|---|---|
| `paused_names()` | is a DISABLED trigger deliberate? | **included** |
| `paused_entries()` | does it exist live and is it off? | **excluded** |

`check()` still iterates `paused_entries()`, so a not-yet-created name cannot become a permanent `missing-in-aws` finding — which is the entire reason `pending` is a separate block.

One test from #1240 asserted the old, wrong semantics (that a pending name is absent from `paused_names()`). Corrected to assert the real invariant against `paused_entries()`, and a new test pins both directions so conflating them again fails in CI rather than reddening a deploy.

## Test plan

- `pytest tests/test_automation_pause.py tests/test_scheduler_reconcile_is_ci_runnable.py tests/test_shell_arg_parse_default_init.py` → **101 passed**
- `check-schedule-drift.py` against live AWS: no longer reports the pending schedule
- `automation_pause.py --check` against live AWS: unchanged, **40/40 DISABLED**

## Not fixed here — and it should not be

The other red deploy, `Deploy sf-watch-reclaim-sweep-handler`, is a different and much larger problem than the missing IAM role its error suggests. Established live this session:

- the Lambda `alpha-engine-sf-watch-reclaim-sweep-handler` **does not exist**
- neither does its execution role, nor its scheduler role
- the two EventBridge rules its deploy.sh claims — `alpha-engine-sf-watch-spot-interruption` and `alpha-engine-sf-watch-instance-terminated` — are live and ENABLED, **targeting a different Lambda** (`alpha-engine-sf-watch-liveness-probe`)

So running the codified `--bootstrap-iam` would create the component **and silently repoint two live enabled rules** onto it. That is a routing change to working infrastructure during an automation pause, not a deploy repair. Escalated on `alpha-engine-config-I6620` rather than actioned.

Refs `alpha-engine-config-I6619`, `alpha-engine-config-I6620`

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)