### PR TITLE
[P1/high] feat(weekly-sf): single declared cadence knob + silence deadman (config-I6689)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -306,6 +306,30 @@ update_or_create "$EOD_ARN" "$EOD_STAMPED" "ne-postclose-trading-pipeline" "Post
 # why PRs #761 and #763's SF definition fixes had zero live effect on actual groom runs.
 update_or_create "$GROOM_ARN" "$GROOM_STAMPED" "alpha-engine-groom-dispatch" "Backlog groom dispatch" "$GROOM_LOGGING_CONFIG"
 
+# ── 3a. Sync the declared weekly exercise-cadence to SSM (config#6689) ───────
+# infrastructure/weekly_cadence.json is the single declared source for whether
+# infrastructure/step_function_eod.json's ReadExerciseCadence/CheckExerciseCadence
+# states launch the weekly pipeline after every trading day's postclose
+# (exercise_cadence="daily", alpha-engine-config#5489), gate it to the Saturday
+# cron only ("weekly-only"), or treat no exercise launch as expected at all
+# ("off"). Writing it here — in the SAME step that just updated the EOD SF
+# definition above — keeps the manifest and the live parameter the SF task
+# actually reads from drifting apart by more than one deploy cycle. Flipping
+# the cadence is therefore a one-line diff to weekly_cadence.json's
+# exercise_cadence field + merge; no SF-topology edit.
+#
+# NOT YET GRANTED (measured 2026-08-09, recorded in this change's PR body): the
+# github-actions-lambda-deploy role (this script's CI identity) has no
+# ssm:PutParameter on this resource, so this step fails loud on AccessDenied
+# until a nous-ergon-ops IAM PR lands the grant. Failing loud here is
+# deliberate — a swallowed AccessDenied would leave the manifest and SSM
+# silently out of sync, which is exactly the two-surface bug config#6689 was
+# filed to close. weekly_cadence_drift.py --check catches the same gap
+# out-of-band once IAM exists.
+echo ""
+echo "==> Syncing declared weekly exercise-cadence to SSM (config#6689)..."
+python3 "$SCRIPT_DIR/weekly_cadence_drift.py" --enforce
+
 # ── 3b. Ensure EventBridge Scheduler trust on the SF-target role (config#2413) ─
 # The CFN template's WeekdayPipelineSchedule (AWS::Scheduler::Schedule, migrated
 # from AWS::Events::Rule in #816) is fired by EventBridge Scheduler, which — at

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 krepis>=0.14.0

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1715,6 +1715,125 @@
         }
       ],
       "ResultPath": "$.stop_result",
+      "Next": "ReadExerciseCadence"
+    },
+    "ReadExerciseCadence": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I6689 deliverable 2/3: reads the declared weekly-exercise cadence from SSM Parameter Store (source of truth: infrastructure/weekly_cadence.json, synced here by infrastructure/deploy-infrastructure.sh on every merge deploy) so flipping daily <-> weekly-only <-> off is a one-line manifest diff instead of an SF-topology edit. TimeoutSeconds=30 + Catch(States.ALL): per weekly-sf-policy §5's run-day-gate precedent (WeeklyRunDayGateChoice: 'missing the weekly run is worse than a duplicate'), a read failure (most likely cause until the follow-up nous-ergon-ops IAM PR lands: alpha-engine-step-functions-role has no ssm:GetParameter on this resource yet — alpha-engine-config#6689 PR body names the exact grant) fails OPEN to the pre-existing 'run it' behavior rather than silently skipping the exercise launch, and pages so the degradation is visible instead of indistinguishable from a deliberate 'off'.",
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Parameters": {
+        "Name": "/alpha-engine/weekly-sf/exercise-cadence"
+      },
+      "ResultSelector": {
+        "value.$": "$.Parameter.Value"
+      },
+      "ResultPath": "$.exercise_cadence_param",
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.TaskFailed",
+            "States.Timeout"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "SetCadenceReadDegraded",
+          "ResultPath": "$.exercise_cadence_read_error"
+        }
+      ],
+      "Next": "CheckExerciseCadence"
+    },
+    "SetCadenceReadDegraded": {
+      "Type": "Pass",
+      "Comment": "ReadExerciseCadence's Catch lands here. Floors $.exercise_cadence_param to a well-formed {'value': 'daily'} so CheckExerciseCadence takes the SAME branch the exercise launch always took before config#6689 — a missed exercise run is the worse failure mode (weekly-sf-policy §5).",
+      "Result": {
+        "value": "daily"
+      },
+      "ResultPath": "$.exercise_cadence_param",
+      "Next": "PublishCadenceReadDegraded"
+    },
+    "PublishCadenceReadDegraded": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I6689: alert that the declared-cadence read degraded, mirroring PublishLibPinGateDegraded's config#2278 shape (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the fail-open path this alert decorates). TopicArn is hardcoded, NOT $.sns_topic_arn — the EOD SF was hardened 2026-05-14 to hardcode the alerts-topic ARN in every Publish state and never bind it from input (test_sf_eod_precondition_probe_wiring.py::TestHandleFailureCostGuardHardening pins the absence of that binding fleet-wide in this file).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine — weekly exercise-cadence read DEGRADED (defaulted to daily)",
+        "Message": "ReadExerciseCadence could not read /alpha-engine/weekly-sf/exercise-cadence from SSM (permission not yet granted — see alpha-engine-config#6689 — throttling, or a transient SSM fault). Proceeding FAIL-OPEN as cadence=daily: the exercise launch is NOT skipped. If the declared cadence is actually weekly-only or off, this run launched the exercise anyway; investigate the SSM read path before trusting any cadence flip. View pipeline status: https://console.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.exercise_cadence_degraded_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "ResultPath": "$.exercise_cadence_degraded_notify_error",
+          "Next": "CheckExerciseCadence"
+        }
+      ],
+      "Next": "CheckExerciseCadence"
+    },
+    "CheckExerciseCadence": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config-I6689 deliverable 2: gates LaunchWeeklyExerciseRun on the declared cadence. 'daily' preserves the pre-existing every-trading-day behavior exactly. 'weekly-only' / 'off' skip straight to CheckDegradedOutcome — LaunchWeeklyExerciseRun's OWN Next on ITS success path — so skipping the exercise launch never touches WeeklyExerciseLaunchFailed's routing (that state alerts only when the LAUNCH ITSELF fails, which cannot happen if it is never attempted). Default (value present but not one of the three declared literals — a manifest/SSM typo, or a future cadence value this SF has not been taught yet) is NOT a silent skip: it routes through SetCadenceUnknownValueDegraded to alert-then-launch, the same fail-toward-running posture as SetCadenceReadDegraded, rather than the invisible 'silently never ran' outcome. A missing/malformed $.exercise_cadence_param.value (ReadExerciseCadence's ResultSelector always sets it, or SetCadenceReadDegraded floors it) also falls through to Default by Step Functions Choice semantics — no separate IsPresent guard needed.",
+      "Choices": [
+        {
+          "Variable": "$.exercise_cadence_param.value",
+          "StringEquals": "daily",
+          "Next": "LaunchWeeklyExerciseRun"
+        },
+        {
+          "Variable": "$.exercise_cadence_param.value",
+          "StringEquals": "weekly-only",
+          "Next": "CheckDegradedOutcome"
+        },
+        {
+          "Variable": "$.exercise_cadence_param.value",
+          "StringEquals": "off",
+          "Next": "CheckDegradedOutcome"
+        }
+      ],
+      "Default": "SetCadenceUnknownValueDegraded"
+    },
+    "SetCadenceUnknownValueDegraded": {
+      "Type": "Pass",
+      "Comment": "CheckExerciseCadence's Default: the read succeeded but matched none of daily/weekly-only/off. Decided posture (alpha-engine-config#6689): treat as daily (fail toward running the exercise — weekly-sf-policy §5, missing a run is worse than an extra one) AND page, so 'ran anyway on an unrecognized value' is never mistaken for 'ran because cadence=daily was correctly read.' Captures the offending raw value under .raw BEFORE overwriting .value, so the alert below can name it.",
+      "Parameters": {
+        "raw.$": "$.exercise_cadence_param.value",
+        "value": "daily"
+      },
+      "ResultPath": "$.exercise_cadence_param",
+      "Next": "PublishCadenceUnknownValueDegraded"
+    },
+    "PublishCadenceUnknownValueDegraded": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I6689: alert on an unrecognized cadence value. Subject is a hardcoded constant (config#1819 discipline); the offending value is the one bounded dynamic field, threaded via States.Format — same pattern WeeklyRunDayGateFailed uses for its single bounded upstream field. TopicArn is hardcoded, NOT $.sns_topic_arn, per the same 2026-05-14 EOD-SF hardening as PublishCadenceReadDegraded above. Best-effort Catch.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine — weekly exercise-cadence value UNRECOGNIZED (defaulted to daily)",
+        "Message.$": "States.Format('ReadExerciseCadence returned a value CheckExerciseCadence does not recognize: {}. Expected one of daily | weekly-only | off (infrastructure/weekly_cadence.json). Proceeding FAIL-OPEN as cadence=daily: the exercise launch is NOT skipped. Check infrastructure/weekly_cadence.json and the live SSM parameter /alpha-engine/weekly-sf/exercise-cadence for a typo or an undeployed manifest edit.', $.exercise_cadence_param.raw)"
+      },
+      "ResultPath": "$.exercise_cadence_unknown_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "ResultPath": "$.exercise_cadence_unknown_notify_error",
+          "Next": "LaunchWeeklyExerciseRun"
+        }
+      ],
       "Next": "LaunchWeeklyExerciseRun"
     },
     "LaunchWeeklyExerciseRun": {

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -200,9 +200,9 @@
     },
     "SetSSMReadyExhaustedError": {
       "Type": "Pass",
-      "Comment": "Normalize SSM-ready exhaustion into $.error so HandleFailure's States.JsonToString($.error) has an object to serialize — the Choice path from SSMReadyChoice does not carry a caught error (the SSM DescribeInstanceInfo calls succeeded; the agent simply never went Online). Without this, HandleFailure itself crashes with States.Runtime on the missing $.error JsonPath, masking the real 'trading instance unreachable' cause behind a broken error-reporting state.",
+      "Comment": "Normalize SSM-ready exhaustion into $.error so HandleFailure's States.JsonToString($.error) has an object to serialize \u2014 the Choice path from SSMReadyChoice does not carry a caught error (the SSM DescribeInstanceInfo calls succeeded; the agent simply never went Online). Without this, HandleFailure itself crashes with States.Runtime on the missing $.error JsonPath, masking the real 'trading instance unreachable' cause behind a broken error-reporting state.",
       "Parameters": {
-        "error": "SSM agent did not come Online within 12 attempts (~3 min) — the trading instance is unreachable. The EOD pipeline cannot proceed without an SSM connection to the box (every work step is SSM:sendCommand)."
+        "error": "SSM agent did not come Online within 12 attempts (~3 min) \u2014 the trading instance is unreachable. The EOD pipeline cannot proceed without an SSM connection to the box (every work step is SSM:sendCommand)."
       },
       "ResultPath": "$.error",
       "Next": "HandleFailure"
@@ -1719,7 +1719,7 @@
     },
     "ReadExerciseCadence": {
       "Type": "Task",
-      "Comment": "alpha-engine-config-I6689 deliverable 2/3: reads the declared weekly-exercise cadence from SSM Parameter Store (source of truth: infrastructure/weekly_cadence.json, synced here by infrastructure/deploy-infrastructure.sh on every merge deploy) so flipping daily <-> weekly-only <-> off is a one-line manifest diff instead of an SF-topology edit. TimeoutSeconds=30 + Catch(States.ALL): per weekly-sf-policy §5's run-day-gate precedent (WeeklyRunDayGateChoice: 'missing the weekly run is worse than a duplicate'), a read failure (most likely cause until the follow-up nous-ergon-ops IAM PR lands: alpha-engine-step-functions-role has no ssm:GetParameter on this resource yet — alpha-engine-config#6689 PR body names the exact grant) fails OPEN to the pre-existing 'run it' behavior rather than silently skipping the exercise launch, and pages so the degradation is visible instead of indistinguishable from a deliberate 'off'.",
+      "Comment": "alpha-engine-config-I6689 deliverable 2/3: reads the declared weekly-exercise cadence from SSM Parameter Store (source of truth: infrastructure/weekly_cadence.json, synced here by infrastructure/deploy-infrastructure.sh on every merge deploy) so flipping daily <-> weekly-only <-> off is a one-line manifest diff instead of an SF-topology edit. TimeoutSeconds=30 + Catch(States.ALL): per weekly-sf-policy \u00a75's run-day-gate precedent (WeeklyRunDayGateChoice: 'missing the weekly run is worse than a duplicate'), a read failure (most likely cause until the follow-up nous-ergon-ops IAM PR lands: alpha-engine-step-functions-role has no ssm:GetParameter on this resource yet \u2014 alpha-engine-config#6689 PR body names the exact grant) fails OPEN to the pre-existing 'run it' behavior rather than silently skipping the exercise launch, and pages so the degradation is visible instead of indistinguishable from a deliberate 'off'.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
       "Parameters": {
         "Name": "/alpha-engine/weekly-sf/exercise-cadence"
@@ -1753,7 +1753,7 @@
     },
     "SetCadenceReadDegraded": {
       "Type": "Pass",
-      "Comment": "ReadExerciseCadence's Catch lands here. Floors $.exercise_cadence_param to a well-formed {'value': 'daily'} so CheckExerciseCadence takes the SAME branch the exercise launch always took before config#6689 — a missed exercise run is the worse failure mode (weekly-sf-policy §5).",
+      "Comment": "ReadExerciseCadence's Catch lands here. Floors $.exercise_cadence_param to a well-formed {'value': 'daily'} so CheckExerciseCadence takes the SAME branch the exercise launch always took before config#6689 \u2014 a missed exercise run is the worse failure mode (weekly-sf-policy \u00a75).",
       "Result": {
         "value": "daily"
       },
@@ -1762,12 +1762,12 @@
     },
     "PublishCadenceReadDegraded": {
       "Type": "Task",
-      "Comment": "alpha-engine-config-I6689: alert that the declared-cadence read degraded, mirroring PublishLibPinGateDegraded's config#2278 shape (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the fail-open path this alert decorates). TopicArn is hardcoded, NOT $.sns_topic_arn — the EOD SF was hardened 2026-05-14 to hardcode the alerts-topic ARN in every Publish state and never bind it from input (test_sf_eod_precondition_probe_wiring.py::TestHandleFailureCostGuardHardening pins the absence of that binding fleet-wide in this file).",
+      "Comment": "alpha-engine-config-I6689: alert that the declared-cadence read degraded, mirroring PublishLibPinGateDegraded's config#2278 shape (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure can never block the fail-open path this alert decorates). TopicArn is hardcoded, NOT $.sns_topic_arn \u2014 the EOD SF was hardened 2026-05-14 to hardcode the alerts-topic ARN in every Publish state and never bind it from input (test_sf_eod_precondition_probe_wiring.py::TestHandleFailureCostGuardHardening pins the absence of that binding fleet-wide in this file).",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine — weekly exercise-cadence read DEGRADED (defaulted to daily)",
-        "Message": "ReadExerciseCadence could not read /alpha-engine/weekly-sf/exercise-cadence from SSM (permission not yet granted — see alpha-engine-config#6689 — throttling, or a transient SSM fault). Proceeding FAIL-OPEN as cadence=daily: the exercise launch is NOT skipped. If the declared cadence is actually weekly-only or off, this run launched the exercise anyway; investigate the SSM read path before trusting any cadence flip. View pipeline status: https://console.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine \u2014 weekly exercise-cadence read DEGRADED (defaulted to daily)",
+        "Message": "ReadExerciseCadence could not read /alpha-engine/weekly-sf/exercise-cadence from SSM (permission not yet granted \u2014 see alpha-engine-config#6689 \u2014 throttling, or a transient SSM fault). Proceeding FAIL-OPEN as cadence=daily: the exercise launch is NOT skipped. If the declared cadence is actually weekly-only or off, this run launched the exercise anyway; investigate the SSM read path before trusting any cadence flip. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.exercise_cadence_degraded_notify",
       "Catch": [
@@ -1775,16 +1775,17 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "Comment": "Best-effort alert \u2014 a publish failure must not halt the fail-open path.",
           "ResultPath": "$.exercise_cadence_degraded_notify_error",
           "Next": "CheckExerciseCadence"
         }
       ],
-      "Next": "CheckExerciseCadence"
+      "Next": "CheckExerciseCadence",
+      "TimeoutSeconds": 30
     },
     "CheckExerciseCadence": {
       "Type": "Choice",
-      "Comment": "alpha-engine-config-I6689 deliverable 2: gates LaunchWeeklyExerciseRun on the declared cadence. 'daily' preserves the pre-existing every-trading-day behavior exactly. 'weekly-only' / 'off' skip straight to CheckDegradedOutcome — LaunchWeeklyExerciseRun's OWN Next on ITS success path — so skipping the exercise launch never touches WeeklyExerciseLaunchFailed's routing (that state alerts only when the LAUNCH ITSELF fails, which cannot happen if it is never attempted). Default (value present but not one of the three declared literals — a manifest/SSM typo, or a future cadence value this SF has not been taught yet) is NOT a silent skip: it routes through SetCadenceUnknownValueDegraded to alert-then-launch, the same fail-toward-running posture as SetCadenceReadDegraded, rather than the invisible 'silently never ran' outcome. A missing/malformed $.exercise_cadence_param.value (ReadExerciseCadence's ResultSelector always sets it, or SetCadenceReadDegraded floors it) also falls through to Default by Step Functions Choice semantics — no separate IsPresent guard needed.",
+      "Comment": "alpha-engine-config-I6689 deliverable 2: gates LaunchWeeklyExerciseRun on the declared cadence. 'daily' preserves the pre-existing every-trading-day behavior exactly. 'weekly-only' / 'off' skip straight to CheckDegradedOutcome \u2014 LaunchWeeklyExerciseRun's OWN Next on ITS success path \u2014 so skipping the exercise launch never touches WeeklyExerciseLaunchFailed's routing (that state alerts only when the LAUNCH ITSELF fails, which cannot happen if it is never attempted). Default (value present but not one of the three declared literals \u2014 a manifest/SSM typo, or a future cadence value this SF has not been taught yet) is NOT a silent skip: it routes through SetCadenceUnknownValueDegraded to alert-then-launch, the same fail-toward-running posture as SetCadenceReadDegraded, rather than the invisible 'silently never ran' outcome. A missing/malformed $.exercise_cadence_param.value (ReadExerciseCadence's ResultSelector always sets it, or SetCadenceReadDegraded floors it) also falls through to Default by Step Functions Choice semantics \u2014 no separate IsPresent guard needed.",
       "Choices": [
         {
           "Variable": "$.exercise_cadence_param.value",
@@ -1806,7 +1807,7 @@
     },
     "SetCadenceUnknownValueDegraded": {
       "Type": "Pass",
-      "Comment": "CheckExerciseCadence's Default: the read succeeded but matched none of daily/weekly-only/off. Decided posture (alpha-engine-config#6689): treat as daily (fail toward running the exercise — weekly-sf-policy §5, missing a run is worse than an extra one) AND page, so 'ran anyway on an unrecognized value' is never mistaken for 'ran because cadence=daily was correctly read.' Captures the offending raw value under .raw BEFORE overwriting .value, so the alert below can name it.",
+      "Comment": "CheckExerciseCadence's Default: the read succeeded but matched none of daily/weekly-only/off. Decided posture (alpha-engine-config#6689): treat as daily (fail toward running the exercise \u2014 weekly-sf-policy \u00a75, missing a run is worse than an extra one) AND page, so 'ran anyway on an unrecognized value' is never mistaken for 'ran because cadence=daily was correctly read.' Captures the offending raw value under .raw BEFORE overwriting .value, so the alert below can name it.",
       "Parameters": {
         "raw.$": "$.exercise_cadence_param.value",
         "value": "daily"
@@ -1816,11 +1817,11 @@
     },
     "PublishCadenceUnknownValueDegraded": {
       "Type": "Task",
-      "Comment": "alpha-engine-config-I6689: alert on an unrecognized cadence value. Subject is a hardcoded constant (config#1819 discipline); the offending value is the one bounded dynamic field, threaded via States.Format — same pattern WeeklyRunDayGateFailed uses for its single bounded upstream field. TopicArn is hardcoded, NOT $.sns_topic_arn, per the same 2026-05-14 EOD-SF hardening as PublishCadenceReadDegraded above. Best-effort Catch.",
+      "Comment": "alpha-engine-config-I6689: alert on an unrecognized cadence value. Subject is a hardcoded constant (config#1819 discipline); the offending value is the one bounded dynamic field, threaded via States.Format \u2014 same pattern WeeklyRunDayGateFailed uses for its single bounded upstream field. TopicArn is hardcoded, NOT $.sns_topic_arn, per the same 2026-05-14 EOD-SF hardening as PublishCadenceReadDegraded above. Best-effort Catch.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine — weekly exercise-cadence value UNRECOGNIZED (defaulted to daily)",
+        "Subject": "Alpha Engine \u2014 weekly exercise-cadence value UNRECOGNIZED (defaulted to daily)",
         "Message.$": "States.Format('ReadExerciseCadence returned a value CheckExerciseCadence does not recognize: {}. Expected one of daily | weekly-only | off (infrastructure/weekly_cadence.json). Proceeding FAIL-OPEN as cadence=daily: the exercise launch is NOT skipped. Check infrastructure/weekly_cadence.json and the live SSM parameter /alpha-engine/weekly-sf/exercise-cadence for a typo or an undeployed manifest edit.', $.exercise_cadence_param.raw)"
       },
       "ResultPath": "$.exercise_cadence_unknown_notify",
@@ -1829,12 +1830,13 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "Comment": "Best-effort alert \u2014 a publish failure must not halt the fail-open path.",
           "ResultPath": "$.exercise_cadence_unknown_notify_error",
           "Next": "LaunchWeeklyExerciseRun"
         }
       ],
-      "Next": "LaunchWeeklyExerciseRun"
+      "Next": "LaunchWeeklyExerciseRun",
+      "TimeoutSeconds": 30
     },
     "LaunchWeeklyExerciseRun": {
       "Type": "Task",
@@ -1906,7 +1908,7 @@
               "BooleanEquals": true
             }
           ],
