### PR TITLE
fix(sf-watch): derive the actual failing state from history, not the shared Fail funnel

### DIFF
--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -310,10 +310,19 @@ OPERATOR_ABORT_ERRORS = frozenset({"OperatorAbort"})
 # pile-on that motivated the original config#2003 blanket suppression is
 # bounded by the config#2269 per-day dispatch ceiling + the charter's
 # same-error escalation rule for BOTH rerun kinds now, not a name-based guard.
-# Bound the history scan: fetch the newest N events (reverseOrder), reconstruct
-# chronological order locally to find the entered-but-not-exited state. The
+# Bound the history scan: fetch the newest N events per page (reverseOrder),
+# reconstruct chronological order locally to find the culprit state. The
 # failed state's enclosing StateEntered is always in the tail of the history.
 _HISTORY_MAX_EVENTS = 1000
+# alpha-engine-config-I6616: a single reverseOrder page can miss the culprit
+# state on a long-running execution (Map/Parallel fan-out, many retries). Page
+# BACKWARD (reverseOrder=True + nextToken) up to this many pages — never
+# forward-paginate with a fixed page cap, which is the earlier sf-digest bug
+# class (it hit a 20-page cap walking forward and rendered "(no workload
+# states in history)" instead of degrading honestly). 5 * 1000 = 5000 events
+# is a generous bound for a fleet SF execution; still finite, per the issue's
+# "bound the walk sensibly" ask.
+_HISTORY_MAX_PAGES = 5
 
 
 def _sf_client():
@@ -469,41 +478,296 @@ def _is_preflight(describe_resp: dict | None) -> bool:
     return bool(payload.get("shell_run"))
 
 
-def _failed_state_from_history(execution_arn: str) -> str | None:
-    """Return the name of the state that was active (entered, not yet exited)
-    when the execution failed — i.e. the culprit state.
+# alpha-engine-config-I6616 fallback ONLY — used when the watched state
+# machine's own definition cannot be fetched/parsed (permissions, throttling,
+# a malformed ASL doc). The daily pipeline's known names are still correct
+# for 2 of the 3 fleet SFs and strictly better than treating nothing as a
+# funnel state; NEVER the sole/primary mechanism (see
+# ``_failure_handling_states`` — the real derivation reads the definition
+# being watched, so the weekly/postclose pipelines' own terminal-state names
+# are handled without hardcoding them here too).
+_DEFAULT_FAILURE_HANDLING_STATES = frozenset({"HandleFailure", "FailExecution"})
 
-    Fetches the newest ``_HISTORY_MAX_EVENTS`` events (reverseOrder), reverses
-    them to chronological order, and tracks the entered-but-not-exited state via
-    a forward scan. A state that fails enters but never cleanly exits, so it is
-    the one left dangling at the terminal failure event. Best-effort: returns
-    ``None`` on any API error (recorded in the artifact).
-    """
-    if not execution_arn:
+# Minimal ASL Choice-rule comparators (alpha-engine-config-I6616 deliverable
+# 2): every comparator this fleet's SF definitions actually use as of
+# 2026-08. Add more here (not a bespoke parallel evaluator) if a future
+# definition needs one — TimestampEquals/StringLessThan/etc. are NOT
+# implemented; an unrecognized comparator simply fails to match (never raises,
+# never fabricates a match).
+_ASL_COMPARATORS = {
+    "BooleanEquals": lambda a, b: isinstance(a, bool) and a is b,
+    "StringEquals": lambda a, b: a == b,
+    "NumericEquals": lambda a, b: a is not None and a == b,
+    "NumericGreaterThan": lambda a, b: a is not None and a > b,
+    "NumericGreaterThanEquals": lambda a, b: a is not None and a >= b,
+    "NumericLessThan": lambda a, b: a is not None and a < b,
+    "NumericLessThanEquals": lambda a, b: a is not None and a <= b,
+}
+
+
+def _describe_state_machine_states(state_machine_arn: str) -> dict | None:
+    """Best-effort: the ASL ``States`` mapping for ``state_machine_arn``, or
+    ``None`` on any failure. One ``describe_state_machine`` call, reused by
+    both the failure-handling-set derivation and the Choice-detail lookup
+    below — never a per-purpose duplicate call."""
+    if not state_machine_arn:
         return None
     try:
