### PR TITLE
[P2/mid] feat(freshness): withhold the page when the producing trigger is deliberately disabled (config-I6570)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -88,6 +88,15 @@
       "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
     },
     {
+      "Sid": "ProducerTriggerStateRead",
+      "Effect": "Allow",
+      "Action": ["events:DescribeRule", "scheduler:GetSchedule"],
+      "Resource": [
+        "arn:aws:events:us-east-1:711398986525:rule/*",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/*/*"
+      ]
+    },
+    {
       "Sid": "FlowDoctorDedupStore",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -88,15 +88,6 @@
       "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
     },
     {
-      "Sid": "ProducerTriggerStateRead",
-      "Effect": "Allow",
-      "Action": ["events:DescribeRule", "scheduler:GetSchedule"],
-      "Resource": [
-        "arn:aws:events:us-east-1:711398986525:rule/*",
-        "arn:aws:scheduler:us-east-1:711398986525:schedule/*/*"
-      ]
-    },
-    {
       "Sid": "FlowDoctorDedupStore",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -317,13 +317,13 @@ def load_registry(s3_client: Any, bucket: str, key: str) -> list[ArtifactSpec]:
 def load_registry_with_recovery(
     s3_client: Any, bucket: str, key: str
 ) -> tuple[list[ArtifactSpec], dict[str, dict], dict[str, list[str]],
-           dict[str, bool], dict[str, str]]:
+           dict[str, bool], dict[str, str], dict[str, str]]:
     """Like :func:`load_registry`, but also returns the per-artifact
     ``recovery:`` spec map (config#1240), the
     ``critical_while_champion_arm`` map (config-I3086), the
-    ``escalate_to_issue`` map (config#2055 Gap 2), and the
-    ``remediation:`` declared-response-lane map (config-I3282), all keyed
-    by ``artifact_id``.
+    ``escalate_to_issue`` map (config#2055 Gap 2), the
+    ``remediation:`` declared-response-lane map (config-I3282), and the
+    ``producer_trigger`` map (config-I6570), all keyed by ``artifact_id``.
 
     ``ArtifactSpec`` is a frozen lib dataclass without a ``recovery``
     field (the monitor's dispatch concern is not the substrate's
@@ -347,6 +347,7 @@ def load_registry_with_recovery(
     critical_arms_by_id: dict[str, list[str]] = {}
     escalate_to_issue_by_id: dict[str, bool] = {}
     remediation_by_id: dict[str, str] = {}
+    producer_trigger_by_id: dict[str, str] = {}
     for entry in data["artifacts"]:
         merged = {**defaults, **entry}
         merged["created_at"] = _coerce_date(merged["created_at"])
@@ -365,8 +366,22 @@ def load_registry_with_recovery(
         remediation = merged.get("remediation")
         if isinstance(remediation, str) and remediation:
             remediation_by_id[spec.artifact_id] = remediation
+        # config-I6570 — only a well-formed trigger is carried. A malformed
+        # value is dropped here rather than raising: the field's whole job is
+        # to REMOVE a page, so a typo must degrade to today's behaviour, not
+        # to a registry that fails to load. The PR-time validator in
+        # alpha-engine-config is the chokepoint that catches the typo.
+        producer_trigger = merged.get("producer_trigger")
+        if parse_producer_trigger(producer_trigger) is not None:
+            producer_trigger_by_id[spec.artifact_id] = producer_trigger
+        elif producer_trigger is not None:
+            logger.warning(
+                "registry row %s carries a malformed producer_trigger %r — "
+                "expected '<events|scheduler>:<name>'; row keeps alerting",
+                spec.artifact_id, producer_trigger,
+            )
     return (specs, recovery_by_id, critical_arms_by_id,
-            escalate_to_issue_by_id, remediation_by_id)
+            escalate_to_issue_by_id, remediation_by_id, producer_trigger_by_id)
 
 
 # ── Dynamic severity (config-I3086) ─────────────────────────────────────────
@@ -434,6 +449,194 @@ def apply_dynamic_severity(
         else:
             out.append(spec)
     return out, coerced
+
+
+# ── Producer-trigger suppression (alpha-engine-config-I6570) ────────────────
+#
+# A registry row's miss means "this artifact is late". It does NOT distinguish
+# "the producer ran and failed" from "the producer was deliberately switched
+# off" — and after the 2026-08-07 automation-pause ruling (config-I6617)
+# disabled 40 triggers, most of the registry is in the second state. Paging on
+# a deliberately-off producer trains the operator to ignore the monitor, which
+# is the same outcome as not having one.
+#
+# The authority is LIVE AWS, never the pause manifest. `automation_pause.json`
+# is the record of the ruling; a rule can also be off for reasons that ruling
+# never covered, and the manifest can drift from reality in both directions.
+# Asking EventBridge whether the producing rule is ENABLED answers the actual
+# question and needs no second source to stay in sync.
+#
+# THREE properties this must not lose:
+#   1. It fails toward PAGING. Any error resolving a trigger's state — denied,
+#      throttled, renamed, absent — leaves the row alerting exactly as today.
+#      A suppression path that fails open is a monitor that can be silenced by
+#      an IAM regression.
+#   2. It is never silent. A suppressed row still lands in check_results.json
+#      with its true state and `alert_suppressed: true` + the trigger name, so
+#      the console renders "stale — producer disabled", never green.
+#      principles.md §2.7: no data is never rendered as green, and neither is
+#      deliberately-off.
+#   3. It EXPIRES. A pause that becomes permanent must not become a permanent
+#      blindfold. First-observed-disabled is persisted, and past
+#      PRODUCER_SUPPRESSION_MAX_DAYS the suppression lapses and the row pages
+#      again — the page then reads as "this has been off for N days", which is
+#      the decision the operator actually owes.
+PRODUCER_SUPPRESSION_MAX_DAYS = int(
+    os.environ.get("PRODUCER_SUPPRESSION_MAX_DAYS", "14")
+)
+PRODUCER_DISABLED_SINCE_KEY = "_freshness_monitor/producer_disabled_since.json"
+
+_PRODUCER_SURFACES = ("events", "scheduler")
+
+
+def parse_producer_trigger(value: Any) -> tuple[str, str] | None:
+    """Parse a registry ``producer_trigger`` scalar into ``(surface, name)``.
+
+    Grammar is ``"<surface>:<name>"`` where surface is ``events`` (an
+    EventBridge rule) or ``scheduler`` (an EventBridge Scheduler schedule) —
+    different APIs, not aliases, exactly as ``automation_pause.py`` splits
+    them. Anything else returns ``None`` and the row keeps today's behaviour;
+    a malformed field must never suppress.
+    """
+    if not isinstance(value, str) or ":" not in value:
+        return None
+    surface, _, name = value.partition(":")
+    surface, name = surface.strip(), name.strip()
+    if surface not in _PRODUCER_SURFACES or not name:
+        return None
+    return surface, name
+
+
+def resolve_disabled_producers(
+    triggers: set[str],
+    events_client: Any = None,
+    scheduler_client: Any = None,
+) -> dict[str, str]:
+    """Return ``{trigger: reason}`` for triggers LIVE-confirmed disabled.
+
+    A trigger absent from the result is treated as enabled, which is the
+    fail-toward-paging direction: an unresolvable trigger must not suppress
+    its artifact's page. Each lookup is trapped individually so one denied or
+    renamed trigger cannot blind the rest of the pass.
+    """
+    disabled: dict[str, str] = {}
+    if not triggers:
+        return disabled
+    for trigger in sorted(triggers):
+        parsed = parse_producer_trigger(trigger)
+        if parsed is None:
+            continue
+        surface, name = parsed
+        try:
+            if surface == "events":
+                client = events_client or boto3.client("events")
+                state = client.describe_rule(Name=name).get("State", "")
+                if state == "DISABLED":
+                    disabled[trigger] = f"EventBridge rule {name} is DISABLED"
+            else:
+                client = scheduler_client or boto3.client("scheduler")
+                state = client.get_schedule(Name=name).get("State", "")
+                if state == "DISABLED":
+                    disabled[trigger] = f"Scheduler schedule {name} is DISABLED"
+        except Exception as exc:  # noqa: BLE001 — fail toward paging, never toward silence
+            logger.warning(
+                "producer-trigger state unresolved for %s (%s: %s) — treating "
+                "as ENABLED so its artifacts keep alerting",
+                trigger, type(exc).__name__, exc,
+            )
+    return disabled
+
+
+def _load_producer_disabled_since(s3_client: Any) -> dict[str, str]:
+    """First-observed-disabled dates, keyed by trigger. Unreadable ⇒ empty,
+    which means today becomes the first observation — the conservative
+    direction, since a shorter observed pause expires sooner."""
+    try:
+        obj = s3_client.get_object(
+            Bucket=REGISTRY_BUCKET, Key=PRODUCER_DISABLED_SINCE_KEY
+        )
+        data = json.loads(obj["Body"].read())
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
+    except Exception as exc:  # noqa: BLE001 — absent on first run; never fatal
+        logger.info(
+            "producer_disabled_since unreadable (%s) — treating every currently "
+            "disabled trigger as first observed today", type(exc).__name__,
+        )
+    return {}
+
+
+def _save_producer_disabled_since(s3_client: Any, mapping: dict[str, str]) -> None:
+    try:
+        s3_client.put_object(
+            Bucket=REGISTRY_BUCKET,
+            Key=PRODUCER_DISABLED_SINCE_KEY,
+            Body=json.dumps(mapping, indent=2, sort_keys=True).encode(),
+            ContentType="application/json",
+        )
+    except Exception as exc:  # noqa: BLE001 — bookkeeping; the pass's deliverables stand
+        logger.warning(
+            "could not persist producer_disabled_since (%s: %s) — suppression "
+            "ages from today on the next pass instead of from first observation",
+            type(exc).__name__, exc,
+        )
+
+
+def apply_producer_suppression(
+    s3_client: Any,
+    producer_trigger_by_id: dict[str, str],
+    now: datetime,
+    events_client: Any = None,
+    scheduler_client: Any = None,
+) -> dict[str, dict[str, Any]]:
+    """Resolve which artifacts have a deliberately-disabled producer.
+
+    Returns ``{artifact_id: {"trigger", "reason", "disabled_since",
+    "days_disabled", "suppressed"}}`` for every artifact whose producer is
+    live-confirmed DISABLED. ``suppressed`` is False once the pause has run
+    past :data:`PRODUCER_SUPPRESSION_MAX_DAYS` — the row is still annotated
+    (so the console can explain the page) but it pages again.
+    """
+    if not producer_trigger_by_id:
+        return {}
+    disabled = resolve_disabled_producers(
+        set(producer_trigger_by_id.values()), events_client, scheduler_client
+    )
+    since = _load_producer_disabled_since(s3_client)
+    today = now.date().isoformat()
+    # Drop triggers that came back — a re-enabled producer restarts the clock.
+    next_since = {k: v for k, v in since.items() if k in disabled}
+    for trigger in disabled:
+        next_since.setdefault(trigger, today)
+    if next_since != since:
+        _save_producer_disabled_since(s3_client, next_since)
+
+    out: dict[str, dict[str, Any]] = {}
+    for artifact_id, trigger in producer_trigger_by_id.items():
+        reason = disabled.get(trigger)
+        if reason is None:
+            continue
+        first_seen = next_since.get(trigger, today)
+        try:
+            days = (now.date() - date.fromisoformat(first_seen)).days
+        except ValueError:
+            days = 0
+        suppressed = days < PRODUCER_SUPPRESSION_MAX_DAYS
+        if not suppressed:
+            logger.warning(
+                "producer-suppression LAPSED for %s: %s has been disabled %d "
+                "days (limit %d) — paging again, a pause this long is a "
+                "decision, not a state",
+                artifact_id, trigger, days, PRODUCER_SUPPRESSION_MAX_DAYS,
+            )
+        out[artifact_id] = {
+            "trigger": trigger,
+            "reason": reason,
+            "disabled_since": first_seen,
+            "days_disabled": days,
+            "suppressed": suppressed,
+        }
+    return out
 
 
 def _load_prev_miss_counts(s3_client: Any) -> dict[str, int]:
@@ -521,6 +724,7 @@ def _serialize_check_results(
     miss_counts: dict[str, int] | None = None,
     coerced_ids: set[str] | None = None,
     issue_filed_by_id: dict[str, str | None] | None = None,
+    suppression_by_id: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the ``check_results.json`` payload — one row per spec for
     the dashboard surface (Phase 5). ``miss_counts``/``coerced_ids``
@@ -530,14 +734,33 @@ def _serialize_check_results(
     ``issue_filed_by_id`` (config#2055 Gap 2) persists the extended-
     staleness escalation's dedup marker — the URL of the P1 filed for
     this artifact's current incident, or ``None``/absent if none is
-    in flight."""
+    in flight.
+
+    ``suppression_by_id`` (config-I6570) annotates rows whose producing
+    trigger is live-confirmed DISABLED. The row keeps its TRUE state — a
+    stale artifact behind a paused producer is still stale — and gains the
+    trigger, the date it was first observed off, and whether the page was
+    suppressed. The console must render these as "producer disabled", never
+    as green and never as a silent omission."""
     miss_counts = miss_counts or {}
     coerced_ids = coerced_ids or set()
     issue_filed_by_id = issue_filed_by_id or {}
+    suppression_by_id = suppression_by_id or {}
     rows = []
     for spec, result in pairs:
+        suppression = suppression_by_id.get(spec.artifact_id)
         rows.append(
             {
+                "producer_trigger": (
+                    suppression["trigger"] if suppression else None
+                ),
+                "producer_disabled": suppression is not None,
+                "producer_disabled_since": (
+                    suppression["disabled_since"] if suppression else None
+                ),
+                "alert_suppressed": bool(
+                    suppression and suppression["suppressed"]
+                ),
                 "artifact_id": spec.artifact_id,
                 "owner_repo": spec.owner_repo,
                 "severity": spec.severity,
@@ -1024,7 +1247,8 @@ _ALERTING_STATES = frozenset({"missing", "stale", "probe_failed"})
 
 
 def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
-                 consecutive_miss_runs: int = 0) -> bool:
+                 consecutive_miss_runs: int = 0,
+                 producer_suppression: dict[str, Any] | None = None) -> bool:
     """Route an alert for a non-fresh probe result. Returns True if
     publish was attempted (OBSERVE-mode short-circuit returns False).
 