-          "Comment": "config-I2767 (2026-07-16 incident): $.degraded_summary is only assigned on the degraded path (SetDegradedFlag) — on a fully-green day the path is ABSENT and an unguarded dereference threw States.Runtime, failing the execution at its very last state. Absent flag = never degraded = NormalSucceeded via Default, which is the semantically exact reading, so no separate malformed route is needed here.",
+          "Comment": "config-I2767 (2026-07-16 incident): $.degraded_summary is only assigned on the degraded path (SetDegradedFlag) \u2014 on a fully-green day the path is ABSENT and an unguarded dereference threw States.Runtime, failing the execution at its very last state. Absent flag = never degraded = NormalSucceeded via Default, which is the semantically exact reading, so no separate malformed route is needed here.",
           "Next": "WriteCompletionMarkerDegraded"
         }
       ],
@@ -1914,7 +1916,7 @@
     },
     "WriteCompletionMarkerNormal": {
       "Type": "Task",
-      "Comment": "config#2857: SF-envelope completion marker — an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Written on the normal outcome, immediately before the distinct NormalSucceeded terminal (config-I2702 deliverable #4 keeps Normal/Degraded as separate named states for the console/notification signal — this marker preserves that split rather than converging them, since both routes must still each reach their own named Succeed). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_postclose_trading_pipeline (cadence eod_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable — exactly the ambiguity this feature exists to surface, not mask.",
+      "Comment": "config#2857: SF-envelope completion marker \u2014 an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Written on the normal outcome, immediately before the distinct NormalSucceeded terminal (config-I2702 deliverable #4 keeps Normal/Degraded as separate named states for the console/notification signal \u2014 this marker preserves that split rather than converging them, since both routes must still each reach their own named Succeed). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_postclose_trading_pipeline (cadence eod_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable \u2014 exactly the ambiguity this feature exists to surface, not mask.",
       "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
       "Parameters": {
         "Bucket": "alpha-engine-research",
@@ -1930,7 +1932,7 @@
           "MaxAttempts": 3,
           "IntervalSeconds": 2,
           "BackoffRate": 2.0,
-          "Comment": "Transient S3 fault coverage — mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
+          "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
         }
       ],
       "Next": "NormalSucceeded"
