### PR TITLE
[P1/mid] fix(deploy): --apply-iam must apply IAM and nothing else (nous-ergon-ops-I520)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -30,7 +30,7 @@
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh             # update code + registry (operator; needs ae-config clone)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only # update code ONLY (CI path; no registry, no ae-config clone)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap # first-time create + wire EventBridge
-#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --apply-iam # re-apply iam-policy.json only (no bootstrap side effects, config#2825)
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --apply-iam # re-apply iam-policy.json and EXIT — no code, no env, no registry (config#2825, config-I6661)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run   # show actions, do not apply
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --smoke     # invoke once after deploy
 
@@ -92,6 +92,27 @@ run() {
     "$@"
   fi
 }
+
+# ----- Apply IAM only, then EXIT (config#2825, config-I6661) ---------------
+# Placed FIRST, before packaging, deliberately. "only" has to mean the whole
+# run, not just the effects at the end: everything below installs pip deps,
+# runs the handler suite and builds a ~29MB zip, none of which an IAM re-apply
+# needs.
+#
+# The exit is the load-bearing line (nous-ergon-ops-I520). Until 2026-08-08
+# this block had none, so --apply-iam applied the policy and then fell through
+# into the code deploy, the environment merge, and the registry upload — and
+# that upload republished ARTIFACT_REGISTRY.yaml from a sibling checkout four
+# commits behind origin/main, silently reverting two rows merged an hour
+# earlier. Every statement below was correct in isolation; the defect was an
+# absent line.
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no registry."
+  exit 0
+fi
 
 # ----- 0a. Syntax-check handler (no imports — works on bare python) --------
 
@@ -159,14 +180,6 @@ ZIP="${PKG}/function.zip"
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
 # ----- 2. Bootstrap (first-time only) ---------------------------------------
-
-# ----- Apply IAM only (config#2825, no bootstrap side effects) -------------
-if $APPLY_IAM; then
-  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
-  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
-fi
 
 if $BOOTSTRAP; then
   echo "Bootstrapping ${FUNCTION_NAME}..."
@@ -401,6 +414,23 @@ fi
 # double-write (harmless) but requires the ae-config clone the CI path lacks.
 
 if ! $CODE_ONLY; then
