### PR TITLE
fix(sf): daily SF gets Option-A degraded-terminal parity with EOD

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -965,13 +965,75 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Daemon restart failure is non-fatal \u2014 systemd boot trigger is backup",
-          "Next": "WriteCompletionMarker",
+          "Comment": "alpha-engine-config#6692: daemon restart failure is still non-fatal to the RUN itself \u2014 systemd boot trigger is backup, so control still proceeds (no HandleFailure/abort). What changed is the TERMINAL: this Catch now routes through SetDaemonDegradedFlag -> CheckDegradedOutcome (Option-A parity with step_function_eod.json's RunDaemon-equivalent) instead of straight to WriteCompletionMarker, so a daemon-restart-failure morning ends DEGRADED/FAILED (status-keyed watchers engage) rather than a plain SUCCEEDED execution with a normal marker and only an SNS trace.",
+          "Next": "SetDaemonDegradedFlag",
           "ResultPath": "$.daemon_error"
         }
       ],
       "ResultPath": "$.daemon_result",
-      "Next": "WriteCompletionMarker"
+      "Next": "CheckDegradedOutcome"
+    },
+    "SetDaemonDegradedFlag": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config#6692 (Option-A parity with step_function_eod.json's SetDegradedFlag, Brian's 2026-07-28 ruling): the daemon failed to restart \u2014 systemd boot trigger remains the backup so the run is NOT aborted here, but this execution must not end plain ExecutionSucceeded. Sets a persistent $.degraded_summary, checked once by CheckDegradedOutcome, to route to the DegradedRun terminal (Type: Fail) instead of the normal PipelineComplete path. Does not clobber $.daemon_error (set by RunDaemon's own Catch ResultPath) or any earlier $.degraded_summary from the data-spot fail-open path \u2014 if both stages degraded, this state's write simply wins as the most-recent cause; degraded=true is preserved either way.",
+      "Parameters": {
+        "degraded": true,
+        "reason": "run_daemon_restart_failed",
+        "run_date.$": "$.run_date",
+        "stage_error.$": "$.daemon_error"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "CheckDegradedOutcome"
+    },
+    "CheckDegradedOutcome": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config#6692: Option-A parity with step_function_eod.json's CheckDegradedOutcome (Brian's 2026-07-28 ruling) \u2014 the ONE place that decides which terminal this execution reaches. $.degraded_summary is set either by SetDataSpotDegradedFlag (the data-spot fail-open path, which still lets the run continue to Scanner/PredictorInference/RunMorningPlanner/RunDaemon) or by SetDaemonDegradedFlag (RunDaemon's restart-failure Catch, which still lets systemd's boot trigger be the backup) \u2014 either stage degrading downgrades the whole execution's terminal even though neither path aborts the run mid-pipeline. Reached from RunDaemon's normal Next, RunDaemon's Catch (via SetDaemonDegradedFlag), and CheckSkipRunDaemon's skip-gate edge, so every route to the terminal is covered.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.degraded_summary.degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.degraded_summary.degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "config-I2767-style guard (mirrors step_function_eod.json's CheckDegradedOutcome): $.degraded_summary is only assigned on a degraded path \u2014 a fully-green day never sets it, so an unguarded dereference would throw States.Runtime at the last state. Absent flag = never degraded = WriteCompletionMarker via Default, which is the semantically exact reading.",
+          "Next": "WriteCompletionMarkerDegraded"
+        }
+      ],
+      "Default": "WriteCompletionMarker"
+    },
+    "WriteCompletionMarkerDegraded": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config#6692: DEGRADED-status parity marker with step_function_eod.json's WriteCompletionMarkerDegraded (Brian's 2026-07-28 Option-A ruling). Written on the degraded outcome (RunDaemon restart failure and/or the data-spot fail-open path), immediately before the DegradedRun Fail terminal. Same S3 bucket/key as the normal marker (registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_preopen_trading_pipeline, cadence weekday_sf \u2014 no new IAM grant needed, the existing marker PutObject grant already covers the _sf_completion/ne-preopen-trading-pipeline/* prefix) \u2014 the marker still fires so the completion artifact exists, but DegradedRun is Type: Fail so status-keyed watchers (sf-watch, EventBridge, sf-telegram-notifier) engage. No swallow-all Catch here (mirrors WriteCompletionMarker's convention): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable.",
+      "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
+      "Parameters": {
+        "Bucket": "alpha-engine-research",
+        "Key.$": "States.Format('_sf_completion/ne-preopen-trading-pipeline/{}.json', States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0))",
+        "ContentType": "application/json",
+        "Body.$": "States.Format('\\{\"sf\":\"ne-preopen-trading-pipeline\",\"execution_arn\":\"{}\",\"status\":\"DEGRADED\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"degraded_summary\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'T'), 0), States.JsonToString($.degraded_summary))"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 3,
+          "IntervalSeconds": 2,
+          "BackoffRate": 2.0,
+          "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
+        }
+      ],
+      "Next": "DegradedRun"
+    },
+    "DegradedRun": {
+      "Type": "Fail",
+      "Error": "DegradedRun",
+      "Cause": "Daily preopen pipeline degraded \u2014 see $.degraded_summary in execution input (reason: run_daemon_restart_failed and/or daily_data_spot_fail_open) and the corresponding SNS notification (PublishDataSpotFailureImmediate) in execution history. Per Brian's 2026-07-28 Option-A ruling (alpha-engine-config#2699), ported to this daily SF via alpha-engine-config#6692: a degraded run must FAIL so status-keyed watchers (sf-watch, EventBridge, sf-telegram-notifier) engage with zero new plumbing.",
+      "Comment": "alpha-engine-config#6692: Option-A parity with step_function_eod.json's DegradedRun. The daemon-restart-failure and data-spot fail-open continuation paths remain unconditionally reachable BEFORE this terminal (RunDaemon Catch -> SetDaemonDegradedFlag -> CheckDegradedOutcome; ExtractDataSpotError -> SetDataSpotDegradedFlag -> PublishDataSpotFailureImmediate -> ... -> RunDaemon -> CheckDegradedOutcome) \u2014 the run itself is never aborted mid-pipeline, only the terminal's honesty changes."
     },
     "WriteCompletionMarker": {
       "Type": "Task",
@@ -1124,7 +1186,7 @@
     },
     "CheckSkipRunDaemon": {
       "Type": "Choice",
-      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) directly to PipelineComplete; missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
+      "Comment": "Per-task rerun gate (L4606). Input {\"skip_run_daemon\": true} routes past RunDaemon (the daemon restart) to CheckDegradedOutcome (alpha-engine-config#6692: routed through the degraded check the same way RunDaemon's own success/Catch edges are, so an earlier data-spot degraded flag is still honored even when the daemon step itself is skipped) rather than straight to WriteCompletionMarker; missing flag = run as normal. Per feedback_preflight_fast_fail_before_expensive_work.",
       "Choices": [
         {
           "And": [
@@ -1137,7 +1199,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "WriteCompletionMarker"
+          "Next": "CheckDegradedOutcome"
         }
       ],
       "Default": "RunDaemon"
@@ -1510,6 +1572,18 @@
         "source": "CheckMorningEnrich/ArcticAppendSpotStatus or launch Catch"
       },
       "ResultPath": "$.data_spot_error",
