### PR TITLE
feat(weekly-sf): operator-actions-to-recover metric (alpha-engine-config-I6686)

### DIFF
--- a/scripts/weekly_sf_recovery_metric.py
+++ b/scripts/weekly_sf_recovery_metric.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Weekly-SF operator-actions-to-recover metric (alpha-engine-config#6686).
+
+weekly-sf-policy.md §2.5 states the target: **mean operator actions to
+recover from any single-stage failure = 1**. Clause
+``WSF-2.5-recovery-is-one-command`` was ``kind: none`` — nothing measured
+it, so the policy's own revisit trigger ("any weekly run requiring >1
+operator rerun") fired only if a human noticed and remembered. This script
+closes that gap: it derives, for a given ``run_date`` of
+``ne-weekly-freshness-pipeline``, how many operator-recovery executions
+(``rerun-*`` / ``watch-rerun-*``, per ``scripts/weekly_sf_rerun.py``'s own
+naming convention) it took to reach a real terminal state, publishes the
+result alongside the run's other artifacts, and alerts when the count
+exceeds the policy's target.
+
+REUSE, NOT DUPLICATION: the execution-history parsing primitives
+(``entered_states``, ``execution_input``, ``fetch_history``,
+``list_all_executions``) are imported directly from
+``scripts/weekly_sf_rerun.py`` — this module owns none of that parsing
+logic itself.
+
+CLASSIFICATION
+---------------
+Every execution of the state machine within the scan window is one of:
+
+- **counted** — a real automated or operator-recovery attempt for the
+  target ``run_date`` (the scheduled ``pipeline_role="weekly"`` cadence
+  execution, or a ``rerun-*``/``watch-rerun-*`` recovery execution).
+- **excluded_exercise** — ``pipeline_role="weekly-exercise"``/``"exercise"``
+  runs belong to the separate weekly-exercise rehearsal chain, never the
+  production recovery count for a real ``run_date``.
+- **excluded_gate_skip** — a ``pipeline_role="weekly"`` execution that
+  SUCCEEDED in well under a minute on a non-run day: ``CheckWeeklyRunDayGate``
+  self-selecting the correct day (config#1824) means the THU-SAT cron fires
+  3x and 2 of those 3 firings Succeed-skip at ``WeeklyRunDaySkip`` before any
+  real work state is entered. That is the run-day gate doing its job, not a
+  pipeline attempt, and must never inflate the recovery count. Detected by
+  duration (cheap, first) and CONFIRMED by execution history (only for the
+  short-duration candidates) so the classification never rests on a fragile
+  timing heuristic alone.
+
+Correlation to a target ``run_date``:
+
+1. ``rerun-{date}-{n}`` / ``watch-rerun-{date}-{n}`` named executions carry
+   the date in the name (the ``weekly_sf_rerun.py`` convention) — cheapest
+   path, no ``describe_execution`` needed.
+2. Everything else (the scheduled cadence execution's SF-generated name) is
+   correlated via its own input: an explicit ``run_date`` if present,
+   otherwise the UTC date of ``startDate`` — which is exactly what
+   ``InitializeInput`` itself stamps when the caller didn't pass one
+   (``States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0)``
+   in ``infrastructure/step_function.json``), so this never has to fetch
+   full execution history just to learn the date.
+
+NO-DATA IS NOT GREEN (principles §2.7): zero *counted* executions for the
+target ``run_date`` is a distinct, LOUD, nonzero-exit condition — it means
+the pipeline never ran or the correlation failed, not that recovery was
+clean. A healthy zero (one clean automated run, no reruns) always has
+``executions_total == 1``.
+
+ALERTING: publishes through ``nousergon_lib.alerts.publish`` (the fleet's
+existing SNS+Telegram fan-out chokepoint — mirrors
+``validators/constituents_drift_check.py``) when ``recovery_actions > 1``.
+Never crashes the metric write: the S3 artifact PUT happens first and
+unconditionally; alert publish failures are caught and logged, never
+raised (mirrors the existing ``alerts.publish``-adjacent call sites in this
+repo).
+
+Read-only against Step Functions / S3 except the one metric PUT (and the
+best-effort alert publish); nothing else is mutated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+# Repo-root bootstrap so `from scripts.weekly_sf_rerun import ...` resolves
+# whether this is invoked as `python scripts/weekly_sf_recovery_metric.py`
+# or `python -m scripts.weekly_sf_recovery_metric` (mirrors tests/conftest.py's
+# sys.path insert; scripts/ carries no __init__.py, so it is only importable
+# as a namespace package with the repo root on sys.path).
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from scripts.weekly_sf_rerun import (  # noqa: E402
+    entered_states,
+    execution_input,
+    fetch_history,
+    list_all_executions,
+)
+
+logger = logging.getLogger(__name__)
+
+STATE_MACHINE_NAME = "ne-weekly-freshness-pipeline"
+DEFAULT_STATE_MACHINE_ARN = (
+    f"arn:aws:states:us-east-1:711398986525:stateMachine:{STATE_MACHINE_NAME}"
+)
+DEFAULT_BUCKET = "alpha-engine-research"
+COMPLETION_PREFIX = f"_sf_completion/{STATE_MACHINE_NAME}/"
+COMPLETION_MARKER_RE = re.compile(
+    re.escape(COMPLETION_PREFIX) + r"(\d{4}-\d{2}-\d{2})\.json$"
+)
+RECOVERY_KEY_TEMPLATE = COMPLETION_PREFIX + "{run_date}-recovery.json"
+
+# Names emitted by scripts/weekly_sf_rerun.py's next_rerun_name (and the
+# legacy pre-"watch-" convention it superseded) — both prefixes carry the
+# run_date directly in the name, so correlation never needs a history fetch.
+NAME_RUN_DATE_RE = re.compile(r"^(?:watch-)?rerun-(\d{4}-\d{2}-\d{2})-\d+$")
+
+# Roles that pull an execution out of the production recovery count
+# entirely — the weekly-exercise rehearsal chain is a distinct pipeline,
+# never a real run_date attempt.
+EXERCISE_ROLES = frozenset({"exercise", "weekly-exercise"})
+
+# A weekly-role SUCCEEDED execution finishing this fast never reached a real
+# work state — it is CheckWeeklyRunDayGate self-selecting the correct day
+# (config#1824), confirmed below via entered_states before being excluded.
+GATE_SKIP_MAX_SECONDS = 60
+GATE_SKIP_WITNESS = "WeeklyRunDaySkip"
+
+
+@dataclass(frozen=True)
+class ExecutionRecord:
+    arn: str
+    name: str
+    status: str
+    start: datetime
+    stop: datetime | None
+    role: str | None
+    run_date: str
+    classification: str  # "counted" | "excluded_exercise" | "excluded_gate_skip"
+
+
+def _duration_seconds(start: datetime, stop: datetime | None) -> float | None:
+    if stop is None:
+        return None
+    return (stop - start).total_seconds()
+
+
+def classify_execution(sf, ex: dict) -> ExecutionRecord:
+    """Classify one `list_executions` summary. Fetches `describe_execution`
+    only for executions whose name doesn't already carry the run_date, and
+    `get_execution_history` only for the (rare) short-duration weekly-role
+    SUCCEEDED candidates that need confirmation as a gate-skip."""
+    name = ex["name"]
+    status = ex["status"]
+    start = ex["startDate"]
+    stop = ex.get("stopDate")
+
+    m = NAME_RUN_DATE_RE.match(name)
+    if m:
+        # weekly_sf_rerun.py always emits EMITTED_ROLE="watch-rerun"; the
+        # legacy "rerun-" prefix (pre config#2277) carried the same
+        # operator-initiated semantics. Either way this is always a counted
+        # recovery attempt — never exercise, never a gate-skip (the gate
+        # only applies to pipeline_role="weekly").
+        return ExecutionRecord(
+            arn=ex["executionArn"], name=name, status=status, start=start,
+            stop=stop, role="watch-rerun", run_date=m.group(1),
+            classification="counted",
+        )
+
+    desc = sf.describe_execution(executionArn=ex["executionArn"])
+    try:
+        input_json = json.loads(desc.get("input") or "{}")
+    except json.JSONDecodeError:
+        input_json = {}
+    role = input_json.get("pipeline_role")
+
+    if isinstance(input_json.get("run_date"), str) and input_json["run_date"]:
+        run_date = input_json["run_date"]
+    else:
+        # Mirrors InitializeInput's own fallback
+        # (States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))
+        # — the UTC date of execution start when no explicit run_date was
+        # passed. True for every scheduled cadence execution.
+        run_date = start.astimezone(timezone.utc).date().isoformat()
+
+    classification = "counted"
+    if role in EXERCISE_ROLES:
+        classification = "excluded_exercise"
+    elif role == "weekly" and status == "SUCCEEDED":
+        dur = _duration_seconds(start, stop)
+        if dur is not None and dur < GATE_SKIP_MAX_SECONDS:
+            events = fetch_history(sf, ex["executionArn"])
+            if GATE_SKIP_WITNESS in entered_states(events):
+                classification = "excluded_gate_skip"
+
+    return ExecutionRecord(
+        arn=ex["executionArn"], name=name, status=status, start=start,
+        stop=stop, role=role, run_date=run_date, classification=classification,
+    )
+
+
+def gather_records(sf, sm_arn: str, run_date: str, *, scan_cap: int = 300) -> list[ExecutionRecord]:
+    """Classify every execution in the scan window and return those
+    correlated to `run_date` (any classification — callers filter for
+    "counted" themselves so excluded classes stay visible for transparency)."""
+    records = []
+    for ex in list_all_executions(sf, sm_arn, cap=scan_cap):
+        rec = classify_execution(sf, ex)
+        if rec.run_date == run_date:
+            records.append(rec)
+    return records
+
+
+def resolve_latest_run_date(s3, bucket: str) -> str:
+    """Default --run-date: the most recent WriteCompletionMarker date under
+    the weekly SF's own `_sf_completion/` prefix (excludes this script's own
+    `-recovery.json` siblings via the strict `{date}.json` match)."""
+    dates: list[str] = []
+    token = None
+    while True:
+        kwargs = {"Bucket": bucket, "Prefix": COMPLETION_PREFIX}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []) or []:
+            m = COMPLETION_MARKER_RE.match(obj["Key"])
+            if m:
+                dates.append(m.group(1))
+        if resp.get("IsTruncated"):
+            token = resp.get("NextContinuationToken")
+        else:
+            break
+    if not dates:
+        raise SystemExit(
+            f"FATAL: no completion markers found under "
+            f"s3://{bucket}/{COMPLETION_PREFIX} — cannot default --run-date "
+            "(no data is not the same as a clean run). Pass --run-date "
+            "explicitly."
+        )
+    return max(dates)
+
+
+def build_metric(run_date: str, records: list[ExecutionRecord]) -> dict:
+    counted = sorted(
+        (r for r in records if r.classification == "counted"),
+        key=lambda r: r.start,
+    )
+    executions_total = len(counted)
+    recovery_actions = max(0, executions_total - 1)
+    first_terminal_status = counted[0].status if counted else None
+    succeeded_after_n_reruns = None
+    for i, r in enumerate(counted):
+        if r.status == "SUCCEEDED":
+            succeeded_after_n_reruns = i
+            break
+
+    return {
+        "run_date": run_date,
+        "executions_total": executions_total,
+        "recovery_actions": recovery_actions,
+        "first_terminal_status": first_terminal_status,
+        "succeeded_after_n_reruns": succeeded_after_n_reruns,
+        "excluded_exercise": sum(1 for r in records if r.classification == "excluded_exercise"),
+        "excluded_gate_skip": sum(1 for r in records if r.classification == "excluded_gate_skip"),
+        "execution_arns": [r.arn for r in counted],
+        "measured_at": datetime.now(timezone.utc).isoformat(),
+        "sf": STATE_MACHINE_NAME,
+    }
+
+
+def _publish_recovery_alert(metric: dict) -> None:
+    """Best-effort alert fan-out (nousergon_lib.alerts.publish — mirrors
+    validators/constituents_drift_check.py). NEVER raises: a failure here
+    must not take down a metric write that already succeeded."""
+    try:
+        from nousergon_lib import alerts  # noqa: PLC0415
+    except ImportError as exc:
+        logger.warning(
+            "alerts publish skipped — nousergon_lib.alerts unavailable: %s", exc,
+        )
+        return
+    message = (
+        f"weekly-sf-policy §2.5 target breached: {STATE_MACHINE_NAME} run_date "
+        f"{metric['run_date']} needed {metric['recovery_actions']} operator "
+        f"recovery action(s) (target: mean=1) to reach terminal status "
+        f"{metric['first_terminal_status']!r}"
+        + (
+            f", SUCCEEDED after {metric['succeeded_after_n_reruns']} rerun(s)"
+            if metric["succeeded_after_n_reruns"] is not None
+            else " (not yet SUCCEEDED)"
+        )
+        + f". {metric['executions_total']} execution(s) total. "
+        f"See s3://{DEFAULT_BUCKET}/{RECOVERY_KEY_TEMPLATE.format(run_date=metric['run_date'])} "
+        "and weekly-sf-policy.md §2.5. (alpha-engine-config#6686)"
+    )
+    try:
+        result = alerts.publish(
+            message,
+            severity="error",
+            source="nousergon-data/scripts/weekly_sf_recovery_metric.py",
+            # Dedup keyed on the exact count: a stable count within the
+            # window sends once; an ESCALATING count (more reruns since the
+            # last check) always sends fresh — the operator needs to know
+            # the recovery got worse, not just that it happened once.
+            dedup_key=f"weekly_sf_recovery_{metric['run_date']}_{metric['recovery_actions']}",
+            dedup_window_min=720,
+        )
+        logger.info(
+            "recovery alert publish: sns_ok=%s telegram_ok=%s any_ok=%s dedup_skipped=%s",
+            result.sns.ok, result.telegram.ok, result.any_ok, result.dedup_skipped,
+        )
+    except Exception as exc:  # noqa: BLE001 — alert delivery must never crash the metric write
+        logger.warning("recovery alert publish failed: %s", exc)
+
+
+def main(argv: list | None = None) -> int:
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO"))
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    ap.add_argument("--run-date", default=None, help="target run_date YYYY-MM-DD (default: latest _sf_completion marker)")
+    ap.add_argument("--state-machine-arn", default=DEFAULT_STATE_MACHINE_ARN)
+    ap.add_argument("--bucket", default=DEFAULT_BUCKET)
+    ap.add_argument("--region", default="us-east-1")
+    ap.add_argument("--scan-cap", type=int, default=300, help="max executions to classify while scanning for the target run_date")
+    ap.add_argument("--no-write", action="store_true", help="print the metric only; do not PUT it to S3")
+    ap.add_argument("--no-alert", action="store_true", help="diagnostic mode: never publish an alert even if recovery_actions>1")
+    args = ap.parse_args(argv)
+
+    import boto3  # deferred so the pure functions above stay import-light for tests
+
+    sf = boto3.client("stepfunctions", region_name=args.region)
+    s3 = boto3.client("s3", region_name=args.region)
+
+    run_date = args.run_date or resolve_latest_run_date(s3, args.bucket)
+
+    records = gather_records(sf, args.state_machine_arn, run_date, scan_cap=args.scan_cap)
+    counted = [r for r in records if r.classification == "counted"]
+
+    if not counted:
+        # NO-DATA IS NOT GREEN: distinct from a healthy zero (executions_total
+        # == 1, recovery_actions == 0). This is either "the pipeline never
+        # ran for run_date" or "correlation failed" — both need an operator,
+        # neither is silently swallowed as a clean run.
+        print(
+            f"NO DATA: 0 counted executions found for run_date={run_date} on "
+            f"{STATE_MACHINE_NAME} (scanned {len(records)} correlated-but-"
+            f"excluded execution(s): exercise or gate-skip). This is NOT the "
+            "same as zero reruns — investigate before trusting any recovery "
+            "metric for this date.",
+            file=sys.stderr,
+        )
+        return 1
+
+    metric = build_metric(run_date, records)
+    print(json.dumps(metric, indent=2, sort_keys=True))
+
+    if not args.no_write:
+        key = RECOVERY_KEY_TEMPLATE.format(run_date=run_date)
+        s3.put_object(
+            Bucket=args.bucket,
+            Key=key,
+            Body=json.dumps(metric, sort_keys=True).encode("utf-8"),
+            ContentType="application/json",
+        )
+        print(f"WROTE s3://{args.bucket}/{key}")
+
+    if metric["recovery_actions"] > 1 and not args.no_alert:
+        _publish_recovery_alert(metric)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -263,6 +263,16 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # data/heal/daily/{run_date}.json in alpha-engine-config/private-docs/
     # ARTIFACT_REGISTRY.yaml.
     "weekly_collector.py": 8,
+    # scripts/weekly_sf_recovery_metric.py (alpha-engine-config#6686):
+    # _sf_completion/ne-weekly-freshness-pipeline/{run_date}-recovery.json —
+    # the operator-actions-to-recover metric (weekly-sf-policy.md §2.5),
+    # written alongside the SF's own WriteCompletionMarker artifact at the
+    # same prefix. FOLLOW-UP (tracked, not yet done in this PR — cross-repo,
+    # private): register this key in alpha-engine-config/private-docs/
+    # ARTIFACT_REGISTRY.yaml and point a console descriptor at it (per
+    # policy-observability: modules log their metrics, the console points
+    # at the source — Brian ruling 2026-08-03).
+    "scripts/weekly_sf_recovery_metric.py": 1,
 }
 
 

