### PR TITLE
ci: rename rehearsal guard job for required-context use (alpha-engine-config-I6711)

### DIFF
--- a/.github/workflows/rehearsal-path-guard.yml
+++ b/.github/workflows/rehearsal-path-guard.yml
@@ -16,7 +16,7 @@ name: Rehearsal Path Guard
 # Two-job shape mirrors canary-replay.yml: `label` runs dorny/paths-filter
 # to decide whether this PR touches a weekly-critical path at all (a PR
 # that doesn't is unconstrained by §7 and the check passes trivially);
-# `check` runs only when it does, and calls the body-parsing logic in
+# `rehearsal-path-guard` runs only when it does, and calls the body-parsing logic in
 # scripts/check_rehearsal_path.py (kept in a script, not inline bash, so
 # tests/test_check_rehearsal_path.py can exercise every branch directly).
 #
@@ -61,7 +61,7 @@ jobs:
               - 'infrastructure/run_weekly_offcycle.sh'
               - 'scripts/weekly_sf_rerun.py'
 
-  check:
+  rehearsal-path-guard:
     needs: label
     if: needs.label.outputs.weekly_critical == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What & why

Part of `alpha-engine-config-I6711` (Part of alpha-engine-config#6711): the rehearsal-path guard's blocking job was named `check` — as a required branch-protection context that string is satisfiable by ANY future job named `check` in any workflow. Renamed to `rehearsal-path-guard` before adding it to `required_status_checks.contexts` (the context add is performed by this same session immediately post-merge — sequenced after, not before, because a required context that has never reported blocks every open PR as "expected" — and verified by re-reading protection; I6711 stays open until that verification).

The job stays conditional on `label.outputs.weekly_critical` — a skipped conditional job satisfies a required check (verified live on today's non-weekly-critical PRs), so non-critical PRs are unaffected.

Deploy-mechanism: N/A — CI workflow rename only.

## Test plan

Full suite locally before opening: 4419 passed, 8 skipped (includes the 34 workflow/rehearsal tests).

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
