### PR TITLE
fix(liveness): deadman alarms on ExecutionsSucceeded; un-pause the pipeline watchdog (config#6697)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -6,7 +6,6 @@
     "duration": "indefinite-but-temporary ('for now'). Un-pausing is per-entry: delete the entry, run automation_pause.py --enforce is NOT needed to re-enable - re-enable explicitly with the AWS CLI or a deploy.sh reconcile.",
     "region": "us-east-1 - the only region in this account carrying EventBridge rules or Scheduler schedules (us-west-2 / us-east-2 / eu-west-1 verified empty 2026-08-07)"
   },
-
   "not_paused": {
     "alpha-engine-saturday": "weekly SF trigger (ne-weekly-freshness-pipeline) - explicitly kept",
     "alpha-engine-weekday": "preopen SF trigger (ne-preopen-trading-pipeline) - explicitly kept",
@@ -15,16 +14,15 @@
     "alpha-engine-spot-orphan-reaper-hourly": "terminates spot instances orphaned by a dead SF. Cost-safety backstop for the kept weekly + preopen pipelines, both of which launch spot",
     "reactive-notifier-rules": "alpha-engine-sf-status-change, alpha-engine-groom-sf-failure, alpha-engine-spot-interruption-warning-record, alpha-engine-sf-watch-instance-terminated, alpha-engine-sf-watch-spot-interruption, overseer-intake-cw-alarm-state - EventPattern rules with no schedule to remove. They carry the failure signal for the kept pipelines; with the drain and dispatchers paused they only notify and record.",
     "DO-NOT-DELETE-AmazonInspectorEcrManagedRule": "AWS-managed",
-    "non-eventbridge": "DLM policy-0047cfbfb7070a3b7 (nightly dashboard-box snapshot, 14d) and the two SSM associations (ae-patch-scan-only, ae-software-inventory, rate(1 day)) are kept: they are read-only or protective hygiene for the 24/7 box, not autonomous processes."
+    "non-eventbridge": "DLM policy-0047cfbfb7070a3b7 (nightly dashboard-box snapshot, 14d) and the two SSM associations (ae-patch-scan-only, ae-software-inventory, rate(1 day)) are kept: they are read-only or protective hygiene for the 24/7 box, not autonomous processes.",
+    "alpha-engine-pipeline-watchdog-daily": "pipeline watchdog - un-paused per Brian ruling 2026-08-09 (config#6697): the only same-day trading-calendar-aware liveness detector for the three KEPT pipelines; the 8/5-8/6 postclose never-fired silence had no other automatic signal. Pages the independent watchdog-alerts topic."
   },
-
   "pending": {
     "_why": "Triggers that do not exist live yet but MUST be created DISABLED when they first appear. Brian's ruling covers 'everything else', which includes automation that lands after 2026-08-07 — but automation_pause.py --check requires every `paused` entry to exist live, so a not-yet-created name cannot go there without turning the check red. pause_state() reads BOTH blocks; --check requires existence only for `paused`. Move an entry up to `paused` once it exists live. Found by alpha-engine-config-I6620: nousergon-data#1207 declares three schedules that its (currently broken) deploy would have created ENABLED mid-pause.",
     "alpha-engine-expense-collector-reconcile-monthly": "nousergon-data#1207; codified in expense-collector/deploy.sh, never created live",
     "alpha-engine-sf-watch-reclaim-sweep-0645-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live",
     "alpha-engine-sf-watch-reclaim-sweep-1445-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live"
   },
