### PR TITLE
feat(sf): split skip_post_eval — ReportCard and Director independently controllable (config#6054)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -4545,7 +4545,7 @@
         {
           "Variable": "$.substrate_check_poll.Status",
           "StringEquals": "Success",
-          "Next": "ReportCard"
+          "Next": "CheckSkipReportCard"
         },
         {
           "And": [
@@ -4589,7 +4589,7 @@
       "Comment": "config#2276: the substrate health check (or its constituents-drift sub-step) could not run to Success. Mirrors SaturdayHealthCheckDegraded / the LibPinGateDegraded shape (config#2278) \u2014 SF-controlled boolean into the completion-email selection. Shares $.health_check_degraded with the freshness twin DELIBERATELY (one flag family, one degraded Subject \u2014 which check degraded lives on the execution record: $.substrate_check_error / $.substrate_check_poll vs $.health_check_error / $.health_check_poll \u2014 avoiding a per-check combinatorial notifier explosion). Continues to ReportCard: the advisory Lambda tail is independent of the dashboard box and must not be skipped because an EC2 health command failed.",
       "Result": true,
       "ResultPath": "$.health_check_degraded",
-      "Next": "ReportCard"
+      "Next": "CheckSkipReportCard"
     },
     "ReportCard": {
       "Type": "Task",
@@ -4626,7 +4626,7 @@
         }
       ],
       "ResultPath": "$.report_card_result",
-      "Next": "Director"
+      "Next": "CheckSkipDirector"
     },
     "ReportCardDegraded": {
       "Type": "Pass",
@@ -4691,7 +4691,7 @@
         }
       ],
       "ResultPath": "$.director_result",
-      "Next": "CheckShellRunNotify"
+      "Next": "DirectorComplete"
     },
     "CheckShellRunNotify": {
       "Type": "Choice",
@@ -5975,6 +5975,51 @@
       "InputPath": "$.weekly_freshness_spot_poll_count.polls",
       "ResultPath": "$.weekly_freshness_spot_polls",
       "Next": "WaitForWeeklyFreshnessSpotBootstrap"
+    },
+    "CheckSkipReportCard": {
+      "Type": "Choice",
+      "Comment": "config#6054: per-stage skip gate splitting the coarse skip_post_eval (which still bypasses the WHOLE tail at CheckSkipPostEval and is retained as a deprecated alias \u2014 remove once a full cycle passes with the split flags). {\"skip_report_card\": true} bypasses only ReportCard, landing on CheckSkipDirector so Director remains independently controllable \u2014 the 2026-08-01 incident this fixes: rerun -5 silently skipped Director behind the shared flag, rerun -6 re-ran an already-green ReportCard as a toll to reach it (weekly-sf-policy \u00a72.1 applied to control, not just failure).",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_report_card",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_report_card",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckSkipDirector"
+        }
+      ],
+      "Default": "ReportCard"
+    },
+    "CheckSkipDirector": {
+      "Type": "Choice",
+      "Comment": "config#6054: {\"skip_director\": true} bypasses only the Director advisory. Sibling of CheckSkipReportCard; see its comment for the split rationale.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_director",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_director",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckShellRunNotify"
+        }
+      ],
+      "Default": "Director"
+    },
+    "DirectorComplete": {
+      "Type": "Pass",
+      "Comment": "config#6054: success-only witness for the rerun deriver (scripts/weekly_sf_rerun.py). Director's success and every bypass path previously converged on CheckShellRunNotify, so no state uniquely witnessed 'Director actually completed' \u2014 the I6055-class trap: a rerun could mark a bypassed Director complete and skip it. Entered ONLY via Director's success edge.",
+      "Next": "CheckShellRunNotify"
     }
   }
 }

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -366,31 +366,67 @@ STAGES: tuple[Stage, ...] = (
         "CheckSkipEvaluator", "Evaluator",
         frozenset({"CheckSkipPostEval"}),
     ),