+  # A publish step sourced from a mutable local checkout is a supply chain with
+  # no version in it (nous-ergon-ops-I520). ${CONFIG_REPO} is a SIBLING repo the
+  # operator has no reason to have refreshed, and concurrent sessions routinely
+  # leave it behind. Refuse rather than silently republish an older registry
+  # over a newer one — this upload is a duplicate of alpha-engine-config's own
+  # sync-artifact-registry.yml, so failing closed costs nothing.
+  if git -C "${CONFIG_REPO}" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "${CONFIG_REPO}" fetch --quiet origin main 2>/dev/null || true
+    BEHIND=$(git -C "${CONFIG_REPO}" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    DIRTY=$(git -C "${CONFIG_REPO}" status --porcelain -- private-docs/ARTIFACT_REGISTRY.yaml 2>/dev/null)
+    if [ "${BEHIND}" -gt 0 ] || [ -n "${DIRTY}" ]; then
+      echo "REFUSING to upload the registry: ${CONFIG_REPO} is ${BEHIND} commit(s) behind origin/main${DIRTY:+ and has uncommitted registry changes}." >&2
+      echo "  Publishing from it would revert the live registry to an older state." >&2
+      echo "  Fix: git -C ${CONFIG_REPO} pull --ff-only   (or re-run with --code-only to skip this step)" >&2
+      exit 1
+    fi
+  fi
   echo "Uploading registry: ${REGISTRY_LOCAL} → s3://${REGISTRY_BUCKET}/${REGISTRY_S3_KEY}"
   run aws s3 cp \
     "${REGISTRY_LOCAL}" \

--- a/tests/test_freshness_deploy_apply_iam_narrows.py
+++ b/tests/test_freshness_deploy_apply_iam_narrows.py
@@ -1,0 +1,139 @@
+"""`--apply-iam` must apply IAM and nothing else.
+
+Bug class — ``narrowing-flag-does-not-narrow``, nous-ergon-ops-I520, 2026-08-08.
+
+The flag was added under config#2825 and documented as "re-apply
+iam-policy.json only (no bootstrap side effects)". It set ``APPLY_IAM=true``,
+ran the IAM block, and then **fell through** into the code deploy, the Lambda
+environment merge, and the registry upload — because the block had no exit.
+
+The registry upload publishes ``private-docs/ARTIFACT_REGISTRY.yaml`` from a
+SIBLING repository's local working copy. On 2026-08-08 an operator ran
+``--apply-iam`` to add two read grants for alpha-engine-config-I6661, and it
+also republished the registry from a checkout four commits behind
+``origin/main`` — silently reverting the two ``producer_trigger`` rows merged
+an hour earlier (alpha-engine-config-PR6660). Detected by reading the command's
+own stdout; nothing in the system would have reported it.
+
+**These tests assert the side effects NOT taken.** That is the countermeasure
+the failure-mode class names, and it is what the existing coverage lacked: a
+test that ``--apply-iam`` applies IAM passes just as happily on the broken
+script. Only "and nothing else happened" distinguishes them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_DEPLOY = _REPO / "infrastructure" / "lambdas" / "freshness-monitor" / "deploy.sh"
+_SRC = _DEPLOY.read_text(encoding="utf-8")
+_CODE = "\n".join(
+    line for line in _SRC.splitlines() if not line.lstrip().startswith("#")
+)
+
+
+def test_deploy_script_exists():
+    assert _DEPLOY.is_file(), f"missing {_DEPLOY}"
+
+
+def test_the_apply_iam_block_exits():
+    """The structural invariant, checked without running anything.
+
+    A narrowing flag's block ends the run. Without this the block is a prefix
+    of the full deploy, not an alternative to it.
+    """
+    match = re.search(r"if \$APPLY_IAM; then(.*?)\nfi\n", _CODE, re.DOTALL)
+    assert match, "the --apply-iam block is gone or no longer matches `if $APPLY_IAM; then`"
+    body = match.group(1)
+    assert re.search(r"^\s*exit 0\s*$", body, re.MULTILINE), (
+        "the --apply-iam block does not exit. Control falls through into the "
+        "code deploy, the environment merge and the registry upload — the "
+        "exact defect recorded as nous-ergon-ops-I520."
+    )
+
+
+def test_apply_iam_runs_before_packaging():
+    """"Only" covers the whole run, not just the effects at the end.
+
+    Everything below the packaging step installs pip deps, runs the handler
+    suite and builds a ~29MB zip. An IAM re-apply needs none of it, and doing
+    it anyway is the same promise broken more cheaply.
+    """
+    iam_at = _CODE.index("if $APPLY_IAM; then")
+    package_at = _CODE.index("lambda_pip_install.sh")
+    assert iam_at < package_at, (
+        "the --apply-iam block runs after packaging — it should short-circuit "
+        "before any pip install, test run or zip is built"
+    )
+
+
+@pytest.mark.parametrize(
+    "forbidden,what",
+    [
+        ("update-function-code", "a code deploy"),
+        ("update-function-configuration", "an environment merge"),
+        ("ARTIFACT_REGISTRY.yaml", "a registry upload"),
+        ("publish-version", "a version publish"),
+    ],
+)
+def test_apply_iam_dry_run_takes_no_other_action(tmp_path, forbidden, what):
+    """Behavioural half: run the script for real with a stubbed ``aws`` and
+    assert the forbidden operation never appears in its output.
+
+    Hermetic — ``aws`` is a stub on PATH that echoes its arguments, so nothing
+    reaches an account, and ``--dry-run`` routes the intended call through the
+    script's own ``run`` helper.
+    """
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    aws_stub = stub_dir / "aws"
+    aws_stub.write_text(textwrap.dedent("""\
+        #!/usr/bin/env bash
+        echo "AWSCALL: $*"
+        # get-role must succeed so the script takes the "role exists" path.
+        exit 0
+    """))
+    aws_stub.chmod(0o755)
+
+    child = dict(os.environ)
+    child["PATH"] = f"{stub_dir}:{child['PATH']}"
+    child["DRY_RUN"] = "true"
+
+    proc = subprocess.run(
+        ["bash", str(_DEPLOY), "--apply-iam", "--dry-run"],
+        capture_output=True, text=True, timeout=120, cwd=str(_REPO),
+        env=child,
+    )
+    combined = proc.stdout + proc.stderr
+
+    assert "Applying IAM" in combined, (
+        f"--apply-iam did not reach the IAM block at all:\n{combined[-2000:]}"
+    )
+    assert forbidden not in combined, (
+        f"--apply-iam performed {what} ({forbidden!r}) — the flag promises IAM "
+        f"and nothing else (nous-ergon-ops-I520):\n{combined[-2000:]}"
+    )
+
+
+def test_registry_upload_refuses_a_stale_source():
+    """The second-order half of I520: the upload publishes from a sibling
+    repo's mutable working copy, which concurrent sessions routinely leave
+    behind ``origin/main``. A publish step sourced from a local checkout is a
+    supply chain with no version in it, so it must fail closed.
+    """
+    assert "REFUSING to upload the registry" in _SRC, (
+        "the registry upload no longer guards against a stale ${CONFIG_REPO} — "
+        "it would silently republish an older registry over a newer one "
+        "(nous-ergon-ops-I520)"
+    )
+    assert "rev-list --count HEAD..origin/main" in _CODE, (
+        "the staleness guard must compare against origin/main, not merely "
+        "check that the checkout exists"
+    )


### PR DESCRIPTION
## What & why

Remediation for **`nous-ergon-ops-I520`** (sev3, class `narrowing-flag-does-not-narrow`).

`deploy.sh --apply-iam` is documented as *"re-apply iam-policy.json only (no bootstrap side effects, config#2825)"*. It set `APPLY_IAM=true`, ran the IAM block, and then **fell through** into the code deploy, the environment merge, and the registry upload — the block had no exit. Every statement below it was correct in isolation; the defect was an absent line.

**Live consequence, 2026-08-08.** An operator ran `--apply-iam` to add two read grants (`alpha-engine-config-I6661`). It also republished `private-docs/ARTIFACT_REGISTRY.yaml` to S3 from the local `alpha-engine-config` checkout, which was **4 commits behind `origin/main`** — silently reverting the two `producer_trigger` rows merged an hour earlier (`config-PR6660`). Caught by reading the command's own stdout, restored in ~36s. No consumer read the stale copy because the freshness monitor is paused under `-I6617`; nothing in the system would have reported it.

## Two defects, two fixes

**1. The block exits — and moves ahead of packaging.** "Only" has to cover the whole run, not just the effects at the end. In its old position an IAM re-apply still pip-installed runtime deps, ran the handler suite, and built a ~29MB zip before doing its one job. `--apply-iam` is now five lines of output.

**2. The registry upload refuses a stale source.** It publishes from a **sibling repository's mutable working copy** — a supply chain with no version in it — and concurrent sessions routinely leave that checkout behind `origin/main`. Nothing about running an IAM command suggests refreshing an unrelated repo first. It now fetches, compares, and fails closed naming the exact `git pull` to run. This upload duplicates `alpha-engine-config`'s own `sync-artifact-registry.yml`, so failing closed costs nothing.

## The tests assert what did *not* happen

That is the countermeasure the failure-mode class names, and precisely what the previous coverage lacked: **"it applied IAM" passes just as happily on the broken script.** Only "and nothing else happened" distinguishes them.

- `test_the_apply_iam_block_exits` — structural, no execution.
- `test_apply_iam_runs_before_packaging` — the flag must short-circuit before any pip install, test run or zip.
- `test_apply_iam_dry_run_takes_no_other_action[×4]` — behavioural. Runs the script with a stubbed `aws` on `PATH` and asserts `update-function-code`, `update-function-configuration`, `ARTIFACT_REGISTRY.yaml` and `publish-version` never appear. Hermetic; nothing reaches an account.
- `test_registry_upload_refuses_a_stale_source` — pins the guard and that it compares against `origin/main`, not merely that the checkout exists.

## Test plan

- **Fault-tested.** With the `exit 0` removed again, **3 tests fail** — the structural one plus the two behavioural ones that observe a real code deploy and a real registry upload. Restored → 8 passed. A guard not shown to fail has not been shown to work.
- `python3 -m pytest tests/test_freshness_deploy_apply_iam_narrows.py -q` → 8 passed.
- `infrastructure/lambdas/freshness-monitor/` handler suite → 97 passed.
- `python3 -m pytest tests -q --continue-on-collection-errors` → 3831 passed / 173 failed / 63 errors, all missing-optional-dependency (`pyarrow`, `bs4`, `tenacity`, `yfinance`) and all pre-existing on `main` at the same SHA.
- `bash -n` clean. `shellcheck -S warning` reports one SC2064 at line 130, pre-existing and untouched.

## Related

- `nous-ergon-ops-I520` — the incident record. The failure-mode class `narrowing-flag-does-not-narrow` is new; the registry entry rides `nous-ergon-ops-PR521`.
- `nousergon-data-PR1244` — the IAM grant this was discovered while applying. Independent; either order.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
