### PR TITLE
fix(sf): Director state TimeoutSeconds 300 -> 930 — cover the resized Lambda budget (config#6050)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -4318,7 +4318,7 @@
           "dry_run.$": "$.research_dry"
         }
       },
-      "TimeoutSeconds": 300,
+      "TimeoutSeconds": 930,
       "Retry": [
         {
           "ErrorEquals": [


### PR DESCRIPTION
## What & why

One line: the weekly SF `Director` state's `TimeoutSeconds` 300 → 930. Companion to crucible-evaluator-PR182 (**merge order: PR182 first**, it resizes the Lambda itself to 900s; this state must exceed the Lambda's budget so a Lambda timeout surfaces as a Lambda error with a cause, not an anonymous `States.Timeout`).

The 2026-08-08 Saturday run died exactly here (execution event 3744, `States.Timeout` at 300s): the Director's ultra-group plan call (measured single-call p99 ≈ 285s) was aborted at krepis's 180s default client timeout, retried, and the retry crossed the 300s wall. With the I6408 fail-hard ruling live, the next full run would terminate FAILED at this state.

**Stated baseline per sf-pipeline-policy §4** (timeouts are budgets, raised only with a reason): the Director's model tier moved to the ultra reasoning group (2026-08-02 router migration); 930 = Lambda 900 (plan 340s×2 + judge 120s×2 + overhead) + 30s margin. Not an accommodation of an unexplained regression — the regression (client-default 180s mid-flight abort) is fixed at its own layer in PR182.

## Test plan

Full suite green locally before opening: 4461 passed, 8 skipped (repo venv). Structural-contract, retry-ladder, wiring, drift-check suites all pass.

Live verification (in-session, after both merges): direct re-invoke of `alpha-engine-evaluator-director:live` for run_date 2026-08-08 — backfills the missed Saturday artifact and exercises the full resized chain; result recorded on config#6050.

Refs: alpha-engine-config-I6050 (fix path ruled by Brian 2026-08-09), crucible-evaluator-PR182, alpha-engine-config-I6408 (fail-hard ruling).

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_structural_contract.py
