### PR TITLE
fix(sf): wire cadence drift --check into daily sweep; retire the can-never-fire weekly deadman (config#6701)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -74,9 +74,14 @@ jobs:
       # config#6701 deliverable 3-wiring: the declared weekly exercise-cadence
       # manifest vs the live SSM parameter, out-of-band of deploys (the deploy
       # path runs --enforce; this catches drift BETWEEN deploys). AccessDenied
-      # here means ops-PR538's grant has not been applied yet — that red is the
-      # form-3 detector for the operator-gated apply, not a bug in this step.
+      # here means ops-PR538's grant has not been applied yet — the DAILY
+      # scheduled run staying red is the form-3 detector for that
+      # operator-gated apply. Schedule/dispatch only: `drift-check` is a
+      # REQUIRED PR check, so running this on the pull_request path before the
+      # grant exists would block every PR on a red only an operator can clear
+      # (the gate-only-the-blocked-actor-can-clear trap).
       - name: Weekly exercise-cadence drift (manifest vs live SSM)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: python3 infrastructure/weekly_cadence_drift.py --check
 
       - name: EventBridge SF-ARN drift (codified vs live)

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -35,6 +35,8 @@ on:
       - 'infrastructure/scheduler/**'
       - 'infrastructure/automation_pause.json'
       - 'infrastructure/automation_pause.py'
+      - 'infrastructure/weekly_cadence.json'
+      - 'infrastructure/weekly_cadence_drift.py'
       - '.github/workflows/sf-arn-drift-check.yml'
   schedule:
     - cron: '30 9 * * *'   # daily, alongside the IAM sweep
@@ -68,6 +70,14 @@ jobs:
       # scheduler:GetSchedule this role already holds.
       - name: Scheduled-automation pause still holds (live)
         run: python3 infrastructure/automation_pause.py --check
+
+      # config#6701 deliverable 3-wiring: the declared weekly exercise-cadence
+      # manifest vs the live SSM parameter, out-of-band of deploys (the deploy
+      # path runs --enforce; this catches drift BETWEEN deploys). AccessDenied
+      # here means ops-PR538's grant has not been applied yet — that red is the
+      # form-3 detector for the operator-gated apply, not a bug in this step.
+      - name: Weekly exercise-cadence drift (manifest vs live SSM)
+        run: python3 infrastructure/weekly_cadence_drift.py --check
 
       - name: EventBridge SF-ARN drift (codified vs live)
         run: python3 infrastructure/eventbridge/check-drift.py

--- a/infrastructure/setup_pipeline_deadman_alarms.sh
+++ b/infrastructure/setup_pipeline_deadman_alarms.sh
@@ -80,12 +80,20 @@ BACKSTOP_ALERT_EMAIL="${BACKSTOP_ALERT_EMAIL:-cipher813@gmail.com}"
 FORWARDER_FUNCTION_NAME="alpha-engine-backstop-telegram-notifier"
 FORWARDER_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FORWARDER_FUNCTION_NAME}"
 
-# The three canonical Alpha Engine orchestration state machines (per the
+# The weekday Alpha Engine orchestration state machines (per the
 # pipeline-reporting-revamp scope / crucible-dashboard views/25_Pipeline_Status.py
 # _SF_ORDER). alpha-engine-groom-pipeline is intentionally excluded — it is
 # not part of the reporting-revamp's operator-facing pipeline set.
+# ne-weekly-freshness-pipeline is intentionally excluded (removed 2026-08-09,
+# config#5599/#6701): a CloudWatch ExecutionsSucceeded deadman cannot carry the
+# weekly pipeline's cadence semantics — AWS/States has no pipeline_role
+# dimension, so daily exercise runs keep the metric warm and a missed Saturday
+# production run can never breach. Its liveness detector is
+# scripts/weekly_sf_silence_deadman.py (sf-pipeline-policy §2.6), which derives
+# per-role expectation from the declared cadence; scheduling rides the
+# config#6617 automation-pause lift. A can-never-fire alarm is worse than no
+# alarm — it renders as coverage while providing none.
 declare -A STATE_MACHINES=(
-  ["weekly-freshness"]="ne-weekly-freshness-pipeline"
   ["preopen-trading"]="ne-preopen-trading-pipeline"
   ["postclose-trading"]="ne-postclose-trading-pipeline"
 )

