### PR TITLE
fix(sf): a ReportCard failure must never terminate the weekly SF at plain NotifyComplete (config#6685)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 krepis>=0.14.0

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -4269,13 +4269,20 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Advisory grading is non-fatal \u2014 continue to the terminal notify regardless. config#2302: the run must still PAGE on entry (silent for 9 days pre-fix), so route through PublishReportCardDegraded before the terminal notify rather than swallowing the error.",
-          "Next": "PublishReportCardDegraded",
+          "Comment": "Advisory grading is non-fatal \u2014 continue to the terminal notify regardless. config#2302: the run must still PAGE on entry (silent for 9 days pre-fix), so route through ReportCardDegraded (sets the SF-controlled visible flag) then PublishReportCardDegraded before the terminal notify rather than swallowing the error. config#6685: pre-fix this Catch skipped straight to the alert Task with NO flag set, so a clean gate/health run still terminated at plain NotifyComplete (\"All steps completed successfully\") \u2014 weekly-sf-policy.md \u00a72.3 violation; the standalone alert is not the terminal notification.",
+          "Next": "ReportCardDegraded",
           "ResultPath": "$.report_card_error"
         }
       ],
       "ResultPath": "$.report_card_result",
       "Next": "Director"
+    },
+    "ReportCardDegraded": {
+      "Type": "Pass",
+      "Comment": "config#6685: ReportCard's Catch(States.ALL) could not run advisory grading \u2014 set report_card_degraded=true (SF-controlled boolean, IsPresent-guarded per config#2275) so it threads into the completion-email selection (CheckGateDegradedNotify) same as $.gate_degraded / $.health_check_degraded. Mirrors LibPinGateDegraded / SaturdayHealthCheckDegraded shape exactly. Proceeds to PublishReportCardDegraded (the immediate PAGE alert, config#2302) unchanged.",
+      "Result": true,
+      "ResultPath": "$.report_card_degraded",
+      "Next": "PublishReportCardDegraded"
     },
     "PublishReportCardDegraded": {
       "Type": "Task",
@@ -4357,8 +4364,50 @@
     },
     "CheckGateDegradedNotify": {
       "Type": "Choice",
-      "Comment": "config#2278 + config#2276: a green run that could not run its pre-spend gates (gate_degraded \u2014 set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states) and/or its tail health checks (health_check_degraded \u2014 set ONLY by the SaturdayHealthCheckDegraded / SubstrateHealthCheckDegraded Pass states) must SAY SO in the completion email. Both are SF-controlled booleans, IsPresent-guarded per config#2275. Rules are ordered most-specific-first (both \u2192 gates-only \u2192 health-only); each routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing flags into NotifyComplete \u2014 preserving config#1819's Subject/Message-are-constants invariant. Composition note (config#2276): the two health checks share ONE flag (which check degraded lives on the execution record), so the enumeration is bounded at 3 degraded notifiers for the 2 flag families; a THIRD flag family should trigger a refactor to a data-driven degraded notifier, not a 7-way enumeration. Name retained from config#2278 (it is the wave-1 chain anchor referenced across tests/comments) \u2014 read it as the degraded-completion selector.",
+      "Comment": "config#2278 + config#2276 + config#6685: a green run that could not run its pre-spend gates (gate_degraded \u2014 set ONLY by the LibPinGateDegraded / PipelineContractGateDegraded Pass states), and/or its tail health checks (health_check_degraded \u2014 set ONLY by the SaturdayHealthCheckDegraded / SubstrateHealthCheckDegraded Pass states), and/or ReportCard's advisory grading (report_card_degraded \u2014 set ONLY by ReportCardDegraded, config#6685) must SAY SO in the completion email (weekly-sf-policy.md \u00a72.3). All three are SF-controlled booleans, IsPresent-guarded per config#2275. Rules are ordered most-specific-first: report_card_degraded combined with EITHER other family routes to the single generic NotifyCompleteMultipleDegraded (config#6685 \u2014 this is the config#2276 comment's predicted 'third flag family': rather than the 7-way enumeration a naive 3-flag cross-product would need, any report_card_degraded+other combination folds into ONE combined notifier whose Message names report card explicitly and points at the execution record for which other family also degraded, instead of enumerating all 4 additional combinations as separate hardcoded Task states); the pre-existing gates+health / gates-only / health-only rules are UNCHANGED (each still implies report_card_degraded is absent, since any report_card_degraded-true path is intercepted by the two rules ahead of them); report_card_degraded alone (gate/health both absent) gets its own single-flag notifier (NotifyCompleteReportCardDegraded) mirroring NotifyCompleteGatesDegraded/NotifyCompleteHealthDegraded exactly. Each still routes to a SEPARATE hardcoded-constant notifier rather than States.Format-ing flags into NotifyComplete \u2014 preserving config#1819's Subject/Message-are-constants invariant. Name retained from config#2278 (it is the wave-1 chain anchor referenced across tests/comments) \u2014 read it as the degraded-completion selector.",
       "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.report_card_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.report_card_degraded",
+              "BooleanEquals": true
+            },
+            {
+              "Variable": "$.gate_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.gate_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyCompleteMultipleDegraded"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.report_card_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.report_card_degraded",
+              "BooleanEquals": true
+            },
+            {
+              "Variable": "$.health_check_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.health_check_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyCompleteMultipleDegraded"
+        },
         {
           "And": [
             {
@@ -4405,6 +4454,19 @@
             }
           ],
           "Next": "NotifyCompleteHealthDegraded"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.report_card_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.report_card_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "NotifyCompleteReportCardDegraded"
         }
       ],
       "Default": "NotifyComplete"
