### PR TITLE
[P1/mid] feat(expense): page before a prepaid provider account hits zero (config-I6613 deliverable 2)

### DIFF
--- a/infrastructure/lambdas/expense-collector/index.py
+++ b/infrastructure/lambdas/expense-collector/index.py
@@ -216,11 +216,73 @@ def _pace(projected: float | None, limit: float | None) -> str | None:
     return "over" if projected > limit else "under"
 
 
+# config-I6613 — days of runway remaining before a PREPAID account hits zero.
+#
+# Root incident: on 2026-08-05..08 the DeepSeek account ran out and every
+# autonomous lane in the fleet returned `402 Insufficient Balance` for three
+# days, through a live three-day trading outage, while sf-watch dutifully
+# dispatched a diagnose agent each morning that died on the same 402 within 90
+# seconds. The balance was ALREADY BEING COLLECTED here — `credits_remaining`
+# for OpenRouter, `total_balance` for DeepSeek — and buried in a `detail` blob
+# nothing reads. Collected is not observed.
+#
+# Threshold is in DAYS, not dollars, because the useful question is "how long
+# have I got", and a dollar floor means something different at $0.30/month and
+# at $30/month. A 402 is the event where days_to_zero already reached 0, so
+# this has to fire strictly before that.
+BALANCE_ALERT_DAYS = float(os.environ.get("BALANCE_ALERT_DAYS", "7"))
+#: Below this the burn estimate is noise and days_to_zero is not computed —
+#: same reasoning as MIN_PROJECTION_FRAC, applied to the same measurement.
+MIN_BURN_USD_PER_DAY = 1e-6
+
+
+def _days_to_zero(balance_usd: float | None, mtd_cost_usd: float | None,
+                  mw: dict, observed_frac: float | None = None) -> float | None:
+    """Runway in days at the burn actually observed this month, or None.
+
+    None where it cannot be honestly computed — no balance, no spend measured,
+    a burn indistinguishable from zero, or an observation window too short to
+    extrapolate from. None is UNKNOWN; the caller must not read it as safe.
+    """
+    if balance_usd is None or mtd_cost_usd is None:
+        return None
+    obs = mw["elapsed_frac"] if observed_frac is None else observed_frac
+    if obs < MIN_PROJECTION_FRAC:
+        return None
+    observed_days = (mw["total_seconds"] / 86400.0) * obs
+    if observed_days <= 0:
+        return None
+    burn_per_day = mtd_cost_usd / observed_days
+    if burn_per_day < MIN_BURN_USD_PER_DAY:
+        return None
+    # A balance already at or below zero is not "0.0 days of runway left" in a
+    # projection sense — it is an outage in progress. Clamp at 0 so the caller
+    # alerts rather than emitting a negative.
+    return round(max(balance_usd, 0.0) / burn_per_day, 2)
+
+
+def _stamp_funded_balance(row: dict, mw: dict, balance_usd: float | None,
+                          observed_frac: float | None = None) -> dict:
+    """Promote a prepaid balance to a first-class row field and derive its
+    runway. Call AFTER the row's ``mtd_cost_usd`` is final (in place)."""
+    row["funded_balance_usd"] = (
+        None if balance_usd is None else round(balance_usd, 4))
+    row["days_to_zero"] = _days_to_zero(
+        balance_usd, row.get("mtd_cost_usd"), mw, observed_frac)
+    return row
+
+
 def _row(key: str, label: str, **kw) -> dict:
     base = {
         "key": key, "label": label, "status": "ok",
         "mtd_cost_usd": None, "projected_month_end_usd": None,
         "budget_usd": None, "pace": None, "quota": None,
+        # config-I6613 — prepaid depletion. `funded_balance_usd` is what is
+        # LEFT, not what has been spent; `days_to_zero` is when the lights go
+        # out at the observed burn. Both are None for a provider that bills in
+        # arrears (Anthropic, AWS, Neon) and for one whose balance could not
+        # be read — None means UNKNOWN and must never render as healthy.
+        "funded_balance_usd": None, "days_to_zero": None,
         "source": None, "detail": {}, "note": None, "error": None,
     }
     base.update(kw)
@@ -371,6 +433,98 @@ def run_over_budget_alerts(s3, period: str, rows: list[dict]) -> dict:
         return {"alerted": [], "error": str(exc)[:300]}
 
 
