### PR TITLE
fix(eod-backstop): dispatch on any trading day with no EOD execution, not just box-running (config-I6690)

### DIFF
--- a/.github/workflows/deploy-eod-backstop.yml
+++ b/.github/workflows/deploy-eod-backstop.yml
@@ -1,0 +1,96 @@
+name: Deploy eod-backstop
+
+# Auto-deploy the alpha-engine-eod-backstop Lambda CODE on merge to main.
+#
+# Why this exists (alpha-engine-config-I6690): this Lambda had NO deploy
+# workflow at all — its own deploy.sh header says "operator-deployed only,
+# narrow OIDC blast radius" and nothing in .github/workflows covers
+# infrastructure/lambdas/eod-backstop/**. A merged fix to this Lambda (the
+# widened box-never-started dispatch condition) would sit in the repo without
+# ever reaching the deployed function — the exact "merge button alone must be
+# deployable" gap deploy-pipeline-watchdog.yml and deploy-freshness-monitor.yml
+# were created to close (config#5606 / 2026-06-26).
+#
+# Mirrors deploy-pipeline-watchdog.yml deliberately rather than inventing a
+# second shape. Code only: deploy.sh with no flags is its update-code path —
+# the BOOTSTRAP block (IAM role/policy, Lambda create, EventBridge rule
+# create) is gated behind --bootstrap/--apply-iam and is NEVER invoked here,
+# so this workflow cannot create or rewire infrastructure, only ship code to
+# a function that already exists. Verified idempotent for CI redeploy: the
+# no-flag path is (1) syntax check, (2) unit tests, (3) pip install + zip,
+# (4) `aws lambda update-function-code` + `wait function-updated` — no
+# already-exists failure mode.
+#
+# IAM: no change needed. github-actions-lambda-deploy's LambdaUpdate statement
+# already grants GetFunction / GetFunctionConfiguration / UpdateFunctionCode /
+# UpdateFunctionConfiguration on arn:aws:lambda:us-east-1:711398986525:
+# function:alpha-engine-*, which covers alpha-engine-eod-backstop. Those four
+# are every AWS call the no-flag deploy.sh path makes (same statement
+# deploy-pipeline-watchdog.yml relies on).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/eod-backstop/**'
+      - '.github/workflows/deploy-eod-backstop.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-eod-backstop-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy eod-backstop Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy eod-backstop (code-only)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/eod-backstop/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-eod-backstop \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-eod-backstop.yml
+
+  # Alert (Telegram) on genuine post-merge failure on the default branch.
+  # Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -9,12 +9,16 @@
 # sessions (the 2026-06-24 → RGEN +14.92% class; config#1228/#1229).
 #
 # Fires ~22:30 UTC MON-FRI (well after the daemon's ~20:15 UTC EOD). Starts the
-# EOD SF IFF the trading box is still running AND no EOD started today. See
-# index.py for the full guard rationale.
+# EOD SF IFF it is a trading day AND no EOD started today — regardless of
+# trading-box state (config-I6690, 2026-08-09: widened from the original
+# box-must-be-running gate, which made a box-never-started day a silent
+# no-op). See index.py for the full guard rationale.
 #
-# Managed outside CloudFormation — same rationale as pipeline-watchdog /
-# sf-telegram-notifier / eod-success-friday-shell-trigger (operator-deployed
-# only, narrow OIDC blast radius).
+# Code-only auto-deploy on merge to main: .github/workflows/deploy-eod-
+# backstop.yml (config-I6690). Infra (IAM/EventBridge rule) stays operator-run
+# via --bootstrap/--apply-iam below — same narrow-OIDC-blast-radius rationale
+# pipeline-watchdog / sf-telegram-notifier / eod-success-friday-shell-trigger
+# use for their own bootstrap paths.
 #
 # SAFE ROLLOUT: --bootstrap creates the EventBridge rule DISABLED. Soak the
 # Lambda via --smoke on a non-trading-day / box-down state (guaranteed no-op),