+    # config#6054: the coarse post_eval span is SPLIT. The two health checks
+    # keep no flag of their own — they are advisory, idempotent, and cheap,
+    # so a tail rerun simply re-runs them (their degraded markers are carried
+    # by the post_eval alias row below, informationally; a health-check
+    # degradation alone never forces a ReportCard re-run, which is why they
+    # are NOT in report_card's degraded_witness). skip_post_eval survives in
+    # the DEFINITION as a deprecated whole-tail alias (CheckSkipPostEval)
+    # for in-flight inputs; the deriver no longer emits it — it emits the
+    # per-stage flags below.
     Stage(
         "post_eval", "skip_post_eval",
         "CheckSkipPostEval", "SaturdayHealthCheck",
         frozenset({"CheckShellRunNotify"}),
-        # Every degraded route in the tail (config#2276 health checks +
-        # config#2302 ReportCard). Director is NO LONGER in this set
-        # (config#6408: Director failure is now TERMINAL via
-        # NormalizeFailureContext → FailExecution). PublishDirectorDegraded
-        # is RETAINED for backward compatibility with pre-fix execution
-        # histories that still reference it — new executions never enter it.
-        # config#6685: ReportCardDegraded is the new Pass state ReportCard's
-        # Catch routes to FIRST (sets $.report_card_degraded before
-        # proceeding, unchanged, to PublishReportCardDegraded) — added
-        # alongside it so a rerun does not treat a ReportCard-degraded
-        # execution as complete.
+        # Health-check degraded routes only (config#2276) — ReportCard's
+        # and Director's moved to their own rows below (config#6054).
         degraded_witness=frozenset({
             "SaturdayHealthCheckDegraded", "SubstrateHealthCheckDegraded",
-            "ReportCardDegraded", "PublishReportCardDegraded",
-            "PublishDirectorDegraded",
         }),
+        emit_skip=False,
         note=(
-            "skip_post_eval covers the whole health-check/report-card/"
-            "director tail; a failure inside it re-runs the whole tail"
-            " (no finer-grained flags exist)."
+            "skip_post_eval is a DEPRECATED whole-tail alias (config#6054): "
+            "the deriver emits skip_report_card / skip_director instead; the "
+            "health checks re-run on any tail rerun (advisory + idempotent). "
+            "Remove the alias once a full cycle has passed on the split "
+            "flags."
         ),
+    ),
+    Stage(
+        "report_card", "skip_report_card",
+        "CheckSkipReportCard", "ReportCard",
+        # Success-only witness: ReportCard's success edge now lands on
+        # CheckSkipDirector (config#6054). Pre-split histories entered
+        # "Director" directly on ReportCard success. A skipped ReportCard
+        # ALSO enters CheckSkipDirector — same convention as evaluator's
+        # CheckSkipPostEval witness: a skip in the original run implies a
+        # completion the earlier run derived.
+        frozenset({"CheckSkipDirector", "Director"}),
+        # config#6685: ReportCardDegraded is the Pass state ReportCard's
+        # Catch routes to FIRST (sets $.report_card_degraded), then
+        # PublishReportCardDegraded — degraded overrides witness (I6055).
+        degraded_witness=frozenset({
+            "ReportCardDegraded", "PublishReportCardDegraded",
+        }),
+    ),
+    Stage(
+        "director", "skip_director",
+        "CheckSkipDirector", "Director",
+        # DirectorComplete is entered ONLY via Director's success edge
+        # (config#6054) — deliberately NOT CheckShellRunNotify, which every
+        # bypass path also enters: witnessing on it would mark a bypassed
+        # Director complete and skip it on the rerun (the I6055 trap, and
+        # the exact 2026-08-01 incident). Pre-split histories have no
+        # success-only witness, so the deriver conservatively RE-RUNS
+        # Director for them — re-running the advisory is the safe
+        # direction.
+        frozenset({"DirectorComplete"}),
+        # config#6408: Director failure is TERMINAL (NormalizeFailureContext
+        # → FailExecution) — no witness is entered, so the stage re-runs.
+        # PublishDirectorDegraded is RETAINED for pre-fix execution
+        # histories only; new executions never enter it.
+        degraded_witness=frozenset({"PublishDirectorDegraded"}),
     ),
 )
 
@@ -461,7 +497,7 @@ def _simulate_reachable_works(flags: dict, original_input: dict) -> set:
         run_linear(["predictor_backtest", "portfolio_optimizer_backtest", "parity"])
     else:
         run_linear(["backtester", "predictor_backtest", "portfolio_optimizer_backtest", "parity"])