+def _alert_balance_depletion(row: dict, period: str) -> bool:
+    """Telegram ping for a prepaid account about to run dry. Delivery-surface
+    failure is logged, never raised — the runway itself is already on the
+    rollup artifact."""
+    bal = row.get("funded_balance_usd")
+    dtz = row.get("days_to_zero")
+    if bal is not None and bal <= 0:
+        headline = (f"*{row['label']}* is at ${bal:,.2f} — **already unfunded**. "
+                    "Every call routed to it is failing with 402.")
+    else:
+        headline = (f"*{row['label']}* has ${bal:,.2f} left, "
+                    f"about **{dtz:.1f} days** at the current burn.")
+    text = (
+        "\U0001f4b3 *Provider balance — running out*\n"
+        + headline
+        + (f"\nMTD spend ${row['mtd_cost_usd']:,.2f} ({period})."
+           if row.get("mtd_cost_usd") is not None else "")
+        + "\n_Top up before it reaches zero — a 402 takes every lane routed "
+          "through this account down at once, and the lanes cannot report it._"
+    )
+    dedup_key = f"{_FLOW_NAME}:balance:{row['key']}:{period}"
+    try:
+        return notify_via_flow_doctor(
+            text, silent=False, severity="critical", dedup_key=dedup_key,
+            flow_name=_FLOW_NAME, topics=_ALERT_TOPICS, db_basename=_DB_BASENAME,
+            context={"provider": row["key"], "period": period,
+                     "funded_balance_usd": bal, "days_to_zero": dtz},
+            source="flow-doctor:expense-collector",
+        )
+    except Exception as exc:  # noqa: BLE001 — delivery surface only
+        logger.warning("balance-depletion alert Telegram send failed (non-fatal): %s", exc)
+        return False
+
+
+def _is_depleting(row: dict) -> bool:
+    """True when a prepaid account is at or below zero, or within
+    ``BALANCE_ALERT_DAYS`` of it at the observed burn.
+
+    A row with no balance (arrears billing) or an unmeasurable burn returns
+    False — this predicate answers "is it running out", and UNKNOWN is not
+    yes. The unknown-ness is visible on the row itself (`days_to_zero: null`),
+    which is where it belongs; an alert that fires on ignorance is noise, and
+    noise is how the last one got ignored.
+    """
+    bal = row.get("funded_balance_usd")
+    if bal is None:
+        return False
+    if bal <= 0:
+        return True
+    dtz = row.get("days_to_zero")
+    return dtz is not None and dtz <= BALANCE_ALERT_DAYS
+
+
+def run_balance_depletion_alerts(s3, period: str, rows: list[dict]) -> dict:
+    """Rising-edge alert pass for prepaid accounts approaching zero
+    (config-I6613, from the 2026-08-05..08 DeepSeek exhaustion).
+
+    Deliberately a MIRROR of :func:`run_over_budget_alerts` — same rising-edge
+    semantics, same per-period state object, same never-raises posture — rather
+    than a second notification mechanism. It differs in exactly two ways, both
+    forced by the failure it exists for:
+
+    * **severity=critical, not warning.** An over-budget month is a number to
+      look at. An unfunded account is every routed lane down at once, and the
+      lanes cannot report it — they die on the 402 before they can.
+    * **A separate state namespace** (``balance:``-prefixed keys), so a
+      provider can be simultaneously over budget and running dry without
+      either flag suppressing the other. They are different questions: one is
+      "spending too fast", the other is "about to stop working".
+
+    Re-arms when the account is topped up, so a second depletion in the same
+    month alerts again.
+    """
+    try:
+        state = _load_alert_state(s3, period)
+        prev = state.get("providers", {})
+        merged = dict(prev)
+        alerted: list[str] = []
+        for row in rows:
+            state_key = f"balance:{row['key']}"
+            depleting = _is_depleting(row)
+            merged[state_key] = depleting
+            if depleting and not prev.get(state_key, False):
+                if _alert_balance_depletion(row, period):
+                    alerted.append(row["key"])
+        _save_alert_state(s3, period, merged)
+        return {"alerted": alerted}
+    except Exception as exc:  # noqa: BLE001 — notification-only; never masks the rollup
+        logger.warning("balance-depletion alert pass failed (non-fatal, rollup unaffected): %s", exc)
+        return {"alerted": [], "error": str(exc)[:300]}
+
+
 def _load_ssm(names: list[str]) -> dict[str, str]:
     """Batch-read SSM params; missing names are simply absent from the result
     (each consumer then reports its own row as not_configured)."""