@@ -168,7 +172,7 @@ if $BOOTSTRAP; then
     --name "${RULE_NAME}" \
     --schedule-expression 'cron(30 22 ? * MON-FRI *)' \
     --state "$(pause_state "${RULE_NAME}")" \
-    --description "EOD-pipeline backstop fire at 22:30 UTC MON-FRI (Lambda gates on trading-day + box-running + no-EOD-today). State is derived from infrastructure/automation_pause.json, not pinned here (I6619); the soak this text referred to completed and the rule has been ENABLED since." \
+    --description "EOD-pipeline backstop fire at 22:30 UTC MON-FRI (Lambda gates on trading-day + no-EOD-today; config-I6690 dropped the box-running requirement). State is derived from infrastructure/automation_pause.json, not pinned here (I6619); the soak this text referred to completed and the rule has been ENABLED since." \
     --region "${REGION}" \
     --query 'RuleArn' --output text
 
@@ -211,11 +215,11 @@ echo "✓ Code deployed."
 
 if $SMOKE; then
   echo ""
-  echo "WARNING: --smoke runs the REAL handler. If today is a trading day AND the"
-  echo "         trading box is running AND no EOD started today, it WILL start the"
-  echo "         EOD Step Function. Run it only when you expect a no-op (non-trading"
-  echo "         day, or box already stopped), or when you genuinely want to recover"
-  echo "         today's missing EOD."
+  echo "WARNING: --smoke runs the REAL handler. If today is a trading day AND no EOD"
+  echo "         started today, it WILL start the EOD Step Function — REGARDLESS of"
+  echo "         trading-box state (config-I6690 dropped the box-running gate). Run"
+  echo "         it only when you expect a no-op (non-trading day, or an EOD already"
+  echo "         ran today), or when you genuinely want to recover today's missing EOD."
   RESP=$(mktemp)
   aws lambda invoke \
     --function-name "${FUNCTION_NAME}" \