-    run_linear(["evaluator", "post_eval"])
+    run_linear(["evaluator", "report_card", "director"])
     return ran
 
 

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -134,6 +134,11 @@ _EXPECTED_SKIPS = {
     "skip_parity",
     "skip_evaluator",
     "skip_post_eval",
+    # config#6054: per-stage split of the post-eval tail — skip_post_eval
+    # stays as the deprecated whole-tail alias; these two gate ReportCard
+    # and Director independently.
+    "skip_report_card",
+    "skip_director",
 }
 
 # KEYSTONE + skip-exception rewire: the 8 SPOT workload states. Under
@@ -925,14 +930,21 @@ class TestConsolidatedNotify:
             for r in states["CheckSubstrateHealthCheckStatus"]["Choices"]
             if r.get("StringEquals") == "Success"
         )
-        assert substrate_success["Next"] == "ReportCard"
+        # config#6054: the substrate check now lands on the per-stage skip
+        # gates rather than directly on ReportCard; the success chain is
+        # CheckSkipReportCard → ReportCard → CheckSkipDirector → Director →
+        # DirectorComplete (success-only rerun witness) → CheckShellRunNotify.
+        assert substrate_success["Next"] == "CheckSkipReportCard"
+        assert states["CheckSkipReportCard"]["Default"] == "ReportCard"
         report_card = states["ReportCard"]
-        assert report_card["Next"] == "Director"
+        assert report_card["Next"] == "CheckSkipDirector"
         assert all(c["Next"] == "ReportCardDegraded" for c in report_card["Catch"])
         assert states["ReportCardDegraded"]["Next"] == "PublishReportCardDegraded"
         assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
+        assert states["CheckSkipDirector"]["Default"] == "Director"
         director = states["Director"]
-        assert director["Next"] == "CheckShellRunNotify"
+        assert director["Next"] == "DirectorComplete"
+        assert states["DirectorComplete"]["Next"] == "CheckShellRunNotify"
         assert all(c["Next"] == "NormalizeFailureContext" for c in director["Catch"])
         assert all(c["ResultPath"] == "$.error" for c in director["Catch"])
 

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -59,7 +59,9 @@ CHECKS = [
     ("WeeklySubstrateHealthCheck", "WaitForWeeklySubstrateHealthCheck",
      "CheckSubstrateHealthCheckStatus", "SubstrateHealthCheckPollWait",
      "SubstrateHealthCheckDegraded", "$.substrate_check_poll",
-     "ReportCard", 240),
+     # config#6054: the tail entry is now the per-stage skip gate; its
+     # Default is ReportCard, so the degrade-then-proceed property holds.
+     "CheckSkipReportCard", 240),
 ]
 _IDS = [c[0] for c in CHECKS]
 

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -120,13 +120,18 @@ class TestChainOrdering:
         # Director's Catch now routes to NormalizeFailureContext — a
         # Director failure terminates the execution FAILED rather than
         # reporting degraded success.
-        assert states["ReportCard"]["Next"] == "Director"
+        # config#6054: ReportCard's success edge lands on the Director's
+        # per-stage skip gate (Default: Director); Director's success edge
+        # lands on the DirectorComplete rerun witness before the notify gate.
+        assert states["ReportCard"]["Next"] == "CheckSkipDirector"
+        assert states["CheckSkipDirector"]["Default"] == "Director"
         assert all(
             c["Next"] == "ReportCardDegraded" for c in states["ReportCard"]["Catch"]
         )
         assert states["ReportCardDegraded"]["Next"] == "PublishReportCardDegraded"
         assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
-        assert states["Director"]["Next"] == "CheckShellRunNotify"
+        assert states["Director"]["Next"] == "DirectorComplete"
+        assert states["DirectorComplete"]["Next"] == "CheckShellRunNotify"
         assert all(
             c["Next"] == "NormalizeFailureContext" for c in states["Director"]["Catch"]
         )
@@ -149,7 +154,9 @@ class TestChainOrdering:
         success = next(
             r for r in choice["Choices"] if r.get("StringEquals") == "Success"
         )