@@ -1941,7 +1943,7 @@
     },
     "WriteCompletionMarkerDegraded": {
       "Type": "Task",
-      "Comment": "config#2857: SF-envelope completion marker — an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Written on the degraded outcome, immediately before the DegradedRun Fail terminal (config-I2702 deliverable #4 + Brian's 2026-07-28 Option-A ruling, alpha-engine-config#2699: the marker still fires so the completion artifact exists, but DegradedRun is Type: Fail so status-keyed watchers engage). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_postclose_trading_pipeline (cadence eod_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable — exactly the ambiguity this feature exists to surface, not mask.",
+      "Comment": "config#2857: SF-envelope completion marker \u2014 an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine). Written on the degraded outcome, immediately before the DegradedRun Fail terminal (config-I2702 deliverable #4 + Brian's 2026-07-28 Option-A ruling, alpha-engine-config#2699: the marker still fires so the completion artifact exists, but DegradedRun is Type: Fail so status-keyed watchers engage). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_postclose_trading_pipeline (cadence eod_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable \u2014 exactly the ambiguity this feature exists to surface, not mask.",
       "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
       "Parameters": {
         "Bucket": "alpha-engine-research",
@@ -1957,7 +1959,7 @@
           "MaxAttempts": 3,
           "IntervalSeconds": 2,
           "BackoffRate": 2.0,
-          "Comment": "Transient S3 fault coverage — mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
+          "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
         }
       ],
       "Next": "DegradedRun"

--- a/infrastructure/weekly_cadence.json
+++ b/infrastructure/weekly_cadence.json
@@ -1,0 +1,15 @@
+{
+  "exercise_cadence": "daily",
+
+  "_provenance": "alpha-engine-config#6689 (mechanism: single declared cadence knob, deploy-time SSM sync, silence deadman). The VALUE below is unchanged by that PR — it is set by alpha-engine-config#5489 (Brian ruling 2026-07-29) and this file only relocates where that value lives, from an SF-topology edit to a one-line manifest diff.",
+
+  "_meaning": {
+    "daily": "infrastructure/step_function_eod.json's LaunchWeeklyExerciseRun fires the FULL weekly pipeline (ne-weekly-freshness-pipeline, pipeline_role=exercise) after every trading day's postclose. alpha-engine-config#5489 (Brian ruling 2026-07-29): a DELIBERATE PUNISHMENT CADENCE, chosen because the weekly pipeline's own iteration rate — 11/60 executions reached a successful terminal state at filing — was the measured failure driver, not compute cost. It carries a stated EXIT CONDITION (sustained weekly-SF health, i.e. this is not meant to run forever) and is NOT the intended steady state. Flip away from 'daily' only on a ruling that the exit condition has been met.",
+    "weekly-only": "LaunchWeeklyExerciseRun is skipped on every postclose; only the Saturday cron (EventBridge rule alpha-engine-saturday, pipeline_role=weekly, self-gated by WeeklyRunDayGate) launches the pipeline. This is the eventual steady state once #5489's exit condition is met — 5 iterations/week collapses back to 1.",
+    "off": "LaunchWeeklyExerciseRun is skipped on every postclose, identically to 'weekly-only' from this knob's point of view — this parameter has exactly one insertion point (the postclose Choice guarding the exercise launch) and does not touch the Saturday cron at all. 'off' exists as a distinct declared value so the silence deadman can be told 'no exercise launch is expected, full stop' without conflating that with 'weekly-only, but the exercise leg happens to be paused for another reason.' Silencing the Saturday cron itself is a SEPARATE decision made in infrastructure/automation_pause.json (alpha-engine-saturday is explicitly kept there by the 2026-08-07 ruling) — this knob deliberately does not reintroduce a second cron/calendar surface."
+  },
+
+  "_mechanism": "Deployed to SSM Parameter Store at /alpha-engine/weekly-sf/exercise-cadence (String) by infrastructure/deploy-infrastructure.sh, in the same step that updates the postclose SF definition (config#6689 deliverable 2) — so the manifest and the live gate can never point at different values for more than one deploy cycle. infrastructure/step_function_eod.json's ReadExerciseCadence task reads that parameter live at execution time; CheckExerciseCadence Choice routes daily -> LaunchWeeklyExerciseRun, {weekly-only, off} -> skip straight to CheckDegradedOutcome (LaunchWeeklyExerciseRun's existing success target), preserving WeeklyExerciseLaunchFailed's routing untouched. Two-directional drift (manifest vs live SSM) is checked by infrastructure/weekly_cadence_drift.py, mirroring automation_pause.py's pattern.",
+
+  "allowed_values": ["daily", "weekly-only", "off"]
+}