-        resp = _sf_client().get_execution_history(
-            executionArn=execution_arn,
-            maxResults=_HISTORY_MAX_EVENTS,
-            reverseOrder=True,
-            includeExecutionData=False,
+        resp = _sf_client().describe_state_machine(stateMachineArn=state_machine_arn)
+        definition = json.loads(resp.get("definition") or "")
+    except Exception as exc:  # noqa: BLE001 — enrichment, degrades to the default sink
+        logger.warning(
+            "describe_state_machine/definition parse failed for %s: %s — "
+            "falling back to the known daily-pipeline failure-handling names",
+            state_machine_arn, exc,
         )
+        return None
+    states = definition.get("States") if isinstance(definition, dict) else None
+    return states if isinstance(states, dict) else None
+
+
+def _failure_handling_states(states: dict | None) -> frozenset[str]:
+    """The terminal failure-handling state set for a state machine: every
+    ``Type: Fail`` state, plus any state whose ONLY transition is an
+    unconditional ``Next`` DIRECTLY into one of those Fail states — one relay
+    hop, not a transitive closure. A ``Choice`` state is NEVER added — by
+    definition it can route to more than one place, which is exactly why it
+    is a genuine culprit (e.g. ``DeployDriftGate``) rather than a
+    failure-handling relay (e.g. ``HandleFailure``).
+
+    Deliberately non-transitive: measured against all three live fleet
+    definitions (``step_function_daily.json``, ``step_function.json``
+    (saturday/weekly), ``step_function_eod.json``), the funnel is always
+    exactly one relay hop (``HandleFailure``/``ForceStopInstance``/etc. ->
+    their own Fail state) — genuinely diagnostic upstream states
+    (``CodeFreshnessPollTimeout``, ``MorningPlannerPollTimeout``,
+    ``StampMorningPlannerUnresponsive``, ...) ALSO have an unconditional
+    single ``Next`` that eventually reaches the same Fail state, but only
+    via ANOTHER relay (``HandleFailure``) in between. A transitive/fixed-point
+    closure would sweep those genuinely diagnostic states into the funnel too
+    — exactly the loss of discriminating power the issue exists to fix, just
+    one layer further back. Capping at one hop keeps every real upstream
+    diagnostic state reportable as its own culprit.
+
+    Derived from the DEFINITION BEING WATCHED (alpha-engine-config-I6616
+    Gotcha #2) — the weekly and postclose pipelines use their own
+    terminal-state names, never assumed to be ``HandleFailure``/
+    ``FailExecution``. Falls back to ``_DEFAULT_FAILURE_HANDLING_STATES`` only
+    when the definition itself could not be read (see
+    ``_describe_state_machine_states``); an empty-but-real definition (no Fail
+    state at all) resolves to that same default harmlessly, since neither
+    name will match anything in a differently-shaped definition.
+    """
+    if not states:
+        return _DEFAULT_FAILURE_HANDLING_STATES
+    fail_states = {
+        name for name, s in states.items()
+        if isinstance(s, dict) and s.get("Type") == "Fail"
+    }
+    sink = set(fail_states)
+    for name, s in states.items():
+        if name in sink or not isinstance(s, dict):
+            continue
+        nxt = s.get("Next")
+        if nxt and "Choices" not in s and nxt in fail_states:
+            sink.add(name)
+    return frozenset(sink) or _DEFAULT_FAILURE_HANDLING_STATES
+
+
+def _resolve_json_path(data, path: str):
+    """Minimal ``$.a.b.c`` dot-path resolver — every ``Variable`` in this
+    fleet's ASL Choice rules is a plain dot-path (no array/filter syntax).
+    Returns ``None`` on any missing segment or non-dict traversal."""
+    if not isinstance(path, str) or not path.startswith("$"):
+        return None
+    cur = data
+    remainder = path[1:].lstrip(".")
+    for seg in remainder.split(".") if remainder else []:
+        if not isinstance(cur, dict) or seg not in cur:
+            return None
+        cur = cur[seg]
+    return cur
+
+
+def _eval_choice_rule(rule: dict, data) -> bool:
+    """Evaluate one ASL Choice rule (incl. And/Or/Not composites) against the
+    state's captured input. Best-effort within the caller's try/except — an
+    unrecognized comparator (not in ``_ASL_COMPARATORS``) simply fails to
+    match rather than raising."""
+    if "And" in rule:
+        return all(_eval_choice_rule(r, data) for r in rule["And"])
+    if "Or" in rule:
+        return any(_eval_choice_rule(r, data) for r in rule["Or"])
+    if "Not" in rule:
+        return not _eval_choice_rule(rule["Not"], data)
+    path = rule.get("Variable")
+    if path is None:
+        return False
+    value = _resolve_json_path(data, path)
+    if "IsPresent" in rule:
+        return (value is not None) == bool(rule["IsPresent"])
+    for op, comparator in _ASL_COMPARATORS.items():
+        if op in rule:
+            return comparator(value, rule[op])
+    return False
+
+
+def _describe_choice_rule(rule: dict) -> str:
+    """Render a matched Choice rule as the compact ``variable op value``
+    string surfaced in ``failed_state_detail`` (e.g.
+    ``drift_result.Payload.has_drift BooleanEquals True``)."""
+    if "And" in rule:
+        return " AND ".join(_describe_choice_rule(r) for r in rule["And"])
+    if "Or" in rule:
+        return " OR ".join(_describe_choice_rule(r) for r in rule["Or"])
+    if "Not" in rule:
+        return f"NOT ({_describe_choice_rule(rule['Not'])})"
+    path = rule.get("Variable", "?")
+    if "IsPresent" in rule:
+        return f"{path} IsPresent={rule['IsPresent']}"
+    for op in _ASL_COMPARATORS:
+        if op in rule:
+            return f"{path} {op} {rule[op]}"
+    return str(path)
+
+
+def _matched_choice_rule(
+    states: dict | None, culprit: str | None, choice_input, sink: frozenset[str],
+) -> str | None:
+    """For a Choice-type culprit, the specific rule whose ``Next`` routes into
+    the failure-handling set AND evaluates True against the captured input —
+    deliverable 2's "condition that matched and the input field it read".
+    ``None`` (never a guess) when the definition, input, or a matching rule is
+    unavailable."""
+    if not states or not culprit or not isinstance(choice_input, dict):
+        return None
+    state = states.get(culprit) or {}
+    if state.get("Type") != "Choice":
+        return None
+    for choice in state.get("Choices") or []:
+        if choice.get("Next") not in sink:
+            continue
+        try:
+            if _eval_choice_rule(choice, choice_input):
+                return _describe_choice_rule(choice)
+        except Exception:  # noqa: BLE001 — best-effort detail, never blocks the state name
+            continue
+    return None
+
+
+def _failed_state_from_history(
+    execution_arn: str, state_machine_arn: str = "",
+) -> tuple[str | None, str | None]:
+    """Return ``(failed_state, failed_state_detail)`` — the state that
+    ACTUALLY caused the routing into failure, not the terminal ``Fail`` state
+    every routed failure shares (alpha-engine-config-I6616).
+
+    Fetches the execution history newest-first (``reverseOrder=True``),
+    paginated backward up to ``_HISTORY_MAX_PAGES`` (never forward-paginated —
+    see that constant's comment for the bug class this avoids), then walks it
+    chronologically tracking two signals:
+
+    - ``last_seen``: the most recently ENTERED state name, updated on every
+      ``StateEntered`` and never cleared on exit. This is what survives past a
+      clean exit — a ``Choice`` state (e.g. ``DeployDriftGate``) enters AND
+      exits normally before its matched rule's ``Next`` routes to
+      ``HandleFailure``, so a dangling-only search loses it the instant it
+      exits.
+    - ``dangling``: the entered-but-not-yet-exited state at any point — the
+      pre-I6616 signal, still correct for an execution that fails WITHOUT
+      ever entering the failure-handling funnel (an unhandled error
+      propagating straight to ``ExecutionFailed`` — the 2026-08-03
+      ``S3.AccessDeniedException`` shape named in the issue's Gotchas).
+
+    The failure-handling set (``_failure_handling_states``, derived from the
+    watched definition) is checked on every ``StateEntered``. The FIRST time
+    it is entered, the resolved culprit is ``last_seen`` AS OF JUST BEFORE
+    that entry — even when that is ``None`` (a funnel entered with no prior
+    state on record is reported honestly as unknown, never the funnel's own
+    name — the degenerate case named in the issue's Gotchas). When the funnel
+    is never entered at all, the resolved culprit is ``dangling``.
+
+    ``failed_state_detail`` carries whatever discriminating payload is cheaply
+    available for the resolved culprit: a Task failure's ``error``/``cause``
+    (deliverable 2), or — for a Choice-type culprit — the specific rule that
+    matched (via ``_matched_choice_rule``). ``None`` when neither applies.
+
+    Best-effort: returns ``(None, None)`` on any execution-history API error.
+    """
+    if not execution_arn:
+        return None, None
+    states = _describe_state_machine_states(state_machine_arn)
+    sink = _failure_handling_states(states)
+
+    events: list[dict] = []
+    token: str | None = None
+    try:
+        for _ in range(_HISTORY_MAX_PAGES):
+            kwargs = {
+                "executionArn": execution_arn,
+                "maxResults": _HISTORY_MAX_EVENTS,
+                "reverseOrder": True,
+                "includeExecutionData": True,
+            }
+            if token:
+                kwargs["nextToken"] = token
+            resp = _sf_client().get_execution_history(**kwargs)
+            events.extend(resp.get("events", []))
+            token = resp.get("nextToken")
+            if not token:
+                break
     except Exception as exc:  # noqa: BLE001 — enrichment, recorded in artifact
         logger.warning("get_execution_history failed for %s: %s", execution_arn, exc)
-        return None
+        return None, None
 
-    events = list(reversed(resp.get("events", [])))  # → chronological
-    current: str | None = None
-    for ev in events:
+    chronological = list(reversed(events))  # newest-first pages → oldest-first overall
+    last_seen: str | None = None
+    dangling: str | None = None
+    pre_sink: str | None = None
+    entered_sink = False
+    choice_input = None
+    task_failed_detail: str | None = None
+
+    for ev in chronological:
         etype = ev.get("type", "")
         if etype.endswith("StateEntered"):
             det = ev.get("stateEnteredEventDetails") or {}
-            current = det.get("name") or current
+            name = det.get("name")
+            if not name:
+                continue
+            if not entered_sink and name in sink:
+                entered_sink = True
+                pre_sink = last_seen
+            elif not entered_sink:
+                # Still on the candidate-culprit path — remember its input so
+                # a Choice culprit's matched rule can be resolved afterward.
+                try:
+                    choice_input = json.loads(det.get("input") or "null")
+                except (ValueError, TypeError):
+                    choice_input = None
+            last_seen = name
+            dangling = name
         elif etype.endswith("StateExited"):
             det = ev.get("stateExitedEventDetails") or {}
-            if det.get("name") == current:
-                current = None
-    return current
+            if det.get("name") == dangling:
+                dangling = None
+        elif etype == "TaskFailed" and not entered_sink:
+            det = ev.get("taskFailedEventDetails") or {}
+            error = (det.get("error") or "").strip()
+            cause = (det.get("cause") or "").strip()
+            if error or cause:
+                task_failed_detail = f"{error}: {cause}" if (error and cause) else (error or cause)
+
+    culprit = pre_sink if entered_sink else dangling
+    if not culprit:
+        return None, None
+    if task_failed_detail:
+        detail = task_failed_detail
+        if len(detail) > _CAUSE_MAX_CHARS:
+            detail = detail[: _CAUSE_MAX_CHARS - 1] + "…"
+    else:
+        detail = _matched_choice_rule(states, culprit, choice_input, sink)
+    return culprit, detail
 
 
 # --- config#1900: deterministic zero-token fast path -------------------------
@@ -771,7 +1035,9 @@ def _build_event_record(
 ) -> dict:
     now_iso = datetime.now(timezone.utc).isoformat()
     cause = _failure_cause(describe_resp)
-    failed_state = _failed_state_from_history(detail.get("executionArn", ""))
+    failed_state, failed_state_detail = _failed_state_from_history(
+        detail.get("executionArn", ""), detail.get("stateMachineArn", ""),
+    )
     # config#1535: "will an agent actually be dispatched" depends on BOTH the
     # global kill-switch AND this specific pipeline having a wired listener —
     # not the global flag alone (that was the bug: claiming "dispatch" for a
@@ -830,6 +1096,11 @@ def _build_event_record(
         "execution_name": detail.get("name", ""),
         "execution_arn": detail.get("executionArn", ""),
         "failed_state": failed_state,
+        # alpha-engine-config-I6616: the discriminating payload that makes
+        # `failed_state` actionable — a Task failure's error/cause, or a
+        # Choice culprit's matched rule. Additive field (S3 schema contract
+        # allows ADD only); `None` when neither is available.
+        "failed_state_detail": failed_state_detail,
         "cause": cause or None,
         "is_preflight": is_preflight,
         # `lane` is filled by the dispatched agent (null until it classifies).
@@ -970,6 +1241,9 @@ def _notify(record: dict, key: str, pipeline_name: str, dispatch: dict) -> bool:
     ]
     if record.get("failed_state"):
         lines.append(f"Failed state: `{record['failed_state']}`")
+    if record.get("failed_state_detail"):
+        safe_detail = _safe_cause_for_telegram(record["failed_state_detail"])
+        lines.append(f"Detail: `{safe_detail}`")
     if record.get("cause"):
         safe_cause = _safe_cause_for_telegram(record['cause'])
         lines.append(f"Cause: `{safe_cause}`")
@@ -1041,6 +1315,8 @@ def _escalate_budget_exhausted(record: dict, key: str, pipeline_name: str, run_d
         f"{record.get('prior_dispatch_count', '?')} today already hit the "
         f"{record.get('dispatch_ceiling', '?')}-attempt ceiling for run_date {run_date}.",
         f"Failed state: `{record.get('failed_state')}`" if record.get("failed_state") else "",
+        f"Detail: `{_safe_cause_for_telegram(record.get('failed_state_detail'))}`"
+        if record.get("failed_state_detail") else "",
         f"Cause: `{_safe_cause_for_telegram(record.get('cause'))}`" if record.get("cause") else "",
         f"Watch log: `s3://{WATCH_BUCKET}/{key}`",
         "_The watch has GIVEN UP on today for this pipeline — no further agent "
@@ -1145,6 +1421,10 @@ def _maybe_dispatch_agent(
         "state_machine_arn": sm_arn,
         "execution_arn": record.get("execution_arn", ""),
         "failed_state": record.get("failed_state"),
+        # alpha-engine-config-I6616: threaded to the executor lambda/agent so
+        # the diagnose step sees the discriminating payload too, not just the
+        # bare state name.
+        "failed_state_detail": record.get("failed_state_detail"),
         "cause": record.get("cause"),
         "run_date": run_date,
         "status": record.get("status"),

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/test_handler.py
@@ -57,15 +57,45 @@ _DEFAULT_HISTORY = [
 ]
 
 
-def _make_clients(*, describe=None, history=None, existing=None, put=None):
-    """Return (factory, sf_mock, s3_mock). ``existing`` None → get_object 404."""
+def _make_clients(*, describe=None, history=None, existing=None, put=None,
+                   sf_definition=None, history_pages=None):
+    """Return (factory, sf_mock, s3_mock). ``existing`` None → get_object 404.
+
+    ``sf_definition`` (dict): when given, wires ``describe_state_machine`` to
+    return it as the ASL definition — the alpha-engine-config-I6616
+    failure-handling-state derivation reads this. Left unset, the mocked
+    ``describe_state_machine`` call returns an unconfigured MagicMock, whose
+    ``json.loads`` fails and falls back to the daily-pipeline default names
+    (``HandleFailure``/``FailExecution``) — correct for every pre-I6616 fixture
+    in this file, none of which name a different pipeline's terminal states.
+
+    ``history_pages`` (list[list[dict]]): when given, each inner list is one
+    page's events in CHRONOLOGICAL order, listed in FETCH order — page 0 is
+    the NEWEST events (what the first, token-less call returns under the real
+    API's ``reverseOrder=True``), page 1 is the next-older batch, etc.
+    ``get_execution_history`` is wired to return them in that order via
+    ``side_effect`` (each reversed to the API's newest-first shape), with a
+    ``nextToken`` on every page but the last — exercises the I6616 pagination
+    walk. Mutually exclusive with ``history``.
+    """
     sf = MagicMock()
     sf.describe_execution.return_value = describe if describe is not None else {
         "input": "{}", "error": "States.TaskFailed", "cause": "RAGIngestion failed",
     }
-    sf.get_execution_history.return_value = _history_chrono_to_resp(
-        history if history is not None else _DEFAULT_HISTORY
-    )
+    if sf_definition is not None:
+        sf.describe_state_machine.return_value = {"definition": json.dumps(sf_definition)}
+    if history_pages is not None:
+        resps = []
+        for i, page in enumerate(history_pages):
+            resp = _history_chrono_to_resp(page)
+            if i < len(history_pages) - 1:
+                resp["nextToken"] = f"token-{i}"
+            resps.append(resp)
+        sf.get_execution_history.side_effect = resps
+    else:
+        sf.get_execution_history.return_value = _history_chrono_to_resp(
+            history if history is not None else _DEFAULT_HISTORY
+        )
     s3 = MagicMock()
     if existing is None:
         s3.get_object.side_effect = FakeClientError("404")
@@ -342,6 +372,232 @@ def test_failed_state_none_when_state_exited_cleanly():
     with patch("index.boto3.client", side_effect=factory):
         result = index.handler(_event("FAILED"), None)
     assert result["failed_state"] is None
+
+
+# ── alpha-engine-config-I6616: failed_state must name the ROUTING state, ────
+# never the shared HandleFailure/FailExecution terminal every failure funnels
+# through (the constant the issue was filed against). Mirrors the definition
+# shape in infrastructure/step_function_daily.json's DeployDriftGate ->
+# HandleFailure -> FailExecution funnel — the exact reference incident cited
+# in the issue (config-I6610/I6588/I6571, three FAILED weekday executions
+# that all reported `failed_state=FailExecution`, all three actually failed
+# at `DeployDriftGate`).
+_DAILY_LIKE_DEFINITION = {
+    "States": {
+        "DeployDriftGate": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "And": [
+                        {"Variable": "$.drift_result.Payload.has_drift", "IsPresent": True},
+                        {"Variable": "$.drift_result.Payload.has_drift", "BooleanEquals": True},
+                    ],
+                    "Next": "HandleFailure",
+                },
+                {
+                    "Not": {"Variable": "$.drift_result.Payload.has_drift", "IsPresent": True},
+                    "Next": "HandleFailure",
+                },
+            ],
+            "Default": "TradingDayGate",
+        },
+        # A genuine Choice (mirrors the real TradingDayGate) — one branch
+        # routes to HandleFailure, the Default continues the real success
+        # path. A Choice state is NEVER added to the failure-handling sink
+        # (see `_failure_handling_states`'s docstring), which is what stops
+        # the sink-derivation closure from sweeping the ENTIRE upstream
+        # success chain (LaunchMorningEnrichSpot -> PollMorningArcticAppendSpot
+        # -> TradingDayGate) into the funnel just because one of TradingDayGate's
+        # branches eventually reaches Fail.
+        "TradingDayGate": {
+            "Type": "Choice",
+            "Choices": [{"Variable": "$.is_trading_day", "IsPresent": False, "Next": "HandleFailure"}],
+            "Default": "PipelineSuccess",
+        },
+        "PipelineSuccess": {"Type": "Succeed"},
+        "LaunchMorningEnrichSpot": {
+            "Type": "Task", "Next": "PollMorningArcticAppendSpot",
+            "Catch": [{"ErrorEquals": ["States.ALL"], "Next": "HandleFailure"}],
+        },
+        "PollMorningArcticAppendSpot": {"Type": "Task", "Next": "TradingDayGate"},
+        "HandleFailure": {"Type": "Task", "Next": "FailExecution"},
+        "FailExecution": {"Type": "Fail", "Error": "DailyPipelineFailure",
+                           "Cause": "One or more weekday pipeline steps failed."},
+    },
+}
+
+
+def test_failed_state_resolves_choice_routing_state_not_fail_execution():
+    """The exact I6616 reference shape: a Choice state (DeployDriftGate)
+    evaluates has_drift=true, exits CLEANLY, and routes to HandleFailure ->
+    FailExecution. The pre-fix algorithm reported `failed_state=FailExecution`
+    for this shape (a dangling-only search loses the Choice state the instant
+    it exits) — the exact bug the issue was filed against."""
+    history = [
+        {"type": "ExecutionStarted"},
+        {"type": "ChoiceStateEntered", "stateEnteredEventDetails": {
+            "name": "DeployDriftGate",
+            "input": json.dumps({
+                "drift_result": {"Payload": {"has_drift": True}},
+                "cf_drift_reason": "stack_in_terminal_state",
+            }),
+        }},
+        {"type": "ChoiceStateExited", "stateExitedEventDetails": {"name": "DeployDriftGate"}},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "HandleFailure"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "HandleFailure"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "FailExecution"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(history=history, sf_definition=_DAILY_LIKE_DEFINITION)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["failed_state"] == "DeployDriftGate"
+    assert result["failed_state"] != "FailExecution"
+    assert result["failed_state"] != "HandleFailure"
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    detail = written["events"][0]["failed_state_detail"]
+    assert detail is not None
+    assert "drift_result.Payload.has_drift" in detail
+    assert "BooleanEquals" in detail
+
+
+def test_failed_state_task_failure_with_multiple_retries_reports_last_task():
+    """A Task state that fails, retries twice more (three TaskFailed events
+    under the SAME StateEntered — SF never re-emits StateEntered per retry),
+    then exhausts its retry budget and routes to HandleFailure -> FailExecution.
+    The culprit is the retried task, not FailExecution; the detail carries the
+    final attempt's error/cause (deliverable 2, Task-failure case)."""
+    history = [
+        {"type": "ExecutionStarted"},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "LaunchMorningEnrichSpot"}},
+        {"type": "TaskFailed", "taskFailedEventDetails": {
+            "error": "Lambda.Unknown", "cause": "attempt 1: transient"}},
+        {"type": "TaskFailed", "taskFailedEventDetails": {
+            "error": "Lambda.Unknown", "cause": "attempt 2: transient"}},
+        {"type": "TaskFailed", "taskFailedEventDetails": {
+            "error": "States.TaskFailed", "cause": "attempt 3: SpotCapacityNotAvailable"}},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "HandleFailure"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "HandleFailure"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "FailExecution"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(history=history, sf_definition=_DAILY_LIKE_DEFINITION)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["failed_state"] == "LaunchMorningEnrichSpot"
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    detail = written["events"][0]["failed_state_detail"]
+    assert detail is not None
+    assert "SpotCapacityNotAvailable" in detail  # the FINAL retry's cause
+
+
+def test_failed_state_resolves_across_paginated_history():
+    """The execution history spans more than one ``get_execution_history``
+    page — the culprit's StateEntered lands in the OLDER (second-fetched)
+    page. Regression guard for the pagination bug class named in the issue:
+    an earlier sf-digest paginated FORWARD with a fixed page cap and silently
+    truncated; this walks BACKWARD (reverseOrder=True) across
+    ``_HISTORY_MAX_PAGES`` instead of stopping at page 1."""
+    older_page = [  # fetched SECOND (further into the past)
+        {"type": "ExecutionStarted"},
+        {"type": "ChoiceStateEntered", "stateEnteredEventDetails": {
+            "name": "DeployDriftGate",
+            "input": json.dumps({"drift_result": {"Payload": {"has_drift": True}}}),
+        }},
+        {"type": "ChoiceStateExited", "stateExitedEventDetails": {"name": "DeployDriftGate"}},
+    ]
+    newer_page = [  # fetched FIRST (newest events)
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "HandleFailure"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "HandleFailure"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "FailExecution"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(
+        history_pages=[newer_page, older_page], sf_definition=_DAILY_LIKE_DEFINITION,
+    )
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["failed_state"] == "DeployDriftGate"
+    assert sf.get_execution_history.call_count == 2
+    second_call_kwargs = sf.get_execution_history.call_args_list[1].kwargs
+    assert second_call_kwargs["nextToken"] == "token-0"
+    assert second_call_kwargs["reverseOrder"] is True
+
+
+def test_failed_state_degenerate_funnel_entry_reports_unknown_never_constant():
+    """The funnel is entered with NO prior recorded state (e.g. a MutexConflict
+    Choice at the very top of the definition, before this bounded history
+    window). The pre-fix bug reported the constant `FailExecution` in this
+    shape too; the fix must report unknown (None) rather than ever
+    substituting the funnel's own name — the issue's Gotcha #4."""
+    history = [
+        {"type": "ExecutionStarted"},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "HandleFailure"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "HandleFailure"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "FailExecution"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(history=history, sf_definition=_DAILY_LIKE_DEFINITION)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["failed_state"] is None
+    assert result["failed_state"] != "FailExecution"
+    assert result["failed_state"] != "HandleFailure"
+
+
+def test_failed_state_unfunneled_unhandled_error_unchanged_behavior():
+    """The 2026-08-03 shape named in the issue's Gotchas: an execution that
+    fails WITHOUT ever entering HandleFailure (an unhandled error propagates
+    straight to ExecutionFailed). Must resolve via the legacy dangling signal,
+    unaffected by the funnel-skip logic — a definition IS supplied here (so
+    the failure-handling-state derivation runs for real) to prove it correctly
+    finds no funnel entry and falls through cleanly."""
+    history = [
+        {"type": "ExecutionStarted"},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "SomeS3Write"}},
+        {"type": "TaskFailed", "taskFailedEventDetails": {
+            "error": "S3.AccessDeniedException", "cause": "Access Denied"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(history=history, sf_definition=_DAILY_LIKE_DEFINITION)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED", sm_arn=WEEKDAY_ARN), None)
+    assert result["failed_state"] == "SomeS3Write"
+    written = json.loads(s3.put_object.call_args.kwargs["Body"])
+    assert written["events"][0]["failed_state_detail"] == "S3.AccessDeniedException: Access Denied"
+
+
+def test_failure_handling_states_derived_per_definition_not_hardcoded():
+    """Gotcha #2: the weekly/postclose pipelines use their OWN terminal-state
+    names, not `HandleFailure`/`FailExecution`. A definition naming its Fail
+    funnel differently must still be resolved correctly — proves the sink set
+    is read from the definition being watched, not a hardcoded pair."""
+    saturday_definition = {
+        "States": {
+            "RationaleClustering": {
+                "Type": "Task", "Next": "Persist",
+                "Catch": [{"ErrorEquals": ["States.ALL"], "Next": "AlertAndFail"}],
+            },
+            "Persist": {"Type": "Task", "Next": "AlertAndFail"},
+            "AlertAndFail": {"Type": "Task", "Next": "TerminalFail"},
+            "TerminalFail": {"Type": "Fail", "Error": "WeeklyPipelineFailure"},
+        },
+    }
+    history = [
+        {"type": "ExecutionStarted"},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "RationaleClustering"}},
+        {"type": "TaskFailed", "taskFailedEventDetails": {
+            "error": "States.Timeout", "cause": "clustering exceeded 900s"}},
+        {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": "AlertAndFail"}},
+        {"type": "TaskStateExited", "stateExitedEventDetails": {"name": "AlertAndFail"}},
+        {"type": "FailStateEntered", "stateEnteredEventDetails": {"name": "TerminalFail"}},
+        {"type": "ExecutionFailed"},
+    ]
+    factory, sf, s3 = _make_clients(history=history, sf_definition=saturday_definition)
+    with patch("index.boto3.client", side_effect=factory):
+        result = index.handler(_event("FAILED"), None)  # SATURDAY_ARN default
+    assert result["failed_state"] == "RationaleClustering"
+    assert result["failed_state"] not in ("AlertAndFail", "TerminalFail")
 
 
 # ── M2: repository_dispatch to the autonomous agent ─────────────────────────

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/index.py
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/index.py
@@ -464,6 +464,11 @@ def _handle_reclaim_event(event: dict) -> dict:
         "execution_arn": source_ev.get("execution_arn", ""),
         "state_machine_arn": f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{pipeline}",
         "failed_state": source_ev.get("failed_state") or "",
+        # alpha-engine-config-I6616: passthrough only — this handler never
+        # derives failed_state itself, it relays the ORIGINAL dispatcher's
+        # (saturday-sf-watch-dispatcher) already-derived value, same as
+        # `failed_state` above.
+        "failed_state_detail": source_ev.get("failed_state_detail") or "",
         "cause": source_ev.get("cause") or "",
         "watch_log_key": watch_log_key,
         "is_preflight": "true" if source_ev.get("is_preflight") else "false",

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/test_handler.py
@@ -250,6 +250,7 @@ def _dispatch_log_event(**overrides):
         "status": "FAILED",
         "execution_arn": EXEC_ARN,
         "failed_state": "RAGIngestion",
+        "failed_state_detail": "States.TaskFailed: RAGIngestion failed",
         "cause": "States.TaskFailed: RAGIngestion failed",
         "is_preflight": False,
     }
@@ -316,6 +317,9 @@ def test_reclaim_without_marker_relaunches_on_demand_once_with_record_and_note()
         "state_machine_arn": ("arn:aws:states:us-east-1:711398986525:"
                               "stateMachine:ne-weekly-freshness-pipeline"),
         "failed_state": "RAGIngestion",
+        # alpha-engine-config-I6616: pure passthrough of the source watch-log
+        # event's already-derived detail — this handler never re-derives it.
+        "failed_state_detail": "States.TaskFailed: RAGIngestion failed",
         "cause": "States.TaskFailed: RAGIngestion failed",
         "watch_log_key": WATCH_LOG_KEY,
         "is_preflight": "false",

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -301,6 +301,15 @@ def _resolve_event_fields(event: dict) -> dict:
     # cause: deliberately unvalidated — arbitrary AWS text, base64-encoded
     # before it ever reaches a shell command (see _bootstrap_command).
     cause = str(event.get("cause") or "")
+    # failed_state_detail (alpha-engine-config-I6616): the discriminating
+    # payload the derived failed_state carries — a Task's error/cause, or a
+    # matched Choice rule (which can embed an arbitrary JSON scalar from the
+    # execution input). Same shape as `cause` above: deliberately unvalidated
+    # free text, base64-encoded before it ever reaches a shell command — a
+    # narrow allowlist here would either reject legitimate values or, if
+    # loosened to fit them, reopen the same injection surface `cause` avoids
+    # by staying off the regex path entirely.
+    failed_state_detail = str(event.get("failed_state_detail") or "")
     return {
         "pipeline_name": pipeline_name,
         "cadence_slug": cadence_slug,
@@ -308,6 +317,7 @@ def _resolve_event_fields(event: dict) -> dict:
         "execution_arn": execution_arn,
         "state_machine_arn": state_machine_arn,
         "failed_state": failed_state,
+        "failed_state_detail": failed_state_detail,
         "watch_log_key": watch_log_key,
         "is_preflight": is_preflight,
         "is_drill": is_drill,
@@ -342,6 +352,12 @@ def _bootstrap_command(fields: dict, run_token: str) -> str:
     it stays a Lambda-side-only correlation id (see the SSM Comment field in
     ``_send_bootstrap``, and the handler's returned JSON)."""
     cause_b64 = base64.b64encode(fields["cause"].encode("utf-8")).decode("ascii")
+    # alpha-engine-config-I6616: same BASE64 treatment as `cause` — arbitrary
+    # text (a matched Choice rule can embed any JSON scalar from the
+    # execution input), never interpolated raw.
+    failed_state_detail_b64 = base64.b64encode(
+        fields.get("failed_state_detail", "").encode("utf-8")
+    ).decode("ascii")
     return f"""set -uo pipefail
 export AWS_DEFAULT_REGION={REGION}
 # SSM RunShellScript runs as root with NO $HOME set; git config/clone need it.
@@ -364,6 +380,7 @@ export SF_STATE_MACHINE_ARN="{fields['state_machine_arn']}"
 export SF_EXECUTION_ARN="{fields['execution_arn']}"
 export SF_RUN_DATE="{fields['run_date']}"
 export SF_FAILED_STATE="{fields['failed_state']}"
+export SF_FAILED_STATE_DETAIL_B64="{failed_state_detail_b64}"
 export SF_CAUSE_B64="{cause_b64}"
 export SF_WATCH_LOG_KEY="{fields['watch_log_key']}"
 export SF_IS_PREFLIGHT="{fields['is_preflight']}"
@@ -538,8 +555,8 @@ def _defer_relaunch(fields: dict, generation: int, context, existing: list[str])
 
     payload = {k: fields[k] for k in (
         "pipeline_name", "cadence_slug", "run_date", "execution_arn",
-        "state_machine_arn", "failed_state", "watch_log_key", "is_preflight",
-        "is_drill", "force_on_demand", "cause",
+        "state_machine_arn", "failed_state", "failed_state_detail",
+        "watch_log_key", "is_preflight", "is_drill", "force_on_demand", "cause",
     )}
     payload["defer_generation"] = next_generation
     fire_at = datetime.now(timezone.utc) + timedelta(seconds=DEFER_DELAY_SECONDS)

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -206,6 +206,7 @@ def _event(**overrides):
         "execution_arn": "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:run-1",
         "run_date": "2026-07-11",
         "failed_state": "RationaleClustering",
+        "failed_state_detail": "error=States.Timeout cause=RationaleClustering exceeded 900s",
         "cause": "States.Timeout",
         "watch_log_key": "consolidated/saturday_sf_watch/2026-07-11.json",
         "is_preflight": "false",
@@ -272,6 +273,14 @@ def test_valid_event_launches_spot_and_sends_async_ssm(monkeypatch):
     expected_b64 = base64.b64encode(b"States.Timeout").decode("ascii")
     assert f'export SF_CAUSE_B64="{expected_b64}"' in cmd
     assert "States.Timeout" not in cmd
+    # alpha-engine-config-I6616: failed_state_detail crosses BASE64 too, same
+    # rationale as cause — it can carry a matched Choice rule embedding an
+    # arbitrary JSON scalar from the execution input.
+    expected_detail_b64 = base64.b64encode(
+        b"error=States.Timeout cause=RationaleClustering exceeded 900s"
+    ).decode("ascii")
+    assert f'export SF_FAILED_STATE_DETAIL_B64="{expected_detail_b64}"' in cmd
+    assert "RationaleClustering exceeded 900s" not in cmd
     assert "export SF_CAUSE=" not in cmd
     # run_token is NOT threaded into the box (no in-box consumer — the
     # completion marker keys directly on cadence/pipeline/run_date) — only a
@@ -780,12 +789,16 @@ def test_missing_pipeline_name_returns_clean_false(monkeypatch):
 
 
 def test_missing_optional_fields_still_launches(monkeypatch):
-    # failed_state/cause/watch_log_key/state_machine_arn/is_preflight are all
-    # optional — only pipeline_name/cadence_slug/execution_arn/run_date are
-    # required (mirrors sf_watch_spot_bootstrap.sh's own FATAL check).
+    # failed_state/failed_state_detail/cause/watch_log_key/state_machine_arn/
+    # is_preflight are all optional — only pipeline_name/cadence_slug/
+    # execution_arn/run_date are required (mirrors sf_watch_spot_bootstrap.sh's
+    # own FATAL check).
     idx = _load(monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"})
     event = _event()
-    for optional in ("state_machine_arn", "failed_state", "cause", "watch_log_key", "is_preflight"):
+    for optional in (
+        "state_machine_arn", "failed_state", "failed_state_detail", "cause",
+        "watch_log_key", "is_preflight",
+    ):
         del event[optional]
     out = idx.handler(event, None)
     assert out["launched"] is True


### PR DESCRIPTION
## What / why

sf-watch reports `failed_state=FailExecution` — the terminal `Fail` state every routed failure shares — instead of the state that actually caused the routing. Bug class: **an alert that names no failing stage gets attributed to the last culprit**, here a constant that repeats on every failure and carries zero discriminating power. Three reference incidents (`alpha-engine-config-I6610`/`I6588`/`I6571`, 2026-08-05..07) all actually failed at `DeployDriftGate`; all three reported `FailExecution`. That window is the 3-day trading outage in `alpha-engine-config-I6615` — the one structured field that could have pointed straight at the stuck CFN stack (`alpha-engine-config-I6536`) pointed at nothing, three times.

Fix (root cause, not one call site — every routed failure in `step_function_daily.json` funnels through `HandleFailure` -> `FailExecution`, and the sibling dispatchers share the same field):

- **`saturday-sf-watch-dispatcher/index.py`** (the actual emitter for all three fleet SFs, despite its name — `sf-watch-spot-dispatcher` only forwards an already-computed value): `_failed_state_from_history` now walks the failed execution's history chronologically, tracking the last state ENTERED before control transferred into a **failure-handling set derived from the watched state machine's own ASL definition** (`_failure_handling_states`) — one relay hop into a `Fail` state, non-transitive, so genuinely diagnostic upstream states (`CodeFreshnessPollTimeout`, `MorningPlannerPollTimeout`, ...) stay reportable on their own rather than getting swept into the funnel too. Falls back to the daily pipeline's known names only when the definition itself can't be fetched (never as the primary mechanism — the weekly/postclose pipelines use their own terminal-state names, verified against `step_function.json` and `step_function_eod.json` in this repo).
- History is fetched `reverseOrder=True` and **paginated backward** up to `_HISTORY_MAX_PAGES` (5 pages / 5000 events) — never forward-paginated with a fixed cap, which is the earlier sf-digest bug class (hit a 20-page cap walking forward, rendered `(no workload states in history)` instead of degrading honestly).
- New `failed_state_detail` field carries the discriminating payload: a Task failure's `error`/`cause`, or — for a Choice-type culprit like `DeployDriftGate` — the specific rule that matched, via a small bounded ASL Choice-rule interpreter (`BooleanEquals`/`StringEquals`/`NumericEquals`/`IsPresent`/`And`/`Or`/`Not`). Verified against the real `step_function_daily.json` + the issue's exact reference history: resolves to `failed_state=DeployDriftGate`, `failed_state_detail=$.drift_result.Payload.has_drift IsPresent=True AND $.drift_result.Payload.has_drift BooleanEquals True`.
- Degenerate case (funnel entered with no prior recorded state) reports `None` (unknown) — **never** substitutes the funnel's own name, which is what the pre-fix code effectively always did.
- Threaded through the class: `sf-watch-spot-dispatcher` now accepts/forwards `failed_state_detail` (base64-encoded across the SSM boundary, same treatment as the existing `cause` field — it's arbitrary text that can embed a JSON scalar from the execution input) into the agent bootstrap env as `SF_FAILED_STATE_DETAIL_B64`/`SF_FAILED_STATE_DETAIL`. `sf-watch-reclaim-sweep-handler` passes it through from the source watch-log event (it never derives independently — confirmed by reading its `_reclaim_*` payload-reconstruction path). Watch-log record, Telegram receipt (`_notify`, `_escalate_budget_exhausted`), and the overseer dispatch payload (`_maybe_dispatch_agent`'s `client_payload`) all carry the field additively.

sf-watch itself is paused under the `alpha-engine-config-I6617` automation pause — this PR does not touch `step_function*.json` or `automation_pause.json` (parallel PRs own those). The code fix lands now; validation below is unit tests with history fixtures, **not a live run**.

## Test plan (run locally before opening, all green)

```
cd infrastructure/lambdas/saturday-sf-watch-dispatcher && python3 -m pytest test_handler.py -q
# 88 passed (82 pre-existing + 6 new I6616 regression tests)

cd infrastructure/lambdas/sf-watch-spot-dispatcher && python3 -m pytest test_handler.py -q
# 43 passed

cd infrastructure/lambdas/sf-watch-reclaim-sweep-handler && python3 -m pytest test_handler.py -q
# 23 passed

cd <repo root> && python3 -m pytest tests/test_sf_watch_exercise_run_budget.py tests/test_sf_watch_rule_pattern_lockstep.py tests/test_sf_watch_defer_prefix_lockstep.py tests/test_sf_watch_deploy_flag_preserve.py -q
# 22 passed
```

New regression tests (`saturday-sf-watch-dispatcher/test_handler.py`), covering the issue's closes-when + Gotchas:
- `test_failed_state_resolves_choice_routing_state_not_fail_execution` — the exact I6616 reference shape (Choice state exits cleanly, routes to `HandleFailure`→`FailExecution`); asserts `failed_state == "DeployDriftGate"` and the matched-condition detail.
- `test_failed_state_task_failure_with_multiple_retries_reports_last_task` — a Task state failing under 3 retries before exhausting into the funnel; asserts the retried task's name + final attempt's error/cause.
- `test_failed_state_resolves_across_paginated_history` — the culprit's `StateEntered` lands in the second (older) `get_execution_history` page; asserts the `nextToken` is threaded through and `reverseOrder=True` is preserved on every call.
- `test_failed_state_degenerate_funnel_entry_reports_unknown_never_constant` — funnel entered with no prior state on record; asserts `None`, never the funnel's own name.
- `test_failed_state_unfunneled_unhandled_error_unchanged_behavior` — the 2026-08-03 `S3.AccessDeniedException` shape (never enters the funnel at all); asserts the legacy dangling behavior is unchanged.
- `test_failure_handling_states_derived_per_definition_not_hardcoded` — a synthetic weekly-shaped definition with its OWN terminal-state names (`TerminalFail`, not `FailExecution`); proves the sink is read from the definition, not hardcoded.

Also verified ad hoc against the real `infrastructure/step_function_daily.json`, `step_function.json` and `step_function_eod.json` in this repo (not committed as a test fixture, but exercised interactively): `_failure_handling_states` resolves to exactly the single-hop relay + Fail state(s) for all three real fleet definitions, with no accidental sweep of the diagnostic Pass/Task states that share their Fail terminal two hops away.

Not run: a live sf-watch invocation against a real Step Functions execution — sf-watch is paused (`alpha-engine-config-I6617`); this PR is code-only, deployed on next merge to main via the existing deploy-on-merge workflows below.

## Deploy-mechanism

All three touched lambdas already have merge-triggered, path-scoped deploy workflows (code-only `deploy.sh`, no `--bootstrap`) — no new workflow needed, this PR is deployable by the merge button alone:
- `.github/workflows/deploy-saturday-sf-watch-dispatcher.yml` — `on: push, branches: [main], paths: ['infrastructure/lambdas/saturday-sf-watch-dispatcher/**', ...]`
- `.github/workflows/deploy-sf-watch-spot-dispatcher.yml` — same shape, scoped to `infrastructure/lambdas/sf-watch-spot-dispatcher/**`
- `.github/workflows/deploy-sf-watch-reclaim-sweep-handler.yml` — same shape, scoped to `infrastructure/lambdas/sf-watch-reclaim-sweep-handler/**`

## Known pre-existing (out of scope)

- `drift-check` may show red repo-wide by known cause until `nousergon-data-PR1252` merges — if seen on this PR, it is unrelated to this diff.
- `pytest tests/ -q -k "sf_watch or..."` at the repo root currently errors on ~17 unrelated modules (`ModuleNotFoundError: yfinance`) during collection — pre-existing environment gap, confirmed present on `origin/main` before this change, unrelated to sf-watch. Ran the sf-watch-specific test files directly instead (see Test plan).

Closes nousergon/alpha-engine-config#6616
Ref: alpha-engine-config-I6616

---
Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)