@@ -1043,6 +1267,24 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
     how many 15min probes have already fired in this window.
     """
     if result.state not in _ALERTING_STATES:
+        return False
+
+    # config-I6570 — the producing trigger is live-confirmed DISABLED, so this
+    # miss is a deliberate switch-off rather than a producer failure. Placed
+    # BEFORE the SLA and severity gates on purpose: severity describes what
+    # the artifact's absence costs downstream, and that cost is unchanged by
+    # WHY it is absent — only the page is. The row still reaches
+    # check_results.json with its true state and `alert_suppressed: true`
+    # (see `_serialize_check_results`), so this removes a page, never a fact.
+    # Suppression lapses past PRODUCER_SUPPRESSION_MAX_DAYS.
+    if producer_suppression and producer_suppression.get("suppressed"):
+        logger.info(
+            "producer-suppressed (config-I6570): %s state=%s — %s "
+            "(disabled since %s, %d days); console-only, no SNS/Telegram",
+            spec.artifact_id, result.state, producer_suppression["reason"],
+            producer_suppression["disabled_since"],
+            producer_suppression["days_disabled"],
+        )
         return False
 
     # Substrate already filters fresh/grace; the SLA-grace filter
@@ -1601,7 +1843,7 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
     )
 
     (specs, recovery_by_id, critical_arms_by_id, _escalate_to_issue_by_id,
-     remediation_by_id) = (
+     remediation_by_id, producer_trigger_by_id) = (
         load_registry_with_recovery(s3_client, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     specs, _coerced = apply_dynamic_severity(s3_client, specs, critical_arms_by_id)
@@ -1613,9 +1855,20 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
             sorted(missing_ids),
         )
 
+    # config-I6570 — restricted to the two intraday rows, so the mini-rule
+    # makes at most two extra describe calls per 30min.
+    intraday_triggers = {
+        aid: t for aid, t in producer_trigger_by_id.items()
+        if aid in INTRADAY_ARTIFACT_IDS
+    }
+    suppression_by_id = apply_producer_suppression(
+        s3_client, intraday_triggers, now
+    )
+
     pairs, alerted, dispatched, per_spec_exceptions, _miss_counts = _run_probe_pass(
         s3_client, intraday_specs, recovery_by_id, now,
         remediation_by_id=remediation_by_id,
+        suppression_by_id=suppression_by_id,
     )
 
     duration_seconds = round(time.time() - started_at, 2)
@@ -1646,6 +1899,7 @@ def _run_probe_pass(
     now: datetime,
     prev_miss_counts: dict[str, int] | None = None,
     remediation_by_id: dict[str, str] | None = None,
+    suppression_by_id: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[tuple[ArtifactSpec, CheckResult]], int, int, int, dict[str, int]]:
     """Walk ``specs``, probe each, dispatch confirmed-miss recoveries, and
     alert. Returns ``(pairs, alerted, dispatched, per_spec_exceptions)``.
