### PR TITLE
Enforce weekly-sf-policy §7 Rehearsal-path trailer on weekly-critical PRs

### DIFF
--- a/.github/workflows/canary-replay.yml
+++ b/.github/workflows/canary-replay.yml
@@ -102,6 +102,19 @@ jobs:
               - 'infrastructure/lambdas/canary-replay-dispatcher/**'
               - 'infrastructure/lambdas/canary-replay-liveness-probe/**'
               - '.github/workflows/canary-replay.yml'
+              # alpha-engine-config-I6688 deliverable 2: the changes most
+              # likely to break a live Saturday (the SF definition itself,
+              # the spot bootstrap scripts, the offcycle rerun path, the
+              # mechanical recovery helper) previously did NOT auto-arm this
+              # canary — the `canary:replay` label was manual for exactly
+              # the PRs where forgetting it mattered most. Kept in lockstep
+              # with scripts/check_rehearsal_path.py's WEEKLY_CRITICAL_GLOBS
+              # and rehearsal-path-guard.yml's own filter by
+              # tests/test_rehearsal_path_guard_lockstep.py.
+              - 'infrastructure/step_function*.json'
+              - 'infrastructure/spot_*.sh'
+              - 'infrastructure/run_weekly_offcycle.sh'
+              - 'scripts/weekly_sf_rerun.py'
       - name: Apply canary:replay label
         if: steps.filter.outputs.weekly_critical == 'true'
         env:

--- a/.github/workflows/rehearsal-path-guard.yml
+++ b/.github/workflows/rehearsal-path-guard.yml
@@ -1,0 +1,79 @@
+name: Rehearsal Path Guard
+
+# Structural enforcement of weekly-sf-policy.md §7 (alpha-engine-config-I6688):
+# a PR touching a weekly-SF-critical path must carry, in its body, one of
+# §7's accepted forms — a `Rehearsal-path:` trailer naming a real §7.1
+# mechanism or an existing test, a §7.3 exemption (`structural` /
+# `complexity:ultra`), or a `Rehearsal-risk-acceptance:` paragraph (§7.2
+# route 3). "Needs a live Saturday" alone is not a legitimate gate.
+#
+# Measured 2026-08-09 (I6688): `git grep "Rehearsal-path"` returned ZERO
+# hits across nousergon-data/alpha-engine-config/nousergon-lib at
+# origin/main — the requirement was never enforced, and hardening changes
+# sat as drafts 2-4 weeks on "needs a live Saturday" while every Saturday
+# ran on the un-hardened path (§7, 2026-07-25 incident).
+#
+# Two-job shape mirrors canary-replay.yml: `label` runs dorny/paths-filter
+# to decide whether this PR touches a weekly-critical path at all (a PR
+# that doesn't is unconstrained by §7 and the check passes trivially);
+# `check` runs only when it does, and calls the body-parsing logic in
+# scripts/check_rehearsal_path.py (kept in a script, not inline bash, so
+# tests/test_check_rehearsal_path.py can exercise every branch directly).
+#
+# `edited` is in the trigger types deliberately: the trailer lives in the
+# PR BODY, and a body is commonly fixed up (trailer added) after the PR is
+# already open — `opened`-only would make that fix invisible to the check
+# until some unrelated push.
+#
+# The PR body is passed to the checker via the `PR_BODY` env var, never
+# spliced into a `run:` shell block — `github.event.pull_request.body` is
+# attacker-controlled text on `pull_request` (same rationale as
+# canary-replay.yml's PR_DATA_REF/PR_SHA handling).
+#
+# Path list MUST stay in lockstep with scripts/check_rehearsal_path.py's
+# WEEKLY_CRITICAL_GLOBS and with the weekly-critical subset of
+# canary-replay.yml's own filter — pinned by
+# tests/test_rehearsal_path_guard_lockstep.py.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      weekly_critical: ${{ steps.filter.outputs.weekly_critical }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        with:
+          filters: |
+            weekly_critical:
+              - 'infrastructure/step_function*.json'
+              - 'infrastructure/spot_*.sh'
+              - 'infrastructure/run_weekly_offcycle.sh'
+              - 'scripts/weekly_sf_rerun.py'
+
+  check:
+    needs: label
+    if: needs.label.outputs.weekly_critical == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Check Rehearsal-path trailer / exemption (weekly-sf-policy §7)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/check_rehearsal_path.py "${{ github.workspace }}"