-
   "paused": {
     "events_rules": {
       "alpha-engine-canary-replay-liveness-probe-tick": "overseer canary-replay liveness probe",
@@ -35,7 +33,6 @@
       "alpha-engine-freshness-monitor-historical-cron": "artifact freshness monitor - historical",
       "alpha-engine-freshness-monitor-intraday-cron": "artifact freshness monitor - intraday",
       "alpha-engine-friday-shell-run-report": "Friday shell-run report",
-      "alpha-engine-pipeline-watchdog-daily": "pipeline watchdog",
       "alpha-engine-predictor-drift-check": "predictor drift check. CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
       "alpha-engine-predictor-health-check": "predictor health check. CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
       "alpha-engine-router-exposure-probe-15min": "model-router exposure probe. Codified in nous-ergon-ops/infrastructure/lambdas/router-exposure-probe/deploy.sh, NOT this repo - paused live and recorded here because this manifest checks live AWS, not source ownership",

--- a/infrastructure/setup_pipeline_deadman_alarms.sh
+++ b/infrastructure/setup_pipeline_deadman_alarms.sh
@@ -9,7 +9,7 @@
 # fails. They cannot detect the strictly worse case — the state machine never
 # starts at all (EventBridge rule silently disabled/deleted, a CFN stack
 # rollback that drops the rule, an IAM permission regression on the
-# EventBridge→SFN invoke role, etc.). AWS/States ExecutionsStarted is the
+# EventBridge→SFN invoke role, etc.). AWS/States ExecutionsSucceeded is the
 # metric that names that gap: alarm when it drops to zero over a window sized
 # to the pipeline's cadence.
 #
@@ -27,7 +27,7 @@
 # (alpha-engine-alarm-backstop) purely for these three deadman alarms, so a
 # blackout of the primary channel cannot also silence the backstop.
 #
-# Metric semantics: AWS/States does not emit an explicit ExecutionsStarted=0
+# Metric semantics: AWS/States does not emit an explicit ExecutionsSucceeded=0
 # datapoint during a quiet period — it emits NO datapoint at all when a state
 # machine has zero executions. So "zero executions" surfaces as MISSING DATA,
 # not as a real zero-valued point. --treat-missing-data breaching is required
@@ -196,7 +196,7 @@ if ! $DRY_RUN && ! aws sns get-topic-attributes --topic-arn "$BACKSTOP_TOPIC_ARN
   exit 1
 fi
 
-# --- 2. Per-state-machine ExecutionsStarted=0 deadman alarms ----------------
+# --- 2. Per-state-machine ExecutionsSucceeded=0 deadman alarms --------------
 
 echo ""
 echo "==> Creating per-state-machine deadman alarms..."
@@ -209,9 +209,9 @@ for label in "${!STATE_MACHINES[@]}"; do
   run aws cloudwatch put-metric-alarm \
     --region "$REGION" \
     --alarm-name "$alarm_name" \
-    --alarm-description "Dead man's switch: fires when ${sf_name} has zero ExecutionsStarted in the trailing 7 days — the state machine did not even start (EventBridge rule disabled/deleted, IAM regression on the invoke role, CFN drift, ...), a failure class the per-execution HandleFailure SNS alert cannot see because it only runs when an execution exists. Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic (not alpha-engine-alerts) so a blackout of the primary alert channel cannot also silence this backstop (config#856 infra item b). TreatMissingData=breaching is required: AWS/States emits no datapoint at all for a quiet state machine, so 'zero executions' IS missing data, not a real zero — notBreaching would make this alarm impossible to fire." \
+    --alarm-description "Dead man's switch: fires when ${sf_name} has zero ExecutionsSucceeded in the trailing 7 days — either it never started (EventBridge rule disabled/deleted, IAM regression on the invoke role, CFN drift, ...) or it started and failed every attempt (an instant-fail loop keeps ExecutionsStarted healthy, measured 2026-08-05..07 when preopen died in 4s daily and the Started-based alarm never left OK — config#6697). A run of DEGRADED terminal states (which end in Fail by the Option-A ruling) also lands here after a week, deliberately: five degraded days in a row deserve this page. Routes to the INDEPENDENT ${BACKSTOP_TOPIC_NAME} topic (not alpha-engine-alerts) so a blackout of the primary alert channel cannot also silence this backstop (config#856 infra item b). TreatMissingData=breaching is required: AWS/States emits no datapoint at all for a quiet state machine, so 'zero executions' IS missing data, not a real zero — notBreaching would make this alarm impossible to fire." \
     --namespace "AWS/States" \
-    --metric-name "ExecutionsStarted" \
+    --metric-name "ExecutionsSucceeded" \
     --dimensions "Name=StateMachineArn,Value=${sf_arn}" \
     --statistic "Sum" \
     --period 604800 \

--- a/tests/test_pipeline_deadman_alarms_script.py
+++ b/tests/test_pipeline_deadman_alarms_script.py
@@ -127,7 +127,7 @@ class TestStateMachineCoverage:
 class TestAlarmSemantics:
     def test_watches_executions_started_metric(self, script_text):
         assert '--namespace "AWS/States"' in script_text
-        assert '--metric-name "ExecutionsStarted"' in script_text
+        assert '--metric-name "ExecutionsSucceeded"' in script_text
 
     def test_dimension_is_state_machine_arn(self, script_text):
         assert "Name=StateMachineArn,Value=" in script_text


### PR DESCRIPTION
## What & why

`alpha-engine-config-I6697`, executing Brian's 2026-08-09 ruling (priority-order item 1 + work half).

1. **Deadman metric: `ExecutionsStarted` → `ExecutionsSucceeded`** in `infrastructure/setup_pipeline_deadman_alarms.sh` (+ its test). The Started-based alarm certified only that something keeps failing on schedule: the 8/5–8/7 outage (preopen failing in 4s daily, postclose silent 2 days) produced **zero** alarm transitions. Same 7-day window — the weekend-tolerance rationale in the script header still holds; DEGRADED Fail-terminals accumulating for a week now page deliberately (noted in the alarm description).
2. **Watchdog un-pause**: `alpha-engine-pipeline-watchdog-daily` moves `paused.events_rules` → `not_paused` in `infrastructure/automation_pause.json` with the ruling recorded — the only same-day trading-calendar-aware liveness detector for the three kept pipelines.

## Deploy-mechanism

Applied live in-session BEFORE this PR opened (pull-request-policy §4.2 form 2):
- `put-metric-alarm` ×3 — verified: all three alarms now `ExecutionsSucceeded`, state OK.
- `enable-rule alpha-engine-pipeline-watchdog-daily` — verified ENABLED.
- `automation_pause.py --check` against this branch's manifest: **39 paused triggers checked, all DISABLED live** — green. **Merge this PR FIRST (measured, wider than first stated): every fresh `drift-check` run in this repo — sibling PRs included, 1249/1251/1256 already hit — is red until this manifest lands, because the pause check compares the branch manifest (watchdog listed paused) against live (ENABLED per ruling). The window closes at this PR's merge; siblings then go green on their next check run or main-merge.**

## Test plan

`pytest tests/test_pipeline_deadman_alarms_script.py` → **22 passed** (updated expectation asserts the new metric). `automation_pause.py --check` green (above), run before opening.

Policy basis: sf-pipeline-policy §4.1 same-day liveness (nous-ergon-ops-PR527; independent — no merge-order dependency).

Closes nousergon/alpha-engine-config#6697
Ref: alpha-engine-config-I6697 · nous-ergon-ops-PR527

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
