### PR TITLE
fix(systemd): report unit COVERAGE, not four files called "installed units"

### DIFF
--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -35,6 +35,50 @@ Usage:
   ./infrastructure/systemd/check-systemd-unit-drift.py --report      # on divergence, also flow-doctor report
 
 Exit codes: 0 clean, 1 drift found, 2 config/source error.
+
+**Scope correction (2026-08-08, alpha-engine-config-I6656).** The above
+describes four units. The dashboard box has **60** locally-installed unit
+files, and this script's closing line read:
+
+    Systemd unit drift check PASSED (installed units match repo).
+
+That is a claim about "installed units" made after comparing four of them —
+and not even the six this repo codifies, since its own
+`systemd-unit-drift-check.{service,timer}` were absent from `ALL_UNITS`.
+From outside, a check with narrow scope and a check with full coverage are
+the same green line. Measured while raising `TimeoutStartSec` on
+`morning-signal.service`: applied to a live box with nothing anywhere that
+would notice it being reverted, hours after this check reported PASSED.
+
+So the scope is now **every regular `.service` / `.timer` file in
+`/etc/systemd/system`**, each classified `clean`, `drift` or `uncodified`.
+Symlinks are skipped — they are systemd's own aliases into `/usr/lib/systemd`
+(`dbus.service` and friends), not units anybody here authored.
+
+Three rules follow:
+
+  * **PASSED is reserved for full coverage.** With 54 of 60 units uncodified,
+    no wording of "passed" is true, so the run states the shortfall instead.
+  * **The known-uncodified set does not fail the run.** There are 54 of them;
+    failing on the backlog would page once per unit on the first run and
+    teach exactly one lesson, which is to disable the check. They live in
+    `UNCODIFIED_BASELINE_FILE` — a work queue that should only shrink — and
+    a unit uncodified but NOT in it is named individually as
+    `uncodified-NEW`, because new is the only kind a given run can act on.
+    `--strict` fails on anything uncodified and is the end state once the
+    baseline is empty.
+  * **The counts are emitted** (`--metric`), including zeros: a number that
+    only appears when something is wrong cannot distinguish healthy from
+    dead (`principles.md` §2.7).
+
+"Codified" means a file of the same name under a `--codified-root` (default:
+this script's directory). Units owned by other repos — `metron-*`,
+`crucible-dash-*`, `nousergon-*`, `vires`, `telos-web`, `mnemon*` — are not
+codified *from here* and sit in the baseline with their owning repo noted.
+Teaching this script to read eight repo trees would move the ownership
+question into a script instead of answering it; `infrastructure-ownership-
+policy` answers it, and the baseline is the register of where that answer has
+not been applied yet.
 """
 
 from __future__ import annotations
@@ -48,15 +92,21 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = SCRIPT_DIR.parent.parent
 INSTALLED_DIR = Path("/etc/systemd/system")
+UNCODIFIED_BASELINE_FILE = SCRIPT_DIR / "uncodified-units-baseline.txt"
 
-# Which units THIS box is expected to have installed. Both daily-news and
-# metron-intraday units live in the repo, but a given box only ever installs
-# the ones relevant to it (dashboard box: daily-news; trading box:
-# metron-intraday) — install-daily-news.sh / install-metron-intraday.sh are
-# each other's only callers of the corresponding pair. This script probes
-# whichever of the two pairs is ALREADY present on disk (a box that has
-# never installed a unit is not "drifted", it's simply not that unit's
-# host) rather than hardcoding a per-box unit list here.
+UNIT_SUFFIXES = (".service", ".timer")
+
+#: CloudWatch namespace for the coverage counts. Shares the box-health
+#: namespace deliberately — coverage of the unit set is a property of the box,
+#: and a separate namespace is one more place to remember to look.
+METRIC_NAMESPACE = "NousErgon/BoxHealth"
+
+# The units this repo codifies and installs. NO LONGER THE SCOPE OF THE
+# CHECK — scope is now whatever is installed (see the docstring). Kept
+# because install-daily-news.sh / install-metron-intraday.sh still describe
+# which pair belongs on which box (dashboard: daily-news; trading:
+# metron-intraday), and because a codified unit missing from a box is
+# reported rather than silently dropped from the comparison.
 ALL_UNITS: tuple[str, ...] = (
     "daily-news.service",
     "daily-news.timer",
@@ -68,21 +118,91 @@ ALL_UNITS: tuple[str, ...] = (
 def _sha256(path: Path) -> str | None:
     try:
         return hashlib.sha256(path.read_bytes()).hexdigest()
-    except FileNotFoundError:
+    except (FileNotFoundError, IsADirectoryError):
         return None
 
 
-def check_unit(name: str) -> tuple[str, str]:
-    """Returns (status, detail). status in {"clean", "drift", "not-installed", "source-error"}."""
-    repo_path = SCRIPT_DIR / name
-    installed_path = INSTALLED_DIR / name
+def installed_units(installed_dir: Path | None = None) -> list[str]:
+    """Every locally-installed unit file, sorted.
 
-    if not repo_path.is_file():
-        return "source-error", f"{name}: no repo copy at {repo_path}"
+    Regular files only. A symlink here is systemd's own alias mechanism
+    pointing into `/usr/lib/systemd`; counting those would put `dbus.service`
+    in our work queue.
+    """
+    d = installed_dir or INSTALLED_DIR
+    if not d.is_dir():
+        return []
+    return sorted(
+        p.name
+        for p in d.iterdir()
+        if p.name.endswith(UNIT_SUFFIXES) and p.is_file() and not p.is_symlink()
+    )
 
-    installed_hash = _sha256(installed_path)
+
+def codified_units(roots: list[Path] | None = None) -> list[str]:
+    """Every unit file present in the codified roots, sorted."""
+    rs = roots or [SCRIPT_DIR]
+    return sorted({
+        p.name for r in rs if r.is_dir()
+        for p in r.iterdir() if p.name.endswith(UNIT_SUFFIXES) and p.is_file()
+    })
+
+
+def load_baseline(path: Path | None = None) -> set[str]:
+    """Unit names already known to be uncodified. Blank lines and `#`
+    comments ignored; the comments carry which repo should own each one."""
+    f = path or UNCODIFIED_BASELINE_FILE
+    if not f.is_file():
+        return set()
+    out = set()
+    for line in f.read_text().splitlines():
+        name = line.split("#", 1)[0].strip()
+        if name:
+            out.add(name)
+    return out
+
+
+def codified_path(name: str, roots: list[Path] | None = None) -> Path | None:
+    for root in (roots or [SCRIPT_DIR]):
+        candidate = root / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def check_unit(
+    name: str,
+    roots: list[Path] | None = None,
+    installed_dir: Path | None = None,
+) -> tuple[str, str]:
+    """Returns (status, detail).
+
+    status in {"clean", "drift", "uncodified", "not-installed"}.
+
+    `SCRIPT_DIR` / `INSTALLED_DIR` are read at CALL time when the arguments
+    are omitted, so a caller (or a test) can repoint the module globals.
+
+    Note the retired status: installed-with-no-repo-copy used to be
+    `source-error`, i.e. a fault in this script's configuration. It is now
+    `uncodified` — a gap in coverage, which is what it always was. 54 of the
+    60 units on the dashboard box are in that state, and calling that a
+    config error made the honest reading unavailable.
+
+    `not-installed` means a codified unit this box does not host. A box
+    legitimately runs a subset (dashboard: daily-news; trading:
+    metron-intraday), so it is informational, never a finding.
+    """
+    d = installed_dir or INSTALLED_DIR
+    installed_hash = _sha256(d / name)
+    repo_path = codified_path(name, roots)
+
     if installed_hash is None:
-        return "not-installed", f"{name}: not present on this box ({installed_path})"
+        if repo_path is None:
+            return "not-installed", f"{name}: neither installed here nor codified"
+        return "not-installed", f"{name}: codified, not present on this box ({d / name})"
+
+    if repo_path is None:
+        return "uncodified", f"{name}: installed here, codified in no known root"
 
     repo_hash = _sha256(repo_path)
     if installed_hash != repo_hash:
@@ -91,47 +211,140 @@ def check_unit(name: str) -> tuple[str, str]:
     return "clean", f"{name}: OK"
 
 
+def _emit_metrics(counts: dict) -> None:
+    """Put the coverage counts to CloudWatch. Best-effort, loudly.
+
+    Every value goes on every run, zeros included: `principles.md` §2.7 — a
+    metric that only appears when something is wrong makes "healthy" and "the
+    emitter is dead" the same shape on the graph.
+    """
+    try:
+        import boto3
+
+        host = socket.gethostname()
+        boto3.client("cloudwatch").put_metric_data(
+            Namespace=METRIC_NAMESPACE,
+            MetricData=[
+                {
+                    "MetricName": f"SystemdUnits{key}",
+                    "Dimensions": [{"Name": "Host", "Value": host}],
+                    "Value": float(value),
+                    "Unit": "Count",
+                }
+                for key, value in counts.items()
+            ],
+        )
+        print(f"[metric] emitted {len(counts)} coverage counts for {host}")
+    except Exception as e:  # noqa: BLE001 - a metric failure must not mask the check
+        # Recorded, never swallowed: this is the surface that says whether the
+        # coverage number is real, so its absence has to be attributable.
+        print(
+            f"[check-systemd-unit-drift] METRIC EMIT FAILED — coverage is "
+            f"UNOBSERVED: {e}",
+            file=sys.stderr,
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--unit", help="check a single unit by filename (e.g. daily-news.timer)")
     parser.add_argument(
         "--report",
         action="store_true",
-        help="on drift, also flow-doctor report (in addition to the exit code + stdout)",
+        help="on a finding, also publish an alert (in addition to the exit code + stdout)",
+    )
+    parser.add_argument("--metric", action="store_true", help="emit the coverage counts to CloudWatch")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat ANY uncodified unit as a failure, not only ones outside the baseline",
+    )
+    parser.add_argument(
+        "--codified-root",
+        action="append",
+        default=None,
+        help="directory holding codified unit files (repeatable; default: this script's directory)",
     )
     args = parser.parse_args()
 
-    units = [args.unit] if args.unit else list(ALL_UNITS)
+    roots = [Path(r).resolve() for r in args.codified_root] if args.codified_root else [SCRIPT_DIR]
+    baseline = load_baseline()
 
-    findings = []
-    saw_installed = False
+    if args.unit:
+        names = [args.unit]
+    else:
+        # The union: what is installed, plus anything codified that is not —
+        # so a unit deleted from the box still appears rather than silently
+        # dropping out of the comparison.
+        names = sorted(set(installed_units()) | set(codified_units(roots)))
+
+    buckets: dict[str, list[str]] = {"clean": [], "drift": [], "uncodified": [], "not-installed": []}
+    details: dict[str, str] = {}
+    for name in names:
+        status, detail = check_unit(name, roots)
+        buckets[status].append(name)
+        details[name] = detail
+        label = "uncodified-NEW" if (status == "uncodified" and name not in baseline) else status
+        print(f"[{label}] {detail}")
+
+    uncodified = buckets["uncodified"]
+    uncodified_new = [n for n in uncodified if n not in baseline]
+    installed_count = len(buckets["clean"]) + len(buckets["drift"]) + len(uncodified)
+
+    print(
+        "SUMMARY "
+        f"installed={installed_count} "
+        f"clean={len(buckets['clean'])} "
+        f"drift={len(buckets['drift'])} "
+        f"uncodified={len(uncodified)} "
+        f"uncodified_new={len(uncodified_new)} "
+        f"codified_not_installed={len(buckets['not-installed'])}"
+    )
+
+    if args.metric:
+        _emit_metrics({
+            "Installed": installed_count,
+            "Clean": len(buckets["clean"]),
+            "Drifted": len(buckets["drift"]),
+            "Uncodified": len(uncodified),
+            "UncodifiedNew": len(uncodified_new),
+        })
+
     exit_code = 0
-    for name in units:
-        status, detail = check_unit(name)
-        print(f"[{status}] {detail}")
-        if status == "source-error":
-            exit_code = max(exit_code, 2)
-        elif status == "drift":
-            saw_installed = True
-            findings.append(detail)
+    findings: list[str] = []
+    if buckets["drift"]:
+        findings.extend(details[n] for n in buckets["drift"])
+        exit_code = max(exit_code, 1)
+    if uncodified_new:
+        findings.append(
+            f"{len(uncodified_new)} unit(s) installed but codified nowhere and absent from the "
+            f"baseline: {', '.join(uncodified_new)}"
+        )
+        if args.strict:
             exit_code = max(exit_code, 1)
-        elif status == "clean":
-            saw_installed = True
-
-    if not saw_installed and exit_code == 0:
-        # Every probed unit was "not-installed" — this box hosts neither
-        # pair. Not an error (a box legitimately hosting neither unit
-        # would otherwise always fail); the daily install scripts are the
-        # enforcement point for "should this unit exist here at all".
-        print("No tracked units installed on this box — nothing to compare.")
-        return 0
+    if uncodified and args.strict:
+        exit_code = max(exit_code, 1)
 
     if findings:
-        print(f"DRIFT: {len(findings)} unit(s) diverged from repo.", file=sys.stderr)
+        print(f"FINDINGS: {len(findings)}", file=sys.stderr)
+        for f in findings:
+            print(f"  {f}", file=sys.stderr)
         if args.report:
             _report_drift(findings)
+
+    # PASSED is reserved for a box where every installed unit is codified AND
+    # matches. Anything else states the shortfall: there is no phrasing of
+    # "passed" that is true while 54 units sit outside the comparison.
+    if not installed_count:
+        print("No unit files installed on this box — nothing to compare.")
+    elif not buckets["drift"] and not uncodified:
+        print("Systemd unit coverage PASSED (every installed unit is codified and matches).")
     else:
-        print("Systemd unit drift check PASSED (installed units match repo).")
+        print(
+            f"Systemd unit coverage INCOMPLETE: {len(buckets['clean'])}/{installed_count} "
+            f"installed units are codified and clean; {len(uncodified)} uncodified, "
+            f"{len(buckets['drift'])} drifted. This is not a pass."
+        )
 
     return exit_code
 

--- a/infrastructure/systemd/uncodified-units-baseline.txt
+++ b/infrastructure/systemd/uncodified-units-baseline.txt
@@ -1,0 +1,97 @@
+# Units installed on a fleet box that are codified in NO repo tree this
+# checker can see. This is a WORK QUEUE, not a permitted-list: every line is
+# a unit that can be hand-edited on a live box with nothing anywhere
+# noticing, and the file should only ever get shorter.
+#
+# Seeded 2026-08-08 from the dashboard box (i-09b539c844515d549), which had
+# 60 locally-installed unit files against a checker that probed 4 — not even
+# the 6 this repo already codifies, so it did not check its own
+# systemd-unit-drift-check.{service,timer} either.
+# alpha-engine-config-I6656.
+#
+# Why a baseline at all: failing on all 54 at once would page once per unit
+# on the first run and teach the reader to turn the check off. A unit NOT in
+# this file is reported as `uncodified-NEW` and named individually, so a
+# newly hand-installed unit is visible immediately rather than blending into
+# a count. `--strict` fails on anything uncodified and is the end state once
+# this file is empty.
+#
+# The comment after each name is the repo that SHOULD own it per
+# infrastructure-ownership-policy (deploy scripts, systemd units and IAM live
+# in the operated-system assembly, i.e. nous-ergon-ops, unless the owning
+# product repo already carries an infrastructure/ tree). Where it says
+# UNKNOWN, that is itself the finding.
+#
+# NOTE: seeded from ONE box. The trading box runs its own set; its entries
+# are added the first time the checker runs there and names them, which is
+# exactly what the `uncodified-NEW` bucket is for. Until then this file is
+# incomplete by construction, and says so rather than implying coverage.
+
+# ── alpha-engine / dashboard box services ──────────────────────────────────
+boot-pull.service              # nous-ergon-ops
+boot-pull.timer                # nous-ergon-ops
+box-health.service             # crucible-dashboard
+box-health.timer               # crucible-dashboard
+box-hygiene.service            # crucible-dashboard
+box-hygiene.timer              # crucible-dashboard
+box-state-backup.service       # crucible-dashboard
+box-state-backup.timer         # crucible-dashboard
+crucible-dash-api.service      # crucible-dashboard
+crucible-dash-web.service      # crucible-dashboard
+dashboard.service              # crucible-dashboard
+emit-oom-metric.service        # crucible-dashboard
+emit-oom-metric.timer          # crucible-dashboard
+nous-ergon-live.service        # UNKNOWN
+nousergon-auth.service         # nousergon-auth
+nousergon-console.service      # nousergon-console
+signal-pull.service            # UNKNOWN
+signal-pull.timer              # UNKNOWN
+signal.service                 # UNKNOWN
+substrate-health-daily.service # nous-ergon-ops
+substrate-health-daily.timer   # nous-ergon-ops
+
+# ── morning-signal ─────────────────────────────────────────────────────────
+# Found live 2026-08-08 (I6567): morning-signal.service took a TimeoutStartSec
+# and three router env vars via drop-ins, on a box where nothing compares the
+# unit to anything. Its drop-in directory is not covered here either — this
+# checker compares unit FILES; `.d/*.conf` coverage is a separate deliverable
+# on I6656.
+morning-signal.service         # nous-ergon-ops
+morning-signal.timer           # nous-ergon-ops
+morning-signal-bakeoff.service # nous-ergon-ops
+morning-signal-bakeoff.timer   # nous-ergon-ops
+morning-signal-watchdog.service # nous-ergon-ops (repo has infrastructure/ copy, not installed from it)
+morning-signal-watchdog.timer  # nous-ergon-ops (repo has infrastructure/ copy, not installed from it)
+morning-signal-pull.service    # UNKNOWN
+morning-signal-pull.timer      # UNKNOWN
+
+# ── metron ─────────────────────────────────────────────────────────────────
+metron-api.service             # metron-ops
+metron-dash-web.service        # metron-ops
+metron-deploy-drift.service    # metron-ops
+metron-deploy-drift.timer      # metron-ops
+metron-reconcile.service       # metron-ops
+metron-reconcile.timer         # metron-ops
+metron-refresh.service         # metron-ops
+metron-refresh.timer           # metron-ops
+metron-refresh-flex.service    # metron-ops
+metron-refresh-flex.timer      # metron-ops
+
+# ── other products co-tenant on this box ───────────────────────────────────
+mnemon.service                 # mnemon
+mnemon-sync.service            # mnemon
+mnemon-sync.timer              # mnemon
+telos-web.service              # telos-ops
+vires.service                  # vires-ops
+
+# ── shared infrastructure ──────────────────────────────────────────────────
+litellm-proxy.service          # nous-ergon-ops (the model router)
+llm-egress-proxy.service       # nous-ergon-ops (the DLP egress proxy)
+ibgateway.service              # nous-ergon-ops
+xvfb.service                   # nous-ergon-ops (ibgateway's display)
+certbot-renew.service          # nous-ergon-ops
+certbot-renew.timer            # nous-ergon-ops
+reboot-if-needed.service       # nous-ergon-ops
+reboot-if-needed.timer         # nous-ergon-ops
+alert-on-failure@.service      # nous-ergon-ops (OnFailure= template)
+amazon-cloudwatch-agent.service # vendor-installed; likely never codified here

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -10,6 +10,7 @@ minus the subprocess mocking since this script never shells out to AWS).
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -74,14 +75,22 @@ def test_not_installed_when_box_never_had_the_unit(cd):
     assert status == "not-installed"
 
 
-def test_source_error_when_repo_copy_missing(cd):
+def test_installed_with_no_repo_copy_is_uncodified_not_a_source_error(cd):
+    """Reclassified 2026-08-08 (alpha-engine-config-I6656).
+
+    This used to assert `source-error` — i.e. that a unit installed with no
+    repo copy meant THIS SCRIPT was misconfigured. On the dashboard box 54 of
+    60 units are in that state; they are not 54 configuration errors, they are
+    the coverage gap, and naming them an error made the honest reading
+    unavailable.
+    """
     module, script_dir, installed_dir = cd
     _write(installed_dir / "ghost.service", "UNIT GHOST\n")
-    # No repo copy at all — a genuinely malformed/renamed source.
 
     status, detail = module.check_unit("ghost.service")
 
-    assert status == "source-error"
+    assert status == "uncodified"
+    assert "codified in no known root" in detail
 
 
 def test_all_not_installed_when_box_hosts_neither_pair(cd):
@@ -211,3 +220,157 @@ class TestDriftReportingPath:
             "exports FlowDoctor/FlowDoctorBuilder. Use krepis.alerts (the "
             "canonical CLI, config#1649)."
         )
+
+
+class TestCoverageAccounting:
+    """alpha-engine-config-I6656 — the defect was not a wrong diff. The diff
+    was right. It was that four units were compared and the closing line said
+    "installed units match repo", on a box with 60 installed unit files. So
+    these assert what the script SAYS as much as what it compares.
+    """
+
+    def test_an_uncodified_unit_is_never_reported_as_a_pass(self, cd, capsys, monkeypatch):
+        module, script_dir, installed_dir = cd
+        _write(script_dir / "covered.service", "X\n")
+        _write(installed_dir / "covered.service", "X\n")
+        _write(installed_dir / "hand-installed.timer", "Y\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: set())
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py"])
+
+        module.main()
+        out = capsys.readouterr().out
+
+        assert "PASSED" not in out
+        assert "INCOMPLETE" in out
+        assert "1/2 installed units are codified and clean" in out
+
+    def test_full_coverage_is_the_only_thing_called_a_pass(self, cd, capsys, monkeypatch):
+        module, script_dir, installed_dir = cd
+        _write(script_dir / "covered.service", "X\n")
+        _write(installed_dir / "covered.service", "X\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: set())
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py"])
+
+        code = module.main()
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "coverage PASSED" in out
+        assert "uncodified=0" in out
+
+    def test_a_baselined_uncodified_unit_does_not_fail_the_run(self, cd, capsys, monkeypatch):
+        """54 of them exist. Failing on the backlog pages once per unit on the
+        first run and teaches the reader to disable the check."""
+        module, script_dir, installed_dir = cd
+        _write(installed_dir / "known.service", "Y\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: {"known.service"})
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py"])
+
+        code = module.main()
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "uncodified_new=0" in out
+        assert "uncodified-NEW" not in out
+
+    def test_an_unbaselined_uncodified_unit_is_named_individually(self, cd, capsys, monkeypatch):
+        """New is the only kind a given run can act on, so it must not blend
+        into the count."""
+        module, script_dir, installed_dir = cd
+        _write(installed_dir / "known.service", "Y\n")
+        _write(installed_dir / "surprise.timer", "Z\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: {"known.service"})
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py"])
+
+        module.main()
+        cap = capsys.readouterr()
+
+        assert "[uncodified-NEW] surprise.timer" in cap.out
+        assert "[uncodified] known.service" in cap.out
+        assert "uncodified=2 uncodified_new=1" in cap.out
+        assert "absent from the baseline" in cap.err
+
+    def test_strict_fails_on_any_uncodified_unit(self, cd, capsys, monkeypatch):
+        """The end state, once the baseline is empty."""
+        module, script_dir, installed_dir = cd
+        _write(installed_dir / "known.service", "Y\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: {"known.service"})
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py", "--strict"])
+
+        assert module.main() == 1
+
+    def test_symlinked_units_are_not_counted(self, cd, capsys, monkeypatch):
+        """`/etc/systemd/system` carries systemd's own aliases into
+        /usr/lib/systemd as symlinks. Counting those puts `dbus.service` in
+        the work queue."""
+        module, script_dir, installed_dir = cd
+        _write(script_dir / "real.service", "X\n")
+        _write(installed_dir / "real.service", "X\n")
+        (installed_dir / "alias.service").symlink_to(installed_dir / "real.service")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: set())
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py"])
+
+        code = module.main()
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "installed=1" in out
+        assert "alias.service" not in out
+
+    def test_metric_failure_is_loud_and_does_not_mask_the_check(self, cd, capsys, monkeypatch):
+        """The counts are the surface that says whether coverage is real, so
+        their absence has to be attributable rather than silent — and a broken
+        metric must not take the drift check itself down with it.
+
+        The failure is injected at the real boundary (the boto3 call), not by
+        replacing `_emit_metrics`: stubbing the function under test would
+        assert the behaviour of the stub.
+        """
+        module, script_dir, installed_dir = cd
+        _write(script_dir / "covered.service", "X\n")
+        _write(installed_dir / "covered.service", "EDITED\n")
+        monkeypatch.setattr(module, "load_baseline", lambda *a, **k: set())
+        monkeypatch.setattr(sys, "argv", ["check-systemd-unit-drift.py", "--metric"])
+
+        import boto3
+
+        monkeypatch.setattr(
+            boto3, "client",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no credentials")),
+        )
+
+        code = module.main()
+        cap = capsys.readouterr()
+
+        # The drift is still detected and still reported.
+        assert code == 1
+        assert "drift=1" in cap.out
+        # And the metric failure is named, not swallowed.
+        assert "METRIC EMIT FAILED" in cap.err
+        assert "UNOBSERVED" in cap.err
+
+    def test_the_shipped_baseline_parses_and_holds_only_unit_names(self, cd):
+        """The baseline is data the check depends on; a typo in it silently
+        un-covers a unit."""
+        module, _, _ = cd
+        baseline = module.load_baseline(_REPO_ROOT / "infrastructure" / "systemd" / "uncodified-units-baseline.txt")
+
+        assert baseline, "the shipped baseline should not be empty — 54 units are uncodified"
+        for name in baseline:
+            assert name.endswith((".service", ".timer")), name
+            assert " " not in name, name
+
+    def test_the_shipped_baseline_covers_the_measured_dashboard_box(self, cd):
+        """Seeded 2026-08-08 from i-09b539c844515d549. Spot-checks the units
+        this session actually touched, so an edit that drops them is caught."""
+        module, _, _ = cd
+        baseline = module.load_baseline(_REPO_ROOT / "infrastructure" / "systemd" / "uncodified-units-baseline.txt")
+
+        for name in (
+            "morning-signal.service",
+            "morning-signal.timer",
+            "morning-signal-bakeoff.service",
+            "box-health.timer",
+            "litellm-proxy.service",
+        ):
+            assert name in baseline, f"{name} missing from the uncodified baseline"


### PR DESCRIPTION
Partially closes alpha-engine-config-I6656 (deliverables 2, 3, 4).

## The defect

The diff was correct. The **claim** was not. This check compared four hardcoded units and closed with:

```
Systemd unit drift check PASSED (installed units match repo).
```

The dashboard box carries **60** locally-installed unit files. It did not even cover the six this repo codifies — its own `systemd-unit-drift-check.{service,timer}` were absent from `ALL_UNITS`. From outside, a narrow check and a complete one are the same green line.

Found 2026-08-08 while raising `TimeoutStartSec` on `morning-signal.service`: the edit went onto a live box with nothing anywhere that would have noticed it being reverted, hours after this check reported PASSED that morning.

## What changes

Scope is now every regular `.service` / `.timer` in `/etc/systemd/system`, each classified `clean` / `drift` / `uncodified`. Symlinks are skipped — they are systemd's own aliases into `/usr/lib/systemd`, and counting them would put `dbus.service` in the work queue.

| Rule | Why |
|---|---|
| PASSED is reserved for full coverage | With 54 of 60 uncodified, no phrasing of "passed" is true. The run states the shortfall: `INCOMPLETE: 6/60 installed units are codified and clean` |
| The known-uncodified set does **not** fail the run | Failing on a 54-unit backlog pages once per unit on the first run and teaches exactly one lesson, which is to turn the check off |
| Anything uncodified and **not** baselined is named individually | New is the only kind a given run can act on, so it must not blend into a count |
| The counts are emitted (`--metric`), zeros included | A number that only appears when something is wrong cannot distinguish healthy from dead (`principles.md` §2.7) |

`uncodified-units-baseline.txt` is a **work queue, not an allowlist** — each line carries the repo that should own that unit per `infrastructure-ownership-policy`, and `UNKNOWN` where even that is not established. `--strict` fails on anything uncodified and is the end state once the file is empty.

`_report_drift` and its `krepis.alerts` dedup path are untouched.

## One retired status, deliberately

Installed-with-no-repo-copy used to be `source-error` — a fault in *this script's configuration*. 54 units are in that state. They are not 54 configuration errors, they are the coverage gap, and calling them an error made the honest reading unavailable. The test asserting `source-error` is **updated with that reasoning**, not deleted.

## Verification

Baseline reconciled against the live box rather than hand-written: 60 installed, 6 codified here, 54 uncodified — the baseline holds exactly those 54, none missing, none extra.

**19 tests pass** in `tests/test_systemd_unit_drift_check.py` (10 existing, 9 added). The metric-failure test injects at the `boto3` boundary rather than stubbing `_emit_metrics`, so it asserts this code's behaviour and not a stub's.

**On the rest of the local suite:** 44 failures from a **stale laptop venv** — `nousergon_lib` 0.124.6 against a pinned `v0.124.37`, and a `krepis` predating `--correlation-id`. CI on this same base SHA (`a39f1256`) is green and none of them touch this script. Filed separately rather than papered over, because a venv 31 patch versions behind makes every local suite run misleading, which is its own defect.

## Not in this PR

Deliverables 1 and 5–8 of I6656 — codifying the 54 units, giving `/opt/nous-ergon-ops` a real delivery mechanism, and asserting a unit against its recovery wrapper. Those are the work; this is the instrument that measures it, and it had to stop lying first.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)