--- a/tests/test_pipeline_deadman_alarms_script.py
+++ b/tests/test_pipeline_deadman_alarms_script.py
@@ -89,12 +89,18 @@ class TestIndependentBackstopTopic:
 
 
 class TestStateMachineCoverage:
-    """All three canonical orchestration state machines must be alarmed."""
+    """The weekday orchestration state machines must be alarmed.
+
+    ne-weekly-freshness-pipeline is deliberately NOT in this set (config#5599,
+    removed 2026-08-09): AWS/States has no pipeline_role dimension, so the
+    daily exercise cadence keeps ExecutionsSucceeded warm and a weekly deadman
+    here can never fire — false coverage. Its liveness detector is
+    scripts/weekly_sf_silence_deadman.py (sf-pipeline-policy §2.6).
+    """
 
     @pytest.mark.parametrize(
         "sf_name",
         [
-            "ne-weekly-freshness-pipeline",
             "ne-preopen-trading-pipeline",
             "ne-postclose-trading-pipeline",
         ],
@@ -115,13 +121,16 @@ class TestStateMachineCoverage:
         ]
         assert "alpha-engine-groom-pipeline" not in block
 
-    def test_three_state_machines_declared(self, script_text):
+    def test_exactly_the_weekday_state_machines_declared(self, script_text):
         assert re.search(r"declare -A STATE_MACHINES=\(", script_text)
-        # Exactly 3 quoted values assigned in the associative array block.
+        # Exactly 2 quoted values assigned in the associative array block —
+        # the weekly pipeline must not silently reappear here (see class
+        # docstring), and a third pipeline must be added deliberately.
         block = script_text[
             script_text.find("declare -A STATE_MACHINES=(") : script_text.find(")", script_text.find("declare -A STATE_MACHINES=("))
         ]
-        assert block.count('"ne-') == 3
+        assert block.count('"ne-') == 2
+        assert "ne-weekly-freshness-pipeline" not in block
 
 
 class TestAlarmSemantics:


### PR DESCRIPTION
## What & why

Completes alpha-engine-config#6701's remaining deliverables (companion to **ops-PR538**; merge order: ops-PR538 first, then this):

1. **`sf-arn-drift-check.yml`** — adds `weekly_cadence_drift.py --check` to the daily sweep + PR paths filter (mirrors the `automation_pause.py --check` shape the issue prescribed). Out-of-band of deploys: the deploy path already runs `--enforce` (verified: `deploy-infrastructure.sh` runs under `set -euo pipefail`, so an `--enforce` failure aborts loud — the issue's noted verification, no swallow to fix). The step is AccessDenied-red until ops-PR538's grant is applied by the operator — that red is the §4.2 form-3 detector for the excluded-from-auto-apply IAM path, by design.
2. **Retire the can-never-fire weekly deadman** (config#5599, closed superseded 2026-08-09): `setup_pipeline_deadman_alarms.sh` drops `ne-weekly-freshness-pipeline` (AWS/States has no `pipeline_role` dimension; daily exercise runs keep `ExecutionsSucceeded` warm, so the weekly alarm renders as coverage while providing none). The live alarm `alpha-engine-pipeline-deadman-weekly-freshness` is deleted in-session alongside this PR. The weekly pipeline's real liveness detector is `scripts/weekly_sf_silence_deadman.py` (sf-pipeline-policy §2.6); its scheduling rides the config#6617 automation-pause lift.
3. Coverage test updated to pin the weekday-only set and forbid the weekly alarm's silent reappearance.

## Test plan

Full suite green locally before opening (repo venv): 4495 passed, 8 skipped.

Refs: alpha-engine-config-I6701, alpha-engine-config-I5599, ops-PR538, ops-PR530 (grants 1+2), sf-pipeline-policy §2.6.

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)