--- a/infrastructure/lambdas/eod-backstop/index.py
+++ b/infrastructure/lambdas/eod-backstop/index.py
@@ -12,24 +12,67 @@ gap → RGEN +14.92% class of bug; config#1229).
 
 This Lambda is the missing backstop. Triggered by EventBridge ~22:30 UTC on
 weekdays (well after the daemon's nominal ~20:15 UTC EOD), it starts the EOD
-SF IFF both:
+SF IFF:
 
-  1. the trading EC2 box is still RUNNING — the daemon never shut it down, so
-     EOD never fired; and CaptureSnapshot needs a live IB session, which only
-     exists while the box is up (this is a SAME-DAY-only recovery), AND
+  1. it is a NYSE trading day (an expected-EOD day at all), AND
   2. no EOD execution has STARTED today — so we never double-run after a
      daemon-triggered EOD that already completed (or is mid-flight).
 
+WIDENED 2026-08-09 (alpha-engine-config-I6690): the original design also
+required the trading box to still be RUNNING before dispatching, on the
+theory that a stopped box meant "EOD already ran" or "box never booted, so
+nothing to reconcile". That second premise was wrong: on 2026-08-05/06 the
+PREOPEN pipeline itself failed pre-boot (config-I6615), the trading box never
+started AT ALL, the daemon never ran, and this backstop's box-running gate
+made it a silent no-op too — no EOD, no ``eod_pnl`` row, and (with
+``alpha-engine-pipeline-watchdog-daily`` paused under I6617) no alert of any
+kind. A box-never-started day is exactly the case this backstop most needs to
+cover, so the box-running condition is dropped entirely: the EOD SF's own
+first real state, ``StartTradingInstance`` (``step_function_eod.json:96``),
+boots the box unconditionally and is idempotent (``ec2:startInstances`` on an
+already-running box is a no-op) — so this Lambda needs no boot logic of its
+own, whether the box was up, down, or never started. ``_trading_box_running``
+is retained purely to TAG the dispatch (``triggered_by``) for observability,
+never to gate it.
+
 If the box is already stopped, EOD either ran (success or failure — both end
-in stopping the box) or the box never booted (no trading → nothing to
-reconcile): either way a no-op. The late-discovery case (box long gone, gap
-found days later) is NOT this Lambda's job — that is the IBKR Flex Query
-``eod_pnl`` backfill (config#1229).
+in stopping the box, caught by the ``eod_ran_today`` guard) or the box never
+booted (caught by the widened dispatch above). The late-discovery case (box
+long gone, gap found days later) is NOT this Lambda's job — that is the IBKR
+Flex Query ``eod_pnl`` backfill (config#1229).
 
 The EOD SF's own DynamoDB mutex (``AcquireMutex``) is the concurrency
 backstop: if a daemon-triggered EOD is mid-flight when this fires, our
 StartExecution would only hit ``MutexConflict`` and fail cleanly — but the
 ``eod_ran_today`` guard means we don't even attempt it.
+
+CaptureSnapshot on a freshly-booted box (config-I6690 evidence, verified
+against crucible-executor + step_function_eod.json, not assumed): IB Gateway
+comes up via the ``ibgateway.service`` systemd unit, which is a hard
+``Requires=``/``After=`` dependency of both ``alpha-engine-daemon.service``
+and ``alpha-engine-morning.service`` (both ``WantedBy=multi-user.target``,
+i.e. boot-enabled) — so any boot of the trading box, cold or warm, pulls
+ibgateway up as a systemd dependency with no separate enablement needed.
+Between ``StartTradingInstance`` and ``CaptureSnapshot`` the EOD SF spends
+several minutes on ``WaitForInstanceReady``/the SSM-readiness poll (up to
+~3 min), the conditional executor-checkout refresh, and — load-bearing —
+``LaunchPostMarketDataSpot``'s post-market-data phase on a wholly separate
+ephemeral spot box (``TimeoutSeconds: 420`` on the launch alone, plus its own
+poll-to-completion), none of which touch or wait on the trading box's IB
+session. That multi-minute buffer comfortably exceeds
+``wait-for-ibgateway.sh``'s own 120s max-wait budget and the ~30s TOTP-auth
+window ``alpha-engine-morning.service`` budgets for. ``executor/
+snapshot_capturer.py``'s ``IBKRClient.connect`` additionally retries 3x with
+exponential backoff (``executor/retry.py``) on its own, an extra ~60-90s of
+tolerance. No explicit ``wait-for-ibgateway`` state exists inside
+``CaptureSnapshot``'s own SSM command, so this is evidence of comfortable
+timing margin, not a guarantee — if a cold-boot CaptureSnapshot failure is
+ever observed in practice, the fix is to add an explicit gateway-readiness
+poll to ``CaptureSnapshot``'s SSM command, not to skip the snapshot (the
+I2700 skip shape assumes a snapshot ALREADY exists from an earlier attempt
+in the same execution — that is never true on a box that never booted, so
+skipping here would just hand ``EODReconcile`` no snapshot to read and it
+would hard-fail with no fallback, by design).
 
 Fail-loud (``feedback_no_silent_fails``): any AWS call failure raises so the
 EventBridge retry + Lambda-error CloudWatch alarm page the operator. We must
@@ -75,17 +118,21 @@ SNS_TOPIC_ARN = os.environ.get(
 )
 
 # Count an EOD as "already fired today" regardless of terminal status — a
-# started-then-failed EOD still ran HandleFailure → ForceStopInstance, so the
-# box would be stopped and the box-running gate already covers it; this guard
-# additionally prevents racing a mid-flight (RUNNING) EOD.
+# started-then-failed EOD still ran HandleFailure → ForceStopInstance (box
+# stopped again either way, config-I6690: no longer load-bearing here since
+# dispatch isn't gated on box state); this guard's job is preventing a
+# double-start, including racing a mid-flight (RUNNING) EOD.
 _STARTED_STATUSES = ("RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED")
 
 
 def _trading_box_running(ec2_client: Optional[object] = None) -> bool:
     """True iff the trading EC2 instance is in the ``running`` state.
 
-    A stopped/terminated/absent box means EOD already ran (and stopped it) or
-    the box never booted — either way the backstop is a no-op. Raises on an
+    OBSERVABILITY-ONLY (config-I6690): no longer gates dispatch — a stopped
+    box is exactly the box-never-started case this backstop must still cover.
+    Used solely to tag ``_start_eod``'s ``triggered_by`` value so a dashboard
+    reader can tell "daemon was up but didn't fire EOD" apart from "box was
+    never running at all" without re-deriving it from EC2 state. Raises on an
     EC2 API failure (fail-loud)."""
     if ec2_client is None:  # pragma: no cover — production path
         ec2_client = boto3.client("ec2", region_name=REGION)
@@ -141,9 +188,11 @@ def _eod_ran_today(now_utc: datetime, sf_client: Optional[object] = None) -> boo
     return False
 
 
-def _start_eod(trading_day: str, sf_client: Optional[object] = None) -> str:
-    """Start the EOD SF with the same input shape as the daemon, tagged
-    ``triggered_by=backstop``. Returns the execution ARN."""
+def _start_eod(trading_day: str, triggered_by: str, sf_client: Optional[object] = None) -> str:
+    """Start the EOD SF with the same input shape the daemon uses (config-I6690:
+    identical regardless of whether the box was running — see the module
+    docstring's CaptureSnapshot-on-a-cold-box evidence), tagged with the given
+    ``triggered_by``. Returns the execution ARN."""
     if sf_client is None:  # pragma: no cover — production path
         sf_client = boto3.client("stepfunctions", region_name=REGION)
     resp = sf_client.start_execution(
@@ -155,16 +204,16 @@ def _start_eod(trading_day: str, sf_client: Optional[object] = None) -> str:
                 "ec2_instance_id": [DASHBOARD_INSTANCE_ID],
                 "sns_topic_arn": SNS_TOPIC_ARN,
                 "run_date": trading_day,
-                "triggered_by": "backstop",
+                "triggered_by": triggered_by,
                 "pipeline_role": "eod",
             }
         ),
     )
     arn = resp.get("executionArn", "")
     logger.warning(
-        "EOD-BACKSTOP fired: trading box was still running and no EOD ran today "
-        "for trading_day=%s — started EOD SF %s",
-        trading_day, arn,
+        "EOD-BACKSTOP fired (triggered_by=%s): no EOD ran today for "
+        "trading_day=%s — started EOD SF %s",
+        triggered_by, trading_day, arn,
     )
     return arn
 
