### PR TITLE
[P1/low] fix(systemd): classify an unreadable unit file instead of crashing the whole sweep (config#6699)

### DIFF
--- a/.github/workflows/deploy-daily-news-units.yml
+++ b/.github/workflows/deploy-daily-news-units.yml
@@ -31,6 +31,13 @@ on:
       - 'infrastructure/systemd/daily-news.service'
       - 'infrastructure/systemd/daily-news.timer'
       - 'infrastructure/install-daily-news.sh'
+      # The unit-coverage check and its baseline deploy the same way: the
+      # box runs them from this checkout, and the `git reset --hard` below
+      # is the only merge-time path that refreshes it (daily-news's own
+      # self-refresh runs at most once a day, so a merged checker fix could
+      # otherwise sit inert past the next 06:18 UTC sweep).
+      - 'infrastructure/systemd/check-systemd-unit-drift.py'
+      - 'infrastructure/systemd/uncodified-units-baseline.txt'
       - '.github/workflows/deploy-daily-news-units.yml'
   workflow_dispatch:
 

--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -70,6 +70,13 @@ Three rules follow:
   * **The counts are emitted** (`--metric`), including zeros: a number that
     only appears when something is wrong cannot distinguish healthy from
     dead (`principles.md` §2.7).
+  * **A unit this check cannot READ is `unreadable` — a failing finding,
+    never a crash.** 2026-08-09: `nousergon-console.service` was installed
+    root-owned 0600 and the whole sweep died on the PermissionError, taking
+    coverage of the other 59 units with it. Unit files on these boxes are
+    world-readable 0644 (secrets belong in an EnvironmentFile or SSM, never
+    inline), so unreadable means both a convention violation and a hole in
+    the coverage claim — it exits 1 until the mode is fixed.
 
 "Codified" means a file of the same name under a `--codified-root` (default:
 this script's directory). Units owned by other repos — `metron-*`,
@@ -177,7 +184,7 @@ def check_unit(
 ) -> tuple[str, str]:
     """Returns (status, detail).
 
-    status in {"clean", "drift", "uncodified", "not-installed"}.
+    status in {"clean", "drift", "uncodified", "not-installed", "unreadable"}.
 
     `SCRIPT_DIR` / `INSTALLED_DIR` are read at CALL time when the arguments
     are omitted, so a caller (or a test) can repoint the module globals.
@@ -193,7 +200,15 @@ def check_unit(
     metron-intraday), so it is informational, never a finding.
     """
     d = installed_dir or INSTALLED_DIR
-    installed_hash = _sha256(d / name)
+    try:
+        installed_hash = _sha256(d / name)
+    except PermissionError:
+        return "unreadable", (
+            f"{name}: installed here but not readable by this user — unit "
+            f"files are world-readable 0644 on this box (secrets belong in an "
+            f"EnvironmentFile or SSM, never inline); drift is unverifiable "
+            f"until the mode is fixed"
+        )
     repo_path = codified_path(name, roots)
 
     if installed_hash is None:
@@ -204,7 +219,10 @@ def check_unit(
     if repo_path is None:
         return "uncodified", f"{name}: installed here, codified in no known root"
 
-    repo_hash = _sha256(repo_path)
+    try:
+        repo_hash = _sha256(repo_path)
+    except PermissionError:
+        return "unreadable", f"{name}: codified copy at {repo_path} is not readable — drift is unverifiable"
     if installed_hash != repo_hash:
         return "drift", f"{name}: installed ({installed_hash[:12]}) != repo ({repo_hash[:12]})"
 
@@ -278,7 +296,9 @@ def main() -> int:
         # dropping out of the comparison.
         names = sorted(set(installed_units()) | set(codified_units(roots)))
 
-    buckets: dict[str, list[str]] = {"clean": [], "drift": [], "uncodified": [], "not-installed": []}
+    buckets: dict[str, list[str]] = {
+        "clean": [], "drift": [], "uncodified": [], "not-installed": [], "unreadable": [],
+    }
     details: dict[str, str] = {}
     for name in names:
         status, detail = check_unit(name, roots)
@@ -289,7 +309,10 @@ def main() -> int:
 
     uncodified = buckets["uncodified"]
     uncodified_new = [n for n in uncodified if n not in baseline]
-    installed_count = len(buckets["clean"]) + len(buckets["drift"]) + len(uncodified)
+    unreadable = buckets["unreadable"]
+    installed_count = (
+        len(buckets["clean"]) + len(buckets["drift"]) + len(uncodified) + len(unreadable)
+    )
 
     print(
         "SUMMARY "
@@ -298,6 +321,7 @@ def main() -> int:
         f"drift={len(buckets['drift'])} "
         f"uncodified={len(uncodified)} "
         f"uncodified_new={len(uncodified_new)} "
+        f"unreadable={len(unreadable)} "
         f"codified_not_installed={len(buckets['not-installed'])}"
     )
 
@@ -308,12 +332,16 @@ def main() -> int:
             "Drifted": len(buckets["drift"]),
             "Uncodified": len(uncodified),
             "UncodifiedNew": len(uncodified_new),
+            "Unreadable": len(unreadable),
         })
 
     exit_code = 0
     findings: list[str] = []
     if buckets["drift"]:
         findings.extend(details[n] for n in buckets["drift"])
+        exit_code = max(exit_code, 1)
+    if unreadable:
+        findings.extend(details[n] for n in unreadable)
         exit_code = max(exit_code, 1)
     if uncodified_new:
         findings.append(
@@ -337,13 +365,14 @@ def main() -> int:
     # "passed" that is true while 54 units sit outside the comparison.
     if not installed_count:
         print("No unit files installed on this box — nothing to compare.")
-    elif not buckets["drift"] and not uncodified:
+    elif not buckets["drift"] and not uncodified and not unreadable:
         print("Systemd unit coverage PASSED (every installed unit is codified and matches).")
     else:
         print(
             f"Systemd unit coverage INCOMPLETE: {len(buckets['clean'])}/{installed_count} "
             f"installed units are codified and clean; {len(uncodified)} uncodified, "
-            f"{len(buckets['drift'])} drifted. This is not a pass."
+            f"{len(buckets['drift'])} drifted, {len(unreadable)} unreadable. "
+            f"This is not a pass."
         )
 
     return exit_code

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -374,3 +374,46 @@ class TestCoverageAccounting:
             "litellm-proxy.service",
         ):
             assert name in baseline, f"{name} missing from the uncodified baseline"
+
+
+class TestUnreadableUnit:
+    """A unit file the check cannot read (2026-08-09: nousergon-console.service
+    was installed root-owned 0600) must be a classified, failing finding — the
+    PermissionError previously escaped `_sha256`'s except clause and killed the
+    whole sweep, taking coverage of the other 59 units with it."""
+
+    @pytest.fixture(autouse=True)
+    def _not_root(self):
+        import os
+        if os.geteuid() == 0:
+            pytest.skip("file modes cannot deny root; unreadable is untestable as uid 0")
+
+    def test_unreadable_installed_unit_is_classified_not_a_crash(self, cd):
+        module, script_dir, installed_dir = cd
+        path = installed_dir / "nousergon-console.service"
+        path.write_text("UNIT SECRETIVE\n")
+        path.chmod(0o000)
+
+        status, detail = module.check_unit("nousergon-console.service")
+
+        assert status == "unreadable"
+        assert "0644" in detail
+
+    def test_main_survives_the_unreadable_unit_and_fails_loud(self, cd, monkeypatch, capsys):
+        """The other units must still be swept — the crash mode reported on
+        NONE of them."""
+        module, script_dir, installed_dir = cd
+        blocked = installed_dir / "nousergon-console.service"
+        blocked.write_text("UNIT SECRETIVE\n")
+        blocked.chmod(0o000)
+        (script_dir / "daily-news.timer").write_text("UNIT A\n")
+        (installed_dir / "daily-news.timer").write_text("UNIT A\n")
+
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        code = module.main()
+        cap = capsys.readouterr()
+
+        assert code == 1
+        assert "unreadable=1" in cap.out
+        assert "[clean] daily-news.timer" in cap.out
+        assert "nousergon-console.service" in cap.err


### PR DESCRIPTION
## What

`systemd-unit-drift-check` died on its 2026-08-09 06:18 UTC run: `nousergon-console.service` is installed root-owned 0600 (accidental — measured zero secret-shaped lines; every other unit on the box is 0644), `_sha256` catches `FileNotFoundError`/`IsADirectoryError` but not `PermissionError`, and the raise killed the sweep mid-run — zero coverage of the remaining units and a box-health CRITICAL page with a traceback instead of a finding.

- `check_unit` gains status **`unreadable`**: a classified, failing finding (exit 1) that names the 0644 convention (secrets belong in an EnvironmentFile or SSM, never inline in a unit). The rest of the sweep completes.
- `SUMMARY` line and `--metric` emission gain `unreadable` / `SystemdUnitsUnreadable`, emitted every run including zero (`principles.md` §2.7).
- `deploy-daily-news-units.yml` path filter now includes `check-systemd-unit-drift.py` and `uncodified-units-baseline.txt` — the box runs the checker from this checkout and the workflow's `git reset --hard` is the only merge-time refresh path, so a merged checker fix no longer sits inert until daily-news's next self-refresh.

## Tests

`TestUnreadableUnit`: classification (not a crash) and that the other units still get swept when one is unreadable. Local: 219 passed, 2 skipped (`-k "systemd or drift"`).

## Post-merge

Deploys on merge via `deploy-daily-news-units.yml` (this PR adds its own path to the filter). The box goes green once `chmod 644 /etc/systemd/system/nousergon-console.service` runs — operator step tracked as alpha-engine-config-I6699 deliverable 3 (agent SSM mutation was classifier-blocked this session); until then the run exits 1 with the classified `unreadable` finding, which is the intended detector-stays-red shape.

Refs: alpha-engine-config-I6699 (tracker), alpha-engine-config-I6656 (codification program, unchanged here).

Prepared by: claude-fable-5 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)