--- a/tests/test_weekly_sf_recovery_metric.py
+++ b/tests/test_weekly_sf_recovery_metric.py
@@ -1,0 +1,414 @@
+"""Unit tests for scripts/weekly_sf_recovery_metric.py (alpha-engine-config#6686).
+
+Covers:
+  - classify_execution's three-way split (counted / excluded_exercise /
+    excluded_gate_skip), including the gate-skip duration+history double
+    check (config#1824's CheckWeeklyRunDayGate self-selection).
+  - build_metric's derived fields against the two documented real shapes:
+    a clean single-run day (0 reruns) and the 2026-08-01 shape (1 FAILED
+    weekly + 6 watch-reruns, mixed FAILED-then-SUCCEEDED -> 6).
+  - resolve_latest_run_date's completion-marker scan (excludes its own
+    "-recovery.json" siblings).
+  - main()'s no-data-is-not-green exit path, the S3 metric PUT, and the
+    recovery_actions>1 alert fan-out via nousergon_lib.alerts.publish
+    (mocked — mirrors tests/test_phase_marker_sweep.py's pattern).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts import weekly_sf_recovery_metric as m
+
+
+UTC = timezone.utc
+
+
+def _dt(y, mo, d, h, mi, s=0):
+    return datetime(y, mo, d, h, mi, s, tzinfo=UTC)
+
+
+class _FakeSF:
+    """Minimal Step Functions client fake: single-page list_executions,
+    describe_execution and get_execution_history keyed by executionArn."""
+
+    def __init__(self, executions, describe_by_arn=None, history_by_arn=None):
+        self._executions = executions
+        self._describe = describe_by_arn or {}
+        self._history = history_by_arn or {}
+
+    def list_executions(self, stateMachineArn, maxResults=200, nextToken=None, statusFilter=None):
+        return {"executions": self._executions}
+
+    def describe_execution(self, executionArn):
+        return self._describe[executionArn]
+
+    def get_execution_history(self, executionArn, maxResults=1000, nextToken=None):
+        return {"events": self._history.get(executionArn, [])}
+
+
+class _FakeS3:
+    def __init__(self, keys=(), *, capture_puts=None):
+        self._keys = list(keys)
+        self._puts = capture_puts if capture_puts is not None else []
+
+    def list_objects_v2(self, Bucket, Prefix, ContinuationToken=None):
+        contents = [{"Key": k} for k in self._keys if k.startswith(Prefix)]
+        return {"Contents": contents, "IsTruncated": False}
+
+    def put_object(self, **kwargs):
+        self._puts.append(kwargs)
+        return {}
+
+
+def _weekly_exec(arn, name, status, start, stop, role="weekly", explicit_run_date=None):
+    inp = {"pipeline_role": role}
+    if explicit_run_date:
+        inp["run_date"] = explicit_run_date
+    return (
+        {"executionArn": arn, "name": name, "status": status, "startDate": start, "stopDate": stop},
+        {"status": status, "startDate": start, "stopDate": stop, "input": json.dumps(inp)},
+    )
+
+
+def _gate_skip_history():
+    return [
+        {"type": "PassStateExited", "stateExitedEventDetails": {
+            "name": "InitializeInput",
+            "output": json.dumps({"pipeline_role": "weekly", "run_date": "2026-08-06"}),
+        }},
+        {"type": "ChoiceStateEntered", "stateEnteredEventDetails": {"name": "CheckWeeklyRunDayGate"}},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "WeeklyRunDayGate"}},
+        {"type": "ChoiceStateEntered", "stateEnteredEventDetails": {"name": "WeeklyRunDayGateChoice"}},
+        {"type": "SucceedStateEntered", "stateEnteredEventDetails": {"name": "WeeklyRunDaySkip"}},
+    ]
+
+
+# ── classify_execution ───────────────────────────────────────────────────
+
+
+def test_classify_named_rerun_is_counted_without_describe():
+    sf = _FakeSF(executions=[])  # describe_execution would KeyError if called
+    ex = {"executionArn": "arn:1", "name": "watch-rerun-2026-08-01-6",
+          "status": "SUCCEEDED", "startDate": _dt(2026, 8, 1, 14, 0), "stopDate": _dt(2026, 8, 1, 15, 0)}
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "counted"
+    assert rec.run_date == "2026-08-01"
+    assert rec.role == "watch-rerun"
+
+
+def test_classify_scheduled_weekly_success_is_counted():
+    ex, desc = _weekly_exec(
+        "arn:weekly", "9f2a-uuid", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 11, 30),
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:weekly": desc})
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "counted"
+    assert rec.run_date == "2026-08-08"  # UTC-date fallback, no explicit run_date
+    assert rec.role == "weekly"
+
+
+def test_classify_exercise_role_excluded():
+    ex, desc = _weekly_exec(
+        "arn:ex", "uuid-ex", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 9, 20),
+        role="exercise", explicit_run_date="2026-08-08",
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:ex": desc})
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "excluded_exercise"
+    assert rec.run_date == "2026-08-08"
+
+
+def test_classify_weekly_exercise_role_variant_excluded():
+    ex, desc = _weekly_exec(
+        "arn:ex2", "uuid-ex2", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 9, 20),
+        role="weekly-exercise", explicit_run_date="2026-08-08",
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:ex2": desc})
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "excluded_exercise"
+
+
+def test_classify_gate_skip_confirmed_via_history():
+    """A fast (2s) SUCCEEDED weekly-role execution on a non-run day
+    (Thursday self-select miss) must be excluded, not counted as a clean
+    healthy run — the false positive this metric exists to prevent."""
+    start = _dt(2026, 8, 6, 9, 0, 0)
+    stop = _dt(2026, 8, 6, 9, 0, 2)
+    ex, desc = _weekly_exec("arn:gate", "uuid-gate", "SUCCEEDED", start, stop)
+    sf = _FakeSF(
+        executions=[ex],
+        describe_by_arn={"arn:gate": desc},
+        history_by_arn={"arn:gate": _gate_skip_history()},
+    )
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "excluded_gate_skip"
+    assert rec.run_date == "2026-08-06"
+
+
+def test_classify_short_but_real_completion_not_mistaken_for_gate_skip():
+    """A short-duration weekly SUCCEEDED execution whose history does NOT
+    show WeeklyRunDaySkip must stay counted — duration alone never
+    excludes; history confirmation is required."""
+    start = _dt(2026, 8, 8, 9, 0, 0)
+    stop = _dt(2026, 8, 8, 9, 0, 5)
+    ex, desc = _weekly_exec("arn:short", "uuid-short", "SUCCEEDED", start, stop)
+    sf = _FakeSF(
+        executions=[ex],
+        describe_by_arn={"arn:short": desc},
+        history_by_arn={"arn:short": [
+            {"type": "PassStateExited", "stateExitedEventDetails": {
+                "name": "InitializeInput", "output": "{}"}},
+        ]},
+    )
+    rec = m.classify_execution(sf, ex)
+    assert rec.classification == "counted"
+
+
+def test_classify_failed_weekly_never_history_checked_for_gate_skip():
+    """status != SUCCEEDED short-circuits the gate-skip check entirely —
+    describe-only, get_execution_history must never be called."""
+    ex, desc = _weekly_exec(
+        "arn:failed", "uuid-failed", "FAILED",
+        _dt(2026, 8, 1, 9, 0), _dt(2026, 8, 1, 9, 0, 2),
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:failed": desc})  # no history configured
+    rec = m.classify_execution(sf, ex)  # would KeyError/blow up if history were fetched
+    assert rec.classification == "counted"
+
+
+# ── gather_records + build_metric: the two documented real shapes ────────
+
+
+def test_clean_single_run_day_zero_recovery_actions():
+    ex, desc = _weekly_exec(
+        "arn:clean", "uuid-clean", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 11, 0),
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:clean": desc})
+    records = m.gather_records(sf, m.DEFAULT_STATE_MACHINE_ARN, "2026-08-08")
+    metric = m.build_metric("2026-08-08", records)
+    assert metric["executions_total"] == 1
+    assert metric["recovery_actions"] == 0
+    assert metric["first_terminal_status"] == "SUCCEEDED"
+    assert metric["succeeded_after_n_reruns"] == 0
+
+
+def test_20260801_shape_one_failed_plus_six_watch_reruns():
+    weekly_ex, weekly_desc = _weekly_exec(
+        "arn:w", "uuid-weekly-0801", "FAILED",
+        _dt(2026, 8, 1, 9, 0), _dt(2026, 8, 1, 9, 45),
+    )
+    executions = [weekly_ex]
+    describe = {"arn:w": weekly_desc}
+    for i in range(1, 6):  # reruns 1-5 FAILED
+        executions.append({
+            "executionArn": f"arn:r{i}", "name": f"watch-rerun-2026-08-01-{i}",
+            "status": "FAILED",
+            "startDate": _dt(2026, 8, 1, 9 + i, 0), "stopDate": _dt(2026, 8, 1, 9 + i, 20),
+        })
+    executions.append({  # rerun 6 SUCCEEDED
+        "executionArn": "arn:r6", "name": "watch-rerun-2026-08-01-6",
+        "status": "SUCCEEDED",
+        "startDate": _dt(2026, 8, 1, 15, 0), "stopDate": _dt(2026, 8, 1, 17, 0),
+    })
+    sf = _FakeSF(executions=executions, describe_by_arn=describe)
+    records = m.gather_records(sf, m.DEFAULT_STATE_MACHINE_ARN, "2026-08-01")
+    metric = m.build_metric("2026-08-01", records)
+    assert metric["executions_total"] == 7
+    assert metric["recovery_actions"] == 6
+    assert metric["first_terminal_status"] == "FAILED"
+    assert metric["succeeded_after_n_reruns"] == 6
+
+
+def test_20260725_shape_sixteen_manual_attempts():
+    weekly_ex, weekly_desc = _weekly_exec(
+        "arn:w2", "uuid-weekly-0725", "FAILED",
+        _dt(2026, 7, 25, 9, 0), _dt(2026, 7, 25, 9, 10),
+    )
+    executions = [weekly_ex]
+    describe = {"arn:w2": weekly_desc}
+    for i in range(1, 17):  # 16 reruns, last one SUCCEEDED
+        executions.append({
+            "executionArn": f"arn:m{i}", "name": f"rerun-2026-07-25-{i}",
+            "status": "SUCCEEDED" if i == 16 else "FAILED",
+            "startDate": _dt(2026, 7, 25, 10, i), "stopDate": _dt(2026, 7, 25, 10, i, 30),
+        })
+    sf = _FakeSF(executions=executions, describe_by_arn=describe)
+    records = m.gather_records(sf, m.DEFAULT_STATE_MACHINE_ARN, "2026-07-25")
+    metric = m.build_metric("2026-07-25", records)
+    assert metric["executions_total"] == 17
+    assert metric["recovery_actions"] == 16
+    assert metric["succeeded_after_n_reruns"] == 16
+
+
+def test_exercise_and_gate_skip_excluded_from_counted_but_visible():
+    weekly_ex, weekly_desc = _weekly_exec(
+        "arn:real", "uuid-real", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 11, 0),
+    )
+    exercise_ex, exercise_desc = _weekly_exec(
+        "arn:ex", "uuid-ex", "SUCCEEDED",
+        _dt(2026, 8, 8, 12, 0), _dt(2026, 8, 8, 12, 20),
+        role="exercise", explicit_run_date="2026-08-08",
+    )
+    sf = _FakeSF(
+        executions=[weekly_ex, exercise_ex],
+        describe_by_arn={"arn:real": weekly_desc, "arn:ex": exercise_desc},
+    )
+    records = m.gather_records(sf, m.DEFAULT_STATE_MACHINE_ARN, "2026-08-08")
+    metric = m.build_metric("2026-08-08", records)
+    assert metric["executions_total"] == 1
+    assert metric["recovery_actions"] == 0
+    assert metric["excluded_exercise"] == 1
+
+
+def test_gate_skip_only_day_is_no_data_not_a_false_clean_run():
+    """Querying the Thursday-that-gate-skipped's own date directly must
+    surface as zero *counted* executions, never as a false healthy run."""
+    start = _dt(2026, 8, 6, 9, 0, 0)
+    stop = _dt(2026, 8, 6, 9, 0, 2)
+    ex, desc = _weekly_exec("arn:gate2", "uuid-gate2", "SUCCEEDED", start, stop)
+    sf = _FakeSF(
+        executions=[ex], describe_by_arn={"arn:gate2": desc},
+        history_by_arn={"arn:gate2": _gate_skip_history()},
+    )
+    records = m.gather_records(sf, m.DEFAULT_STATE_MACHINE_ARN, "2026-08-06")
+    counted = [r for r in records if r.classification == "counted"]
+    assert counted == []
+    metric = m.build_metric("2026-08-06", records)
+    assert metric["executions_total"] == 0
+    assert metric["excluded_gate_skip"] == 1
+
+
+# ── resolve_latest_run_date ────────────────────────────────────────────
+
+
+def test_resolve_latest_run_date_picks_max_excludes_recovery_siblings():
+    s3 = _FakeS3(keys=[
+        f"{m.COMPLETION_PREFIX}2026-07-25.json",
+        f"{m.COMPLETION_PREFIX}2026-08-01.json",
+        f"{m.COMPLETION_PREFIX}2026-08-01-recovery.json",
+        f"{m.COMPLETION_PREFIX}2026-08-08.json",
+    ])
+    assert m.resolve_latest_run_date(s3, "alpha-engine-research") == "2026-08-08"
+
+
+def test_resolve_latest_run_date_no_markers_raises():
+    s3 = _FakeS3(keys=[])
+    with pytest.raises(SystemExit):
+        m.resolve_latest_run_date(s3, "alpha-engine-research")
+
+
+# ── main(): no-data exit, S3 write, alert fan-out ─────────────────────
+
+
+def _patch_boto3(monkeypatch, sf, s3):
+    fake_boto3 = MagicMock()
+    fake_boto3.client.side_effect = lambda service, region_name=None: {
+        "stepfunctions": sf, "s3": s3,
+    }[service]
+    monkeypatch.setitem(__import__("sys").modules, "boto3", fake_boto3)
+
+
+def test_main_no_data_exits_nonzero(monkeypatch, capsys):
+    sf = _FakeSF(executions=[])
+    s3 = _FakeS3(keys=[])
+    _patch_boto3(monkeypatch, sf, s3)
+    rc = m.main(["--run-date", "2026-09-01"])
+    assert rc == 1
+    assert "NO DATA" in capsys.readouterr().err
+
+
+def test_main_writes_metric_and_skips_alert_below_threshold(monkeypatch, capsys):
+    ex, desc = _weekly_exec(
+        "arn:clean2", "uuid-clean2", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 11, 0),
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:clean2": desc})
+    puts = []
+    s3 = _FakeS3(keys=[], capture_puts=puts)
+    _patch_boto3(monkeypatch, sf, s3)
+    fake_alerts = MagicMock()
+    with patch.dict("sys.modules", {"nousergon_lib": MagicMock(alerts=fake_alerts),
+                                     "nousergon_lib.alerts": fake_alerts}):
+        rc = m.main(["--run-date", "2026-08-08"])
+    assert rc == 0
+    assert len(puts) == 1
+    assert puts[0]["Key"] == f"{m.COMPLETION_PREFIX}2026-08-08-recovery.json"
+    body = json.loads(puts[0]["Body"])
+    assert body["recovery_actions"] == 0
+    fake_alerts.publish.assert_not_called()
+
+
+def test_main_alerts_when_recovery_actions_exceeds_one(monkeypatch):
+    weekly_ex, weekly_desc = _weekly_exec(
+        "arn:w3", "uuid-weekly-alert", "FAILED",
+        _dt(2026, 8, 1, 9, 0), _dt(2026, 8, 1, 9, 45),
+    )
+    executions = [weekly_ex]
+    for i in range(1, 4):  # 3 reruns -> recovery_actions == 3 (> 1)
+        executions.append({
+            "executionArn": f"arn:ra{i}", "name": f"watch-rerun-2026-08-01-{i}",
+            "status": "SUCCEEDED" if i == 3 else "FAILED",
+            "startDate": _dt(2026, 8, 1, 9 + i, 0), "stopDate": _dt(2026, 8, 1, 9 + i, 20),
+        })
+    sf = _FakeSF(executions=executions, describe_by_arn={"arn:w3": weekly_desc})
+    s3 = _FakeS3(keys=[])
+    _patch_boto3(monkeypatch, sf, s3)
+    fake_alerts = MagicMock()
+    fake_alerts.publish.return_value = MagicMock(
+        sns=MagicMock(ok=True), telegram=MagicMock(ok=True), any_ok=True, dedup_skipped=False,
+    )
+    with patch.dict("sys.modules", {"nousergon_lib": MagicMock(alerts=fake_alerts),
+                                     "nousergon_lib.alerts": fake_alerts}):
+        rc = m.main(["--run-date", "2026-08-01"])
+    assert rc == 0
+    fake_alerts.publish.assert_called_once()
+    _, kwargs = fake_alerts.publish.call_args
+    assert kwargs["dedup_key"] == "weekly_sf_recovery_2026-08-01_3"
+    assert kwargs["severity"] == "error"
+
+
+def test_main_no_alert_flag_suppresses_publish_even_above_threshold(monkeypatch):
+    weekly_ex, weekly_desc = _weekly_exec(
+        "arn:w4", "uuid-weekly-noalert", "FAILED",
+        _dt(2026, 8, 1, 9, 0), _dt(2026, 8, 1, 9, 45),
+    )
+    executions = [weekly_ex]
+    for i in range(1, 4):
+        executions.append({
+            "executionArn": f"arn:na{i}", "name": f"watch-rerun-2026-08-01-{i}",
+            "status": "SUCCEEDED" if i == 3 else "FAILED",
+            "startDate": _dt(2026, 8, 1, 9 + i, 0), "stopDate": _dt(2026, 8, 1, 9 + i, 20),
+        })
+    sf = _FakeSF(executions=executions, describe_by_arn={"arn:w4": weekly_desc})
+    s3 = _FakeS3(keys=[])
+    _patch_boto3(monkeypatch, sf, s3)
+    fake_alerts = MagicMock()
+    with patch.dict("sys.modules", {"nousergon_lib": MagicMock(alerts=fake_alerts),
+                                     "nousergon_lib.alerts": fake_alerts}):
+        rc = m.main(["--run-date", "2026-08-01", "--no-alert"])
+    assert rc == 0
+    fake_alerts.publish.assert_not_called()
+
+
+def test_main_no_write_flag_skips_s3_put(monkeypatch):
+    ex, desc = _weekly_exec(
+        "arn:nw", "uuid-nowrite", "SUCCEEDED",
+        _dt(2026, 8, 8, 9, 0), _dt(2026, 8, 8, 11, 0),
+    )
+    sf = _FakeSF(executions=[ex], describe_by_arn={"arn:nw": desc})
+    puts = []
+    s3 = _FakeS3(keys=[], capture_puts=puts)
+    _patch_boto3(monkeypatch, sf, s3)
+    rc = m.main(["--run-date", "2026-08-08", "--no-write", "--no-alert"])
+    assert rc == 0
+    assert puts == []


### PR DESCRIPTION
## What & why

Implements `alpha-engine-config-I6686` (Part of alpha-engine-config#6686): weekly-sf-policy §2.5 sets a target of **1 operator action to recover** from any single-stage failure, and clause `WSF-2.5-recovery-is-one-command` records that nothing measures it — the 2026-08-01 run took 6 watch-reruns and 2026-07-25 took 16, visible only to an operator who remembers.

New `scripts/weekly_sf_recovery_metric.py`:
- Derives reruns-per-`run_date` from `ne-weekly-freshness-pipeline` execution history: counts `rerun-*`/`watch-rerun-*` and same-`run_date` retries; excludes `pipeline_role=exercise` runs and the 2-second Thu/Fri run-day-gate no-ops (classified, not dropped — counts reported per class).
- Writes `_sf_completion/ne-weekly-freshness-pipeline/{run_date}-recovery.json` alongside the SF's own completion markers: `{run_date, executions_total, recovery_actions, first_terminal_status, succeeded_after_n_reruns, excluded_*}`.
- Alerts through the repo's existing notification chokepoint when `recovery_actions > 1` (the policy's revisit trigger, automated); `--no-alert` diagnostic mode.
- **No-data is not zero:** no executions found for the run_date is a loud nonzero exit, distinct from a healthy zero-rerun day (principles §2.7).

Deliberately deferred, stated per the issue: no EventBridge schedule while the automation pause (alpha-engine-config#6617) holds — the script is manually invocable and importable; wiring into the SF tail or a schedule follows the pause lift. Registering the new S3 key in `alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml` + console descriptor is a cross-repo follow-up noted inline in `tests/test_artifact_registry_coverage.py`.

Rehearsal-exempt: structural — read-only metric derivation, no weekly-SF runtime behavior change (weekly-sf-policy §7.3).

Deploy-mechanism: EC2 picks up on next `git pull`; no Lambda, no SF definition change.

## Test plan

19 new tests in `tests/test_weekly_sf_recovery_metric.py` (fixtured SF histories, no network): clean day → 0; the measured 2026-08-01 shape → 6; exercise/gate-skip classification; no-data nonzero. Full suite run locally before opening: **4267 passed, 8 skipped** (repo venv). `test_artifact_registry_coverage.py` pins updated for the new PUT site with the cross-repo registry follow-up noted.

Prepared by: Claude Sonnet 4.5 + Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