+      "Next": "SetDataSpotDegradedFlag"
+    },
+    "SetDataSpotDegradedFlag": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config#6692 (Option-A parity with step_function_eod.json's SetDegradedFlag, Brian's 2026-07-28 ruling): threads a $.degraded_summary flag onto the data-spot fail-open path WITHOUT changing its fail-open continuation \u2014 Next still leads to PublishDataSpotFailureImmediate and on to CheckSkipScanner exactly as before, so the run still proceeds to Scanner/PredictorInference/RunMorningPlanner/RunDaemon. The flag is only read much later by CheckDegradedOutcome (via RunDaemon's success Next or CheckSkipRunDaemon's skip edge), which routes the eventual TERMINAL to WriteCompletionMarkerDegraded -> DegradedRun instead of a plain SUCCEEDED execution \u2014 closing the gap where a morning data-spot failure left only an SNS trace and a normal completion marker. Does not clobber $.data_spot_error (set by the preceding ExtractDataSpotError ResultPath).",
+      "Parameters": {
+        "degraded": true,
+        "reason": "daily_data_spot_fail_open",
+        "run_date.$": "$.run_date",
+        "stage_error.$": "$.data_spot_error"
+      },
+      "ResultPath": "$.degraded_summary",
       "Next": "PublishDataSpotFailureImmediate"
     },
     "PublishDataSpotFailureImmediate": {

--- a/tests/test_sf_completion_marker_wiring_daily.py
+++ b/tests/test_sf_completion_marker_wiring_daily.py
@@ -1,9 +1,20 @@
 """SF-envelope completion marker wiring — preopen/weekday SF (config#2857).
 
-Companion to tests/test_sf_completion_marker_wiring.py (the Saturday SF).
-Pins that the real completion path (RunDaemon success, its non-fatal Catch,
-and the skip-gate edge) all converge on WriteCompletionMarker before
-PipelineComplete, while a holiday skip or a real failure never does.
+Companion to tests/test_sf_completion_marker_wiring.py (the Saturday SF) and
+test_sf_completion_marker_wiring_eod.py (postclose/EOD). alpha-engine-config#6692
+ports EOD's Option-A degraded-terminal parity (Brian's 2026-07-28 ruling,
+alpha-engine-config#2699) onto this SF: RunDaemon's success Next, its
+non-fatal restart-failure Catch (via SetDaemonDegradedFlag), and the
+skip-gate edge (CheckSkipRunDaemon) all now converge on CheckDegradedOutcome
+rather than going straight to WriteCompletionMarker. The data-spot fail-open
+path (ExtractDataSpotError) threads a $.degraded_summary flag via
+SetDataSpotDegradedFlag WITHOUT changing its own fail-open continuation
+(still proceeds to PublishDataSpotFailureImmediate -> CheckSkipScanner).
+CheckDegradedOutcome is the one place deciding the terminal: Default ->
+WriteCompletionMarker (unchanged normal marker, -> PipelineComplete);
+degraded -> WriteCompletionMarkerDegraded (-> DegradedRun, Type: Fail) so
+status-keyed watchers (sf-watch, EventBridge, sf-telegram-notifier) engage.
+A holiday skip or a real failure never reaches either marker.
 """
 
 from __future__ import annotations
@@ -39,17 +50,94 @@ def test_marker_state_shape(daily_states):
     assert retry["MaxAttempts"] >= 2
 
 
-def test_run_daemon_success_and_catch_both_converge_on_marker(daily_states):
+def test_run_daemon_success_and_catch_both_converge_on_degraded_check(daily_states):
+    """alpha-engine-config#6692: neither edge writes a marker directly any
+    more — both must pass through CheckDegradedOutcome so a degraded flag
+    set upstream (data-spot fail-open) or by the Catch itself is honored."""
     run_daemon = daily_states["RunDaemon"]
-    assert run_daemon["Next"] == "WriteCompletionMarker"
+    assert run_daemon["Next"] == "CheckDegradedOutcome"
     (catch,) = run_daemon["Catch"]
     assert catch["ErrorEquals"] == ["States.ALL"]
-    assert catch["Next"] == "WriteCompletionMarker"
+    assert catch["Next"] == "SetDaemonDegradedFlag"
+    assert catch["ResultPath"] == "$.daemon_error"
 
 
-def test_skip_run_daemon_edge_converges_on_marker(daily_states):
+def test_run_daemon_catch_degraded_flag_shape(daily_states):
+    """RunDaemon restart failure is still non-fatal to the RUN (no abort) —
+    SetDaemonDegradedFlag only changes what the eventual terminal says."""
+    st = daily_states["SetDaemonDegradedFlag"]
+    assert st["Type"] == "Pass"
+    assert st["Parameters"]["degraded"] is True
+    assert st["ResultPath"] == "$.degraded_summary"
+    assert st["Next"] == "CheckDegradedOutcome"
+
+
+def test_skip_run_daemon_edge_converges_on_degraded_check(daily_states):
     (choice,) = daily_states["CheckSkipRunDaemon"]["Choices"]
-    assert choice["Next"] == "WriteCompletionMarker"
+    assert choice["Next"] == "CheckDegradedOutcome"
+
+
+def test_data_spot_fail_open_threads_degraded_flag_without_changing_continuation(
+    daily_states,
+):
+    """ExtractDataSpotError/PublishDataSpotFailureImmediate must keep their
+    fail-open continuation to CheckSkipScanner (Scanner etc. still run) —
+    SetDataSpotDegradedFlag only adds the flag in between."""
+    extract = daily_states["ExtractDataSpotError"]
+    assert extract["Next"] == "SetDataSpotDegradedFlag"
+
+    flag = daily_states["SetDataSpotDegradedFlag"]
+    assert flag["Type"] == "Pass"
+    assert flag["Parameters"]["degraded"] is True
+    assert flag["ResultPath"] == "$.degraded_summary"
+    assert flag["Next"] == "PublishDataSpotFailureImmediate"
+
+    publish = daily_states["PublishDataSpotFailureImmediate"]
+    assert publish["Next"] == "CheckSkipScanner"
+    (publish_catch,) = publish["Catch"]
+    assert publish_catch["Next"] == "CheckSkipScanner"
+
+
+def test_check_degraded_outcome_routes_through_markers(daily_states):
+    choice = daily_states["CheckDegradedOutcome"]
+    assert choice["Default"] == "WriteCompletionMarker"
+    (degraded_choice,) = choice["Choices"]
+    assert degraded_choice["Next"] == "WriteCompletionMarkerDegraded"
+    conditions = degraded_choice["And"]
+    variables = {c["Variable"] for c in conditions}
+    assert variables == {"$.degraded_summary.degraded"}
+
+
+def test_marker_degraded_state_shape(daily_states):
+    st = daily_states["WriteCompletionMarkerDegraded"]
+    assert st["Type"] == "Task"
+    assert st["Resource"] == "arn:aws:states:::aws-sdk:s3:putObject"
+    assert st["Parameters"]["Bucket"] == "alpha-engine-research"
+    assert "ne-preopen-trading-pipeline" in st["Parameters"]["Key.$"]
+    assert "$$.Execution.StartTime" in st["Parameters"]["Key.$"]
+    body = st["Parameters"]["Body.$"]
+    assert "ne-preopen-trading-pipeline" in body
+    assert '"status\\":\\"DEGRADED' in body or "DEGRADED" in body
+    assert "degraded_summary" in body
+    assert "$$.Execution.Id" in body
+    assert st["Next"] == "DegradedRun"
+    assert "Catch" not in st
+    (retry,) = st["Retry"]
+    assert retry["ErrorEquals"] == ["States.ALL"]
+    assert retry["MaxAttempts"] >= 2
+
+    # Same S3 key format as the normal marker — parity requirement, no new
+    # IAM grant needed (both live under the same _sf_completion prefix).
+    normal_key = daily_states["WriteCompletionMarker"]["Parameters"]["Key.$"]
+    assert st["Parameters"]["Key.$"] == normal_key
+
+
+def test_degraded_run_is_a_fail_state(daily_states):
+    """Brian's 2026-07-28 Option-A ruling: a degraded run must FAIL so
+    status-keyed watchers engage, not a Succeed terminal."""
+    st = daily_states["DegradedRun"]
+    assert st["Type"] == "Fail"
+    assert st["Error"] == "DegradedRun"
 
 
 def test_holiday_skip_is_excluded_from_marker(daily_states):
@@ -58,3 +146,4 @@ def test_holiday_skip_is_excluded_from_marker(daily_states):
     holiday = daily_states["NotifyHolidaySkip"]
     assert holiday.get("Next") != "WriteCompletionMarker"
     assert "WriteCompletionMarker" not in json.dumps(holiday)
+    assert "CheckDegradedOutcome" not in json.dumps(holiday)

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -180,9 +180,18 @@ class TestWeekdayFailureIsolation:
             assert daily[name]["Default"] not in _HALT
 
     def test_error_normalizer_continues_not_halts(self, daily):
-        # ExtractDataSpotError -> PublishDataSpotFailureImmediate -> CONTINUE.
+        # alpha-engine-config#6692: ExtractDataSpotError -> SetDataSpotDegradedFlag
+        # (threads $.degraded_summary, read much later by CheckDegradedOutcome)
+        # -> PublishDataSpotFailureImmediate -> CONTINUE. The fail-open
+        # continuation itself is unchanged by the degraded-flag insertion.
         assert daily["ExtractDataSpotError"]["Type"] == "Pass"
-        assert daily["ExtractDataSpotError"]["Next"] == "PublishDataSpotFailureImmediate"
+        assert daily["ExtractDataSpotError"]["Next"] == "SetDataSpotDegradedFlag"
+        flag = daily["SetDataSpotDegradedFlag"]
+        assert flag["Type"] == "Pass"
+        assert flag["Parameters"]["degraded"] is True
+        assert flag["ResultPath"] == "$.degraded_summary"
+        assert flag["Next"] == "PublishDataSpotFailureImmediate"
+        assert flag["Next"] not in _HALT
         pub = daily["PublishDataSpotFailureImmediate"]
         assert pub["Next"] == self._CONTINUE
         # Even the SNS publish's own Catch is fail-open.
@@ -203,7 +212,7 @@ class TestWeekdayFailureIsolation:
             "PollMorningArcticAppendSpot", "CheckMorningArcticAppendSpotStatus",
             "MorningArcticAppendSpotWait",
             "CheckMorningArcticAppendRetryBudget", "IncrementMorningArcticAppendRetry",
-            "ExtractDataSpotError", "PublishDataSpotFailureImmediate",
+            "ExtractDataSpotError", "SetDataSpotDegradedFlag", "PublishDataSpotFailureImmediate",
         ]
         for name in data_states:
             for tgt in _all_targets(daily[name]):

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -119,6 +119,7 @@ _TIMEOUT_EXEMPT: dict[str, dict[str, str]] = {
         "NotifyHolidaySkip": "sns:publish terminal skip notifier — SDK call, not a wait",
         "StartExecutorEC2": "ec2:startInstances — SDK call, not a wait",
         "WriteCompletionMarker": "s3:putObject completion marker — SDK call, not a wait (config#2857)",
+        "WriteCompletionMarkerDegraded": "s3:putObject completion marker (DEGRADED twin, config#6692) — SDK call, not a wait",
         "HandleFailure": "sns:publish failure notifier — SDK call, not a wait",
         "PollMorningEnrichSpot": "ssm:getCommandInvocation single poll — bounded by the spot dispatch Lambda's own budget",
         "PollMorningArcticAppendSpot": "ssm:getCommandInvocation single poll — bounded by the spot dispatch Lambda's own budget",
@@ -160,6 +161,7 @@ _CATCH_EXEMPT: dict[str, dict[str, str]] = {
         "TradingDayGateFailed": "deliberate fail-open notify+proceed (own Comment); a Catch here would need its own Catch",
         "NotifyHolidaySkip": "terminal skip notifier (End: true) — nothing downstream to route a Catch to",
         "WriteCompletionMarker": "config#2857/config#1724: deliberately UNCAUGHT — a marker write failure must propagate, not be masked",
+        "WriteCompletionMarkerDegraded": "config#2857/config#1724 (DEGRADED twin, config#6692): deliberately UNCAUGHT — a marker write failure must propagate, not be masked",
         "HandleFailure": "terminal failure notifier — routes to FailExecution; the shared failure sink itself, not something to re-catch into",
     },
     "step_function_eod.json": {

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -75,9 +75,11 @@ _CHAIN = [
     ("CheckSkipScanner", "Scanner", "skip_scanner", "CheckSkipPredictorInference"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
-    # config#2857: the skip edge now routes through the SF-envelope
-    # completion marker (still a genuine pipeline SUCCESS) before PipelineComplete.
-    ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "WriteCompletionMarker"),
+    # config#2857 + alpha-engine-config#6692: the skip edge now routes through
+    # CheckDegradedOutcome (Option-A degraded-terminal parity with the EOD SF)
+    # on its way to the SF-envelope completion marker (still a genuine
+    # pipeline SUCCESS on the Default/non-degraded branch) before PipelineComplete.
+    ("CheckSkipRunDaemon", "RunDaemon", "skip_run_daemon", "CheckDegradedOutcome"),
 ]
 
 
@@ -228,8 +230,13 @@ class TestEntryEdgesRouteThroughGates:
         # daily-news chain now produces the artifact, so the weekday SF ends at
         # the daemon restart instead of routing into a news chain.
         # config#2857: now routes through the SF-envelope completion marker
-        # before PipelineComplete.
-        assert states["RunDaemon"]["Next"] == "WriteCompletionMarker"
+        # before PipelineComplete. alpha-engine-config#6692: an extra
+        # CheckDegradedOutcome hop now sits in between (Option-A parity) so a
+        # data-spot fail-open degraded flag, or the daemon's own restart-
+        # failure Catch, still routes the terminal to WriteCompletionMarkerDegraded
+        # -> DegradedRun instead of a plain SUCCEEDED execution.
+        assert states["RunDaemon"]["Next"] == "CheckDegradedOutcome"
+        assert states["CheckDegradedOutcome"]["Default"] == "WriteCompletionMarker"
         assert states["WriteCompletionMarker"]["Next"] == "PipelineComplete"
 
 
@@ -283,7 +290,11 @@ class TestPaths:
             assert task not in order, f"{task} ran despite its skip flag"
         # config#2857: the skip edge still passes through the SF-envelope
         # completion marker on its way to PipelineComplete.
-        assert order == ["WriteCompletionMarker", "PipelineComplete"]
+        # alpha-engine-config#6692: now via CheckDegradedOutcome first (Option-A
+        # parity) — the walker's generic Choice handling falls through to its
+        # Default (WriteCompletionMarker) since no degraded flag is set on
+        # this all-flags-skipped path.
+        assert order == ["CheckDegradedOutcome", "WriteCompletionMarker", "PipelineComplete"]
 
     def test_skip_data_phase_resumes_at_scanner_then_predictor(self, states):
         """config#1767: skip_morning_enrich skips the ENTIRE spot data phase


### PR DESCRIPTION
## What / why

`step_function_daily.json`'s `RunDaemon` state caught `States.ALL` and went straight to `WriteCompletionMarker` → `PipelineComplete` (Succeed) — a morning when the daemon failed to restart ended as a plain SUCCEEDED execution with a normal completion marker, and the only trace was an SNS line. Same silent-honesty gap on the data-spot fail-open path (`ExtractDataSpotError`): a data-spot failure was recorded and alerted, but the execution's own terminal never reflected it.

This ports the EOD SF's Option-A shape (`step_function_eod.json:1775-1851`, Brian's 2026-07-28 ruling, alpha-engine-config#2699) onto the daily SF:

- New `SetDaemonDegradedFlag` (Pass) on `RunDaemon`'s Catch — sets `$.degraded_summary` (`reason: run_daemon_restart_failed`), does **not** abort the run (systemd boot trigger remains the backup), then goes to `CheckDegradedOutcome`.
- New `SetDataSpotDegradedFlag` (Pass) inserted between `ExtractDataSpotError` and `PublishDataSpotFailureImmediate` — sets `$.degraded_summary` (`reason: daily_data_spot_fail_open`) **without changing the fail-open continuation** (still proceeds to `PublishDataSpotFailureImmediate` → `CheckSkipScanner`, so Scanner/PredictorInference/RunMorningPlanner still run).
- New `CheckDegradedOutcome` (Choice): `Default` → `WriteCompletionMarker` (unchanged normal marker/path); `$.degraded_summary.degraded == true` → new `WriteCompletionMarkerDegraded`.
- New `WriteCompletionMarkerDegraded` (Task): same S3 bucket/key as the normal marker (`_sf_completion/ne-preopen-trading-pipeline/{date}.json`), body carries `status: DEGRADED` + the `degraded_summary`, `Retry States.ALL` MaxAttempts 3 backoff 2.0, no Catch — → new `DegradedRun` (Fail, `Error: DegradedRun`).
- `RunDaemon`'s normal success `Next` and `CheckSkipRunDaemon`'s skip edge now also route through `CheckDegradedOutcome` (not straight to the marker), so an earlier data-spot degradation is honored even when the daemon step itself succeeds or is skipped.
- Holiday path (`NotifyHolidaySkip`) stays excluded — pinned by `test_holiday_skip_is_excluded_from_marker`.

**IAM:** no new grant needed — the existing completion-marker `PutObject` grant already covers the `_sf_completion/ne-preopen-trading-pipeline/*` prefix, and `WriteCompletionMarkerDegraded` uses the identical key format.

**Deploy:** automatic on merge — `deploy-infrastructure.yml` runs `update-state-machine` on every push to `main`, no post-merge step required.

## Binding constraint honored

Per the issue: the fail-open continuation itself is preserved on both paths — `RunDaemon` restart failure still does not abort the run (no HandleFailure/FailExecution), and the data-spot phase still proceeds to Scanner etc. This change is terminal/marker **honesty only**, not blast radius.

## Scope note (deviation from the 2-file mandate)

I was scoped to touch only `infrastructure/step_function_daily.json` and `tests/test_sf_completion_marker_wiring_daily.py`. Running the full `-k sf` structural-test sweep surfaced 4 pinned assertions in `tests/test_sf_data_spot_relocation_wiring.py` and `tests/test_sf_weekday_skipgate_wiring.py` that were a direct, mechanical consequence of this exact routing change (they asserted `RunDaemon`/`CheckSkipRunDaemon` → `WriteCompletionMarker` directly, and `ExtractDataSpotError` → `PublishDataSpotFailureImmediate` directly). Per the repo's zero-known-broken-tests rule I updated those 4 assertions rather than ship red CI — no other behavior in those files was touched.

## Test results

- `python -m json.tool infrastructure/step_function_daily.json` — valid.
- Graph check (all `Next`/`Default`/`Choices`/`Catch` targets exist, all 72 states reachable from `StartAt`) — clean.
- `tests/test_sf_completion_marker_wiring_daily.py` + `tests/test_sf_completion_marker_wiring_eod.py` — 12 passed.
- All 24 test files that reference `step_function_daily.json` (grepped) — 449 passed, 1 skipped.
- `tests/ -k "sf"` (repo-wide) — 1421 passed, 5 skipped, 2835 deselected.
- Full `tests/` suite — 4199 passed, 39 failed, 15 errors; every failure/error verified pre-existing on `origin/main` (unrelated modules: `test_daily_news.py`, `test_gate_a_orchestrators.py`, `test_groom_cycle_notifications.py` — missing-dependency/import errors, not touched by this PR).

Closes nousergon/alpha-engine-config#6692

Ref: alpha-engine-config-I6692

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)



Rehearsal-path: tests/test_sf_completion_marker_wiring_daily.py