@@ -4475,9 +4537,53 @@
       ],
       "Next": "WriteCompletionMarker"
     },
+    "NotifyCompleteReportCardDegraded": {
+      "Type": "Task",
+      "Comment": "config#6685: SUCCESS notifier for a run whose ReportCard advisory grading was DEGRADED (Lambda failure — PublishReportCardDegraded already paged on entry; this is the terminal completion notice) and neither pre-spend gates nor tail health checks were. Mirrors NotifyCompleteGatesDegraded/NotifyCompleteHealthDegraded exactly — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (report card DEGRADED)",
+        "Message": "All steps completed successfully — BUT ReportCard (the Evaluator Report Card v2 Lambda, advisory grading) failed and did not run; a report-card-degraded alert fired earlier in this run. See $.report_card_error on the execution record for detail. The weekly run's real trading artifacts are unaffected; only the advisory grading layer (report_card.json, and downstream Director) did not run. View pipeline status: https://console.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.notify_result",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "ResultPath": "$.notify_error",
+          "Next": "NotifyCompleteDegraded"
+        }
+      ],
+      "Next": "WriteCompletionMarker"
+    },
+    "NotifyCompleteMultipleDegraded": {
+      "Type": "Task",
+      "Comment": "config#6685: SUCCESS notifier for a run where ReportCard's advisory grading was DEGRADED TOGETHER WITH one or both of the pre-spend gates and/or the tail health checks. Folded (config#2276's own comment predicted a third flag family would need a data-driven notifier rather than a 7-way enumeration): a single generic combined-degradation notifier for every report_card_degraded+other combination, instead of 4 additional hardcoded per-combination Task states. Names report card explicitly (weekly-sf-policy.md §2.3 requires naming), points at the execution record for which OTHER family also degraded rather than enumerating every combination in prose. Mirrors NotifyCompleteGatesDegraded's shape — constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline — SUCCESS (multiple stages DEGRADED, incl. report card)",
+        "Message": "All steps completed successfully — BUT ReportCard (advisory grading) was DEGRADED on this run, ALONG WITH one or more pre-spend gates and/or tail health checks. Exact combination is on the execution record: $.gate_degraded / $.health_check_degraded / $.report_card_degraded, with detail at $.report_card_error and (if set) $.health_check_error / $.substrate_check_error. View pipeline status: https://console.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.notify_result",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 — best-effort: a SUCCESS-path notifier must never fail an otherwise-succeeded pipeline.",
+          "ResultPath": "$.notify_error",
+          "Next": "NotifyCompleteDegraded"
+        }
+      ],
+      "Next": "WriteCompletionMarker"
+    },
     "WriteCompletionMarker": {
       "Type": "Task",
-      "Comment": "config#2857: SF-envelope completion marker — an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine: a hung/failed SF must not be indistinguishable from a healthy one just because a prior run already wrote today's downstream artifacts). Converges the 5 real-completion notify paths (NotifyComplete, its degraded-catch fallback, and the 3 gate/health-degraded variants) — deliberately EXCLUDES NotifyShellRunComplete/NotifyShellRunCompleteDegraded (the Friday-PM preflight dry-pass is not a real weekly completion; marking it would let a dry run silently satisfy the SLA). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_weekly_freshness_pipeline (cadence saturday_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable — exactly the ambiguity this feature exists to surface, not mask.",
+      "Comment": "config#2857: SF-envelope completion marker — an end-of-SF terminal artifact, independent of downstream pipeline deliverables, that proves THIS Step Functions execution reached its real success terminal (config#1724 independent-signal doctrine: a hung/failed SF must not be indistinguishable from a healthy one just because a prior run already wrote today's downstream artifacts). Converges the 7 real-completion notify paths (NotifyComplete, its degraded-catch fallback, the 3 gate/health-degraded variants, and the 2 report-card-degraded variants added config#6685) — deliberately EXCLUDES NotifyShellRunComplete/NotifyShellRunCompleteDegraded (the Friday-PM preflight dry-pass is not a real weekly completion; marking it would let a dry run silently satisfy the SLA). Registered in ARTIFACT_REGISTRY.yaml as sf_completion_ne_weekly_freshness_pipeline (cadence saturday_sf). No swallow-all Catch here (unlike the SNS notifiers' config#1819 pattern): Retry covers transient S3 faults, but a marker that genuinely cannot be written means this execution's own completion is unverifiable — exactly the ambiguity this feature exists to surface, not mask.",
       "Resource": "arn:aws:states:::aws-sdk:s3:putObject",
       "Parameters": {
         "Bucket": "alpha-engine-research",

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.39
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.40
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -351,9 +351,15 @@ STAGES: tuple[Stage, ...] = (
         # NormalizeFailureContext → FailExecution). PublishDirectorDegraded
         # is RETAINED for backward compatibility with pre-fix execution
         # histories that still reference it — new executions never enter it.
+        # config#6685: ReportCardDegraded is the new Pass state ReportCard's
+        # Catch routes to FIRST (sets $.report_card_degraded before
+        # proceeding, unchanged, to PublishReportCardDegraded) — added
+        # alongside it so a rerun does not treat a ReportCard-degraded
+        # execution as complete.
         degraded_witness=frozenset({
             "SaturdayHealthCheckDegraded", "SubstrateHealthCheckDegraded",
-            "PublishReportCardDegraded", "PublishDirectorDegraded",
+            "ReportCardDegraded", "PublishReportCardDegraded",
+            "PublishDirectorDegraded",
         }),
         note=(
             "skip_post_eval covers the whole health-check/report-card/"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -868,13 +868,15 @@ class TestConsolidatedNotify:
     def test_substrate_check_routes_to_notify_gate(self, states):
         # The substrate check flows into two advisory states (evaluator
         # Report Card v2, then the Director) before the notify gate. ReportCard's
-        # SUCCESS Next feeds the Director; its Catch routes to
+        # SUCCESS Next feeds the Director; its Catch routes to ReportCardDegraded
+        # (config#6685: sets $.report_card_degraded so it threads into the
+        # terminal-notify selection) which then continues, unchanged, to
         # PublishReportCardDegraded (config#2302: a WARNING page — advisory grading
-        # failed silently for 9 days pre-fix) which then continues to
-        # CheckShellRunNotify. The Director's own Next lands on CheckShellRunNotify
-        # on success. config#6408 (Brian's 2026-08-04 operator ruling): Director's
-        # Catch now routes to NormalizeFailureContext — a Director failure
-        # terminates the execution FAILED.
+        # failed silently for 9 days pre-fix) and on to CheckShellRunNotify. The
+        # Director's own Next lands on CheckShellRunNotify on success. config#6408
+        # (Brian's 2026-08-04 operator ruling): Director's Catch now routes to
+        # NormalizeFailureContext — a Director failure terminates the execution
+        # FAILED.
         # The path to the notify gate is preserved when grading succeeds and
         # advisory succeeds. On the Friday preflight the states still RUN (dry,
         # see test_advisory_tail_runs_dry_on_preflight) — they are not skipped —
@@ -893,7 +895,8 @@ class TestConsolidatedNotify:
         assert substrate_success["Next"] == "ReportCard"
         report_card = states["ReportCard"]
         assert report_card["Next"] == "Director"
-        assert all(c["Next"] == "PublishReportCardDegraded" for c in report_card["Catch"])
+        assert all(c["Next"] == "ReportCardDegraded" for c in report_card["Catch"])
+        assert states["ReportCardDegraded"]["Next"] == "PublishReportCardDegraded"
         assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
         director = states["Director"]
         assert director["Next"] == "CheckShellRunNotify"

--- a/tests/test_sf_report_card_degraded_wiring.py
+++ b/tests/test_sf_report_card_degraded_wiring.py
@@ -1,0 +1,211 @@
+"""alpha-engine-config#6685 — a ReportCard failure must never terminate the
+weekly SF at plain ``NotifyComplete`` ("All steps completed successfully").
+
+Pre-fix: ``ReportCard``'s ``Catch(States.ALL)`` routed straight to
+``PublishReportCardDegraded`` (a standalone, best-effort SNS PAGE alert) and
+then continued to ``CheckShellRunNotify`` → ``CheckGateDegradedNotify``,
+which branched ONLY on ``$.gate_degraded`` / ``$.health_check_degraded``. A
+ReportCard failure on an otherwise-clean run (both of those absent) fell
+through the ``Default`` edge straight to ``NotifyComplete`` — the terminal
+notification never named ReportCard as degraded, violating
+weekly-sf-policy.md §2.3 ("a pipeline reaching NotifyComplete having
+degraded any stage must say so, by name, in the notification"). The
+Director had the identical shape; Brian ruled 2026-08-04
+(alpha-engine-config#6408) that a Director failure is terminal instead
+(nousergon-data#1233). ReportCard is advisory-only (non-fatal by design —
+see ReportCard's own Comment), so the fix here is the OTHER shape: make the
+degradation VISIBLE in the terminal notify, not fail the execution.
+
+Shape pinned here (mirrors test_sf_prespend_gate_alerting.py /
+test_sf_health_check_honesty_wiring.py):
+  1. ``ReportCard``'s Catch now routes to a new ``ReportCardDegraded`` Pass
+     state (mirrors ``LibPinGateDegraded`` / ``SaturdayHealthCheckDegraded``
+     shape) which sets ``$.report_card_degraded: true`` before continuing,
+     unchanged, to ``PublishReportCardDegraded`` (the immediate PAGE alert,
+     config#2302).
+  2. ``report_card_degraded`` threads into ``CheckGateDegradedNotify``
+     alongside the pre-existing ``gate_degraded`` / ``health_check_degraded``
+     flags. Per that Choice state's own config#2276 comment predicting this
+     exact moment ("a THIRD flag family should trigger a refactor to a
+     data-driven degraded notifier, not a 7-way enumeration"), the fix FOLDS
+     rather than enumerates: any combination of report_card_degraded with
+     EITHER other family routes to one generic ``NotifyCompleteMultipleDegraded``
+     (names report card explicitly, points at the execution record for
+     which other family also fired) instead of 4 additional per-combination
+     hardcoded Task states; report_card_degraded alone gets its own
+     single-flag notifier ``NotifyCompleteReportCardDegraded`` mirroring
+     ``NotifyCompleteGatesDegraded`` / ``NotifyCompleteHealthDegraded``
+     exactly. The pre-existing gates/health-only rules are untouched.
+  3. The hard invariant this module exists to assert: for EVERY one of the
+     8 boolean combinations of (gate_degraded, health_check_degraded,
+     report_card_degraded), a payload with report_card_degraded=true NEVER
+     resolves to plain ``NotifyComplete``, and always resolves to a notifier
+     whose Subject/Message names "report card".
+"""
+from __future__ import annotations
+
+import itertools
+import json
+import pathlib
+
+import pytest
+
+_WEEKLY = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_WEEKLY.read_text())["States"]
+
+
+# ---------------------------------------------------------------------------
+# ReportCard's Catch sets the flag before alerting (config#6685)
+# ---------------------------------------------------------------------------
+
+
+def test_report_card_catch_routes_through_degraded_pass(states):
+    (catch,) = states["ReportCard"]["Catch"]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "ReportCardDegraded", (
+        "ReportCard's Catch must set the degraded flag via ReportCardDegraded, "
+        f"not {catch['Next']!r} — a direct jump to the alert Task is the exact "
+        "silent-terminal-notify gap config#6685 closed"
+    )
+    assert catch["ResultPath"] == "$.report_card_error"
+
+
+def test_report_card_degraded_pass_shape_and_proceeds_to_publish(states):
+    st = states["ReportCardDegraded"]
+    assert st["Type"] == "Pass"
+    assert st["Result"] is True
+    assert st["ResultPath"] == "$.report_card_degraded"
+    # Fail-soft: set the flag, then proceed to the existing PAGE alert
+    # (config#2302) unchanged.
+    assert st["Next"] == "PublishReportCardDegraded"
+
+
+def test_only_report_card_degraded_pass_sets_the_flag(states):
+    """SF-controlled: exactly one Pass state may write
+    $.report_card_degraded (mirror of test_only_health_degraded_passes_set_
+    health_check_degraded in test_sf_health_check_honesty_wiring.py)."""
+    writers = [
+        name for name, st in states.items()
+        if st.get("ResultPath") == "$.report_card_degraded"
+    ]
+    assert writers == ["ReportCardDegraded"]
+
+
+def test_publish_report_card_degraded_unchanged_downstream(states):
+    """The existing immediate PAGE alert (config#2302) still fires and still
+    proceeds to CheckShellRunNotify — this fix adds a flag upstream of it,
+    it does not change its own wiring."""
+    st = states["PublishReportCardDegraded"]
+    assert st["Next"] == "CheckShellRunNotify"
+    (catch,) = st["Catch"]
+    assert catch["Next"] == "CheckShellRunNotify"
+
+
+# ---------------------------------------------------------------------------
+# The hard invariant: no path from ReportCard's Catch reaches plain
+# NotifyComplete, for every combination of the three degraded flags.
+# ---------------------------------------------------------------------------
+
+
+def _notify_target(states, data: dict) -> str:
+    """Evaluate the CheckShellRunNotify -> CheckGateDegradedNotify selection
+    with ASL short-circuit semantics against a partial payload. Flat
+    IsPresent-guarded And-rules only (no Or-in-And) — matches this SF's
+    established style throughout CheckGateDegradedNotify."""
+    def eval_rule(rule):
+        if "And" in rule:
+            return all(eval_rule(op) for op in rule["And"])
+        var = rule["Variable"].lstrip("$.")
+        present = var in data
+        if "IsPresent" in rule:
+            return present == rule["IsPresent"]
+        assert present, f"unguarded dereference of {var} in drill payload {data}"
+        return data[var] == rule["BooleanEquals"]
+
+    cur = "CheckShellRunNotify"
+    while states[cur]["Type"] == "Choice":
+        for rule in states[cur]["Choices"]:
+            if eval_rule(rule):
+                cur = rule["Next"]
+                break
+        else:
+            cur = states[cur]["Default"]
+    return cur
+
+
+_FLAG_COMBOS = [
+    dict(zip(("gate_degraded", "health_check_degraded", "report_card_degraded"), bits))
+    for bits in itertools.product([True, False], repeat=3)
+]
+
+
+@pytest.mark.parametrize("combo", _FLAG_COMBOS, ids=lambda c: (
+    "g" if c["gate_degraded"] else "-")
+    + ("h" if c["health_check_degraded"] else "-")
+    + ("r" if c["report_card_degraded"] else "-")
+)
+def test_report_card_degraded_never_reaches_plain_notify_complete(states, combo):
+    # A Choice payload only carries the flags that are actually set — an
+    # absent flag is IsPresent-guarded, not present-as-false.
+    payload = {k: True for k, v in combo.items() if v}
+    target = _notify_target(states, payload)
+    if combo["report_card_degraded"]:
+        assert target != "NotifyComplete", (
+            f"payload {payload} reached plain NotifyComplete — a ReportCard "
+            "degradation must always surface in the terminal notification "
+            "(weekly-sf-policy.md §2.3)"
+        )
+        assert target in (
+            "NotifyCompleteReportCardDegraded", "NotifyCompleteMultipleDegraded",
+        )
+        subject = states[target]["Parameters"]["Subject"]
+        message = states[target]["Parameters"]["Message"]
+        assert "report card" in subject.lower() or "report card" in message.lower(), (
+            f"{target}'s Subject/Message must name ReportCard as degraded, by name"
+        )
+    else:
+        assert target not in (
+            "NotifyCompleteReportCardDegraded", "NotifyCompleteMultipleDegraded",
+        )
+
+
+# ---------------------------------------------------------------------------
+# The two new notify states mirror the established config#1819 shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("notifier", [
+    "NotifyCompleteReportCardDegraded", "NotifyCompleteMultipleDegraded",
+])
+def test_new_notifiers_mirror_config_1819_shape(states, notifier):
+    st = states[notifier]
+    assert st["Type"] == "Task"
+    assert st["Resource"] == "arn:aws:states:::sns:publish"
+    assert st["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
+    # config#1819: constants only — no States.Format against state fields.
+    assert "Subject.$" not in st["Parameters"]
+    assert "Message.$" not in st["Parameters"]
+    subject = st["Parameters"]["Subject"]
+    assert "SUCCESS" in subject and "DEGRADED" in subject
+    assert 0 < len(subject) <= 100
+    assert "\n" not in subject
+    # config#2857: converges into the SF-envelope completion marker.
+    assert "End" not in st
+    assert st["Next"] == "WriteCompletionMarker"
+    (catch,) = st["Catch"]
+    assert catch["ErrorEquals"] == ["States.ALL"]
+    assert catch["Next"] == "NotifyCompleteDegraded"
+
+
+def test_report_card_only_subject_names_report_card(states):
+    subject = states["NotifyCompleteReportCardDegraded"]["Parameters"]["Subject"]
+    assert "report card" in subject.lower()
+
+
+def test_multiple_degraded_subject_names_report_card(states):
+    subject = states["NotifyCompleteMultipleDegraded"]["Parameters"]["Subject"]
+    assert "report card" in subject.lower()

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -78,6 +78,8 @@ _TIMEOUT_EXEMPT: dict[str, dict[str, str]] = {
         "NotifyCompleteGatesDegraded": "sns:publish completion notifier — SDK call, not a wait",
         "NotifyCompleteHealthDegraded": "sns:publish completion notifier — SDK call, not a wait",
         "NotifyCompleteGatesAndHealthDegraded": "sns:publish completion notifier — SDK call, not a wait",
+        "NotifyCompleteReportCardDegraded": "sns:publish completion notifier — SDK call, not a wait (config#6685)",
+        "NotifyCompleteMultipleDegraded": "sns:publish completion notifier — SDK call, not a wait (config#6685)",
         "NotifyShellRunComplete": "sns:publish completion notifier — SDK call, not a wait",
         "NotifyComplete": "sns:publish completion notifier — SDK call, not a wait",
         "HandleFailure": "sns:publish failure notifier — SDK call, not a wait",

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -101,17 +101,21 @@ class TestChainOrdering:
         # Two advisory states (evaluator Report Card v2, then the Director)
         # sit between the substrate poll and the notify gate. ReportCard's
         # SUCCESS edge feeds the Director (which weighs the fresh card);
-        # ReportCard's Catch routes to PublishReportCardDegraded (config#2302:
-        # a WARNING alert — advisory grading failed silently for 9 days pre-fix)
-        # which then continues to notify (no card to weigh). The Director's own
-        # Next lands on CheckShellRunNotify on success. config#6408 (Brian's
-        # 2026-08-04 operator ruling): Director's Catch now routes to
-        # NormalizeFailureContext — a Director failure terminates the execution
-        # FAILED rather than reporting degraded success.
+        # ReportCard's Catch routes to ReportCardDegraded (config#6685: sets
+        # $.report_card_degraded so it threads into the terminal-notify
+        # selection) which then continues, unchanged, to
+        # PublishReportCardDegraded (config#2302: a WARNING alert — advisory
+        # grading failed silently for 9 days pre-fix) and on to notify (no
+        # card to weigh). The Director's own Next lands on CheckShellRunNotify
+        # on success. config#6408 (Brian's 2026-08-04 operator ruling):
+        # Director's Catch now routes to NormalizeFailureContext — a
+        # Director failure terminates the execution FAILED rather than
+        # reporting degraded success.
         assert states["ReportCard"]["Next"] == "Director"
         assert all(
-            c["Next"] == "PublishReportCardDegraded" for c in states["ReportCard"]["Catch"]
+            c["Next"] == "ReportCardDegraded" for c in states["ReportCard"]["Catch"]
         )
+        assert states["ReportCardDegraded"]["Next"] == "PublishReportCardDegraded"
         assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
         assert states["Director"]["Next"] == "CheckShellRunNotify"
         assert all(


### PR DESCRIPTION
## What & why

Closes alpha-engine-config-I6685 (`Part of alpha-engine-config#6685`).

weekly-sf-policy.md §2.3: a pipeline reaching `NotifyComplete` having degraded any stage must say so, by name, in the terminal notification. Measured 2026-08-09: `ReportCard`'s `Catch(States.ALL)` routed straight to the standalone `PublishReportCardDegraded` PAGE alert (config#2302) and then continued `CheckShellRunNotify` → `CheckGateDegradedNotify`, which branched ONLY on `$.gate_degraded` / `$.health_check_degraded`. A ReportCard failure on an otherwise-clean run fell through to plain `NotifyComplete` — "All steps completed successfully" — with the degradation carried only by the earlier standalone alert.

The Director had the identical shape; Brian ruled 2026-08-04 (alpha-engine-config#6408) that a Director failure is terminal instead — implemented in **nousergon-data#1233 (merged)**. ReportCard is advisory-only (non-fatal by design), so this PR is the *other* shape: make the degradation VISIBLE in the terminal notify, not fail the execution.

### Design

- `ReportCard`'s Catch now routes to a new `ReportCardDegraded` Pass state (mirrors `LibPinGateDegraded` / `SaturdayHealthCheckDegraded`) that sets `$.report_card_degraded` before proceeding, unchanged, to `PublishReportCardDegraded`.
- `CheckGateDegradedNotify`: `report_card_degraded` threads in alongside the existing two flags. Per that Choice's own config#2276 comment predicting this exact moment ("a third flag family should trigger a refactor to a data-driven degraded notifier, not a 7-way enumeration") — and coordinating with the derived-totality design intent of **alpha-engine-config#5950** — any `report_card_degraded` combination with an OTHER family folds into one generic `NotifyCompleteMultipleDegraded` (names report card, points at the execution record for which other family also fired) instead of enumerating the 4 additional 3-flag combinations as separate hardcoded Task states. `report_card_degraded` alone gets its own `NotifyCompleteReportCardDegraded`, mirroring `NotifyCompleteGatesDegraded`/`NotifyCompleteHealthDegraded` exactly. **The pre-existing gates/health-only rules are unchanged.** Chosen over full ASL-native derivation (a single state literally interpolating all 3 flags via `States.Format`) because that would require floor-defaulting all three flags before the Choice and would replace 3 well-tested, well-commented existing notify states — larger blast radius for a rare corner case (report card degrading in the SAME run as a gate/health issue) than this fold.
- `tests/test_sf_report_card_degraded_wiring.py` (new): asserts, for all 8 boolean combinations of the three degraded flags, that `report_card_degraded=true` never resolves to plain `NotifyComplete` and always resolves to a notifier naming "report card" by name — the structural test alpha-engine-config#6685 calls for.

### Fixture/test updates for the `ReportCard.Catch.Next` rename (`PublishReportCardDegraded` → `ReportCardDegraded`)
`tests/test_sf_friday_shell_run_wiring.py`, `tests/test_sf_substrate_check_wiring.py`, `scripts/weekly_sf_rerun.py` (`STAGES` `degraded_witness`), `tests/test_sf_structural_contract.py` (`_TIMEOUT_EXEMPT` entries for the 2 new sns:publish notify Tasks — same exemption every other notify Task in this file already carries).

## Cross-repo dependency — BLOCKED on nousergon-lib#296

`tests/test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday]` requires every substantive Task state to have a `nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE` entry, sourced from the pinned `nousergon-lib` version — per that test's own docstring: *"Add each state to the registry in nousergon-lib... merge that lib PR... then bump this repo's requirements.txt pin in the SAME PR that adds the state — do not merge the SF JSON change ahead of the registry entry."*

**nousergon-lib-PR296** (https://github.com/nousergon/nousergon-lib/pull/296, green CI, ready for review) adds the two required entries (`NotifyCompleteReportCardDegraded`, `NotifyCompleteMultipleDegraded`). It cannot be self-merged (no standing auto-merge exception applies to a registry addition). **Unblock sequence:**
1. Brian merges nousergon-lib#296.
2. `auto-version-bump.yml` tags the new patch version on merge.
3. Bump this PR's `requirements.txt` pin to that tag (fast-follow commit on this branch — not a separate PR, per the source test's own instruction).
4. `test_pipeline_status_registry_source_check.py` goes green; this PR flips out of draft.

This is a deviation from "zero tolerance" for local test failures before push: the one remaining failure is a genuine, documented cross-repo sequencing dependency (not a shortcut or an unrelated pre-existing gap) — the robust fix (companion registry PR) is done and green, only the merge+pin-bump step is outside this session's authority.

## Merge order

Independent of **nousergon-data#1230** (adds `WeeklyPreflight` states to `step_function.json`) and **nousergon-data#1257** (touches `step_function_eod.json` only). This PR's diff is confined to the `ReportCard` Catch path and the `CheckGateDegradedNotify`/terminal-notify region — whichever of #1230/this PR lands second rebases trivially. #1257 touches a different file entirely.

## Test plan

Full local suite (repo venv, nousergon-lib v0.124.39 installed):
```
4337 passed, 8 skipped, 1 failed (test_pipeline_status_registry_source_check.py — see cross-repo dependency above)
```
Focused new module: `tests/test_sf_report_card_degraded_wiring.py` — 16 passed.
Re-ran `tests/test_sf_structural_contract.py tests/test_sf_health_check_honesty_wiring.py tests/test_sf_notifier_totality_wiring.py tests/test_sf_prespend_gate_alerting.py tests/test_sf_completion_marker_wiring.py tests/test_artifact_registry_coverage.py` in isolation (95 passed) and with `-p no:randomly` — no order-dependent flakes observed.

## Deploy-mechanism

SF definition auto-applies via `deploy-infrastructure.yml` on merge — no manual apply.

## Rehearsal-path

Rehearsal-path: infrastructure/run_weekly_offcycle.sh

Per weekly-sf-policy.md §7 — the shell run exercises the `ReportCard` stage; a forced `ReportCard` failure on that rehearsal path will now terminate at `NotifyCompleteReportCardDegraded`, not plain `NotifyComplete`.

## Known non-required check

`drift-check` will be red by-design on this SF-changing PR (definition differs from live pre-merge) — not a required check (required: `test`, `gate-label-guard`, `iam-policy-change-guard`).

Prepared by: Claude Sonnet 4.5 via [Claude Code](https://claude.com/claude-code)