@@ -180,15 +229,19 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     trading_day = last_closed_trading_day(now_utc).isoformat()
 
-    if not _trading_box_running():
-        logger.info(
-            "Trading box not running — EOD already ran or box never booted; no-op."
-        )
-        return {"action": "noop", "reason": "trading_box_not_running", "trading_day": trading_day}
-
     if _eod_ran_today(now_utc):
         logger.info("An EOD execution already started today — no-op.")
         return {"action": "noop", "reason": "eod_already_ran_today", "trading_day": trading_day}
 
-    execution_arn = _start_eod(trading_day)
-    return {"action": "started_eod", "trading_day": trading_day, "execution_arn": execution_arn}
+    # config-I6690: box state no longer gates dispatch — it is checked only
+    # to tag the run (StartTradingInstance boots the box unconditionally and
+    # idempotently either way; see module docstring).
+    box_was_running = _trading_box_running()
+    triggered_by = "backstop" if box_was_running else "backstop-box-stopped"
+    execution_arn = _start_eod(trading_day, triggered_by)
+    return {
+        "action": "started_eod",
+        "trading_day": trading_day,
+        "execution_arn": execution_arn,
+        "box_was_running": box_was_running,
+    }

--- a/infrastructure/lambdas/eod-backstop/test_handler.py
+++ b/infrastructure/lambdas/eod-backstop/test_handler.py
@@ -1,7 +1,9 @@
-"""Unit tests for the alpha-engine-eod-backstop Lambda (config#1229).
+"""Unit tests for the alpha-engine-eod-backstop Lambda (config#1229, widened
+config-I6690).
 