@@ -1721,7 +1975,9 @@ def _run_probe_pass(
         )
         paged = False
         if not suppress_page and _maybe_alert(
-                spec, result, now, consecutive_miss_runs=miss_runs):
+                spec, result, now, consecutive_miss_runs=miss_runs,
+                producer_suppression=(suppression_by_id or {}).get(
+                    spec.artifact_id)):
             alerted += 1
             paged = True
 
@@ -1791,24 +2047,39 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # Load registry. If THIS fails, we want the Lambda to error out
     # so the CW alarm fires — a broken registry must not be silent.
     (specs, recovery_by_id, critical_arms_by_id, escalate_to_issue_by_id,
-     remediation_by_id) = (
+     remediation_by_id, producer_trigger_by_id) = (
         load_registry_with_recovery(s3, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     logger.info(
         "loaded %d specs from registry (%d with recovery specs, %d with "
         "champion-arm dynamic severity, %d flagged for issue escalation, "
-        "%d with declared remediation lanes)",
+        "%d with declared remediation lanes, %d with a declared producer "
+        "trigger)",
         len(specs), len(recovery_by_id), len(critical_arms_by_id),
         len(escalate_to_issue_by_id), len(remediation_by_id),
+        len(producer_trigger_by_id),
     )
 
     # config-I3086: dynamic severity + warning-escalation counters.
     specs, coerced_ids = apply_dynamic_severity(s3, specs, critical_arms_by_id)
     prev_miss_counts = _load_prev_miss_counts(s3)
+    # config-I6570: which producers are deliberately switched off right now.
+    suppression_by_id = apply_producer_suppression(s3, producer_trigger_by_id, now)
+    if suppression_by_id:
+        logger.info(
+            "producer-trigger suppression active for %d artifact(s): %s",
+            len(suppression_by_id),
+            sorted(
+                f"{a}({v['trigger']},{v['days_disabled']}d,"
+                f"{'suppressed' if v['suppressed'] else 'LAPSED'})"
+                for a, v in suppression_by_id.items()
+            ),
+        )
 
     pairs, alerted, dispatched, per_spec_exceptions, miss_counts = _run_probe_pass(
         s3, specs, recovery_by_id, now, prev_miss_counts,
         remediation_by_id=remediation_by_id,
+        suppression_by_id=suppression_by_id,
     )
 
     # config#2055 Gap 2: extended-staleness -> Decision Queue P1. Runs after
@@ -1824,6 +2095,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     check_results = _serialize_check_results(
         pairs, now, miss_counts=miss_counts, coerced_ids=coerced_ids,
         issue_filed_by_id=issue_filed_by_id,
+        suppression_by_id=suppression_by_id,
     )
     heartbeat = _serialize_heartbeat(pairs, now, started_at)
 

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -1718,7 +1718,7 @@ def test_load_registry_with_recovery_parses_block(monkeypatch, fake_s3):
     artifact_id; artifacts without a block are absent from the map."""
     fake_s3._registry_body = _RECOVERY_REGISTRY
     import index
-    specs, recovery, critical_arms, _esc, _rem = index.load_registry_with_recovery(
+    specs, recovery, critical_arms, _esc, _rem, _pt = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert len(specs) == 2
     assert set(recovery) == {"closes_recoverable"}
@@ -1773,7 +1773,7 @@ def _keyed_get_object(fake_s3, extra: dict[str, bytes]) -> None:
 def test_load_registry_parses_critical_while_champion_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    _specs, _recovery, critical_arms, _esc, _rem = index.load_registry_with_recovery(
+    _specs, _recovery, critical_arms, _esc, _rem, _pt = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert critical_arms == {"champion_feed": ["scanner_predictor_direct"]}
 
@@ -1781,7 +1781,7 @@ def test_load_registry_parses_critical_while_champion_arm(fake_s3):
 def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY:
             b'{"schema_version": 1, "champion": "scanner_predictor_direct"}',
@@ -1797,7 +1797,7 @@ def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
 def test_dynamic_severity_not_coerced_for_other_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY: b'{"schema_version": 1, "champion": "think_tank"}',
     })
@@ -1812,7 +1812,7 @@ def test_dynamic_severity_pointer_read_failure_fails_toward_critical(fake_s3):
     fail toward paging, never toward silence."""
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {index.CHAMPION_POINTER_KEY: None})
     coerced_specs, coerced_ids = index.apply_dynamic_severity(
         fake_s3, specs, arms)
@@ -1960,7 +1960,7 @@ artifacts:
     created_at: 2025-01-01
 """
     import index
-    _specs, _recovery, _arms, escalate, _rem = index.load_registry_with_recovery(
+    _specs, _recovery, _arms, escalate, _rem, _pt = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert escalate == {"config_scoring_weights": True}
 
@@ -2299,7 +2299,7 @@ def test_load_registry_parses_remediation_map(monkeypatch, fake_s3):
     undeclared rows are simply absent."""
     import index
     fake_s3._registry_body = _DRAIN_REGISTRY
-    _s, _r, _a, _e, remediation = index.load_registry_with_recovery(
+    _s, _r, _a, _e, remediation, _pt = index.load_registry_with_recovery(
         fake_s3, "b", "k"
     )
     assert remediation == {
@@ -2418,3 +2418,251 @@ def test_drain_dispatch_failure_does_not_sink_pass(
     put_keys = [k for (_, k, _) in fake_s3._put_calls]
     assert "_freshness_monitor/heartbeat.json" in put_keys
     assert "_freshness_monitor/check_results.json" in put_keys
+
+
+# ── Producer-trigger suppression (alpha-engine-config-I6570) ────────────────
+#
+# The property under test is narrow and load-bearing: a deliberately-disabled
+# producer must remove the PAGE and nothing else. The row's state, its
+# severity, and its presence on the console surface are all unchanged, and any
+# failure to establish that the producer is off leaves the page intact.
+
+_PRODUCER_REGISTRY = b"""\
+schema_version: 1
+defaults:
+  s3_bucket: alpha-engine-research
+  grace_period_cycles: 2
+  calendar_aware: true
+  severity: warning
+artifacts:
+  - artifact_id: paused_producer
+    s3_key_template: "thinktank/challenger_selection/latest.json"
+    cadence: continuous
+    interval_minutes: 1440
+    sla_minutes_after_cron: 720
+    severity: critical
+    producer_trigger: "events:alpha-research-thinktank-daily"
+    owner_repo: crucible-research
+    created_at: 2025-01-01
+  - artifact_id: scheduler_producer
+    s3_key_template: "overseer/drain/latest.json"
+    cadence: continuous
+    interval_minutes: 360
+    sla_minutes_after_cron: 60
+    severity: critical
+    producer_trigger: "scheduler:alpha-engine-alert-drain-0400utc"
+    owner_repo: nousergon-data
+    created_at: 2025-01-01
+  - artifact_id: malformed_producer
+    s3_key_template: "staging/x/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    producer_trigger: "alpha-research-thinktank-daily"
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+  - artifact_id: no_producer
+    s3_key_template: "staging/y/{trading_day}.parquet"
+    cadence: weekday_sf
+    sla_minutes_after_cron: 30
+    owner_repo: alpha-engine-data
+    created_at: 2025-01-01
+"""
+
+
+def _events(state):
+    c = mock.Mock()
+    c.describe_rule.return_value = {"State": state}
+    return c
+
+
+def _scheduler(state):
+    c = mock.Mock()
+    c.get_schedule.return_value = {"State": state}
+    return c
+
+
+def test_parse_producer_trigger_grammar():
+    import index
+    assert index.parse_producer_trigger("events:r") == ("events", "r")
+    assert index.parse_producer_trigger("scheduler:s") == ("scheduler", "s")
+    assert index.parse_producer_trigger(" events : r ") == ("events", "r")
+    # Anything that is not the declared grammar must not suppress.
+    for bad in (None, "", "r", "lambda:r", "events:", ":r", 42, ["events:r"]):
+        assert index.parse_producer_trigger(bad) is None
+
+
+def test_loader_parses_producer_trigger_and_drops_malformed(fake_s3):
+    """A well-formed trigger is carried; a malformed one is dropped rather
+    than raising — the field's job is to REMOVE a page, so a typo degrades to
+    today's alerting behaviour instead of taking the registry down."""
+    import index
+    fake_s3._registry_body = _PRODUCER_REGISTRY
+    specs, _r, _a, _e, _rem, producer = index.load_registry_with_recovery(
+        fake_s3, "b", "k"
+    )
+    assert {s.artifact_id for s in specs} == {
+        "paused_producer", "scheduler_producer", "malformed_producer", "no_producer",
+    }
+    assert producer == {
+        "paused_producer": "events:alpha-research-thinktank-daily",
+        "scheduler_producer": "scheduler:alpha-engine-alert-drain-0400utc",
+    }
+
+
+def test_resolve_disabled_producers_reads_live_state():
+    import index
+    assert index.resolve_disabled_producers(
+        {"events:r"}, events_client=_events("DISABLED")
+    ) == {"events:r": "EventBridge rule r is DISABLED"}
+    assert index.resolve_disabled_producers(
+        {"events:r"}, events_client=_events("ENABLED")
+    ) == {}
+    assert index.resolve_disabled_producers(
+        {"scheduler:s"}, scheduler_client=_scheduler("DISABLED")
+    ) == {"scheduler:s": "Scheduler schedule s is DISABLED"}
+
+
+def test_resolve_disabled_producers_fails_toward_paging():
+    """An unresolvable trigger — denied, throttled, renamed, absent — is
+    treated as ENABLED. A suppression path that fails open is a monitor that
+    an IAM regression can silence."""
+    import index
+    boom = mock.Mock()
+    boom.describe_rule.side_effect = RuntimeError("AccessDeniedException")
+    assert index.resolve_disabled_producers({"events:r"}, events_client=boom) == {}
+
+
+def test_apply_producer_suppression_stamps_first_observation(fake_s3, fixed_now):
+    import index
+    fake_s3._registry_body = b"not json"  # disabled_since store absent/unreadable
+    out = index.apply_producer_suppression(
+        fake_s3,
+        {"paused_producer": "events:r"},
+        fixed_now,
+        events_client=_events("DISABLED"),
+    )
+    assert out["paused_producer"]["suppressed"] is True
+    assert out["paused_producer"]["disabled_since"] == fixed_now.date().isoformat()
+    assert out["paused_producer"]["days_disabled"] == 0
+    # First observation is persisted so the expiry clock survives the invocation.
+    assert any(
+        key == index.PRODUCER_DISABLED_SINCE_KEY
+        for _bucket, key, _body in fake_s3._put_calls
+    )
+
+
+def test_apply_producer_suppression_lapses_past_max_days(fake_s3, fixed_now, monkeypatch):
+    """A pause that becomes permanent must not become a permanent blindfold:
+    past the ceiling the row is still annotated but pages again."""
+    import index
+    monkeypatch.setattr(index, "PRODUCER_SUPPRESSION_MAX_DAYS", 14)
+    monkeypatch.setattr(
+        index, "_load_producer_disabled_since",
+        lambda _s3: {"events:r": "2026-05-01"},   # 29 days before fixed_now
+    )
+    out = index.apply_producer_suppression(
+        fake_s3, {"a": "events:r"}, fixed_now, events_client=_events("DISABLED")
+    )
+    assert out["a"]["days_disabled"] == 29
+    assert out["a"]["suppressed"] is False
+
+
+def test_apply_producer_suppression_clears_a_re_enabled_trigger(fake_s3, fixed_now, monkeypatch):
+    import index
+    saved: list[dict] = []
+    monkeypatch.setattr(
+        index, "_load_producer_disabled_since", lambda _s3: {"events:r": "2026-05-01"}
+    )
+    monkeypatch.setattr(
+        index, "_save_producer_disabled_since",
+        lambda _s3, mapping: saved.append(mapping),
+    )
+    out = index.apply_producer_suppression(
+        fake_s3, {"a": "events:r"}, fixed_now, events_client=_events("ENABLED")
+    )
+    assert out == {}            # enabled producer ⇒ no annotation at all
+    assert saved == [{}]        # and the clock is reset, not carried forward
+
+
+def test_maybe_alert_suppressed_when_producer_disabled(monkeypatch, fixed_now):
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="paused_producer", s3_bucket="b", s3_key_template="k",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="critical", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="missing", sla_violated_by_minutes=999)
+    publish_mock = mock.Mock()
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock())
+
+    suppression = {
+        "trigger": "events:r", "reason": "EventBridge rule r is DISABLED",
+        "disabled_since": "2026-05-29", "days_disabled": 1, "suppressed": True,
+    }
+    assert index._maybe_alert(
+        spec, result, fixed_now, producer_suppression=suppression) is False
+    assert publish_mock.call_count == 0
+
+    # Same critical row, same miss — suppression lapsed ⇒ it pages.
+    assert index._maybe_alert(
+        spec, result, fixed_now,
+        producer_suppression={**suppression, "suppressed": False}) is True
+    assert publish_mock.call_count == 1
+
+
+def test_check_results_row_records_suppression_without_hiding_the_state(fixed_now):
+    """A suppressed row keeps its TRUE state on the console surface. The
+    console must be able to render 'stale — producer disabled'; it must never
+    render green and the row must never be omitted (principles.md §2.7)."""
+    import index
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="paused_producer", s3_bucket="b", s3_key_template="k",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="critical", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="stale", sla_violated_by_minutes=4320)
+    payload = index._serialize_check_results(
+        [(spec, result)], fixed_now,
+        suppression_by_id={
+            "paused_producer": {
+                "trigger": "events:alpha-research-thinktank-daily",
+                "reason": "EventBridge rule alpha-research-thinktank-daily is DISABLED",
+                "disabled_since": "2026-05-20", "days_disabled": 10,
+                "suppressed": True,
+            }
+        },
+    )
+    row = payload["results"][0]
+    assert row["state"] == "stale"                     # not rewritten
+    assert row["severity"] == "critical"               # not downgraded
+    assert row["sla_violated_by_minutes"] == 4320      # not zeroed
+    assert row["producer_disabled"] is True
+    assert row["alert_suppressed"] is True
+    assert row["producer_trigger"] == "events:alpha-research-thinktank-daily"
+    assert row["producer_disabled_since"] == "2026-05-20"
+
+
+def test_check_results_row_defaults_are_inert_without_suppression(fixed_now):
+    import index
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+
+    spec = ArtifactSpec(
+        artifact_id="no_producer", s3_bucket="b", s3_key_template="k",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity="warning", owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    row = index._serialize_check_results(
+        [(spec, CheckResult(state="fresh"))], fixed_now
+    )["results"][0]
+    assert row["producer_disabled"] is False
+    assert row["alert_suppressed"] is False
+    assert row["producer_trigger"] is None
+    assert row["producer_disabled_since"] is None


### PR DESCRIPTION
## What & why

Closes the runtime half of `alpha-engine-config-I6570`, per Brian's 2026-08-08 SOTA ruling. A registry miss means "this artifact is late". It did **not** distinguish "the producer ran and failed" from "the producer was switched off on purpose" — and since the 2026-08-07 automation-pause ruling (`config-I6617`) disabled 40 triggers, most of the registry is in the second state.

The concrete page this fixes: `thinktank_challenger_selection` is `critical`, genuinely frozen at 2026-07-31 (`config-I6613`), and its producer `alpha-research-thinktank-daily` is `DISABLED`. Paging on a deliberately-off producer trains the operator to ignore the monitor, which is the same outcome as not having one.

**The authority is live AWS, never the pause manifest.** `automation_pause.json` is the record of a ruling; a rule can also be off for reasons that ruling never covered, and the manifest can drift from reality in both directions. Asking EventBridge whether the producing rule is `ENABLED` answers the actual question and needs no second source to stay in sync — and it generalises past this pause to any disabled trigger, for any reason.

## How

Follows the loader's existing parallel-map convention (`recovery` / `remediation` / `critical_while_champion_arm`) rather than extending `ArtifactSpec` — so **no `nousergon-lib` change and no version floor**.

| | |
|---|---|
| `load_registry_with_recovery` | returns a 6th map, `producer_trigger_by_id` |
| `resolve_disabled_producers` | live `events:DescribeRule` / `scheduler:GetSchedule` |
| `apply_producer_suppression` | per-artifact verdict; persists first-observed-disabled to `_freshness_monitor/producer_disabled_since.json` |
| `_maybe_alert` | returns `False` for a suppressed row, **before** the SLA and severity gates |
| IAM | **deliberately NOT in this PR** — see below |

The gate sits ahead of the severity check on purpose: severity describes what the artifact's absence costs downstream, and that cost is unchanged by *why* it is absent. Only the page changes.

## The IAM grant is split out on purpose

`deploy-freshness-monitor.yml` runs `deploy.sh --code-only` on merge — CODE only, never IAM, stated in its own header. An `iam-policy.json` change committed here would therefore be **inert on merge**: a post-merge step in disguise, which `pull-request-policy.md` §4.2 does not permit in any of its three forms, and which `iam-policy-change-guard` correctly failed this PR for. Applying it in-session (form 2) was attempted and denied by this laptop's permission classifier.

**The split is safe because the feature fails toward paging.** Without `events:DescribeRule` / `scheduler:GetSchedule`, every lookup raises `AccessDeniedException`, is trapped, logs a warning naming the trigger, and the artifact keeps alerting exactly as it does today. So this PR merges correct-and-inert rather than correct-and-half-applied, and the suppression switches itself on the moment the grant lands — no redeploy, no code change.

Tracked with the exact command and its verification at **`alpha-engine-config-I6661`** (`gate:operator`). The durable fix — teaching the deploy workflow to apply IAM on merge — needs `github-actions-lambda-deploy` to hold `iam:PutRolePolicy`, which is a privilege expansion and Brian's ruling; it is deliverable 3 on that issue.

## Three properties deliberately preserved

1. **It fails toward paging.** Any error resolving a trigger — denied, throttled, renamed, absent — leaves the row alerting exactly as today. A suppression path that fails open is a monitor an IAM regression can silence. Pinned by `test_resolve_disabled_producers_fails_toward_paging`.
2. **It is never silent.** A suppressed row still lands in `check_results.json` with its true state, its true severity, its true SLA breach, plus `alert_suppressed: true`, the trigger name, and the date it went off — so the console renders "stale — producer disabled". `principles.md` §2.7: no data is never rendered green, and neither is deliberately-off. Pinned by `test_check_results_row_records_suppression_without_hiding_the_state`.
3. **It expires.** Past `PRODUCER_SUPPRESSION_MAX_DAYS` (14) the suppression lapses and the row pages again. A pause that becomes permanent must not become a permanent blindfold; at that point "this has been off for N days" is the decision the operator owes. Pinned by `test_apply_producer_suppression_lapses_past_max_days`.

## Test plan

- `python3 -m pytest test_handler.py -q` in `infrastructure/lambdas/freshness-monitor/` → **97 passed** (10 new). Existing 7 tests updated for the loader's new tuple arity.
- `python3 -m pytest tests -q --continue-on-collection-errors` → 3823 passed / 173 failed. Every failure is a missing optional dependency in the local interpreter (`pyarrow`, `bs4`, `tenacity`, `yfinance`) and is **pre-existing**: the identical command on `origin/main` in the shared checkout gives 3819 passed / 177 failed at the same SHA. None of them touch the freshness monitor. CI installs those deps.

## Cross-repo

- `alpha-engine-config-PR6660` — the `producer_trigger` registry field, the PR-time validator, and the two Think Tank declarations.
- `alpha-engine-config-I6661` — the IAM grant, as an operator action with the command and its verification.
- **Merge `alpha-engine-config-PR6660` first**, then this. The loader strips unknown keys by design so neither order can break the live registry; this order just avoids a window where the monitor looks for a field no row carries.

Closes nousergon/alpha-engine-config#6570

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
