### PR TITLE
[P1/mid] feat(systemd): six more codified roots + region env for --metric; baseline 22→12 (config#6656)

### DIFF
--- a/infrastructure/systemd/systemd-unit-drift-check.service
+++ b/infrastructure/systemd/systemd-unit-drift-check.service
@@ -6,7 +6,11 @@ Type=oneshot
 User=ec2-user
 Group=ec2-user
 WorkingDirectory=/home/ec2-user/alpha-engine-data
-ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python /home/ec2-user/alpha-engine-data/infrastructure/systemd/check-systemd-unit-drift.py --report --metric --codified-root /home/ec2-user/alpha-engine-data/infrastructure/systemd --codified-root /home/ec2-user/alpha-engine-dashboard/infrastructure/systemd --codified-root /home/ec2-user/metron-ops/infrastructure/systemd --codified-root /home/ec2-user/telos-ops/infrastructure/systemd
+# boto3 does not infer the region from IMDS; without this every --metric
+# emit dies with "You must specify a region" (seen live 2026-08-09).
+Environment=AWS_REGION=us-east-1
+Environment=AWS_DEFAULT_REGION=us-east-1
+ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python /home/ec2-user/alpha-engine-data/infrastructure/systemd/check-systemd-unit-drift.py --report --metric --codified-root /home/ec2-user/alpha-engine-data/infrastructure/systemd --codified-root /home/ec2-user/alpha-engine-dashboard/infrastructure/systemd --codified-root /home/ec2-user/metron-ops/infrastructure/systemd --codified-root /home/ec2-user/telos-ops/infrastructure/systemd --codified-root /home/ec2-user/alpha-engine-dashboard/infrastructure --codified-root /home/ec2-user/alpha-engine-dashboard/live/infrastructure --codified-root /home/ec2-user/nousergon-auth/infrastructure --codified-root /home/ec2-user/nousergon-console/infrastructure --codified-root /home/ec2-user/the-cyphering-ops/infrastructure --codified-root /home/ec2-user/vires/infrastructure
 # Reads /etc/systemd/system/*, no writes — runs as ec2-user like the units
 # it checks, not root.
 StandardOutput=journal

--- a/infrastructure/systemd/uncodified-units-baseline.txt
+++ b/infrastructure/systemd/uncodified-units-baseline.txt
@@ -28,15 +28,6 @@
 # incomplete by construction, and says so rather than implying coverage.
 
 # ── alpha-engine / dashboard box services ──────────────────────────────────
-crucible-dash-api.service      # crucible-dashboard
-crucible-dash-web.service      # crucible-dashboard
-dashboard.service              # crucible-dashboard
-nous-ergon-live.service        # UNKNOWN
-nousergon-auth.service         # nousergon-auth
-nousergon-console.service      # nousergon-console
-signal-pull.service            # UNKNOWN
-signal-pull.timer              # UNKNOWN
-signal.service                 # UNKNOWN
 
 # ── morning-signal ─────────────────────────────────────────────────────────
 # Found live 2026-08-08 (I6567): morning-signal.service took a TimeoutStartSec
@@ -53,7 +44,6 @@ morning-signal-pull.timer      # UNKNOWN
 mnemon.service                 # mnemon
 mnemon-sync.service            # mnemon
 mnemon-sync.timer              # mnemon
-vires.service                  # vires-ops
 
 # ── shared infrastructure ──────────────────────────────────────────────────
 litellm-proxy.service          # nous-ergon-ops (the model router)

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -372,10 +372,10 @@ class TestCoverageAccounting:
         for name in (
             "litellm-proxy.service",
             "llm-egress-proxy.service",
-            "nousergon-auth.service",
-            "nousergon-console.service",
-            "dashboard.service",
-            "crucible-dash-api.service",
+            "mnemon.service",
+            "morning-signal-pull.service",
+            "certbot-renew.timer",
+            "ibgateway.service",
         ):
             assert name in baseline, f"{name} missing from the uncodified baseline"
 
@@ -384,6 +384,11 @@ class TestCoverageAccounting:
             "box-health.timer",            # alpha-engine-dashboard root
             "metron-refresh.service",      # metron-ops root
             "telos-web.service",           # telos-ops root
+            "dashboard.service",           # alpha-engine-dashboard top-level root
+            "nous-ergon-live.service",     # alpha-engine-dashboard live/ root
+            "nousergon-console.service",   # nousergon-console root
+            "signal.service",              # the-cyphering-ops root
+            "vires.service",               # vires root
         ):
             assert name not in baseline, (
                 f"{name} is covered by a --codified-root and must not be baselined "
@@ -403,8 +408,18 @@ class TestCoverageAccounting:
             "/home/ec2-user/alpha-engine-dashboard/infrastructure/systemd",
             "/home/ec2-user/metron-ops/infrastructure/systemd",
             "/home/ec2-user/telos-ops/infrastructure/systemd",
+            "/home/ec2-user/alpha-engine-dashboard/infrastructure",
+            "/home/ec2-user/alpha-engine-dashboard/live/infrastructure",
+            "/home/ec2-user/nousergon-auth/infrastructure",
+            "/home/ec2-user/nousergon-console/infrastructure",
+            "/home/ec2-user/the-cyphering-ops/infrastructure",
+            "/home/ec2-user/vires/infrastructure",
         ):
             assert f"--codified-root {root}" in line, f"missing codified root {root}"
+        # boto3 does not infer region from IMDS: without these, --metric dies
+        # with "You must specify a region" (seen live 2026-08-09).
+        assert "Environment=AWS_REGION=us-east-1" in unit
+        assert "Environment=AWS_DEFAULT_REGION=us-east-1" in unit
 
     def test_metric_namespace_is_one_the_box_role_may_put_to(self, cd):
         """The box role's PutMetricData grant is namespace-conditioned to


### PR DESCRIPTION
## What

Follow-up to nousergon-data-PR1261, same shape, second measurement pass. A full-box `find` (not just `infrastructure/systemd` dirs) shows 10 of the remaining 22 "uncodified" units are codified **byte-identically** in checkouts the checker wasn't reading: `alpha-engine-dashboard/infrastructure` top level (`crucible-dash-api`, `crucible-dash-web`, `dashboard`), `alpha-engine-dashboard/live/infrastructure` (`nous-ergon-live`), `nousergon-auth`, `nousergon-console`, `the-cyphering-ops` (`signal`, `signal-pull` ×2), `vires`. All root checkouts measured current against origin/main (`behind=0`).

- ExecStart gains six `--codified-root` paths; baseline shrinks 22 → 12 (the 12 remaining are genuinely codified nowhere, each annotated with its owning repo — I6656 deliverable 1).
- `Environment=AWS_REGION/AWS_DEFAULT_REGION=us-east-1` on the unit: the first live `--metric` run failed loud with "You must specify a region" — boto3 does not infer region from IMDS.

## Tests

Spot-checks re-derived for both directions (six genuinely-uncodified stay; nine root-covered must not reappear); ExecStart guard covers all ten roots + the region env. Local before push: 236 passed, 2 skipped (`-k "systemd or drift"`).

## Deploy

On merge via `deploy-daily-news-units.yml`. I will re-run the check on the box after deploy and confirm `clean=48 uncodified=12 unreadable=0`, exit 0, and a `[metric] emitted` line with datapoints in `AlphaEngine/Box`.

Refs: alpha-engine-config-I6656, nousergon-data-PR1261 (merged), nousergon-data-PR1250 (merged).

Prepared by: claude-fable-5 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)