@@ -514,10 +668,14 @@ def collect_openrouter(mw: dict, budgets: dict, secrets: dict,
         row.update(status="not_configured", error=f"SSM {SSM_OPENROUTER} missing")
         return row
     usage_now = counters["openrouter_total_usage"]
+    remaining = counters["openrouter_credits_remaining"]
     row["detail"] = {"lifetime_usage_usd": round(usage_now, 4),
-                     "credits_remaining_usd": round(counters["openrouter_credits_remaining"], 4)}
-    return _diff_row(row, mw, budgets, "openrouter", usage_now, baseline,
-                     "openrouter_total_usage")
+                     "credits_remaining_usd": round(remaining, 4)}
+    row = _diff_row(row, mw, budgets, "openrouter", usage_now, baseline,
+                    "openrouter_total_usage")
+    # config-I6613 — prepaid credits. Kept in `detail` too for the console's
+    # existing read, but the depletion signal reads the first-class field.
+    return _stamp_funded_balance(row, mw, remaining)
 
 
 def collect_deepseek(mw: dict, budgets: dict, secrets: dict,
@@ -534,7 +692,12 @@ def collect_deepseek(mw: dict, budgets: dict, secrets: dict,
     row = _diff_row(row, mw, budgets, "deepseek", -bal, baseline, "deepseek_neg_balance")
     if row.get("mtd_cost_usd") == 0.0 and row["status"] == "ok":
         row["note"] = (row.get("note") or "") + " (top-ups mid-month can mask spend)"
-    return row
+    # config-I6613. Note the interaction with the clamp above: a mid-month
+    # top-up shows as zero MTD spend, which makes the burn unmeasurable and
+    # days_to_zero None — UNKNOWN, not infinite runway. That is the correct
+    # reading; the balance itself is still reported and a zero balance still
+    # alerts on its own.
+    return _stamp_funded_balance(row, mw, bal)
 
 
 def _diff_row(row: dict, mw: dict, budgets: dict, key: str, counter_now: float,
@@ -1382,6 +1545,10 @@ def _collect(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # (notification-only enhancement layered on top of an already-successful
     # rollup).
     alert_result = run_over_budget_alerts(s3, mw["period"], rows)
+    # config-I6613 — the depletion pass runs alongside, not instead. Over
+    # budget and out of money are different questions, and the fleet was taken
+    # down by the second one while the first was green.
+    balance_alert_result = run_balance_depletion_alerts(s3, mw["period"], rows)
 
     if err_rows and not ok_rows:
         # Every live adapter failed — systemic (network/creds/deploy) breakage,
@@ -1390,4 +1557,5 @@ def _collect(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                            f"{[(r['key'], r['error']) for r in err_rows]}")
     return {"period": mw["period"], "providers": len(rows),
             "errors": [(r["key"], r["error"]) for r in err_rows],
-            "totals": totals, "alerts": alert_result}
+            "totals": totals, "alerts": alert_result,
+            "balance_alerts": balance_alert_result}

--- a/infrastructure/lambdas/expense-collector/test_balance_depletion.py
+++ b/infrastructure/lambdas/expense-collector/test_balance_depletion.py
@@ -1,0 +1,273 @@
+"""A prepaid provider account must page BEFORE it reaches zero.
+
+Root incident — alpha-engine-config-I6613, 2026-08-05..08. The DeepSeek account
+all autonomous lanes route to as primary ran out of credit. Every lane returned
+``402 Insufficient Balance`` for three days, through a live three-day trading
+outage, while sf-watch dispatched a diagnose agent each morning that died on the
+same 402 within ninety seconds and filed an issue whose entire content was "the
+diagnoser crashed". Detection fired, produced nothing, and the outage ran.
+
+**The balance was already being collected.** ``credits_remaining`` for
+OpenRouter, ``total_balance`` for DeepSeek — both fetched every run and both
+buried in a ``detail`` blob no alert reads. That is `principles.md` §2.7 in its
+pure form: a component emitting nothing is not healthy, it is unobserved, and a
+number written to an artifact nobody alerts on is emitting nothing.
+
+What these tests pin is therefore not "can we read a balance" — we always
+could — but that the balance now produces a **page, before zero**, and that the
+predicate refuses to fire on ignorance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# ── Stub nousergon_lib + flow_doctor_telegram before importing index ─────────
+# Mirrors test_handler.py exactly: both are git-only / bundled deps this suite
+# does not require installed, and the notify path must be a no-op by default so
+# no test can reach the live ops-health channel with fixture data.
+_ng = types.ModuleType("nousergon_lib")
+_ng_fleet = types.ModuleType("nousergon_lib.flow_doctor_fleet")
+
+
+class _FleetTelegramTopic:
+    CRITICAL = "CRITICAL"
+    OPS_HEALTH = "OPS_HEALTH"
+
+
+_ng_fleet.FleetTelegramTopic = _FleetTelegramTopic
+_ng.flow_doctor_fleet = _ng_fleet
+sys.modules.setdefault("nousergon_lib", _ng)
+sys.modules.setdefault("nousergon_lib.flow_doctor_fleet", _ng_fleet)
+
+_fdt = types.ModuleType("flow_doctor_telegram")
+_fdt.notify_via_flow_doctor = lambda *a, **k: True  # type: ignore[attr-defined]
+sys.modules["flow_doctor_telegram"] = _fdt
+
+from _shared.hermetic_import_guard import (  # noqa: E402
+    assert_hermetic_imports_satisfied,
+)
+
+assert_hermetic_imports_satisfied(__file__)
+
+import index  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reload():
+    """Each test gets a clean module — several read env-driven module
+    constants that other tests monkeypatch."""
+    importlib.reload(index)
+    yield
+
+
+def _mw(elapsed_frac: float = 0.5, days_in_month: int = 30) -> dict:
+    total = days_in_month * 86400.0
+    start = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    return {
+        "period": "2026-08", "start": start, "total_seconds": total,
+        "elapsed_frac": elapsed_frac,
+        "now": start,
+    }
+
+
+# ── The runway arithmetic ───────────────────────────────────────────────────
+
+
+def test_days_to_zero_is_computed_from_observed_burn():
+    """15 days into a 30-day month, $15 spent ⇒ $1/day. $10 left ⇒ 10 days."""
+    assert index._days_to_zero(10.0, 15.0, _mw(0.5)) == 10.0
+
+
+def test_days_to_zero_scales_with_the_observation_window():
+    """The same balance and spend measured over HALF the window is twice the
+    burn and therefore half the runway. Getting this backwards would report a
+    comfortable margin on an account about to die."""
+    fast = index._days_to_zero(10.0, 15.0, _mw(0.5), observed_frac=0.25)
+    assert fast == 5.0
+
+
+@pytest.mark.parametrize(
+    "balance,mtd,frac,why",
+    [
+        (None, 15.0, 0.5, "no balance — the provider bills in arrears"),
+        (10.0, None, 0.5, "no measured spend"),
+        (10.0, 0.0, 0.5, "burn indistinguishable from zero"),
+        (10.0, 15.0, 0.001, "observation window too short to extrapolate"),
+    ],
+)
+def test_days_to_zero_returns_unknown_rather_than_a_guess(balance, mtd, frac, why):
+    """None is UNKNOWN. Every one of these could be rendered as a large number
+    or as infinity, and both would read as 'plenty of runway' on the surface a
+    human scans."""
+    assert index._days_to_zero(balance, mtd, _mw(frac)) is None, why
+
+
+def test_a_zero_balance_reports_no_runway_rather_than_a_negative():
+    """An account already at or below zero is an outage in progress, not a
+    projection. A negative days_to_zero would sort oddly and read as a
+    forecast."""
+    assert index._days_to_zero(-4.20, 15.0, _mw(0.5)) == 0.0
+
+
+def test_stamp_promotes_the_balance_to_a_first_class_field():
+    row = index._row("deepseek", "DeepSeek")
+    row["mtd_cost_usd"] = 15.0
+    index._stamp_funded_balance(row, _mw(0.5), 10.0)
+    assert row["funded_balance_usd"] == 10.0
+    assert row["days_to_zero"] == 10.0
+
+
+def test_rows_default_to_unknown_not_absent():
+    """Every row carries both keys. An arrears-billed provider reports null,
+    which the console must render as 'n/a' — a MISSING key is indistinguishable
+    from a healthy one to a template that uses `.get`."""
+    row = index._row("anthropic_api", "Anthropic API")
+    assert row["funded_balance_usd"] is None
+    assert row["days_to_zero"] is None
+
+
+# ── The predicate ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "row,expected,why",
+    [
+        ({"funded_balance_usd": 0.0, "days_to_zero": None}, True, "at zero"),
+        ({"funded_balance_usd": -4.2, "days_to_zero": 0.0}, True, "already negative"),
+        ({"funded_balance_usd": 3.0, "days_to_zero": 2.0}, True, "inside the window"),
+        ({"funded_balance_usd": 300.0, "days_to_zero": 90.0}, False, "comfortable"),
+        ({"funded_balance_usd": None, "days_to_zero": None}, False, "arrears billing"),
+        ({"funded_balance_usd": 300.0, "days_to_zero": None}, False, "burn unmeasurable"),
+    ],
+)
+def test_is_depleting(row, expected, why):
+    assert index._is_depleting(row) is expected, why
+
+
+def test_the_threshold_is_days_not_dollars(monkeypatch):
+    """A dollar floor means something different at $0.30/month and $30/month.
+    'How long have I got' is the question that transfers across providers."""
+    row = {"funded_balance_usd": 50.0, "days_to_zero": 10.0}
+    assert index._is_depleting(row) is False          # default 7 days
+    monkeypatch.setattr(index, "BALANCE_ALERT_DAYS", 14.0)
+    assert index._is_depleting(row) is True
+
+
+def test_a_402_is_the_state_this_must_fire_before():
+    """The incident's own end state: balance exhausted, every routed lane
+    returning 402. If the predicate only fired here it would be a post-mortem,
+    not a monitor — so the runway case above is the load-bearing one and this
+    is the backstop."""
+    assert index._is_depleting({"funded_balance_usd": 0.0, "days_to_zero": 0.0})
+
+
+# ── The rising-edge pass ────────────────────────────────────────────────────
+
+
+class _FakeS3:
+    def __init__(self, state=None):
+        self.state = state or {}
+        self.saved = []
+
+    def get_object(self, **_kw):
+        raise RuntimeError("no prior state")
+
+    def put_object(self, **kw):
+        self.saved.append(kw)
+
+
+def _run(monkeypatch, rows, prior=None):
+    sent = []
+    monkeypatch.setattr(index, "_load_alert_state",
+                        lambda _s3, _p: {"providers": prior or {}})
+    monkeypatch.setattr(index, "_save_alert_state",
+                        lambda _s3, _p, breached: sent.append(("state", breached)))
+    monkeypatch.setattr(index, "_alert_balance_depletion",
+                        lambda row, period: sent.append(("alert", row["key"])) or True)
+    result = index.run_balance_depletion_alerts(_FakeS3(), "2026-08", rows)
+    return result, sent
+
+
+def test_alerts_once_on_the_rising_edge(monkeypatch):
+    row = {"key": "deepseek", "label": "DeepSeek", "funded_balance_usd": 1.0,
+           "days_to_zero": 2.0, "mtd_cost_usd": 15.0}
+    result, sent = _run(monkeypatch, [row])
+    assert result["alerted"] == ["deepseek"]
+    assert ("alert", "deepseek") in sent
+
+
+def test_stays_quiet_on_a_sustained_breach(monkeypatch):
+    """Three days of the same 402 produced three identical issues last time.
+    Sustained means already-known."""
+    row = {"key": "deepseek", "label": "DeepSeek", "funded_balance_usd": 1.0,
+           "days_to_zero": 2.0, "mtd_cost_usd": 15.0}
+    result, sent = _run(monkeypatch, [row], prior={"balance:deepseek": True})
+    assert result["alerted"] == []
+    assert not [s for s in sent if s[0] == "alert"]
+
+
+def test_re_arms_after_a_top_up(monkeypatch):
+    """A second depletion in the same month must alert again — the account
+    being topped up is exactly when the flag has to clear."""
+    healthy = {"key": "deepseek", "label": "DeepSeek", "funded_balance_usd": 500.0,
+               "days_to_zero": 120.0, "mtd_cost_usd": 15.0}
+    _result, sent = _run(monkeypatch, [healthy], prior={"balance:deepseek": True})
+    saved = [s[1] for s in sent if s[0] == "state"][0]
+    assert saved["balance:deepseek"] is False
+
+
+def test_state_namespace_does_not_collide_with_the_over_budget_flag(monkeypatch):
+    """Over budget and out of money are different questions about the same
+    provider, and a provider can be both. Sharing one flag would let either
+    suppress the other."""
+    row = {"key": "deepseek", "label": "DeepSeek", "funded_balance_usd": 1.0,
+           "days_to_zero": 2.0, "mtd_cost_usd": 15.0}
+    # The over-budget pass has already flagged this provider under its bare key.
+    result, sent = _run(monkeypatch, [row], prior={"deepseek": True})
+    assert result["alerted"] == ["deepseek"], (
+        "the over-budget flag suppressed the depletion alert — they must use "
+        "separate state namespaces"
+    )
+    saved = [s[1] for s in sent if s[0] == "state"][0]
+    assert saved["deepseek"] is True, "the over-budget flag must survive this pass"
+    assert saved["balance:deepseek"] is True
+
+
+def test_the_pass_never_raises(monkeypatch):
+    """Notification layered after a successful rollup write — a bug here must
+    not cost the rollup, mirroring run_over_budget_alerts."""
+    monkeypatch.setattr(index, "_load_alert_state",
+                        mock.Mock(side_effect=RuntimeError("boom")))
+    result = index.run_balance_depletion_alerts(_FakeS3(), "2026-08", [])
+    assert result["alerted"] == []
+    assert "boom" in result["error"]
+
+
+def test_the_alert_is_critical_not_warning():
+    """An over-budget month is a number to look at. An unfunded account is
+    every routed lane down at once, and the lanes cannot report it — they die
+    on the 402 before they can."""
+    captured = {}
+
+    def _notify(text, **kw):
+        captured.update(kw)
+        captured["text"] = text
+        return True
+
+    with mock.patch.object(index, "notify_via_flow_doctor", _notify):
+        index._alert_balance_depletion(
+            {"key": "deepseek", "label": "DeepSeek", "funded_balance_usd": 0.0,
+             "days_to_zero": 0.0, "mtd_cost_usd": 15.0}, "2026-08")
+    assert captured["severity"] == "critical"
+    assert "already unfunded" in captured["text"]

--- a/tests/test_severity_taxonomy_chokepoint.py
+++ b/tests/test_severity_taxonomy_chokepoint.py
@@ -253,6 +253,20 @@ _REGISTRY: dict[str, dict[str, list[dict]]] = {
                 "citation": "reconciled from live code 2026-07-31 — pending taxonomy entry",
             },
         ],
+        # alpha-engine-config-I6613. Deliberately a tier above its sibling
+        # above: over budget is a number to look at, an unfunded account is
+        # every lane routed through it down at once — and the lanes cannot
+        # report it, because they die on the 402 before they can. The
+        # 2026-08-05..08 DeepSeek exhaustion ran three days on exactly that
+        # asymmetry, through a live trading outage.
+        "_alert_balance_depletion": [
+            {
+                "event_class": "Provider prepaid balance depletion",
+                "severity": "critical",
+                "silent": False,
+                "citation": "alpha-engine-config-I6613 (2026-08-08) — pending taxonomy entry",
+            },
+        ],
     },
     "infrastructure/lambdas/ci-watch-liveness-probe/index.py": {
         "_escalate": [


### PR DESCRIPTION
## What & why

`alpha-engine-config-I6613` **deliverable 2**, per Brian's ruling 2026-08-08 (option b — build it regardless of whether the account is funded).

On 2026-08-05..08 the DeepSeek account every autonomous lane routes to as primary ran out of credit. Every lane returned `402 Insufficient Balance` for three days, through a live three-day trading outage, while sf-watch dispatched a diagnose agent each morning that died on the same 402 within ninety seconds and filed an issue whose entire content was "the diagnoser crashed". **Detection fired, produced nothing, and the outage ran.**

## The finding that changes the size of this

**The balance was already being collected.** `credits_remaining` for OpenRouter, `total_balance` for DeepSeek — both fetched on every run since this collector shipped, and both buried in a `detail` blob no alert reads.

That is `principles.md` §2.7 in its pure form: a number written to an artifact nobody alerts on is emitting nothing. The issue's deliverable reads "extend it to also read remaining balance where the provider exposes it" — the data plane was already built. What was missing was deriving a **signal** from it. So this PR is far smaller than the issue implies, and the gap was correspondingly more embarrassing: the fleet went dark for three days holding the number that would have predicted it.

## What ships

| | |
|---|---|
| `funded_balance_usd`, `days_to_zero` | first-class row fields, on **every** row. An arrears-billed provider (Anthropic, AWS, Neon) reports `null`, so the console renders "n/a" rather than inheriting a missing key's silence |
| `_days_to_zero` | runway from the burn **actually observed this month**, reusing the same `observed_frac` arithmetic the existing projection uses, so a mid-month baseline never fabricates early-month spend |
| `run_balance_depletion_alerts` | rising-edge pass, mirroring `run_over_budget_alerts` |

`_days_to_zero` returns `None` — **UNKNOWN** — whenever it cannot be honestly computed: no balance, no measured spend, a burn indistinguishable from zero, or a window too short to extrapolate. Each of those could have been rendered as a large number or as infinity, and both read as "plenty of runway" on the surface a human scans.

## Mirrored, with two deliberate differences

It reuses the existing state machine, Telegram path and dedup convention rather than adding a second notification plane (`policy-shared-code` — mirror the pattern that exists). Two things differ, both forced by the incident:

- **`severity=critical`, not `warning`.** An over-budget month is a number to look at. An unfunded account is every routed lane down at once, and the lanes cannot report it — they die on the 402 before they can.
- **A separate `balance:`-prefixed state namespace**, so a provider can be simultaneously over budget and running dry without either flag suppressing the other. Pinned by `test_state_namespace_does_not_collide_with_the_over_budget_flag`.

**The threshold is in days, not dollars** (`BALANCE_ALERT_DAYS`, default 7). A dollar floor means something different at $0.30/month and at $30/month; "how long have I got" transfers across providers. A 402 is the state where `days_to_zero` already reached 0, so this has to fire strictly before it.

## Honest caveat — this cannot fire yet

`alpha-engine-expense-collector-twicedaily` is **DISABLED** under the automation-pause ruling (`config-I6617`). The detector is correct and tested but its producer has no schedule, so it will emit nothing until the pause lifts. Shipping a detector that emits nothing is the anti-pattern this issue is about, so stating it rather than letting it read as coverage: **I6613's deliverable 2 is code-complete and not yet load-bearing.**

## Test plan

- `python3 -m pytest . -q` in `infrastructure/lambdas/expense-collector/` → **79 passed** (56 pre-existing + 23 new). `deploy.sh` preflights this suite before every ship.
- New coverage is organised around what the incident needed: the runway arithmetic (including that halving the observation window halves the runway — getting that backwards reports a comfortable margin on a dying account), the UNKNOWN cases, the predicate, the rising-edge/re-arm/no-collision state behaviour, never-raises, and that the alert is critical.
- `python3 -m pytest tests -q --continue-on-collection-errors` → 3822 passed / 174 failed / 63 errors, all missing-optional-dependency (`pyarrow`, `bs4`, `tenacity`, `yfinance`, bitcoin libs) and all pre-existing on `main`. Zero failures under `expense-collector`.
- Hermetic: `nousergon_lib` and `flow_doctor_telegram` are stubbed in `sys.modules` before `import index`, mirroring `test_handler.py`, and `assert_hermetic_imports_satisfied` enforces it — no test can reach the live ops-health channel with fixture data.

## Not in this PR

- **Deliverable 1** (restore the balance) is an operator action.
- **Deliverable 3** — `402`/`401` as a first-class `provider_unfunded` lane outcome instead of a generic `rc=1` — is in the lane runners (`scheduled-groom-dispatcher`), a different surface.
- **Deliverable 4** — honest degradation to a funded fallback member — is router-level and overlaps `alpha-engine-config-I6561`.

Refs nousergon/alpha-engine-config#6613

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
