### PR TITLE
[P3/low] docs(systemd): annotate baseline with measured codification state (config#6656)

### DIFF
--- a/infrastructure/systemd/uncodified-units-baseline.txt
+++ b/infrastructure/systemd/uncodified-units-baseline.txt
@@ -39,15 +39,15 @@
 # ── metron ─────────────────────────────────────────────────────────────────
 
 # ── other products co-tenant on this box ───────────────────────────────────
-mnemon.service                 # mnemon
-mnemon-sync.service            # mnemon
-mnemon-sync.timer              # mnemon
+mnemon.service                 # mnemon — BLOCKED on config#6712: unit embeds the live MNEMON_TOKEN; rotate + EnvironmentFile before codifying
+mnemon-sync.service            # mnemon — codify with mnemon.service after config#6712
+mnemon-sync.timer              # mnemon — codify with mnemon.service after config#6712
 
 # ── shared infrastructure ──────────────────────────────────────────────────
-litellm-proxy.service          # nous-ergon-ops (the model router)
-llm-egress-proxy.service       # nous-ergon-ops (the DLP egress proxy)
-ibgateway.service              # nous-ergon-ops
-xvfb.service                   # nous-ergon-ops (ibgateway's display)
-certbot-renew.service          # nous-ergon-ops
-certbot-renew.timer            # nous-ergon-ops
+litellm-proxy.service          # CODIFIED nous-ergon-ops alpha-engine-dashboard/live/infrastructure/systemd/, byte-identical 2026-08-09 — leaves this file when the checker gains a root for that repo (deploy-path ruling on config#6337)
+llm-egress-proxy.service       # CODIFIED nous-ergon-ops (ops-PR533), byte-identical 2026-08-09 — same root gap as litellm-proxy
+ibgateway.service              # CODIFIED nous-ergon-ops (ops-PR534), byte-identical 2026-08-09 — same root gap
+xvfb.service                   # CODIFIED nous-ergon-ops (ops-PR534, ibgateway's display), byte-identical 2026-08-09 — same root gap
+certbot-renew.service          # CODIFIED nous-ergon-ops (8/8 arc), byte-identical 2026-08-09 — same root gap
+certbot-renew.timer            # CODIFIED nous-ergon-ops (8/8 arc), byte-identical 2026-08-09 — same root gap
 amazon-cloudwatch-agent.service # vendor-installed; likely never codified here


### PR DESCRIPTION
## What

Comment-only baseline update: 6 of the 10 remaining units are codified byte-identically in nous-ergon-ops (litellm-proxy, llm-egress-proxy via ops-PR533, xvfb + ibgateway via ops-PR534, certbot pair from the 8/8 arc) and wait only on the config#6337 deploy-path ruling for checker root-verification; mnemon ×3 are blocked on config#6712 (inline token — rotate first); amazon-cloudwatch-agent is vendor-installed. Keeps the work queue self-describing for the groom.

## Tests

236 passed, 2 skipped locally before push (`-k "systemd or drift"`). No behavior change — comments only.

Refs: alpha-engine-config-I6656, I6337, I6712.

Prepared by: claude-fable-5 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)