--- a/infrastructure/weekly_cadence_drift.py
+++ b/infrastructure/weekly_cadence_drift.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""weekly_cadence_drift.py — two-directional check between the declared
+weekly-exercise cadence (``infrastructure/weekly_cadence.json``) and its live
+copy at SSM Parameter Store ``/alpha-engine/weekly-sf/exercise-cadence``.
+
+**Background (alpha-engine-config#6689 deliverable 2).** Before this file, the
+weekly pipeline's exercise cadence lived on TWO uncoordinated surfaces (an SF
+Choice hardcoded in ``step_function_eod.json``, no declared parameter
+anywhere) — flipping daily<->weekly meant an SF-topology edit. The manifest is
+now the single declared source; ``infrastructure/deploy-infrastructure.sh``
+writes it to SSM in the same step that updates the postclose SF definition
+(config#6689 deliverable 2), and ``infrastructure/step_function_eod.json``'s
+``ReadExerciseCadence`` task reads the SSM copy live at execution time. This
+script is the mirror of ``automation_pause.py``'s two-directional check for
+that pair: a manifest value nobody deployed is as much a bug as a live value
+nobody declared.
+
+Two-directional by design, same rationale as ``automation_pause.py``: a drift
+that silently reverted the deployed cadence and a manifest edit that was never
+actually deployed are both findings — a check that can never fail either
+direction is a comment, not a record.
+
+Usage:
+  ./infrastructure/weekly_cadence_drift.py --check     # compare manifest vs live SSM; exit 1 on drift
+  ./infrastructure/weekly_cadence_drift.py --enforce    # write the manifest value to SSM
+  ./infrastructure/weekly_cadence_drift.py --check --json
+
+``--check`` needs ``ssm:GetParameter`` on
+``arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/weekly-sf/exercise-cadence``;
+``--enforce`` additionally needs ``ssm:PutParameter`` on the same resource.
+NEITHER grant exists yet on any of the three identities that touch this
+parameter (the GitHub Actions deploy role, the SF execution role, and the IAM
+drift-check role) — measured 2026-08-09 by grepping
+``nous-ergon-ops/infrastructure/iam/`` for ``ssm:GetParameter`` /
+``ssm:PutParameter`` against ``nousergon-data``. Until a nous-ergon-ops IAM PR
+adds them, both ``--check`` and ``--enforce`` fail loud with the AWS
+AccessDenied error rather than silently reporting success — see this repo's
+PR body for the exact grants needed. IAM is owned by nous-ergon-ops
+(infrastructure-ownership-policy.md §35); this repo does not write IAM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MANIFEST = Path(__file__).parent.resolve() / "weekly_cadence.json"
+SSM_PARAM_NAME = "/alpha-engine/weekly-sf/exercise-cadence"
+REGION = "us-east-1"
+ALLOWED_VALUES = {"daily", "weekly-only", "off"}
+
+
+def load_manifest(path: Path = MANIFEST) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def declared_cadence(manifest: dict | None = None) -> str:
+    m = manifest if manifest is not None else load_manifest()
+    value = m.get("exercise_cadence")
+    if value not in ALLOWED_VALUES:
+        raise ValueError(
+            f"infrastructure/weekly_cadence.json exercise_cadence={value!r} is not one of "
+            f"{sorted(ALLOWED_VALUES)}"
+        )
+    return value
+
+
+def _aws(args: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["aws"] + args + ["--region", REGION], capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _live_value() -> str | None:
+    """Return the live SSM parameter value, or None if it does not exist.
+
+    Any failure that is NOT a genuine not-found (including AccessDenied) is
+    raised — a permissions error read as "not deployed yet" would let this
+    check grade itself green by losing its own access, the same failure mode
+    ``automation_pause.py``'s ``_live_state`` guards against.
+    """
+    rc, out, err = _aws(
+        ["ssm", "get-parameter", "--name", SSM_PARAM_NAME, "--query", "Parameter.Value", "--output", "text"]
+    )
+    if rc != 0:
+        if "ParameterNotFound" in err:
+            return None
+        raise RuntimeError(f"aws ssm get-parameter --name {SSM_PARAM_NAME}: {err}")
+    return out
+
+
+def check() -> list[dict]:
+    declared = declared_cadence()
+    live = _live_value()
+    findings: list[dict] = []
+    if live is None:
+        findings.append({
+            "kind": "missing-in-aws",
+            "detail": (
+                f"{SSM_PARAM_NAME} does not exist live — the manifest declares "
+                f"exercise_cadence={declared!r} but nothing has deployed it. Run "
+                "infrastructure/deploy-infrastructure.sh (or "
+                f"./infrastructure/weekly_cadence_drift.py --enforce)."
+            ),
+        })
+    elif live != declared:
+        findings.append({
+            "kind": "value-mismatch",
+            "detail": (
+                f"manifest declares exercise_cadence={declared!r} but live SSM value is "
+                f"{live!r} — a deploy did not run, or the parameter was edited out of band. "
+                "Fix: ./infrastructure/weekly_cadence_drift.py --enforce"
+            ),
+        })
+    return findings
+
+
+def enforce() -> bool:
+    """Write the manifest value to SSM. Returns True iff a write was made."""
+    declared = declared_cadence()
+    live = _live_value()
+    if live == declared:
+        return False
+    rc, _, err = _aws([
+        "ssm", "put-parameter",
+        "--name", SSM_PARAM_NAME,
+        "--type", "String",
+        "--value", declared,
+        "--overwrite",
+    ])
+    if rc != 0:
+        raise RuntimeError(f"aws ssm put-parameter --name {SSM_PARAM_NAME}: {err}")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="weekly exercise-cadence manifest vs live SSM drift check")
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="verify manifest == live SSM value")
+    mode.add_argument("--enforce", action="store_true", help="write the manifest value to SSM")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    try:
+        if args.enforce:
+            wrote = enforce()
+            if args.json:
+                print(json.dumps({"wrote": wrote}, indent=2))
+            else:
+                print("✓ SSM value already matches the manifest" if not wrote else "✓ wrote manifest value to SSM")
+            return 0
+
+        findings = check()
+    except (RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps({"findings": findings}, indent=2))
+    else:
+        if not findings:
+            print(f"✓ {SSM_PARAM_NAME} matches infrastructure/weekly_cadence.json")
+        for f in findings:
+            print(f"  ✗ [{f['kind']}]")
+            print(f"      {f['detail']}")
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.37
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/scripts/weekly_sf_silence_deadman.py
+++ b/scripts/weekly_sf_silence_deadman.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""weekly_sf_silence_deadman.py — silence deadman for the weekly pipeline's
+two trigger roles (alpha-engine-config#6689 deliverable 3, resolving #5599).
+
+**Background.** The weekly pipeline (``ne-weekly-freshness-pipeline``) is
+launched two ways: the Saturday EventBridge cron (``pipeline_role=weekly``,
+self-gated by ``step_function.json``'s ``WeeklyRunDayGateChoice`` to the one
+correct calendar day per week) and, when ``infrastructure/weekly_cadence.json``
+declares ``exercise_cadence=daily``, a chained launch from every trading day's
+postclose (``pipeline_role=exercise``, ``step_function_eod.json``'s
+``LaunchWeeklyExerciseRun``). Measured over 2026-07-26 -> 08-09: 4 of 10
+trading days got no exercise run with ZERO signal — postclose FAILED before
+the launch state on 07-27/07-28, and postclose never fired AT ALL on 08-05/
+08-06. Nothing paged on the silent days because the only prior deadman
+candidate, the CloudWatch ``AWS/States`` ``ExecutionsStarted`` metric, carries
+no ``pipeline_role`` dimension — it cannot tell a gated-off day from a dead
+one. **This script supersedes that metric-dimension approach** (alpha-engine-
+config#5599's proposed resolution): it reads the declared cadence and the
+NYSE trading calendar directly, derives the run-slots that SHOULD exist, and
+checks the pipeline's own execution history for each one — no new metric
+dimension needed.
+
+**Classification, per expected slot:**
+
+  * ``GATED_OFF`` (OK, exit 0) — the declared cadence says this slot should
+    NOT fire (e.g. an exercise slot on a trading day when
+    ``exercise_cadence`` is ``weekly-only`` or ``off``).
+  * ``OK`` (exit 0) — expected, and a matching execution exists.
+  * ``CRITICAL`` (pages, exit 1) — expected, and none does. This is the
+    silence this script exists to catch: a day the pipeline should have run
+    and produced nothing, indistinguishable from a holiday until now.
+
+**Gotchas this script is built around (measured, not theoretical):**
+
+  * A SUCCEEDED ``pipeline_role=weekly`` execution that completes in under
+    ``GATE_NOOP_MAX_SECONDS`` is ``WeeklyRunDayGateChoice``'s designed 2-second
+    no-op skip on a non-run day (2 of every 3 THU-SAT cron firings), NOT a
+    real weekly run. Counting it as "ran" would hide a genuinely silent week.
+  * Neither launch path passes an explicit Step Functions ``Name`` — every
+    execution gets an AWS-generated UUID name. ``pipeline_role`` is read from
+    each execution's OWN INPUT via ``describe_execution``, never inferred
+    from the name.
+  * The weekly cron fires THU-SAT and self-gates true on the day AFTER the
+    week's last trading session (Saturday on a normal week; Friday/Thursday
+    on a holiday-shortened one — real precedent Fri 2026-07-03). This script
+    therefore expects the REAL weekly run on ``last_session + 1 calendar
+    day``, not on the last session itself — a deliberate refinement of the
+    filing issue's "weekly for the week's last session" wording, recorded as
+    a documented deviation in this change's PR body.
+
+No scheduling/EventBridge wiring in this change (automation pause,
+alpha-engine-config#6617): this script is invocable manually only. On a
+CRITICAL finding it best-effort publishes to the fleet's existing
+``alpha-engine-alerts`` SNS topic (the same topic every SF Publish*Degraded
+state in this repo already uses) and always exits non-zero regardless of
+whether the publish succeeds — the exit code is the durable signal a future
+CI/cron wiring would page on.
+
+Usage:
+  ./scripts/weekly_sf_silence_deadman.py                     # manifest cadence, 5-day window
+  ./scripts/weekly_sf_silence_deadman.py --live               # cadence read from live SSM instead
+  ./scripts/weekly_sf_silence_deadman.py --window-days 10
+  ./scripts/weekly_sf_silence_deadman.py --json --no-notify   # for scripted/CI consumption
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "infrastructure" / "weekly_cadence.json"
+SSM_PARAM_NAME = "/alpha-engine/weekly-sf/exercise-cadence"
+STATE_MACHINE_NAME = "ne-weekly-freshness-pipeline"
+REGION = "us-east-1"
+ACCOUNT_ID = "711398986525"
+SNS_TOPIC_ARN = f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts"
+
+ALLOWED_CADENCE = {"daily", "weekly-only", "off"}
+DEFAULT_WINDOW_DAYS = 5
+GATE_NOOP_MAX_SECONDS = 90
+
+
+# ---------------------------------------------------------------------------
+# Cadence source
+# ---------------------------------------------------------------------------
+
+def _validate_cadence(value: object, source: str) -> str:
+    if value not in ALLOWED_CADENCE:
+        raise ValueError(f"{source} declared exercise_cadence={value!r}, not one of {sorted(ALLOWED_CADENCE)}")
+    return value  # type: ignore[return-value]
+
+
+def load_cadence_from_manifest(path: Path = MANIFEST_PATH) -> str:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    return _validate_cadence(manifest.get("exercise_cadence"), str(path))
+
+
+def load_cadence_from_ssm(ssm_client) -> str:
+    resp = ssm_client.get_parameter(Name=SSM_PARAM_NAME)
+    return _validate_cadence(resp["Parameter"]["Value"], SSM_PARAM_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Expected run-slot derivation (pure — no AWS)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExpectedSlot:
+    day: date
+    role: str  # "exercise" | "weekly"
+    gated_off: bool = False
+    note: str = ""
+
+
+def _is_last_session_of_week(
+    d: date,
+    is_trading_day: Callable[[date], bool],
+    next_trading_day: Callable[[date], date],
+) -> bool:
+    """True iff d is a trading day and the NEXT trading day falls in a
+    different ISO week — i.e. d is the last trading session of its week."""
+    if not is_trading_day(d):
+        return False
+    nxt = next_trading_day(d)
+    return nxt.isocalendar()[:2] != d.isocalendar()[:2]
+
+
+def compute_expected_slots(
+    today: date,
+    cadence: str,
+    window_days: int,
+    is_trading_day: Callable[[date], bool],
+    next_trading_day: Callable[[date], date],
+) -> list[ExpectedSlot]:
+    """Derive every run-slot expected in [today - window_days, today].
+
+    Exercise slots: one per trading day in the window, gated_off when
+    ``cadence != "daily"`` — LaunchWeeklyExerciseRun's CheckExerciseCadence
+    only fires the launch on 'daily' (step_function_eod.json).
+
+    Weekly slots: one per week whose last-trading-session-plus-one-day run
+    date falls within the window. NEVER gated by ``cadence`` — the Saturday
+    cron is a separate trigger this knob deliberately does not touch.
+    """
+    slots: list[ExpectedSlot] = []
+    d = today - timedelta(days=window_days)
+    while d <= today:
+        if is_trading_day(d):
+            gated = cadence != "daily"
+            slots.append(ExpectedSlot(
+                day=d,
+                role="exercise",
+                gated_off=gated,
+                note=(
+                    f"cadence={cadence} — LaunchWeeklyExerciseRun is skipped on trading days"
+                    if gated else
+                    f"cadence={cadence} — LaunchWeeklyExerciseRun fires after this trading day's postclose"
+                ),
+            ))
+        if _is_last_session_of_week(d, is_trading_day, next_trading_day):
+            run_day = d + timedelta(days=1)
+            if today - timedelta(days=window_days) <= run_day <= today:
+                slots.append(ExpectedSlot(
+                    day=run_day,
+                    role="weekly",
+                    gated_off=False,
+                    note=(
+                        f"day after the week's last trading session ({d.isoformat()}) — "
+                        "Saturday-cron WeeklyRunDayGateChoice self-gates true on this day"
+                    ),
+                ))
+        d += timedelta(days=1)
+    return slots
+
+
+# ---------------------------------------------------------------------------
+# Execution matching (pure — takes already-fetched records)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExecutionRecord:
+    name: str
+    role: str | None
+    status: str
+    start: datetime  # tz-aware UTC
+    stop: datetime | None
+
+
+def normalize_role(raw: object) -> str | None:
+    return raw if raw in ("exercise", "weekly") else None
+
+
+@dataclass(frozen=True)
+class SlotResult:
+    slot: ExpectedSlot
+    classification: str  # "OK" | "GATED_OFF" | "CRITICAL"
+    matched_execution: str | None
+    detail: str
+
+
+def _is_gate_noop(e: ExecutionRecord) -> bool:
+    if e.status != "SUCCEEDED" or e.stop is None:
+        return False
+    return (e.stop - e.start).total_seconds() < GATE_NOOP_MAX_SECONDS
+
+
+def evaluate_slot(slot: ExpectedSlot, executions: list[ExecutionRecord]) -> SlotResult:
+    if slot.gated_off:
+        return SlotResult(slot, "GATED_OFF", None, slot.note)
+
+    candidates = [e for e in executions if e.role == slot.role and e.start.date() == slot.day]
+
+    if slot.role == "weekly":
+        real = [e for e in candidates if not _is_gate_noop(e)]
+        if real:
+            e = real[0]
+            return SlotResult(slot, "OK", e.name, f"found {e.name} status={e.status}")
+        if candidates:
+            return SlotResult(
+                slot, "CRITICAL", None,
+                f"only run-day-gate no-op(s) found on {slot.day.isoformat()} "
+                f"({len(candidates)}) — WeeklyRunDayGateChoice's skip is not a real run",
+            )
+        return SlotResult(
+            slot, "CRITICAL", None,
+            f"no weekly-role execution found on {slot.day.isoformat()} — expected the Saturday-cron run",
+        )
+
+    # exercise: not gated by the run-day gate (bypasses it by design), so any
+    # matching execution is a real run.
+    if candidates:
+        e = candidates[0]
+        return SlotResult(slot, "OK", e.name, f"found {e.name} status={e.status}")
+    return SlotResult(
+        slot, "CRITICAL", None,
+        f"no exercise-role execution found on {slot.day.isoformat()} — postclose should have chained it (cadence=daily)",
+    )
+
+
+def evaluate(slots: list[ExpectedSlot], executions: list[ExecutionRecord]) -> list[SlotResult]:
+    return [evaluate_slot(s, executions) for s in slots]
+
+
+# ---------------------------------------------------------------------------
+# AWS plumbing (thin, injectable — mirrors weekly_sf_rerun.py's shape)
+# ---------------------------------------------------------------------------
+
+def _list_all_executions(sf_client, sm_arn: str, cap: int = 500) -> list[dict]:
+    out: list[dict] = []
+    token = None
+    while len(out) < cap:
+        kwargs = {"stateMachineArn": sm_arn, "maxResults": 200}
+        if token:
+            kwargs["nextToken"] = token
+        resp = sf_client.list_executions(**kwargs)
+        out.extend(resp["executions"])
+        token = resp.get("nextToken")
+        if not token:
+            break
+    return out[:cap]
+
+
+def fetch_execution_records(sf_client, window_days: int) -> list[ExecutionRecord]:
+    """Live AWS fetch: list recent executions, then describe each one for its
+    pipeline_role (never present on the list-executions summary itself —
+    every launch path here omits an explicit Name, so role must come from
+    input, not the name)."""
+    sm_arn = f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{STATE_MACHINE_NAME}"
+    # +2 day pad: a weekly slot's run_day can land one calendar day after the
+    # window's nominal start when the window boundary splits a week. Derived
+    # from _today() (not a fresh datetime.now() call) so a test that pins
+    # _today() gets a fully deterministic window.
+    since = datetime.combine(_today(), datetime.min.time(), tzinfo=timezone.utc) - timedelta(days=window_days + 2)
+
+    records: list[ExecutionRecord] = []
+    for ex in _list_all_executions(sf_client, sm_arn):
+        start = ex["startDate"]
+        if start < since:
+            continue
+        role = None
+        try:
+            desc = sf_client.describe_execution(executionArn=ex["executionArn"])
+            inp = json.loads(desc.get("input") or "{}")
+            role = normalize_role(inp.get("pipeline_role"))
+        except Exception as exc:  # noqa: BLE001 — best-effort per-execution; unrecognized role is a safe fallback, not a hidden failure (surfaced below)
+            print(f"WARN: could not read input of {ex['executionArn']}: {exc}", file=sys.stderr)
+        records.append(ExecutionRecord(
+            name=ex["name"],
+            role=role,
+            status=ex["status"],
+            start=start,
+            stop=ex.get("stopDate"),
+        ))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Reporting + CLI
+# ---------------------------------------------------------------------------
+
+def _today() -> date:
+    """Isolated seam so CLI-level tests can pin 'today' deterministically
+    without depending on the real wall clock."""
+    return datetime.now(timezone.utc).date()
+
+
+def format_report(results: list[SlotResult]) -> str:
+    marks = {"OK": "✓", "GATED_OFF": "·", "CRITICAL": "✗"}
+    lines = []
+    for r in sorted(results, key=lambda r: (r.slot.day, r.slot.role)):
+        lines.append(
+            f"  {marks[r.classification]} {r.slot.day.isoformat()} {r.slot.role:8s} "
+            f"[{r.classification}] {r.detail}"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS, help=f"trailing days to check (default {DEFAULT_WINDOW_DAYS})")
+    ap.add_argument("--live", action="store_true", help="read the declared cadence from live SSM instead of the local manifest")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--no-notify", action="store_true", help="never publish to SNS, even on CRITICAL (dry runs / CI)")
+    args = ap.parse_args(argv)
+
+    import boto3  # local import: keeps the pure functions above importable/testable with zero AWS deps
+    from nousergon_lib.trading_calendar import is_trading_day, next_trading_day
+
+    sf = boto3.client("stepfunctions", region_name=REGION)
+
+    if args.live:
+        ssm = boto3.client("ssm", region_name=REGION)
+        cadence = load_cadence_from_ssm(ssm)
+    else:
+        cadence = load_cadence_from_manifest()
+
+    today = _today()
+    executions = fetch_execution_records(sf, args.window_days)
+    slots = compute_expected_slots(today, cadence, args.window_days, is_trading_day, next_trading_day)
+    results = evaluate(slots, executions)
+    critical = [r for r in results if r.classification == "CRITICAL"]
+
+    if args.json:
+        print(json.dumps({
+            "cadence": cadence,
+            "window_days": args.window_days,
+            "checked": len(results),
+            "critical": len(critical),
+            "results": [
+                {
+                    "day": r.slot.day.isoformat(),
+                    "role": r.slot.role,
+                    "classification": r.classification,
+                    "matched_execution": r.matched_execution,
+                    "detail": r.detail,
+                }
+                for r in results
+            ],
+        }, indent=2))
+    else:
+        print(f"weekly-sf silence deadman — cadence={cadence} window={args.window_days}d")
+        print(format_report(results))
+        print(f"\n✗ {len(critical)} CRITICAL slot(s) — expected and absent" if critical else "\n✓ no silent slots")
+
+    if critical and not args.no_notify:
+        try:
+            sns = boto3.client("sns", region_name=REGION)
+            detail = "\n".join(f"- {r.slot.day.isoformat()} {r.slot.role}: {r.detail}" for r in critical)
+            sns.publish(
+                TopicArn=SNS_TOPIC_ARN,
+                Subject="Alpha Engine — weekly-SF silence deadman: CRITICAL",
+                Message=(
+                    "weekly_sf_silence_deadman.py found expected run-slot(s) with no matching "
+                    f"execution on {STATE_MACHINE_NAME} (cadence={cadence}):\n\n{detail}\n\n"
+                    "This means a day the pipeline should have run produced NO execution at "
+                    "all — not a failure, silence. See alpha-engine-config#6689."
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort page; exit code below is the durable signal regardless
+            print(f"WARN: SNS publish failed: {exc}", file=sys.stderr)
+
+    return 1 if critical else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sf_eod_precondition_probe_wiring.py
+++ b/tests/test_sf_eod_precondition_probe_wiring.py
@@ -181,13 +181,29 @@ class TestDegradedTerminalState:
 
     def test_stop_trading_instance_leads_to_the_degraded_check(self, states):
         """config-I5489 inserted the weekly-exercise launch between the cost
-        guard and the degraded check, so this is now a two-hop path. What the
-        test actually protects is unchanged: StopTradingInstance is not a
-        terminal, and the degraded check is still what decides the terminal —
-        the inserted state must not swallow or bypass it.
+        guard and the degraded check; alpha-engine-config-I6689 further
+        inserted the declared-cadence read + gate ahead of the launch itself
+        (StopTradingInstance -> ReadExerciseCadence -> CheckExerciseCadence ->
+        LaunchWeeklyExerciseRun on cadence=daily). What the test actually
+        protects is unchanged: StopTradingInstance is not a terminal, and the
+        degraded check is still what decides the terminal — none of the
+        inserted states may swallow or bypass it.
         """
         assert "End" not in states["StopTradingInstance"]
-        assert states["StopTradingInstance"]["Next"] == "LaunchWeeklyExerciseRun"
+        assert states["StopTradingInstance"]["Next"] == "ReadExerciseCadence"
+        assert states["ReadExerciseCadence"]["Next"] == "CheckExerciseCadence"
+        # cadence=daily is the ONLY branch that launches; weekly-only/off skip
+        # straight to the degraded check, same as LaunchWeeklyExerciseRun's
+        # own success Next.
+        daily_choice = next(
+            c for c in states["CheckExerciseCadence"]["Choices"] if c.get("StringEquals") == "daily"
+        )
+        assert daily_choice["Next"] == "LaunchWeeklyExerciseRun"
+        for value in ("weekly-only", "off"):
+            choice = next(
+                c for c in states["CheckExerciseCadence"]["Choices"] if c.get("StringEquals") == value
+            )
+            assert choice["Next"] == "CheckDegradedOutcome"
         # both the success and launch-failure routes converge on the check
         assert states["LaunchWeeklyExerciseRun"]["Next"] == "CheckDegradedOutcome"
         assert states["WeeklyExerciseLaunchFailed"]["Next"] == "CheckDegradedOutcome"

--- a/tests/test_sf_eod_skipgate_wiring.py
+++ b/tests/test_sf_eod_skipgate_wiring.py
@@ -198,7 +198,16 @@ class TestPaths:
                     [c["Next"] for c in st.get("Choices", []) if _ops(c).get("BooleanEquals") is True]
                     if cur.endswith("SpotLaunched") else []
                 )
-                cur = (succ or launched or [st.get("Default")])[0]
+                # alpha-engine-config-I6689: CheckExerciseCadence branches on
+                # StringEquals "daily"/"weekly-only"/"off", not "Success" or a
+                # *SpotLaunched BooleanEquals — the happy-path simulation here
+                # always takes the "daily" branch (LaunchWeeklyExerciseRun),
+                # matching this SF's actual pre-config#6689 default behavior.
+                cadence_daily = (
+                    [c["Next"] for c in st.get("Choices", []) if c.get("StringEquals") == "daily"]
+                    if cur == "CheckExerciseCadence" else []
+                )
+                cur = (succ or launched or cadence_daily or [st.get("Default")])[0]
             else:
                 cur = st.get("Next")
         return order
@@ -212,7 +221,7 @@ class TestPaths:
         # terminates the execution directly — a fully-green run (no gap ever
         # detected, $.degraded_summary never set) routes through
         # CheckDegradedOutcome to the ordinary NormalSucceeded terminal.
-        assert order[-5:] == ["StopTradingInstance", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
+        assert order[-7:] == ["StopTradingInstance", "ReadExerciseCadence", "CheckExerciseCadence", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
 
     def test_full_skip_still_stops_the_instance(self, states):
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN})
@@ -225,6 +234,7 @@ class TestPaths:
         # test_operator_replay_still_honors_skips below.
         assert order == [
             "ProbeEODReconcilePrecondition", "StopTradingInstance",
+            "ReadExerciseCadence", "CheckExerciseCadence",
             "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded",
         ]
 
@@ -237,7 +247,7 @@ class TestPaths:
         assert "RefreshExecutorDeploy" not in order
         assert order[0] == "InitDataSpotRetryCounter"
         assert order[1] == "LaunchPostMarketDataSpot"
-        assert order[-5:] == ["StopTradingInstance", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
+        assert order[-7:] == ["StopTradingInstance", "ReadExerciseCadence", "CheckExerciseCadence", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
 
     def test_skip_data_phase_resumes_at_snapshot(self, states):
         # config#1767: skip_post_market_data now skips the ENTIRE spot data phase
@@ -247,7 +257,7 @@ class TestPaths:
         assert "LaunchPostMarketDataSpot" not in order
         assert "LaunchPostMarketArcticAppendSpot" not in order
         assert order[0] == "CaptureSnapshot"
-        assert order[-5:] == ["StopTradingInstance", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
+        assert order[-7:] == ["StopTradingInstance", "ReadExerciseCadence", "CheckExerciseCadence", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
 
     def test_happy_path_runs_data_phase_on_spot(self, states):
         # config#1767: the EOD data phase runs as spot-launch states, in order,
@@ -268,7 +278,7 @@ class TestSkipFlagsInertOutsideOperatorReplay:
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role="eod")
         for task in (c[1] for c in _CHAIN):
             assert task in order, f"{task} was skipped despite non-replay role"
-        assert order[-5:] == ["StopTradingInstance", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
+        assert order[-7:] == ["StopTradingInstance", "ReadExerciseCadence", "CheckExerciseCadence", "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded"]
 
     def test_all_skips_inert_when_role_absent(self, states):
         order = self._walk(states, skip_flags={c[2] for c in _CHAIN}, pipeline_role=None)
@@ -287,6 +297,7 @@ class TestSkipFlagsInertOutsideOperatorReplay:
         # unconditionally) before its own skip_eod_reconcile flag takes over.
         assert order == [
             "ProbeEODReconcilePrecondition", "StopTradingInstance",
+            "ReadExerciseCadence", "CheckExerciseCadence",
             "LaunchWeeklyExerciseRun", "CheckDegradedOutcome", "WriteCompletionMarkerNormal", "NormalSucceeded",
         ]
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -586,6 +586,21 @@ class TestEODSFTopLevelFieldsClosed:
             "weekly_exercise_launch_error",
             "weekly_exercise_launch_notify",
             "weekly_exercise_launch_notify_error",
+            # alpha-engine-config-I6689: ReadExerciseCadence reads the
+            # declared cadence from SSM (source: infrastructure/
+            # weekly_cadence.json) and gates LaunchWeeklyExerciseRun via
+            # CheckExerciseCadence, so daily<->weekly-only<->off is a
+            # one-line manifest diff instead of an SF-topology edit.
+            # $.exercise_cadence_param is both the Task's ResultPath AND
+            # the value SetCadenceReadDegraded / SetCadenceUnknownValueDegraded
+            # float, so all three fail-open paths (read failure, unrecognized
+            # value) agree on one field name for CheckExerciseCadence to read.
+            "exercise_cadence_param",
+            "exercise_cadence_read_error",
+            "exercise_cadence_degraded_notify",
+            "exercise_cadence_degraded_notify_error",
+            "exercise_cadence_unknown_notify",
+            "exercise_cadence_unknown_notify_error",
         }
     )
 

--- a/tests/test_sf_weekly_cadence_wiring.py
+++ b/tests/test_sf_weekly_cadence_wiring.py
@@ -1,0 +1,177 @@
+"""Structural wiring for the declared weekly exercise-cadence gate
+(alpha-engine-config-I6689) inserted into step_function_eod.json between
+StopTradingInstance and LaunchWeeklyExerciseRun:
+
+  StopTradingInstance -> ReadExerciseCadence -> CheckExerciseCadence
+    -> "daily"                -> LaunchWeeklyExerciseRun
+    -> "weekly-only" / "off"  -> CheckDegradedOutcome (skip the launch)
+    -> anything else (Default) -> SetCadenceUnknownValueDegraded -> alert -> LaunchWeeklyExerciseRun
+
+ReadExerciseCadence's own Catch(States.ALL) -> SetCadenceReadDegraded -> alert
+-> CheckExerciseCadence (re-enters with value floored to "daily").
+
+These tests pin the properties that make the gate safe to deploy before its
+own IAM grant lands (alpha-engine-config#6689 PR body): every failure mode
+here fails OPEN toward running the exercise, never toward silently skipping
+it, and every fail-open path pages instead of degrading silently. Separately,
+test_sf_weekly_exercise_chain_wiring.py and
+test_sf_eod_precondition_probe_wiring.py pin that the pre-existing launch
+(LaunchWeeklyExerciseRun onward) and postclose-failure-isolation properties
+are unchanged by this insertion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_ALERTS_TOPIC_ARN = "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+_SSM_PARAM_NAME = "/alpha-engine/weekly-sf/exercise-cadence"
+
+
+@pytest.fixture(scope="module")
+def eod() -> dict:
+    return json.loads((_INFRA / "step_function_eod.json").read_text())["States"]
+
+
+class TestReadExerciseCadence:
+    def test_reads_the_declared_ssm_parameter(self, eod):
+        st = eod["ReadExerciseCadence"]
+        assert st["Resource"] == "arn:aws:states:::aws-sdk:ssm:getParameter"
+        assert st["Parameters"]["Name"] == _SSM_PARAM_NAME
+
+    def test_has_a_small_bounded_timeout(self, eod):
+        assert eod["ReadExerciseCadence"]["TimeoutSeconds"] <= 30
+
+    def test_catches_everything_and_never_reaches_handle_failure(self, eod):
+        catch = eod["ReadExerciseCadence"]["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "SetCadenceReadDegraded"
+        assert catch["Next"] != "HandleFailure"
+
+    def test_result_is_selected_and_isolated(self, eod):
+        st = eod["ReadExerciseCadence"]
+        assert st["ResultSelector"] == {"value.$": "$.Parameter.Value"}
+        assert st["ResultPath"] == "$.exercise_cadence_param"
+
+    def test_success_enters_the_check(self, eod):
+        assert eod["ReadExerciseCadence"]["Next"] == "CheckExerciseCadence"
+
+
+class TestReadFailureFailsOpenAndPages:
+    def test_floors_to_daily(self, eod):
+        st = eod["SetCadenceReadDegraded"]
+        assert st["Type"] == "Pass"
+        assert st["Result"] == {"value": "daily"}
+        assert st["ResultPath"] == "$.exercise_cadence_param"
+        assert st["Next"] == "PublishCadenceReadDegraded"
+
+    def test_publishes_to_the_alerts_topic_hardcoded(self, eod):
+        """The EOD SF was hardened 2026-05-14 to hardcode the alerts-topic ARN
+        in every Publish state, never bind $.sns_topic_arn from input — this
+        alert must follow the SAME convention as every sibling Publish*Degraded
+        state in this file, not the weekly SF's $.sns_topic_arn.$ convention."""
+        st = eod["PublishCadenceReadDegraded"]
+        assert st["Resource"] == "arn:aws:states:::sns:publish"
+        assert st["Parameters"]["TopicArn"] == _ALERTS_TOPIC_ARN
+        assert "TopicArn.$" not in st["Parameters"]
+
+    def test_publish_is_best_effort_and_still_reaches_the_check(self, eod):
+        st = eod["PublishCadenceReadDegraded"]
+        assert st["Next"] == "CheckExerciseCadence"
+        catch = st["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "CheckExerciseCadence"
+
+
+class TestCheckExerciseCadence:
+    def _choice(self, eod, value):
+        return next(c for c in eod["CheckExerciseCadence"]["Choices"] if c.get("StringEquals") == value)
+
+    def test_daily_launches(self, eod):
+        assert self._choice(eod, "daily")["Next"] == "LaunchWeeklyExerciseRun"
+
+    @pytest.mark.parametrize("value", ["weekly-only", "off"])
+    def test_weekly_only_and_off_skip_to_the_launchs_own_success_target(self, eod, value):
+        """Must be LaunchWeeklyExerciseRun's OWN Next on success — never
+        WeeklyExerciseLaunchFailed's routing, which exists only to alert when
+        the launch is ATTEMPTED and fails. Skipping the launch is not a
+        launch failure."""
+        assert self._choice(eod, value)["Next"] == eod["LaunchWeeklyExerciseRun"]["Next"]
+        assert self._choice(eod, value)["Next"] == "CheckDegradedOutcome"
+
+    def test_variable_is_the_read_result(self, eod):
+        for c in eod["CheckExerciseCadence"]["Choices"]:
+            assert c["Variable"] == "$.exercise_cadence_param.value"
+
+    def test_default_is_the_unknown_value_path_not_a_silent_skip(self, eod):
+        assert eod["CheckExerciseCadence"]["Default"] == "SetCadenceUnknownValueDegraded"
+
+    def test_all_three_declared_values_are_distinct_branches(self, eod):
+        values = {c.get("StringEquals") for c in eod["CheckExerciseCadence"]["Choices"]}
+        assert values == {"daily", "weekly-only", "off"}
+
+
+class TestUnknownValueFailsOpenAndPages:
+    def test_floors_to_daily_and_preserves_the_offending_raw_value(self, eod):
+        st = eod["SetCadenceUnknownValueDegraded"]
+        assert st["Type"] == "Pass"
+        assert st["Parameters"]["value"] == "daily"
+        assert st["Parameters"]["raw.$"] == "$.exercise_cadence_param.value"
+        assert st["ResultPath"] == "$.exercise_cadence_param"
+        assert st["Next"] == "PublishCadenceUnknownValueDegraded"
+
+    def test_publish_names_the_offending_value_and_uses_the_hardcoded_topic(self, eod):
+        st = eod["PublishCadenceUnknownValueDegraded"]
+        assert st["Resource"] == "arn:aws:states:::sns:publish"
+        assert st["Parameters"]["TopicArn"] == _ALERTS_TOPIC_ARN
+        assert "TopicArn.$" not in st["Parameters"]
+        assert "$.exercise_cadence_param.raw" in st["Parameters"]["Message.$"]
+
+    def test_unknown_value_still_launches_after_alerting(self, eod):
+        """Decided posture (config#6689): treat as daily AND page — a missed
+        run is worse than an extra one, but 'ran on garbage input' must never
+        look identical to 'ran because cadence=daily was read correctly.'"""
+        st = eod["PublishCadenceUnknownValueDegraded"]
+        assert st["Next"] == "LaunchWeeklyExerciseRun"
+        catch = st["Catch"][0]
+        assert catch["ErrorEquals"] == ["States.ALL"]
+        assert catch["Next"] == "LaunchWeeklyExerciseRun"
+
+
+class TestNoDanglingReferences:
+    def test_every_new_state_next_target_resolves(self, eod):
+        new_states = [
+            "ReadExerciseCadence", "SetCadenceReadDegraded", "PublishCadenceReadDegraded",
+            "CheckExerciseCadence", "SetCadenceUnknownValueDegraded", "PublishCadenceUnknownValueDegraded",
+        ]
+        names = set(eod)
+        for state_name in new_states:
+            assert state_name in eod
+            st = eod[state_name]
+            targets = []
+            if st.get("Next"):
+                targets.append(st["Next"])
+            if st.get("Default"):
+                targets.append(st["Default"])
+            for c in st.get("Choices", []) or []:
+                if c.get("Next"):
+                    targets.append(c["Next"])
+            for c in st.get("Catch", []) or []:
+                if c.get("Next"):
+                    targets.append(c["Next"])
+            dangling = [t for t in targets if t not in names]
+            assert not dangling, f"{state_name} references unresolvable target(s): {dangling}"
+
+    def test_none_of_the_new_states_route_to_handle_failure(self, eod):
+        new_states = [
+            "ReadExerciseCadence", "SetCadenceReadDegraded", "PublishCadenceReadDegraded",
+            "CheckExerciseCadence", "SetCadenceUnknownValueDegraded", "PublishCadenceUnknownValueDegraded",
+        ]
+        for state_name in new_states:
+            st = eod[state_name]
+            for c in st.get("Catch", []) or []:
+                assert c["Next"] != "HandleFailure", f"{state_name}'s Catch must not fail postclose itself"

--- a/tests/test_sf_weekly_exercise_chain_wiring.py
+++ b/tests/test_sf_weekly_exercise_chain_wiring.py
@@ -33,8 +33,18 @@ def weekly() -> dict:
 
 def test_postclose_tail_routes_through_the_exercise_launch(eod):
     """StopTradingInstance is the cost guard and always runs — chaining after
-    it means the exercise run fires on both the green and degraded paths."""
-    assert eod["StopTradingInstance"]["Next"] == "LaunchWeeklyExerciseRun"
+    it means the exercise run fires on both the green and degraded paths.
+    alpha-engine-config-I6689 inserted the declared-cadence read + gate
+    (ReadExerciseCadence -> CheckExerciseCadence) ahead of the launch itself,
+    so this is now a three-hop path on the cadence=daily branch — pinned in
+    full (including the fail-open routes) by
+    tests/test_sf_weekly_cadence_wiring.py."""
+    assert eod["StopTradingInstance"]["Next"] == "ReadExerciseCadence"
+    assert eod["ReadExerciseCadence"]["Next"] == "CheckExerciseCadence"
+    daily_choice = next(
+        c for c in eod["CheckExerciseCadence"]["Choices"] if c.get("StringEquals") == "daily"
+    )
+    assert daily_choice["Next"] == "LaunchWeeklyExerciseRun"
     assert eod["LaunchWeeklyExerciseRun"]["Next"] == "CheckDegradedOutcome"
 
 

--- a/tests/test_weekly_cadence_drift.py
+++ b/tests/test_weekly_cadence_drift.py
@@ -1,0 +1,172 @@
+"""The declared weekly exercise-cadence must stay a record, not a comment.
+
+alpha-engine-config#6689: before this file, the weekly pipeline's exercise
+cadence lived on TWO uncoordinated surfaces (an SF Choice hardcoded in
+step_function_eod.json, no declared parameter anywhere) — flipping daily<->
+weekly meant an SF-topology edit. infrastructure/weekly_cadence.json is now
+the single declared source; infrastructure/weekly_cadence_drift.py verifies
+it against the live SSM copy the SF actually reads, mirroring
+automation_pause.py's two-directional check.
+
+These tests pin: the manifest parses and declares an allowed value with
+documented meaning for all three (§1); the drift script both directions
+(missing-in-aws / value-mismatch) plus the AccessDenied-is-not-absence
+guard (§2, the same failure mode automation_pause.py's _live_state guards
+against); deploy-infrastructure.sh actually invokes --enforce in the same
+step that updates the postclose SF (§3); the SF definition itself
+(§4, structural).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INFRA = REPO_ROOT / "infrastructure"
+MANIFEST_PATH = INFRA / "weekly_cadence.json"
+MODULE_PATH = INFRA / "weekly_cadence_drift.py"
+DEPLOY_SCRIPT = INFRA / "deploy-infrastructure.sh"
+
+ALLOWED_VALUES = {"daily", "weekly-only", "off"}
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("weekly_cadence_drift", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["weekly_cadence_drift"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def module():
+    return _load_module()
+
+
+# ── §1: manifest shape ──────────────────────────────────────────────────────
+
+def test_manifest_declares_an_allowed_value(manifest):
+    assert manifest["exercise_cadence"] in ALLOWED_VALUES
+
+
+def test_manifest_declares_daily_unchanged_by_this_change(manifest):
+    """config#6689 changes the MECHANISM, never the cadence itself — the
+    value stays 'daily' (alpha-engine-config#5489, Brian ruling 2026-07-29)."""
+    assert manifest["exercise_cadence"] == "daily"
+
+
+def test_allowed_values_field_matches_the_real_allowed_set(manifest):
+    assert set(manifest["allowed_values"]) == ALLOWED_VALUES
+
+
+def test_every_allowed_value_has_documented_meaning(manifest):
+    meaning = manifest["_meaning"]
+    for value in ALLOWED_VALUES:
+        assert meaning.get(value, "").strip(), f"{value} has no documented meaning"
+
+
+def test_meaning_names_the_ruling_and_the_issue(manifest):
+    daily_meaning = manifest["_meaning"]["daily"]
+    assert "5489" in daily_meaning, "the daily-cadence ruling (#5489) is not referenced"
+    assert "6689" in manifest["_provenance"], "the mechanism issue (#6689) is not referenced"
+
+
+# ── §2: drift script, both directions ───────────────────────────────────────
+
+def test_declared_cadence_returns_the_manifest_value(module):
+    assert module.declared_cadence() == "daily"
+
+
+def test_declared_cadence_rejects_an_invalid_value(module, tmp_path):
+    bad = tmp_path / "weekly_cadence.json"
+    bad.write_text(json.dumps({"exercise_cadence": "hourly"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        module.declared_cadence(module.load_manifest(bad))
+
+
+def test_check_reports_missing_in_aws_when_param_absent(module, monkeypatch):
+    monkeypatch.setattr(module, "_live_value", lambda: None)
+    findings = module.check()
+    assert len(findings) == 1
+    assert findings[0]["kind"] == "missing-in-aws"
+
+
+def test_check_reports_value_mismatch(module, monkeypatch):
+    monkeypatch.setattr(module, "_live_value", lambda: "weekly-only")
+    findings = module.check()
+    assert len(findings) == 1
+    assert findings[0]["kind"] == "value-mismatch"
+    assert "weekly-only" in findings[0]["detail"]
+    assert "daily" in findings[0]["detail"]
+
+
+def test_check_is_clean_when_manifest_matches_live(module, monkeypatch):
+    monkeypatch.setattr(module, "_live_value", lambda: "daily")
+    assert module.check() == []
+
+
+def test_access_denied_is_not_read_as_absence(module, monkeypatch):
+    """The same failure mode automation_pause.py's _live_state guards
+    against: a permissions error read as 'not deployed yet' would let this
+    check grade itself green by losing its own access."""
+    def _boom(*_a, **_k):
+        return (254, "", "An error occurred (AccessDenied) when calling the GetParameter operation")
+    monkeypatch.setattr(module, "_aws", _boom)
+    with pytest.raises(RuntimeError, match="AccessDenied"):
+        module._live_value()
+
+
+def test_enforce_writes_when_live_differs(module, monkeypatch):
+    calls = []
+    monkeypatch.setattr(module, "_live_value", lambda: "off")
+
+    def _fake_aws(args):
+        calls.append(args)
+        return (0, "", "")
+
+    monkeypatch.setattr(module, "_aws", _fake_aws)
+    wrote = module.enforce()
+    assert wrote is True
+    assert calls and calls[0][:2] == ["ssm", "put-parameter"]
+    assert "daily" in calls[0]
+
+
+def test_enforce_is_a_noop_when_already_in_sync(module, monkeypatch):
+    monkeypatch.setattr(module, "_live_value", lambda: "daily")
+    monkeypatch.setattr(module, "_aws", lambda args: pytest.fail("should not call aws when already in sync"))
+    assert module.enforce() is False
+
+
+# ── §3: deploy wiring ────────────────────────────────────────────────────────
+
+def test_deploy_infrastructure_invokes_enforce_after_the_eod_sf_update():
+    src = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    assert "weekly_cadence_drift.py" in src and "--enforce" in src, (
+        "deploy-infrastructure.sh does not sync the declared cadence to SSM — "
+        "a manifest edit alone would never reach the live parameter the SF reads"
+    )
+    # Must run AFTER the EOD SF definition is updated, not before — otherwise a
+    # deploy could push a new SF definition that reads a stale parameter value
+    # for however long the rest of the script takes.
+    eod_update_idx = src.index('update_or_create "$EOD_ARN"')
+    sync_idx = src.index("weekly_cadence_drift.py")
+    assert eod_update_idx < sync_idx
+
+
+def test_deploy_infrastructure_sync_step_is_not_conditionally_skipped():
+    """The section this line lives in (### 3a) must run unconditionally on
+    every deploy — a merge-cadence flip should never depend on a flag."""
+    src = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    section = src.split("# ── 3a. Sync the declared weekly exercise-cadence", 1)[1]
+    section = section.split("# ── 3b.", 1)[0]
+    assert "if " not in section and "if [" not in section

--- a/tests/test_weekly_sf_silence_deadman.py
+++ b/tests/test_weekly_sf_silence_deadman.py
@@ -1,0 +1,369 @@
+"""weekly_sf_silence_deadman.py — the silence deadman for the weekly
+pipeline's two trigger roles (alpha-engine-config#6689 deliverable 3,
+resolving #5599).
+
+Structured in three layers, each tested at its own layer so a boto3 mock
+never has to stand in for calendar or classification logic:
+
+  1. Expected-slot derivation (pure calendar math — no AWS, no executions).
+  2. Slot <-> execution matching (pure — takes pre-built ExecutionRecords,
+     including the WeeklyRunDayGateChoice no-op-vs-real-run distinction).
+  3. CLI plumbing (boto3 mocked at the client-factory level) — the
+     --no-notify flag and the exit-code contract.
+
+The measured-shape regression (`TestMeasured20260805And0806Shape`) replays
+the exact failure this script exists to catch: postclose never fired at all
+on 2026-08-05/08-06, with zero signal anywhere else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "weekly_sf_silence_deadman.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("weekly_sf_silence_deadman", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["weekly_sf_silence_deadman"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+# nousergon_lib.trading_calendar re-exports krepis's NYSE calendar — reuse
+# directly rather than faking it, since the whole point of #6689's slot
+# derivation is to agree with the SAME calendar the live SF gates use.
+from nousergon_lib.trading_calendar import is_trading_day, next_trading_day  # noqa: E402
+
+
+def _utc(d: date, hour: int = 21) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: expected-slot derivation
+# ---------------------------------------------------------------------------
+
+class TestLastSessionOfWeek:
+    def test_friday_is_last_session_on_a_normal_week(self, mod):
+        # 2026-08-07 is a Friday; 2026-08-10 (next trading day) is Monday —
+        # a different ISO week.
+        assert mod._is_last_session_of_week(date(2026, 8, 7), is_trading_day, next_trading_day) is True
+
+    def test_wednesday_is_not_last_session(self, mod):
+        assert mod._is_last_session_of_week(date(2026, 8, 5), is_trading_day, next_trading_day) is False
+
+    def test_a_weekend_day_is_not_a_session_at_all(self, mod):
+        assert mod._is_last_session_of_week(date(2026, 8, 8), is_trading_day, next_trading_day) is False
+
+
+class TestComputeExpectedSlots:
+    def test_daily_cadence_expects_exercise_on_every_trading_day_ungated(self, mod):
+        today = date(2026, 8, 9)  # Sunday
+        slots = mod.compute_expected_slots(today, "daily", 5, is_trading_day, next_trading_day)
+        exercise_days = {s.day for s in slots if s.role == "exercise"}
+        assert exercise_days == {date(2026, 8, 4), date(2026, 8, 5), date(2026, 8, 6), date(2026, 8, 7)}
+        assert all(not s.gated_off for s in slots if s.role == "exercise")
+
+    def test_weekly_only_gates_every_exercise_slot(self, mod):
+        today = date(2026, 8, 9)
+        slots = mod.compute_expected_slots(today, "weekly-only", 5, is_trading_day, next_trading_day)
+        exercise = [s for s in slots if s.role == "exercise"]
+        assert exercise  # still derived — just gated
+        assert all(s.gated_off for s in exercise)
+
+    def test_off_gates_every_exercise_slot(self, mod):
+        today = date(2026, 8, 9)
+        slots = mod.compute_expected_slots(today, "off", 5, is_trading_day, next_trading_day)
+        exercise = [s for s in slots if s.role == "exercise"]
+        assert exercise
+        assert all(s.gated_off for s in exercise)
+
+    def test_weekly_slot_is_never_gated_by_cadence(self, mod):
+        """The knob has exactly one insertion point (the exercise launch);
+        the Saturday cron is untouched regardless of the declared value."""
+        today = date(2026, 8, 9)
+        for cadence in ("daily", "weekly-only", "off"):
+            slots = mod.compute_expected_slots(today, cadence, 5, is_trading_day, next_trading_day)
+            weekly = [s for s in slots if s.role == "weekly"]
+            assert weekly and all(not s.gated_off for s in weekly), cadence
+
+    def test_weekly_slot_lands_the_day_after_the_last_session(self, mod):
+        """Friday 2026-08-07 is the week's last session; the real weekly run
+        (WeeklyRunDayGateChoice self-gated true) lands 2026-08-08 (Saturday) —
+        deliberately the day AFTER the session, not the session day itself.
+        See this script's module docstring for why this refines the filing
+        issue's 'weekly for the week's last session' wording."""
+        today = date(2026, 8, 9)
+        slots = mod.compute_expected_slots(today, "daily", 5, is_trading_day, next_trading_day)
+        weekly_days = {s.day for s in slots if s.role == "weekly"}
+        assert date(2026, 8, 8) in weekly_days
+        assert date(2026, 8, 7) not in weekly_days
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: slot <-> execution matching
+# ---------------------------------------------------------------------------
+
+class TestEvaluateSlot:
+    def test_gated_off_is_ok_without_touching_executions(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 5), role="exercise", gated_off=True, note="gated")
+        result = mod.evaluate_slot(slot, executions=[])
+        assert result.classification == "GATED_OFF"
+
+    def test_exercise_ok_when_a_matching_execution_exists(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 4), role="exercise")
+        execs = [mod.ExecutionRecord(name="abc", role="exercise", status="SUCCEEDED",
+                                      start=_utc(date(2026, 8, 4)), stop=_utc(date(2026, 8, 4), 22))]
+        result = mod.evaluate_slot(slot, execs)
+        assert result.classification == "OK"
+        assert result.matched_execution == "abc"
+
+    def test_exercise_critical_when_absent(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 5), role="exercise")
+        result = mod.evaluate_slot(slot, executions=[])
+        assert result.classification == "CRITICAL"
+
+    def test_exercise_ignores_a_weekly_role_execution_on_the_same_day(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 8), role="exercise")
+        execs = [mod.ExecutionRecord(name="weekly1", role="weekly", status="SUCCEEDED",
+                                      start=_utc(date(2026, 8, 8)), stop=_utc(date(2026, 8, 8), 23))]
+        assert mod.evaluate_slot(slot, execs).classification == "CRITICAL"
+
+    def test_weekly_ok_with_a_real_run(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 8), role="weekly")
+        start = _utc(date(2026, 8, 8), 9)
+        execs = [mod.ExecutionRecord(name="w1", role="weekly", status="SUCCEEDED",
+                                      start=start, stop=start + timedelta(hours=3))]
+        result = mod.evaluate_slot(slot, execs)
+        assert result.classification == "OK"
+        assert result.matched_execution == "w1"
+
+    def test_weekly_critical_when_only_the_run_day_gate_noop_exists(self, mod):
+        """A 2-second SUCCEEDED weekly-role execution is
+        WeeklyRunDayGateChoice's designed skip on a non-run day, not a real
+        run — counting it as 'ran' would hide a genuinely silent week."""
+        slot = mod.ExpectedSlot(day=date(2026, 8, 8), role="weekly")
+        start = _utc(date(2026, 8, 8), 9)
+        execs = [mod.ExecutionRecord(name="noop", role="weekly", status="SUCCEEDED",
+                                      start=start, stop=start + timedelta(seconds=2))]
+        result = mod.evaluate_slot(slot, execs)
+        assert result.classification == "CRITICAL"
+        assert "no-op" in result.detail
+
+    def test_weekly_critical_when_nothing_at_all(self, mod):
+        slot = mod.ExpectedSlot(day=date(2026, 8, 8), role="weekly")
+        assert mod.evaluate_slot(slot, executions=[]).classification == "CRITICAL"
+
+    def test_weekly_real_run_status_need_not_be_succeeded(self, mod):
+        """Existence, not success, is what the SILENCE deadman checks — a
+        FAILED weekly execution is a different (already-alerted) problem, but
+        it is not SILENCE."""
+        slot = mod.ExpectedSlot(day=date(2026, 8, 8), role="weekly")
+        start = _utc(date(2026, 8, 8), 9)
+        execs = [mod.ExecutionRecord(name="w1", role="weekly", status="FAILED",
+                                      start=start, stop=start + timedelta(hours=1))]
+        assert mod.evaluate_slot(slot, execs).classification == "OK"
+
+
+class TestNormalizeRole:
+    @pytest.mark.parametrize("raw,expected", [
+        ("exercise", "exercise"),
+        ("weekly", "weekly"),
+        ("operator-replay", None),
+        ("watch-rerun", None),
+        (None, None),
+        ("", None),
+    ])
+    def test_only_the_two_declared_roles_pass_through(self, mod, raw, expected):
+        assert mod.normalize_role(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Measured-shape regression: 2026-08-05 / 2026-08-06 (postclose never fired)
+# ---------------------------------------------------------------------------
+
+class TestMeasured20260805And0806Shape:
+    """Replays alpha-engine-config#6689's filing evidence: postclose FAILED
+    before the launch state on 07-27/07-28 and never fired AT ALL on
+    08-05/08-06 — silence, not failure, with zero prior signal. cadence=daily
+    throughout (the value in effect when this was measured, and unchanged by
+    this PR)."""
+
+    TODAY = date(2026, 8, 9)
+
+    def _executions(self, mod):
+        # Real exercise runs on the trading days that DID chain successfully.
+        return [
+            _record(mod, "e0804", "exercise", "SUCCEEDED", date(2026, 8, 4)),
+            _record(mod, "e0807", "exercise", "SUCCEEDED", date(2026, 8, 7)),
+            # A real weekly run landed on the gate day (Saturday 08-08) — this
+            # regression is scoped to the exercise silence, not the weekly leg.
+            _record(mod, "w0808", "weekly", "SUCCEEDED", date(2026, 8, 8), hours=3),
+        ]
+
+    def test_the_two_silent_days_are_critical(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "daily", 5, is_trading_day, next_trading_day)
+        results = {(r.slot.day, r.slot.role): r.classification for r in mod.evaluate(slots, self._executions(mod))}
+        assert results[(date(2026, 8, 5), "exercise")] == "CRITICAL"
+        assert results[(date(2026, 8, 6), "exercise")] == "CRITICAL"
+
+    def test_the_days_that_actually_ran_are_ok(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "daily", 5, is_trading_day, next_trading_day)
+        results = {(r.slot.day, r.slot.role): r.classification for r in mod.evaluate(slots, self._executions(mod))}
+        assert results[(date(2026, 8, 4), "exercise")] == "OK"
+        assert results[(date(2026, 8, 7), "exercise")] == "OK"
+        assert results[(date(2026, 8, 8), "weekly")] == "OK"
+
+    def test_exactly_two_criticals_fleet_wide_in_this_window(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "daily", 5, is_trading_day, next_trading_day)
+        results = mod.evaluate(slots, self._executions(mod))
+        critical = [r for r in results if r.classification == "CRITICAL"]
+        assert len(critical) == 2
+        assert {(r.slot.day, r.slot.role) for r in critical} == {
+            (date(2026, 8, 5), "exercise"), (date(2026, 8, 6), "exercise"),
+        }
+
+
+class TestWeeklyOnlyCadenceShape:
+    """No exercise runs at all — every exercise slot is a designed gate-off,
+    not silence. The weekly leg is unaffected and still separately checked."""
+
+    TODAY = date(2026, 8, 9)
+
+    def test_exercise_slots_are_gated_off_not_critical(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "weekly-only", 5, is_trading_day, next_trading_day)
+        results = mod.evaluate(slots, executions=[])
+        exercise_results = [r for r in results if r.slot.role == "exercise"]
+        assert exercise_results
+        assert all(r.classification == "GATED_OFF" for r in exercise_results)
+
+    def test_weekly_slot_is_still_checked_and_critical_when_silent(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "weekly-only", 5, is_trading_day, next_trading_day)
+        results = mod.evaluate(slots, executions=[])
+        weekly_results = [r for r in results if r.slot.role == "weekly"]
+        assert weekly_results and all(r.classification == "CRITICAL" for r in weekly_results)
+
+    def test_no_gated_off_result_ever_publishes(self, mod):
+        slots = mod.compute_expected_slots(self.TODAY, "weekly-only", 5, is_trading_day, next_trading_day)
+        results = mod.evaluate(slots, executions=[_record(mod, "w0808", "weekly", "SUCCEEDED", date(2026, 8, 8), hours=3)])
+        critical = [r for r in results if r.classification == "CRITICAL"]
+        assert not critical  # weekly ran; exercise is gated-off — nothing to page
+
+
+def _record(mod, name, role, status, day, hours=1):
+    start = _utc(day, 21)
+    stop = start + timedelta(hours=hours)
+    return mod.ExecutionRecord(name=name, role=role, status=status, start=start, stop=stop)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: CLI plumbing (boto3 mocked)
+# ---------------------------------------------------------------------------
+
+class _FakeSF:
+    def __init__(self, executions):
+        self._executions = executions
+
+    def list_executions(self, **kwargs):
+        return {"executions": self._executions, "nextToken": None}
+
+    def describe_execution(self, executionArn):
+        for e in self._executions:
+            if e["executionArn"] == executionArn:
+                return {"input": json.dumps({"pipeline_role": e["_role"]})}
+        raise KeyError(executionArn)
+
+
+class _FakeSNS:
+    def __init__(self):
+        self.published = []
+
+    def publish(self, **kwargs):
+        self.published.append(kwargs)
+        return {}
+
+
+def _fake_execution(name, role, status, day, hours=1):
+    start = _utc(day, 21)
+    stop = start + timedelta(hours=hours)
+    return {
+        "executionArn": f"arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:{name}",
+        "name": name,
+        "status": status,
+        "startDate": start,
+        "stopDate": stop,
+        "_role": role,
+    }
+
+
+class TestMainCLI:
+    def _patch_boto3(self, monkeypatch, mod, executions, sns):
+        import boto3
+        fake_sf = _FakeSF(executions)
+
+        def _client(service, region_name=None):
+            if service == "stepfunctions":
+                return fake_sf
+            if service == "sns":
+                return sns
+            if service == "ssm":
+                raise AssertionError("ssm should not be called without --live")
+            raise AssertionError(f"unexpected client: {service}")
+
+        monkeypatch.setattr(boto3, "client", _client)
+        monkeypatch.setattr(mod, "load_cadence_from_manifest", lambda: "daily")
+        monkeypatch.setattr(mod, "_today", lambda: date(2026, 8, 9))
+
+    def test_exit_zero_when_every_expected_slot_is_covered(self, mod, monkeypatch, capsys):
+        # today=2026-08-09, window=5 -> exercise slots on 08-04..08-07, weekly
+        # slot on 08-08 (day after the week's last session, 08-07).
+        execs = [
+            _fake_execution("e0804", "exercise", "SUCCEEDED", date(2026, 8, 4)),
+            _fake_execution("e0805", "exercise", "SUCCEEDED", date(2026, 8, 5)),
+            _fake_execution("e0806", "exercise", "SUCCEEDED", date(2026, 8, 6)),
+            _fake_execution("e0807", "exercise", "SUCCEEDED", date(2026, 8, 7)),
+            _fake_execution("w0808", "weekly", "SUCCEEDED", date(2026, 8, 8), hours=3),
+        ]
+        sns = _FakeSNS()
+        self._patch_boto3(monkeypatch, mod, execs, sns)
+        rc = mod.main(["--window-days", "5", "--no-notify"])
+        assert rc == 0
+        assert sns.published == []
+
+    def test_critical_triggers_sns_publish_by_default(self, mod, monkeypatch):
+        sns = _FakeSNS()
+        self._patch_boto3(monkeypatch, mod, executions=[], sns=sns)
+        rc = mod.main(["--window-days", "10"])
+        assert rc == 1
+        assert len(sns.published) == 1
+        assert sns.published[0]["TopicArn"] == mod.SNS_TOPIC_ARN
+
+    def test_no_notify_suppresses_the_publish_but_exit_code_is_unchanged(self, mod, monkeypatch):
+        sns = _FakeSNS()
+        self._patch_boto3(monkeypatch, mod, executions=[], sns=sns)
+        rc = mod.main(["--window-days", "10", "--no-notify"])
+        assert rc == 1
+        assert sns.published == []
+
+    def test_json_output_is_valid_json(self, mod, monkeypatch, capsys):
+        sns = _FakeSNS()
+        self._patch_boto3(monkeypatch, mod, executions=[], sns=sns)
+        mod.main(["--window-days", "3", "--no-notify", "--json"])
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["cadence"] == "daily"
+        assert "results" in parsed


### PR DESCRIPTION
## What & why

Mechanism half of `alpha-engine-config-I6689` (Part of alpha-engine-config#6689). Before this PR the weekly pipeline's exercise cadence lived on two uncoordinated surfaces (an EventBridge cron + a hardcoded `states:startExecution` inside `step_function_eod.json`) — flipping daily<->weekly meant an SF-topology edit, and 4 of 10 trading days (07-27, 07-28, 08-05, 08-06) got no exercise run with zero signal because the only deadman candidate (`AWS/States` `ExecutionsStarted`) carries no `pipeline_role` dimension.

- **`infrastructure/weekly_cadence.json`** — single declared source, `exercise_cadence: daily | weekly-only | off`. Value stays `daily` (alpha-engine-config#5489, Brian ruling 2026-07-29) — this PR changes the mechanism, never the cadence itself.
- **`infrastructure/deploy-infrastructure.sh` §3a** — syncs the manifest to SSM (`/alpha-engine/weekly-sf/exercise-cadence`, String) in the same step that updates the postclose SF definition.
- **`infrastructure/weekly_cadence_drift.py`** — two-directional manifest-vs-live-SSM check, mirroring `automation_pause.py`'s shape (`--check` / `--enforce`).
- **`infrastructure/step_function_eod.json`** — `ReadExerciseCadence` -> `CheckExerciseCadence` inserted ahead of `LaunchWeeklyExerciseRun`. `daily` -> launches (unchanged behavior); `weekly-only`/`off` -> skip straight to `LaunchWeeklyExerciseRun`'s own success target (`CheckDegradedOutcome`), `WeeklyExerciseLaunchFailed` routing untouched. Both failure modes (SSM read failure, unrecognized value) fail OPEN to `daily` and page via a best-effort SNS alert (`PublishCadenceReadDegraded` / `PublishCadenceUnknownValueDegraded`) — a missed exercise run is worse than an extra one, per weekly-sf-policy §5's run-day-gate precedent.
- **`scripts/weekly_sf_silence_deadman.py`** — resolves `alpha-engine-config#5599`. Derives expected exercise/weekly run-slots from the declared cadence + `nousergon_lib.trading_calendar`, checks `ne-weekly-freshness-pipeline`'s own execution history (role read from each execution's input, not its name — nothing sets an explicit `Name`), and distinguishes "gated off" (OK) from "expected and absent" (CRITICAL, exit 1, best-effort SNS page). **Supersedes the CloudWatch `ExecutionsStarted` metric-dimension approach proposed in #5599** — that metric carries no `pipeline_role` dimension and cannot make this distinction at all; recommend closing #5599 as superseded by this script.

## One-line-flip demonstration

Flipping the cadence to `weekly-only` (NOT applied — demonstration only):

```diff
--- a/infrastructure/weekly_cadence.json
+++ b/infrastructure/weekly_cadence.json
@@ -1,5 +1,5 @@
 {
-  "exercise_cadence": "daily",
+  "exercise_cadence": "weekly-only",
```

No SF-topology edit, no `deploy_step_function.sh`/`deploy-infrastructure.sh` code change — the merge alone flips the live gate on the next deploy.

## IAM (measured 2026-08-09, not fixed in this PR)

None of the three identities that touch `/alpha-engine/weekly-sf/exercise-cadence` currently have a grant on it (`git -C nous-ergon-ops grep -rn "GetParameter\|PutParameter" -- infrastructure/iam/` against each role's policy file):

1. `alpha-engine-step-functions-role` needs `ssm:GetParameter` (ReadExerciseCadence).
2. `github-actions-lambda-deploy` needs `ssm:GetParameter` + `ssm:PutParameter` (weekly_cadence_drift.py --enforce, called from deploy-infrastructure.sh).
3. `github-actions-iam-drift-check` needs `ssm:GetParameter` (future --check CI wiring — not wired in this PR, see Deviations).

IAM is owned by `nous-ergon-ops` (infrastructure-ownership-policy.md §35) — not edited here. Filed as **alpha-engine-config-I6701** with the exact grants. **This PR is safe to merge without that grant landing first** — every failure mode fails open to the pre-existing `daily` behavior and pages, so postclose's own reliability is unaffected either way. The cadence knob itself (flipping to `weekly-only`/`off`) will not take effect live until I6701's grant #1 lands.

## Merge order

`nousergon-lib-PR295` must merge FIRST. It registers `PublishCadenceReadDegraded` / `PublishCadenceUnknownValueDegraded` in `nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE` (both use `sns:publish`, a substantive resource) — required by `tests/test_pipeline_status_registry_source_check.py` (alpha-engine-config#2480 source-side guard), which currently fails CI on this branch for exactly that reason. Once nousergon-lib-PR295 merges and tags, this PR's `requirements.txt` / `Dockerfile` / `requirements-daily-news.txt` `nousergon-lib` pin needs bumping to that tag in the same class of follow-up as the `nousergon-lib#226` precedent (v0.124.8) — I will push that bump once the tag exists.

## Deviations from the design

1. **Weekly slot day**: the filing issue says "weekly for the week's last session"; the deadman actually expects the real weekly run on `last_session + 1 calendar day` (the day `WeeklyRunDayGateChoice` self-gates true — Saturday on a normal week, Fri/Thu on a holiday-shortened one). Documented in the script's own module docstring and covered by `test_weekly_slot_lands_the_day_after_the_last_session`.
2. **`weekly_cadence_drift.py --check` not wired into `sf-arn-drift-check.yml`** in this PR — wiring it now would just always AccessDeny for the same reason `ReadExerciseCadence` would (see IAM section); deferred to alpha-engine-config-I6701 alongside the grant. `deploy-infrastructure.sh`'s `--enforce` call is the live-checked path in this PR.
3. **No scheduling/EventBridge for the deadman script** (automation pause, alpha-engine-config#6617) — `scripts/weekly_sf_silence_deadman.py` is manual-invocation only; CI/cron wiring deferred, tracked implicitly by the automation-pause ruling's own re-examination trigger.

## Test plan

Full repo suite, run locally before pushing (all extras installed):

```
$ pytest -q
4311 passed, 8 skipped, 1 failed in 81.61s
FAILED tests/test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[EOD-json_path2]
```

The one failure is the expected, gated cross-repo dependency (see Merge order) — resolves automatically once `nousergon-lib-PR295` merges and the pin bumps in a same-day follow-up push. Every other test, including the 5 pre-existing SF-wiring test files this PR had to update for the new topology (`test_sf_eod_skipgate_wiring.py`, `test_sf_eod_precondition_probe_wiring.py`, `test_sf_weekly_exercise_chain_wiring.py`, `test_sf_payload_uniqueness.py`), plus 3 new test files (`test_sf_weekly_cadence_wiring.py`, `test_weekly_cadence_drift.py`, `test_weekly_sf_silence_deadman.py` — including a regression fixture replaying the measured 2026-08-05/08-06 silent-postclose shape), is green.

## Rehearsal path

`infrastructure/run_weekly_offcycle.sh` does NOT exercise this change — that script drives the weekly SF itself, not postclose. Per weekly-sf-policy §7.2: the postclose change (`ReadExerciseCadence`/`CheckExerciseCadence`) is exercised by every trading day's real postclose run once merged (fail-open to today's behavior either way, so the very first run after merge is a live rehearsal with no blast radius). Structural correctness is pinned by `tests/test_sf_weekly_cadence_wiring.py` (19 tests: read failure, unknown-value, and daily/weekly-only/off routing, all Next-target resolution, HandleFailure isolation).

## Repo template

**Deploy-mechanism:** `deploy-infrastructure.yml` (runs `deploy-infrastructure.sh` on every push to main — syncs the cadence manifest to SSM in §3a, alongside the existing SF-definition update).

Closes-when: nousergon-lib-PR295 merged + pin bumped here, alpha-engine-config-I6701's grant #1 landed, a synthetic silent day pages via `weekly_sf_silence_deadman.py`, alpha-engine-config#5599 closed as superseded.

Part of alpha-engine-config#6689. Blocked-by: nousergon-lib-PR295.

Prepared by: Claude Sonnet 4.5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_weekly_cadence_wiring.py (structural + wiring assertions over the exact step_function_eod.json path; the change is additionally exercised by every trading day's postclose run — the chained launch IS the rehearsal surface)