--- a/scripts/check_rehearsal_path.py
+++ b/scripts/check_rehearsal_path.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Enforce weekly-sf-policy.md §7 (Rehearsal path requirement) on PRs that
+touch weekly-SF-critical paths (alpha-engine-config-I6688).
+
+Policy summary (nous-ergon-ops/policies/weekly-sf-policy.md §7): a weekly-SF
+change whose validation "needs a live Saturday" must, in the SAME PR, take
+one of four routes instead of waiting for one:
+
+  1. Nominate a rehearsal path (§7.1) — a `Rehearsal-path:` trailer naming
+     one of the two existing mechanisms (the Friday shell-run,
+     `infrastructure/run_weekly_offcycle.sh`; or the Replay canary,
+     `.github/workflows/canary-replay.yml` / the `canary:replay` label /
+     `alpha-engine-canary-replay-dispatcher`), OR a CI-validatable
+     alternative — a repo-relative test path that actually exists in the
+     checked-out tree (§7.2 route 1).
+  2. Declare one of the two §7.3 exemptions, verbatim: `structural` (CI
+     already covers pure structural validation — IAM grants, SF definition
+     syntax, static analysis) or `complexity:ultra` (human-authored
+     topology changes per §5).
+  3. Record a `Rehearsal-risk-acceptance:` paragraph (§7.2 route 3) — the
+     specific constraint that prevents any rehearsal (a live-only IAM
+     boundary, an irreversible mutation, an externally-triggered
+     dependency), for a reviewer to evaluate as a risk-acceptance decision.
+
+A body reading only "needs a Saturday run" satisfies none of these and the
+check fails — that is the exact discipline gap I6688 measured (zero
+`Rehearsal-path:` hits across the fleet at origin/main, 2026-08-09).
+
+This module is deliberately import-only logic with no I/O beyond the CLI
+entrypoint, so `tests/test_check_rehearsal_path.py` can exercise every
+branch directly. The invoking workflow
+(`.github/workflows/rehearsal-path-guard.yml`) passes the PR body via the
+`PR_BODY` env var (never spliced into a shell `run:` block — PR bodies are
+attacker-controlled text on `pull_request`) and the checked-out repo root as
+argv[1].
+
+``WEEKLY_CRITICAL_GLOBS`` is the canonical path list for this check's own
+paths-filter AND must stay in lockstep with the equivalent entries in
+canary-replay.yml's filter (deliverable 2 of I6688) — pinned by
+tests/test_rehearsal_path_guard_lockstep.py so the two workflows cannot
+silently drift apart the way the duplicate §7/§8 sections of the policy
+itself once did (§7.4).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Kept identical, in both entries and order, to the `weekly_critical` filter
+# in .github/workflows/rehearsal-path-guard.yml and to the weekly-critical
+# subset of .github/workflows/canary-replay.yml's filter. Pinned by
+# tests/test_rehearsal_path_guard_lockstep.py.
+WEEKLY_CRITICAL_GLOBS: tuple[str, ...] = (
+    "infrastructure/step_function*.json",
+    "infrastructure/spot_*.sh",
+    "infrastructure/run_weekly_offcycle.sh",
+    "scripts/weekly_sf_rerun.py",
+)
+
+# §7.1 mechanism names/aliases a `Rehearsal-path:` trailer may cite. Matched
+# case-insensitively as a substring so both the artifact and trigger names
+# from the policy table are accepted (e.g. "canary-replay" or
+# "canary:replay" or "alpha-engine-canary-replay-dispatcher").
+_MECHANISM_KEYWORDS = (
+    "run_weekly_offcycle.sh",
+    "canary-replay",
+    "canary:replay",
+    "canary_replay",
+)
+
+# §7.3, exhaustive. Matched exactly (case-insensitive), not by substring —
+# these are declared exemptions, not free text.
+_EXEMPT_VALUES = {"structural", "complexity:ultra"}
+
+# Trailers are matched as `Key: value` at the start of a line, mirroring how
+# `Verified-when:` / `Closes-when:` trailers are already written across the
+# fleet's PR bodies.
+_REHEARSAL_PATH_RE = re.compile(r"^Rehearsal-path:[ \t]*(.+)$", re.MULTILINE)
+_REHEARSAL_EXEMPT_RE = re.compile(r"^Rehearsal-exempt:[ \t]*(.+)$", re.MULTILINE)
+# Risk-acceptance is a *paragraph* (§7.2 route 3), not a single trailer
+# value — capture the rest of the line plus every following line up to the
+# next blank line or the end of the body.
+_REHEARSAL_RISK_RE = re.compile(
+    r"^Rehearsal-risk-acceptance:[ \t]*(.*(?:\n(?![ \t]*\n)[^\n]*)*)",
+    re.MULTILINE,
+)
+
+# A risk-acceptance paragraph shorter than this is treated as a placeholder,
+# not a recorded constraint — the policy requires "the specific constraint",
+# not an empty trailer.
+_MIN_RISK_ACCEPTANCE_CHARS = 20
+
+_ACCEPTED_FORMS = """Accepted forms (weekly-sf-policy.md §7), any ONE of:
+  1. `Rehearsal-path: <mechanism or test path>` naming one of the §7.1
+     mechanisms (a value containing "run_weekly_offcycle.sh" or
+     "canary-replay"/"canary:replay"), OR a repo-relative path to a test
+     that exists in the checked-out tree (§7.2 route 1).
+  2. `Rehearsal-exempt: structural` or `Rehearsal-exempt: complexity:ultra`
+     (§7.3, exhaustive — exactly these two values).
+  3. A `Rehearsal-risk-acceptance:` paragraph naming the specific constraint
+     that prevents any rehearsal (§7.2 route 3) — a live-only IAM boundary,
+     an irreversible mutation, an externally-triggered dependency.
+
+"Needs a Saturday run" alone is not a legitimate gate (§7.2)."""
+
+
+@dataclass
+class CheckResult:
+    ok: bool
+    message: str
+
+
+def weekly_critical_paths_touched(
+    changed_paths: list[str], globs: tuple[str, ...] = WEEKLY_CRITICAL_GLOBS
+) -> list[str]:
+    """Return the subset of ``changed_paths`` matching a weekly-critical glob.
+
+    Mirrors dorny/paths-filter's own glob semantics closely enough for unit
+    testing; the workflow itself is the source of truth for the real gate
+    (this function exists so the glob list is testable without a live CI
+    run, and so a future non-GHA caller — e.g. a pre-commit hook — can reuse
+    it).
+    """
+    hits = []
+    for raw in changed_paths:
+        normalized = raw.replace(os.sep, "/").lstrip("/")
+        if any(fnmatch.fnmatch(normalized, glob) for glob in globs):
+            hits.append(normalized)
+    return hits
+
+
+def _extract(pattern: re.Pattern, body: str) -> str | None:
+    match = pattern.search(body)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _rehearsal_path_is_valid(value: str, repo_root: Path) -> bool:
+    if not value:
+        return False
+    lowered = value.lower()
+    if any(keyword in lowered for keyword in _MECHANISM_KEYWORDS):
+        return True
+
+    # Treat the trailer value as a repo-relative path (strip surrounding
+    # backticks/quotes and any trailing prose after the first whitespace
+    # token, e.g. "Rehearsal-path: tests/test_foo.py (new)").
+    candidate = value.strip().strip("`\"'").split()[0] if value.split() else ""
+    if not candidate:
+        return False
+
+    resolved_root = repo_root.resolve()
+    candidate_path = (resolved_root / candidate).resolve()
+    try:
+        candidate_path.relative_to(resolved_root)
+    except ValueError:
+        return False  # path escapes the repo (e.g. "../../etc/passwd")
+    return candidate_path.is_file()
+
+
+def evaluate(body: str, repo_root: Path) -> CheckResult:
+    """Evaluate a PR body against weekly-sf-policy.md §7's accepted forms."""
+    body = body or ""
+
+    rehearsal_path = _extract(_REHEARSAL_PATH_RE, body)
+    if rehearsal_path is not None:
+        if _rehearsal_path_is_valid(rehearsal_path, repo_root):
+            return CheckResult(True, f"Rehearsal-path OK: {rehearsal_path!r}")
+        return CheckResult(
+            False,
+            f"Rehearsal-path {rehearsal_path!r} names neither a §7.1 "
+            "mechanism nor an existing repo-relative test path.\n\n"
+            + _ACCEPTED_FORMS,
+        )
+
+    exempt = _extract(_REHEARSAL_EXEMPT_RE, body)
+    if exempt is not None:
+        if exempt.strip().lower() in _EXEMPT_VALUES:
+            return CheckResult(True, f"Rehearsal-exempt OK: {exempt.strip()}")
+        return CheckResult(
+            False,
+            f"Rehearsal-exempt {exempt!r} is not one of the two §7.3 "
+            "exemptions ('structural' or 'complexity:ultra').\n\n"
+            + _ACCEPTED_FORMS,
+        )
+
+    risk = _extract(_REHEARSAL_RISK_RE, body)
+    if risk is not None:
+        if len(risk.strip()) >= _MIN_RISK_ACCEPTANCE_CHARS:
+            return CheckResult(True, "Rehearsal-risk-acceptance OK")
+        return CheckResult(
+            False,
+            "Rehearsal-risk-acceptance paragraph is too short to name a "
+            "specific constraint (§7.2 route 3 needs the actual boundary, "
+            "not a placeholder).\n\n" + _ACCEPTED_FORMS,
+        )
+
+    return CheckResult(
+        False,
+        "This PR touches a weekly-SF-critical path but its body carries "
+        "none of the required trailers.\n\n" + _ACCEPTED_FORMS,
+    )
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(argv[1]) if len(argv) > 1 else Path(".")
+    body = os.environ.get("PR_BODY", "")
+    result = evaluate(body, repo_root)
+    print(result.message)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_check_rehearsal_path.py
+++ b/tests/test_check_rehearsal_path.py
@@ -1,0 +1,212 @@
+"""Unit tests for scripts/check_rehearsal_path.py (alpha-engine-config-I6688).
+
+Exercises every branch of weekly-sf-policy.md §7's accepted-forms decision:
+no trailer at all, a valid/invalid `Rehearsal-path:` (mechanism keyword vs.
+repo-relative test path vs. neither), both §7.3 exemption values plus a
+bogus one, and a `Rehearsal-risk-acceptance:` paragraph both long enough and
+too short to count as "the specific constraint" §7.2 route 3 requires.
+
+Also asserts `weekly_critical_paths_touched` (the glob-matching helper) and
+the module's own CLI entrypoint (reads `PR_BODY` from the environment,
+never from a shell-interpolated body, since a PR body is attacker-controlled
+text on `pull_request`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_rehearsal_path.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_rehearsal_path", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_rehearsal_path"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def mod():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# evaluate() — no trailer at all
+# ---------------------------------------------------------------------------
+
+
+def test_no_trailers_fails(mod):
+    result = mod.evaluate("This change hardens preflight. Needs a live Saturday to validate.", REPO_ROOT)
+    assert result.ok is False
+    assert "§7" in result.message or "accepted forms" in result.message.lower() or "Accepted forms" in result.message
+
+
+def test_empty_body_fails(mod):
+    result = mod.evaluate("", REPO_ROOT)
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Rehearsal-path: §7.1 mechanism keywords
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "run_weekly_offcycle.sh",
+        "the Friday shell-run (infrastructure/run_weekly_offcycle.sh)",
+        "canary-replay",
+        "canary:replay label",
+        "Replay canary (.github/workflows/canary-replay.yml)",
+    ],
+)
+def test_rehearsal_path_mechanism_keyword_passes(mod, value):
+    body = f"What & why.\n\nRehearsal-path: {value}\n\nVerified-when: ...\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is True
+
+
+def test_rehearsal_path_existing_test_file_passes(mod):
+    # This very test file exists in the checked-out tree.
+    rel = "tests/test_check_rehearsal_path.py"
+    body = f"Rehearsal-path: {rel}\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is True
+
+
+def test_rehearsal_path_nonexistent_file_fails(mod):
+    body = "Rehearsal-path: tests/test_does_not_exist_anywhere_260809.py\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+def test_rehearsal_path_escaping_repo_root_fails(mod):
+    body = "Rehearsal-path: ../../etc/passwd\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+def test_rehearsal_path_prose_only_fails(mod):
+    body = "Rehearsal-path: needs a Saturday, no rehearsal exists\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Rehearsal-exempt: §7.3, exhaustive two values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["structural", "complexity:ultra", "Structural", "COMPLEXITY:ULTRA"])
+def test_rehearsal_exempt_valid_values_pass(mod, value):
+    body = f"Rehearsal-exempt: {value}\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is True
+
+
+def test_rehearsal_exempt_bogus_value_fails(mod):
+    body = "Rehearsal-exempt: low-risk\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Rehearsal-risk-acceptance: §7.2 route 3 paragraph
+# ---------------------------------------------------------------------------
+
+
+def test_rehearsal_risk_acceptance_specific_constraint_passes(mod):
+    body = (
+        "Rehearsal-risk-acceptance: this touches the live IAM trust boundary "
+        "for the weekly execution role; no sandbox account holds an "
+        "equivalent role to rehearse the assume-role path against, so this "
+        "is a genuine risk-acceptance decision rather than a deferral.\n"
+    )
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is True
+
+
+def test_rehearsal_risk_acceptance_multiline_paragraph_passes(mod):
+    body = (
+        "Rehearsal-risk-acceptance:\n"
+        "The EventBridge rule change is irreversible once the current\n"
+        "week's schedule fires; there is no dry-run mode for a live rule.\n"
+        "\n"
+        "Verified-when: manual review of the rule diff.\n"
+    )
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is True
+
+
+def test_rehearsal_risk_acceptance_placeholder_fails(mod):
+    body = "Rehearsal-risk-acceptance: n/a\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+def test_rehearsal_risk_acceptance_empty_fails(mod):
+    body = "Rehearsal-risk-acceptance:\n\nVerified-when: ...\n"
+    result = mod.evaluate(body, REPO_ROOT)
+    assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# weekly_critical_paths_touched()
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_critical_paths_touched_matches_expected(mod):
+    changed = [
+        "infrastructure/step_function.json",
+        "infrastructure/step_function_offcycle.json",
+        "infrastructure/spot_backtest.sh",
+        "infrastructure/run_weekly_offcycle.sh",
+        "scripts/weekly_sf_rerun.py",
+        "README.md",
+        ".github/workflows/canary-replay.yml",
+    ]
+    hits = mod.weekly_critical_paths_touched(changed)
+    assert set(hits) == {
+        "infrastructure/step_function.json",
+        "infrastructure/step_function_offcycle.json",
+        "infrastructure/spot_backtest.sh",
+        "infrastructure/run_weekly_offcycle.sh",
+        "scripts/weekly_sf_rerun.py",
+    }
+
+
+def test_weekly_critical_paths_touched_empty_when_no_match(mod):
+    assert mod.weekly_critical_paths_touched(["README.md", "tests/test_foo.py"]) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint — reads PR_BODY from the environment, not argv/shell
+# ---------------------------------------------------------------------------
+
+
+def test_main_reads_pr_body_from_env_and_exits_nonzero_on_failure(mod, monkeypatch, capsys):
+    monkeypatch.setenv("PR_BODY", "no trailers here")
+    rc = mod.main(["check_rehearsal_path.py", str(REPO_ROOT)])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Accepted forms" in out
+
+
+def test_main_reads_pr_body_from_env_and_exits_zero_on_success(mod, monkeypatch, capsys):
+    monkeypatch.setenv("PR_BODY", "Rehearsal-exempt: structural\n")
+    rc = mod.main(["check_rehearsal_path.py", str(REPO_ROOT)])
+    assert rc == 0
+
+
+def test_main_defaults_repo_root_and_missing_pr_body(mod, monkeypatch):
+    monkeypatch.delenv("PR_BODY", raising=False)
+    rc = mod.main(["check_rehearsal_path.py"])
+    assert rc == 1

--- a/tests/test_rehearsal_path_guard_lockstep.py
+++ b/tests/test_rehearsal_path_guard_lockstep.py
@@ -1,0 +1,72 @@
+"""Lockstep guard for alpha-engine-config-I6688 deliverable 2: the weekly-SF-
+critical path list must be identical across three places, or the check that
+requires a Rehearsal-path trailer and the canary that auto-arms on those
+same paths silently drift apart — exactly the shape weekly-sf-policy.md
+§7.4 documents happening to the policy text itself (two sections, same
+requirement, different vocabulary, different exemption sets).
+
+The three places:
+
+  1. ``scripts/check_rehearsal_path.py``'s ``WEEKLY_CRITICAL_GLOBS`` — the
+     canonical list.
+  2. ``.github/workflows/rehearsal-path-guard.yml``'s own ``weekly_critical``
+     paths-filter (decides whether the trailer check even runs).
+  3. The weekly-critical subset of ``.github/workflows/canary-replay.yml``'s
+     ``weekly_critical`` paths-filter (decides whether the canary auto-arms
+     — this filter also carries its own pre-existing entries unrelated to
+     I6688, e.g. ``rag/pipelines/**``, so this test asserts a SUBSET
+     relationship there, not equality).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECK_SCRIPT = REPO_ROOT / "scripts" / "check_rehearsal_path.py"
+GUARD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rehearsal-path-guard.yml"
+CANARY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "canary-replay.yml"
+
+
+def _load_check_module():
+    spec = importlib.util.spec_from_file_location("check_rehearsal_path", CHECK_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_rehearsal_path"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _weekly_critical_filter_globs(workflow_path: Path, job_id: str) -> list[str]:
+    """Extract the `weekly_critical` filter list embedded as a YAML string
+    inside a `dorny/paths-filter` step's `with.filters` block."""
+    definition = yaml.safe_load(workflow_path.read_text())
+    steps = definition["jobs"][job_id]["steps"]
+    filter_step = next(s for s in steps if s.get("id") == "filter")
+    filters_block = filter_step["with"]["filters"]
+    parsed = yaml.safe_load(filters_block)
+    return list(parsed["weekly_critical"])
+
+
+def test_check_script_globs_match_guard_workflow_filter():
+    canonical = list(_load_check_module().WEEKLY_CRITICAL_GLOBS)
+    guard_globs = _weekly_critical_filter_globs(GUARD_WORKFLOW, "label")
+    assert guard_globs == canonical, (
+        "rehearsal-path-guard.yml's paths-filter has drifted from "
+        "scripts/check_rehearsal_path.py's WEEKLY_CRITICAL_GLOBS — "
+        f"guard={guard_globs!r} canonical={canonical!r}"
+    )
+
+
+def test_canary_replay_filter_is_superset_of_weekly_critical_globs():
+    canonical = set(_load_check_module().WEEKLY_CRITICAL_GLOBS)
+    canary_globs = set(_weekly_critical_filter_globs(CANARY_WORKFLOW, "label"))
+    missing = canonical - canary_globs
+    assert not missing, (
+        "canary-replay.yml's paths-filter is missing weekly-critical paths "
+        f"that rehearsal-path-guard.yml enforces: {missing!r} — the canary "
+        "will not auto-arm on a PR that the trailer check gates."
+    )


### PR DESCRIPTION
## What & why

`alpha-engine-config#6688` measured (2026-08-09) that weekly-sf-policy.md §7's `Rehearsal-path:` trailer has never been enforced — zero hits across `nousergon-data`/`alpha-engine-config`/`nousergon-lib` at origin/main — and that `canary-replay.yml`'s paths-filter did not cover `infrastructure/step_function.json`, `infrastructure/spot_*.sh`, `infrastructure/run_weekly_offcycle.sh`, or `scripts/weekly_sf_rerun.py`: the changes most likely to break a live Saturday did not auto-arm the canary, and hardening PRs sat as drafts 2-4 weeks on "needs a live Saturday" while every Saturday ran un-hardened (§7, 2026-07-25 incident).

Two deliverables, per the issue:

1. **`.github/workflows/rehearsal-path-guard.yml`** — new required-on-path check. `dorny/paths-filter` detects a touch to any of the four weekly-critical paths; if touched, `scripts/check_rehearsal_path.py` requires the PR body to carry one of §7's accepted forms:
   - `Rehearsal-path:` naming a real §7.1 mechanism (`run_weekly_offcycle.sh` / `canary-replay` / `canary:replay`) or a repo-relative test path that exists in the checked-out tree (§7.2 route 1);
   - `Rehearsal-exempt: structural` or `Rehearsal-exempt: complexity:ultra` (§7.3, exhaustive);
   - a `Rehearsal-risk-acceptance:` paragraph naming the specific constraint (§7.2 route 3).

   Triggers on `opened, edited, synchronize, reopened` — `edited` matters because the trailer lives in the PR *body*, commonly fixed up after the PR is already open. Body-parsing logic lives in `scripts/check_rehearsal_path.py` (not inline bash) for testability; the PR body reaches the script via the `PR_BODY` env var, never spliced into a shell `run:` block (a PR body is attacker-controlled text on `pull_request`, same handling as `canary-replay.yml`'s existing `PR_DATA_REF`/`PR_SHA`).

2. **`canary-replay.yml`** — its own `weekly_critical` paths-filter now also includes the same four paths, so the canary auto-arms on definition-touching PRs instead of requiring a manual `canary:replay` label.

3. **`tests/test_rehearsal_path_guard_lockstep.py`** — pins the path list identical across `scripts/check_rehearsal_path.py`'s `WEEKLY_CRITICAL_GLOBS`, the new guard's filter, and (as a subset check) `canary-replay.yml`'s filter, so the two workflows cannot silently drift apart the way weekly-sf-policy.md's own §7/§8 duplication once did (§7.4).

Governing policy: `nous-ergon-ops/policies/weekly-sf-policy.md` §7 / §7.1 / §7.2 / §7.3.

Part of alpha-engine-config#6688.

## Test plan

Local run, full suite, before opening (venv outside the checkout, `/tmp/nd-i6688-venv`):

```
$ python3 -m pytest tests/ -q
4275 passed, 8 skipped, 416 warnings in 106.52s (0:01:46)
```

New tests (27 total, all included in the run above):
- `tests/test_check_rehearsal_path.py` (25 cases) — every accepted/rejected form: no trailer, empty body, all §7.1 mechanism-keyword variants, an existing vs. nonexistent vs. path-traversal `Rehearsal-path:`, both valid `Rehearsal-exempt:` values plus a bogus one, single-line and multi-line `Rehearsal-risk-acceptance:` paragraphs plus a too-short placeholder, `weekly_critical_paths_touched()` glob matching, and the `PR_BODY`-env-var CLI entrypoint.
- `tests/test_rehearsal_path_guard_lockstep.py` (2 cases) — the guard's filter list equals the canonical `WEEKLY_CRITICAL_GLOBS`; `canary-replay.yml`'s filter is a superset of it.

8 pre-existing skips, zero pre-existing failures — unrelated to this change.

Manual closes-when verification (per the issue): a synthetic PR body with no trailer against a diff touching `step_function.json` evaluates to `ok=False` (see `test_no_trailers_fails`); the same body with `Rehearsal-exempt: structural` evaluates to `ok=True` (see `test_rehearsal_exempt_valid_values_pass`) — both exercised directly against `evaluate()` in the unit tests above rather than a live throwaway PR, since the check only runs where the label job's paths-filter fires `true` on this repo's own PRs.

## Deploy mechanism

**Deploy-mechanism:** N/A — CI workflow change, no runtime deploy.

## Scope note

This PR is confined to `.github/workflows/` and `scripts/`/`tests/`, per session instruction, to avoid colliding with other concurrent work in this repo touching `infrastructure/step_function.json` or other test files.

Closes-when: alpha-engine-config#6688's three closing conditions (trailer-less PR red, trailer'd PR green, canary auto-triggers on a definition-touching PR) — the first two are unit-tested directly above; the third is structural (canary-replay.yml's filter now includes the same paths) and will be visible on the next real PR touching one of them.

---

**Prepared by: Claude Sonnet 4.5 via [Claude Code](https://claude.com/claude-code)**