-The backstop starts the EOD SF IFF the trading box is still running AND no
-EOD ran today; it is a no-op otherwise and fail-loud on AWS errors.
+The backstop starts the EOD SF IFF it is a trading day AND no EOD execution
+has started today — regardless of trading-box state (StartTradingInstance
+boots it either way); it is a no-op otherwise and fail-loud on AWS errors.
 """
 
 from __future__ import annotations
@@ -91,17 +93,32 @@ class TestHandler:
         return result, start
 
     def test_starts_eod_when_box_up_and_no_eod_today(self):
+        # box running + no execution + trading day -> dispatch (existing
+        # behavior preserved), tagged triggered_by="backstop".
         result, start = self._run(box="running", eod_started=None)
         assert result["action"] == "started_eod"
         assert result["execution_arn"] == "arn:exec:backstop"
-        start.assert_called_once()
+        assert result["box_was_running"] is True
+        start.assert_called_once_with(self.TRADING_NOW.date().isoformat(), "backstop")
 
-    def test_noop_when_box_stopped(self):
-        result, start = self._run(box="stopped")
-        assert result["action"] == "noop" and result["reason"] == "trading_box_not_running"
+    def test_starts_eod_when_box_stopped_and_no_eod_today(self):
+        # config-I6690: box stopped + no execution + trading day -> dispatch
+        # (the widened case — a box-never-started day must not be a silent
+        # no-op), tagged triggered_by="backstop-box-stopped".
+        result, start = self._run(box="stopped", eod_started=None)
+        assert result["action"] == "started_eod"
+        assert result["execution_arn"] == "arn:exec:backstop"
+        assert result["box_was_running"] is False
+        start.assert_called_once_with(self.TRADING_NOW.date().isoformat(), "backstop-box-stopped")
+
+    def test_noop_when_box_stopped_and_execution_exists(self):
+        # box stopped + execution exists -> no dispatch, regardless of box
+        # state (the eod_ran_today guard alone decides this).
+        result, start = self._run(box="stopped", eod_started=self.TRADING_NOW)
+        assert result["action"] == "noop" and result["reason"] == "eod_already_ran_today"
         start.assert_not_called()
 
-    def test_noop_when_eod_already_ran(self):
+    def test_noop_when_box_running_and_eod_already_ran(self):
         result, start = self._run(box="running", eod_started=self.TRADING_NOW)
         assert result["action"] == "noop" and result["reason"] == "eod_already_ran_today"
         start.assert_not_called()
@@ -111,11 +128,26 @@ class TestHandler:
         assert result["action"] == "noop" and result["reason"] == "not_a_trading_day"
         start.assert_not_called()
 
+    def test_eod_ran_today_checked_before_box_state(self):
+        # eod_ran_today is decisive on its own — box state must not even be
+        # consulted once an execution is already found for today (avoids an
+        # unnecessary EC2 describe_instances call on the common no-op path).
+        with patch("index.datetime") as dt, \
+             patch("index.is_trading_day", return_value=True), \
+             patch("index.last_closed_trading_day", return_value=self.TRADING_NOW.date()), \
+             patch("index._trading_box_running") as box_running, \
+             patch("index._eod_ran_today", return_value=True), \
+             patch("index._start_eod") as start:
+            dt.now.return_value = self.TRADING_NOW
+            index.handler({}, None)
+        box_running.assert_not_called()
+        start.assert_not_called()
+
 
 class TestStartEodInput:
     def test_start_execution_mirrors_daemon_input(self):
         sf = _sf(None)
-        index._start_eod("2026-06-25", sf)
+        index._start_eod("2026-06-25", "backstop", sf)
         kwargs = sf.start_execution.call_args.kwargs
         assert kwargs["stateMachineArn"].endswith("ne-postclose-trading-pipeline")
         assert kwargs["name"].startswith("eod-backstop-2026-06-25-")
@@ -125,6 +157,22 @@ class TestStartEodInput:
         assert payload["pipeline_role"] == "eod"
         assert payload["run_date"] == "2026-06-25"
         assert payload["trading_instance_id"] == [index.TRADING_INSTANCE_ID]
+
+    def test_start_execution_input_identical_when_box_was_stopped(self):
+        # config-I6690: the ONLY difference in the box-stopped case is the
+        # triggered_by tag — CaptureSnapshot has comfortable timing margin
+        # on a freshly-booted box (see module docstring evidence), so the
+        # SF input is otherwise identical to the box-was-running dispatch.
+        sf = _sf(None)
+        index._start_eod("2026-06-25", "backstop-box-stopped", sf)
+        import json
+        payload = json.loads(sf.start_execution.call_args.kwargs["input"])
+        assert payload["triggered_by"] == "backstop-box-stopped"
+        assert payload["pipeline_role"] == "eod"
+        assert payload["run_date"] == "2026-06-25"
+        assert payload["trading_instance_id"] == [index.TRADING_INSTANCE_ID]
+        assert payload["ec2_instance_id"] == [index.DASHBOARD_INSTANCE_ID]
+        assert payload["sns_topic_arn"] == index.SNS_TOPIC_ARN
 
 
 # ── Fail-loud ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What / why

`alpha-engine-eod-backstop` (`infrastructure/lambdas/eod-backstop/index.py`) previously dispatched `ne-postclose-trading-pipeline` only when **(a)** the trading box was still `running` **AND (b)** no EOD execution had started today. On 2026-08-05/06 the PREOPEN pipeline failed pre-boot (config-I6615), the trading box never started at all, the daemon never ran — and this backstop's box-running gate made it a silent no-op too. No `eod_pnl` row, no alert (`alpha-engine-pipeline-watchdog-daily` paused under I6617). Exactly the case this backstop most needs to cover.

**Fix:** drop the box-running requirement. Dispatch iff (trading day) AND (no postclose execution started today), regardless of instance state. `StartTradingInstance` — the EOD SF's own first real state (`step_function_eod.json:96`) — boots the box unconditionally and idempotently (`ec2:startInstances` on an already-running box is a no-op), so the Lambda needs no boot logic of its own. `_trading_box_running` is retained solely to tag the dispatch (`triggered_by=backstop` vs `backstop-box-stopped`) for observability — it no longer gates anything.

Trading-day logic (`is_trading_day`) was already present and unchanged — NYSE holidays that fall on the MON-FRI EventBridge cron are still correctly no-op'd, independent of the EventBridge rule's own weekday-only schedule.

## Step-2 decision: input shape on a cold-booted box (evidence-based, not assumed)

Kept the SF input **identical** to the existing backstop dispatch (`pipeline_role: "eod"`, full `CaptureSnapshot` path) — just tagging `triggered_by: "backstop-box-stopped"` — rather than the I2700 reconcile-only skip shape (`step_function_eod.json:1598`, `skip_post_market_data`/`skip_capture_snapshot`). The I2700 shape assumes a snapshot **already exists** from an earlier attempt in the same execution (its own comment: "Skip only when the snapshot ... already exists from a prior run" — `step_function_eod.json:1068`). On a box that never booted today, no such snapshot exists — skipping `CaptureSnapshot` would just hand `EODReconcile` nothing to read, and it hard-fails with no fallback by design. So the skip shape is wrong for this case.

Verified `CaptureSnapshot` is safe on a freshly-booted box (crucible-executor + `step_function_eod.json`, not assumed):
- `ibgateway.service` is a hard `Requires=`/`After=` systemd dependency of both `alpha-engine-daemon.service` and `alpha-engine-morning.service` (`crucible-executor/infrastructure/systemd/*.service`), both `WantedBy=multi-user.target` (boot-enabled) — so any trading-box boot, cold or warm, pulls `ibgateway.service` up as a dependency with no separate enablement needed.
- Between `StartTradingInstance` and `CaptureSnapshot`, the EOD SF spends several minutes on the SSM-readiness poll (up to ~3 min) and — load-bearing — `LaunchPostMarketDataSpot`'s post-market-data phase on a wholly separate ephemeral spot box (`TimeoutSeconds: 420` on the launch alone, plus its own poll-to-completion). None of that touches the trading box's IB session, but it comfortably exceeds `wait-for-ibgateway.sh`'s own 120s max-wait budget and the ~30s TOTP-auth window `alpha-engine-morning.service` budgets for.
- `executor/snapshot_capturer.py`'s `IBKRClient.connect` additionally retries 3x with exponential backoff (`executor/retry.py`) on its own — another ~60-90s of tolerance.
- No explicit `wait-for-ibgateway` state exists inside `CaptureSnapshot`'s own SSM command in the EOD SF — this is evidence of comfortable timing margin, not a hard guarantee. Documented as a residual risk in `index.py`'s module docstring: if a cold-boot `CaptureSnapshot` failure is ever observed live, the fix is an explicit gateway-readiness poll inside `CaptureSnapshot`'s SSM command, not skipping the snapshot.

## Tests

`test_handler.py` extended to cover the full decision matrix:
- box stopped + no execution + trading day → dispatch (`triggered_by=backstop-box-stopped`) — new
- box stopped + execution exists → no dispatch — new
- box running + no execution + trading day → dispatch (`triggered_by=backstop`, existing behavior preserved)
- box running + execution exists → no dispatch
- not a trading day → no dispatch
- `eod_ran_today` decided before `_trading_box_running` is even called (avoids an unneeded EC2 call on the common no-op path) — new
- `_start_eod` input-shape parity test for the box-stopped case (identical payload except `triggered_by`) — new

Results: `python -m py_compile index.py` — OK. `pytest infrastructure/lambdas/eod-backstop/` — **16/16 passed**. `pytest tests/ -k "eod or backstop" -x` — **221 passed** (0 failed; 1 unrelated pre-existing collection error in `tests/test_async_and_cache.py` from a missing `tenacity` install in the bare system Python was bypassed by using the repo's own `.venv`, confirmed unrelated to this change). `deploy.sh --dry-run` (full preflight: syntax check + unit tests + packaging) — clean.

## Deploy-on-merge

This Lambda had **no** deploy workflow at all — `deploy.sh`'s own header said "operator-deployed only" and nothing in `.github/workflows` covered `infrastructure/lambdas/eod-backstop/**`. Added `.github/workflows/deploy-eod-backstop.yml`, mirroring `deploy-pipeline-watchdog.yml` exactly (OIDC role, SHA-pinned actions, path filter on the lambda dir + the workflow file itself). Code-only: invokes the existing `deploy.sh` with no flags, which is the idempotent update-code path — `create-function`/EventBridge-rule creation is gated behind `--bootstrap`/`--apply-iam` and is never invoked by this workflow. IAM already covers it: `github-actions-lambda-deploy`'s `LambdaUpdate` statement grants `GetFunction`/`GetFunctionConfiguration`/`UpdateFunctionCode`/`UpdateFunctionConfiguration` on `function:alpha-engine-*`, which matches `alpha-engine-eod-backstop` — no IAM change needed. **This makes the fix merge-button-deployable**: hitting merge ships the code; no post-merge operator step required.

Also touched `deploy.sh` (same directory) to correct two comment/warning strings that described the now-removed box-running gate (`--bootstrap`'s EventBridge rule `--description`, and the `--smoke` warning) — no behavioral change.

Closes nousergon/alpha-engine-config#6690

Ref: alpha-engine-config-I6690

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
