### PR TITLE
[P2/low] fix(iam): grant the freshness-monitor role events:DescribeRule + scheduler:GetSchedule (config-I6661)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -88,6 +88,15 @@
       "Resource": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*"
     },
     {
+      "Sid": "ProducerTriggerStateRead",
+      "Effect": "Allow",
+      "Action": ["events:DescribeRule", "scheduler:GetSchedule"],
+      "Resource": [
+        "arn:aws:events:us-east-1:711398986525:rule/*",
+        "arn:aws:scheduler:us-east-1:711398986525:schedule/*/*"
+      ]
+    },
+    {
       "Sid": "FlowDoctorDedupStore",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## What & why

Closes `alpha-engine-config-I6661`. `config-I6570`'s producer suppression (merged in `nousergon-data-PR1243`) reads the **live** state of a registry row's producing trigger, so the freshness monitor can withhold a page for a producer that is deliberately switched off. It needs two read actions the role did not have:

- `events:DescribeRule` on `arn:aws:events:us-east-1:711398986525:rule/*`
- `scheduler:GetSchedule` on `arn:aws:scheduler:us-east-1:711398986525:schedule/*/*`

Read-only, this account only. The resource paths are wildcarded because the monitor must be able to ask about any trigger a registry row names, and rows name triggers across the fleet.

## Already applied — this PR records it, it does not promise it

`pull-request-policy.md` §4.2 form 2. The policy was applied to `alpha-engine-freshness-monitor-role` / `alpha-engine-freshness-monitor-policy` **before this commit existed**, and `aws iam get-role-policy` returns this exact `ProducerTriggerStateRead` statement now — verified by a `jq -S` normalised diff against this file (identical). `iam-policy-change-guard`'s branch 3 ("ALREADY LIVE") passes on the measured outcome rather than on a label or a promise.

That route matters here: `deploy-freshness-monitor.yml` runs `deploy.sh --code-only`, so an IAM change committed to this repo is **never** applied by a merge. Committing it without applying it first would have been a post-merge step in disguise, which is why it was deliberately split out of PR1243 in the first place.

## A defect found while applying it

`deploy.sh --apply-iam` does **not** apply IAM only, despite its own header saying "re-apply iam-policy.json only (no bootstrap side effects, config#2825)". `APPLY_IAM=true` runs the IAM block and then **falls through** to the code deploy, the environment merge, and the registry upload. The registry upload sources `private-docs/ARTIFACT_REGISTRY.yaml` from the local `alpha-engine-config` checkout, which was 4 commits behind `origin/main` — so it silently replaced the live registry in S3 with a stale copy that lacked the two `producer_trigger` rows merged an hour earlier.

Detected and restored from `origin/main` within ~36 seconds; the live object is 161346 bytes with both declarations present, and the freshness monitor's schedule is disabled under `config-I6617` so nothing read the stale copy. **Filed separately — that fix is not in this PR**, which stays confined to the grant.

## Test plan

No code changed — this is an IAM policy document. Verification is the live state:

```
aws iam get-role-policy --role-name alpha-engine-freshness-monitor-role \
  --policy-name alpha-engine-freshness-monitor-policy \
  --query "PolicyDocument.Statement[?Sid=='ProducerTriggerStateRead']"
```

returns the statement, and `jq -S` normalised live vs. this file are identical (`diff -q` clean).

## Related

- `nousergon-data-PR1243` — the code that needs this grant (merged; correct and inert without it).
- `alpha-engine-config-PR6660` — the registry declarations (merged).
- Follow-up, not addressed here: teaching `deploy-freshness-monitor.yml` to apply IAM on merge needs `github-actions-lambda-deploy` to hold `iam:PutRolePolicy` — a privilege expansion and a Brian ruling, deliverable 3 on I6661.

Closes nousergon/alpha-engine-config#6661

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
