### PR TITLE
[P2/low] chore(systemd): baseline 12→10 — morning-signal-pull codified (config#6656)

### DIFF
--- a/infrastructure/systemd/uncodified-units-baseline.txt
+++ b/infrastructure/systemd/uncodified-units-baseline.txt
@@ -35,8 +35,6 @@
 # unit to anything. Its drop-in directory is not covered here either — this
 # checker compares unit FILES; `.d/*.conf` coverage is a separate deliverable
 # on I6656.
-morning-signal-pull.service    # UNKNOWN
-morning-signal-pull.timer      # UNKNOWN
 
 # ── metron ─────────────────────────────────────────────────────────────────
 

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -373,7 +373,6 @@ class TestCoverageAccounting:
             "litellm-proxy.service",
             "llm-egress-proxy.service",
             "mnemon.service",
-            "morning-signal-pull.service",
             "certbot-renew.timer",
             "ibgateway.service",
         ):
@@ -389,6 +388,7 @@ class TestCoverageAccounting:
             "nousergon-console.service",   # nousergon-console root
             "signal.service",              # the-cyphering-ops root
             "vires.service",               # vires root
+            "morning-signal-pull.service", # codified by crucible-dashboard-PR635
         ):
             assert name not in baseline, (
                 f"{name} is covered by a --codified-root and must not be baselined "


### PR DESCRIPTION
## What

crucible-dashboard-PR635 (merged + deployed 2026-08-09) codified `morning-signal-pull.{service,timer}`; the live coverage run now reports them clean (`SUMMARY installed=60 clean=50 drift=0 uncodified=10 unreadable=0`). The baseline is a shrink-only work queue — these two leave it, and the spot-check test flips them to the must-not-reappear list.

Merge order: crucible-dashboard-PR635 first (already merged) → this.

## Tests

236 passed, 2 skipped locally before push (`-k "systemd or drift"`).

Refs: alpha-engine-config-I6656, crucible-dashboard-PR635.

Prepared by: claude-fable-5 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)