-        assert success["Next"] == "ReportCard"
+        # config#6054: success lands on the per-stage gate (Default: ReportCard).
+        assert success["Next"] == "CheckSkipReportCard"
+        assert states["CheckSkipReportCard"]["Default"] == "ReportCard"
 
 
 class TestCatchSemantics:
@@ -181,10 +188,12 @@ class TestCatchSemantics:
     def test_substrate_degraded_continues_to_advisory_tail(self, states):
         degraded = states["SubstrateHealthCheckDegraded"]
         assert degraded["Type"] == "Pass"
-        assert degraded["Next"] == "ReportCard", (
+        assert degraded["Next"] == "CheckSkipReportCard", (
             "A degraded substrate check must not skip the ReportCard/Director "
-            "Lambda tail — it is independent of the dashboard box."
+            "Lambda tail — it is independent of the dashboard box. "
+            "(config#6054: the tail entry is the skip gate, Default: ReportCard.)"
         )
+        assert states["CheckSkipReportCard"]["Default"] == "ReportCard"
 
 
 class TestCommandShape:

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -440,6 +440,19 @@ class TestStageTableLockstep:
                     "ValidatePredictorSkipWeightsFresh",
                 }
                 continue
+            if stage.name == "director":
+                # config#6054: DELIBERATE exception, inverted from the
+                # convention. director's witness is the success-only
+                # DirectorComplete Pass state, and its skip route lands on
+                # CheckShellRunNotify — which every bypass path also enters.
+                # Witnessing on the skip target would mark a bypassed
+                # Director complete and skip it on the rerun (the I6055
+                # trap). Cost of the inversion: an original run that SKIPPED
+                # director yields a rerun that re-runs it — the safe
+                # direction for an advisory stage.
+                assert skip_targets == {"CheckShellRunNotify"}
+                assert "DirectorComplete" not in skip_targets
+                continue
             if stage.name == "backtester_stage_only":
                 # config#2362 Option A additive gate: deliberately empty
                 # witness (it shares Backtester's work state with the


### PR DESCRIPTION
## What & why

Implements alpha-engine-config#6054 (Brian's 2026-08-01 ruling): `ReportCard` and `Director` are already separate states but shared one `skip_post_eval` flag, so neither could be skipped or resumed independently — rerun `-5` silently skipped Director behind the shared flag; rerun `-6` re-ran an already-green ReportCard as a toll to reach it (§2.1 applied to control, not just failure).

- New `CheckSkipReportCard` / `CheckSkipDirector` Choice gates; edges rewired (substrate check → RC gate; ReportCard → Director gate; Director → `DirectorComplete` → notify).
- `skip_post_eval` retained at `CheckSkipPostEval` as the deprecated whole-tail alias (unchanged behavior for in-flight inputs); remove after one full cycle on the split flags.
- **`DirectorComplete`** (Pass) is the success-only rerun witness: every bypass path also enters `CheckShellRunNotify`, so witnessing there would mark a bypassed Director complete and skip it on the rerun — the I6055 trap and the exact 2026-08-01 incident. Deliberate inversion of the skip-target∈witness convention, documented in the lockstep test's exception.
- `scripts/weekly_sf_rerun.py`: `post_eval` row split into `report_card` + `director` rows, each deriving its flag from its own stage's completion; the alias row stays `emit_skip=False`; pre-split histories conservatively re-run Director (safe direction for an advisory).
- Ordering preserved; nothing parallelized (deliverable 4).

## Test plan

Full suite green locally before opening (repo venv): **4549 passed, 8 skipped**. Edge pins updated deliberately in `test_sf_friday_shell_run_wiring.py`, `test_sf_substrate_check_wiring.py`, `test_sf_health_check_honesty_wiring.py`, `test_weekly_sf_rerun.py` — each still asserts the property it was written for (degrade-then-proceed now asserts the gate's Default lands on ReportCard).

closes-when residual: the issue's live demonstration (`skip_report_card: true, skip_director: false` on a real rerun) runs on the next rerun occasion — noted on the issue rather than blocking this PR.

Closes nousergon/alpha-engine-config#6054

Refs: alpha-engine-config-I6054, I6055 (deriver degraded-counts-complete — separate, still open), I6408, weekly-sf-policy §2.1. Coordinated with feat/i6030-parity-split (separate region of the same definition; whichever lands second rebases).

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_friday_shell_run_wiring.py
