### PR TITLE
feat(watchdog): prior-day started-but-never-succeeded check, independent of the SF's own notifier (config#6732)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -58,6 +58,17 @@
       ]
     },
     {
+      "Sid": "CompletionMarkerRead",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-preopen-trading-pipeline/*",
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-postclose-trading-pipeline/*"
+      ]
+    },
+    {
       "Sid": "DedupMarkerS3IO",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -88,7 +88,9 @@
         "StringLike": {
           "s3:prefix": [
             "_alerts/_dedup",
-            "_alerts/_dedup/*"
+            "_alerts/_dedup/*",
+            "_sf_completion/ne-preopen-trading-pipeline/*",
+            "_sf_completion/ne-postclose-trading-pipeline/*"
           ]
         }
       }

--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -915,10 +915,270 @@ def _check_preopen_buffer(
     )
 
 
+# ── Prior-day failed-run check (alpha-engine-config#6732) ─────────────────
+#
+# sf-pipeline-policy §4.1 requires a liveness detector INDEPENDENT of the
+# pipeline's own notifier that is sensitive to started-but-never-succeeded.
+# The three liveness checks above answer only "did it fire" — a day where
+# every execution FAILED satisfies them by design (``_STARTED_STATUSES``),
+# failure alerting was delegated to the SF's own HandleFailure path (which
+# is exactly the dependent channel §4.1 says not to rely on), and the
+# independent deadman (ExecutionsSucceeded, 7-day period) needs a week of
+# silence to breach. This check closes that combination: on the watchdog
+# firing after a trading day whose weekday/EOD executions all terminated
+# without success AND without a DEGRADED completion marker (the Option-A
+# visible-degrade terminal, which status-keyed watchers already engage on,
+# config#6692), page. Zero-execution days are deliberately excluded — that
+# is the never-fired case the ``_check_sf`` liveness checks above own.
+
+MARKER_BUCKET = os.environ.get("COMPLETION_MARKER_BUCKET", "alpha-engine-research")
+
+# (sf_label suffix, SF ARN, marker pipeline segment). Marker keys follow the
+# definitions' WriteCompletionMarker states: the {date} segment is the UTC
+# date-part of $$.Execution.StartTime — for both pipelines every legal start
+# (preopen 12:15 UTC, postclose ~20:15–23:00 UTC incl. the backstop path)
+# lands on the same UTC calendar date as the PT trading date, so a lookup by
+# PT trading date is exact.
+_FAILED_DAY_PIPELINES = (
+    ("Weekday SF", WEEKDAY_SF_ARN, "ne-preopen-trading-pipeline"),
+    ("EOD SF", EOD_SF_ARN, "ne-postclose-trading-pipeline"),
+)
+
+
+@dataclass(frozen=True)
+class FailedDayCheckResult:
+    """Per-SF outcome of one prior-day failed-run check."""
+
+    sf_label: str
+    checked: bool
+    target_trading_day: Optional[str] = None
+    skip_reason: Optional[str] = None
+    executions_on_day: Optional[int] = None
+    succeeded_on_day: Optional[int] = None
+    marker_status: Optional[str] = None  # None = not consulted
+    alert_emitted: bool = False
+    alert_detail: Optional[str] = None
+
+
+def _statuses_for_day(
+    client: object, sf_arn: str, target_date: date
+) -> "dict[str, int]":
+    """Count executions per status whose ``startDate`` falls on
+    ``target_date`` in PT calendar terms. Pages newest-first per status and
+    stops once rows predate the target day. Date comparison only — no
+    datetime construction, so ``patch("index.datetime")`` in tests never
+    bites (see the module's ``_eod_window_seconds`` note for the pattern).
+    """
+    counts: "dict[str, int]" = {}
+    for status_filter in _STARTED_STATUSES:
+        next_token: Optional[str] = None
+        while True:
+            kwargs = {
+                "stateMachineArn": sf_arn,
+                "statusFilter": status_filter,
+                "maxResults": 100,
+            }
+            if next_token:
+                kwargs["nextToken"] = next_token
+            resp = client.list_executions(**kwargs)
+            stop_paging = False
+            for row in resp.get("executions") or []:
+                start = row.get("startDate")
+                if start is None or not hasattr(start, "astimezone"):
+                    continue
+                start_utc = (
+                    start.astimezone(timezone.utc)
+                    if start.tzinfo
+                    else start.replace(tzinfo=timezone.utc)
+                )
+                start_pt_date = start_utc.astimezone(PT_ZONE).date()
+                if start_pt_date == target_date:
+                    counts[status_filter] = counts.get(status_filter, 0) + 1
+                elif start_pt_date < target_date:
+                    # Newest-first ordering → everything further is older.
+                    stop_paging = True
+                    break
+            if stop_paging:
+                break
+            next_token = resp.get("nextToken")
+            if not next_token:
+                break
+    return counts
+
+
+def _completion_marker_status(
+    s3_client: object, pipeline_name: str, target_date: date
+) -> str:
+    """Status field of the day's completion marker, ``"ABSENT"`` when the
+    key does not exist, ``"UNREADABLE"`` on any other failure.
+
+    UNREADABLE is deliberately distinct from ABSENT and both page (§2.3a:
+    a missing verdict propagates as UNKNOWN, never as pass) — the swallowed
+    failure modes here (S3 errors other than NoSuchKey, unparseable JSON,
+    missing status field) all route to the caller's alert path plus a
+    WARNING log, never to a silent pass.
+    """
+    key = f"_sf_completion/{pipeline_name}/{target_date.isoformat()}.json"
+    try:
+        resp = s3_client.get_object(Bucket=MARKER_BUCKET, Key=key)
+        marker = json.loads(resp["Body"].read())
+        status = marker.get("status") if isinstance(marker, dict) else None
+        if isinstance(status, str) and status:
+            return status
+        logger.warning(
+            "failed-day check: marker s3://%s/%s has no usable status field",
+            MARKER_BUCKET, key,
+        )
+        return "UNREADABLE"
+    except Exception as exc:  # classified below — never a silent pass
+        code = ""
+        response = getattr(exc, "response", None)
+        if isinstance(response, dict):
+            code = (response.get("Error") or {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            return "ABSENT"
+        logger.warning(
+            "failed-day check: marker s3://%s/%s unreadable (%s: %s)",
+            MARKER_BUCKET, key, type(exc).__name__, exc,
+        )
+        return "UNREADABLE"
+
+
+def _check_failed_day(
+    *,
+    sf_label: str,
+    sf_arn: str,
+    pipeline_name: str,
+    target_date: date,
+    client: Optional[object] = None,
+    s3_client: Optional[object] = None,
+) -> FailedDayCheckResult:
+    """Page when ``target_date`` (the most recent closed trading day) had
+    executions for this SF but none SUCCEEDED and no DEGRADED marker was
+    written. See the block comment above for why this exists."""
+    if client is None:  # pragma: no cover — production path
+        client = boto3.client("stepfunctions", region_name=REGION)
+
+    counts = _statuses_for_day(client, sf_arn, target_date)
+    total = sum(counts.values())
+    succeeded = counts.get("SUCCEEDED", 0)
+
+    if total == 0:
+        return FailedDayCheckResult(
+            sf_label=sf_label,
+            checked=True,
+            target_trading_day=target_date.isoformat(),
+            executions_on_day=0,
+            succeeded_on_day=0,
+            skip_reason=(
+                "no executions on the target day — never-fired is the "
+                "liveness checks' case, not this one's"
+            ),
+        )
+    if succeeded > 0:
+        return FailedDayCheckResult(
+            sf_label=sf_label,
+            checked=True,
+            target_trading_day=target_date.isoformat(),
+            executions_on_day=total,
+            succeeded_on_day=succeeded,
+        )
+
+    running = counts.get("RUNNING", 0)
+    if running > 0:
+        # A prior-day execution still RUNNING at 14:00 UTC the next day is
+        # inside the definitions' top-level TimeoutSeconds only marginally
+        # (postclose ceiling 18h from a ~20:15 UTC start). Don't declare the
+        # day failed yet — but say so at warning severity rather than
+        # silently deferring: an 18h run is itself a hang in the making.
+        message = (
+            f"{sf_label} ({pipeline_name}) still has {running} RUNNING "
+            f"execution(s) from trading day {target_date} at watchdog time — "
+            f"no SUCCEEDED execution for that day yet. This is at or beyond "
+            f"the definition's top-level timeout horizon; investigate: "
+            f"`aws stepfunctions list-executions --state-machine-arn {sf_arn} "
+            f"--max-results 10`."
+        )
+        dedup_key = f"pipeline-watchdog-failed-day-{pipeline_name}-{target_date.isoformat()}"
+        alert_detail = _publish_watchdog_alert(
+            message,
+            severity="warning",
+            dedup_key=dedup_key,
+            context={"sf_label": sf_label, "sf_arn": sf_arn,
+                     "target_trading_day": target_date.isoformat()},
+        )
+        return FailedDayCheckResult(
+            sf_label=sf_label,
+            checked=True,
+            target_trading_day=target_date.isoformat(),
+            executions_on_day=total,
+            succeeded_on_day=0,
+            alert_emitted=True,
+            alert_detail=alert_detail,
+        )
+
+    if s3_client is None:  # pragma: no cover — production path
+        s3_client = boto3.client("s3", region_name=REGION)
+    marker_status = _completion_marker_status(s3_client, pipeline_name, target_date)
+
+    if marker_status == "DEGRADED":
+        # Option-A visible degrade (config#6692): the run terminated in a
+        # Fail state on purpose, the marker says so, and status-keyed
+        # watchers engaged. Not a silent failure — do not double-page.
+        logger.info(
+            "failed-day clear (degraded-by-design): sf=%s day=%s marker=DEGRADED",
+            sf_label, target_date,
+        )
+        return FailedDayCheckResult(
+            sf_label=sf_label,
+            checked=True,
+            target_trading_day=target_date.isoformat(),
+            executions_on_day=total,
+            succeeded_on_day=0,
+            marker_status=marker_status,
+        )
+
+    marker_clause = {
+        "ABSENT": "no completion marker was written",
+        "UNREADABLE": "the completion marker could not be read/parsed (UNKNOWN ≠ pass)",
+    }.get(marker_status, f"completion marker status={marker_status!r}")
+    message = (
+        f"{sf_label} ({pipeline_name}) FAILED trading day {target_date}: "
+        f"{total} execution(s) started, none SUCCEEDED, and {marker_clause}. "
+        f"This is the independent started-but-never-succeeded detector "
+        f"(sf-pipeline-policy §4.1, alpha-engine-config#6732) — do not assume "
+        f"the SF's own failure notification fired. Recover mechanically with "
+        f"the rerun helper: `python scripts/weekday_sf_rerun.py "
+        f"--execution-arn <failed execution arn> --dry-run` (then `--start`); "
+        f"list candidates: `aws stepfunctions list-executions "
+        f"--state-machine-arn {sf_arn} --max-results 10`."
+    )
+    dedup_key = f"pipeline-watchdog-failed-day-{pipeline_name}-{target_date.isoformat()}"
+    alert_detail = _publish_watchdog_alert(
+        message,
+        severity="error",
+        dedup_key=dedup_key,
+        context={"sf_label": sf_label, "sf_arn": sf_arn,
+                 "target_trading_day": target_date.isoformat(),
+                 "marker_status": marker_status},
+    )
+    return FailedDayCheckResult(
+        sf_label=sf_label,
+        checked=True,
+        target_trading_day=target_date.isoformat(),
+        executions_on_day=total,
+        succeeded_on_day=0,
+        marker_status=marker_status,
+        alert_emitted=True,
+        alert_detail=alert_detail,
+    )
+
+
 def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
-    """EventBridge cron handler. Runs the 3 per-SF liveness checks + the
-    preopen schedule-buffer canary, and returns a structured summary the
-    Lambda console / CW logs can read at a glance."""
+    """EventBridge cron handler. Runs the 3 per-SF liveness checks, the
+    preopen schedule-buffer canary, and the 2 prior-day failed-run checks,
+    and returns a structured summary the Lambda console / CW logs can read
+    at a glance."""
     now_utc = datetime.now(timezone.utc)
     is_trading_today = _is_trading_day_now(now_utc)
     is_sunday = now_utc.weekday() == 6  # Mon=0..Sun=6
@@ -968,6 +1228,21 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         is_watch_day=is_trading_today,
     )
 
+    # Prior-day failed-run checks (config#6732). The target is the most
+    # recent CLOSED trading day, which exists on every calendar day — so
+    # these run on weekends and holidays too (a Friday failure pages
+    # Saturday 14:00 UTC, not Monday).
+    failed_day_target = last_closed_trading_day(now_utc)
+    failed_day = [
+        _check_failed_day(
+            sf_label=label,
+            sf_arn=arn,
+            pipeline_name=pipeline,
+            target_date=failed_day_target,
+        )
+        for label, arn, pipeline in _FAILED_DAY_PIPELINES
+    ]
+
     summary = {
         "fired_at_utc": now_utc.isoformat(),
         "is_trading_today": is_trading_today,
@@ -996,6 +1271,20 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             "trend_days_used": preopen_buffer.trend_days_used,
             "trend_alert_emitted": preopen_buffer.trend_alert_emitted,
         },
+        "failed_day_checks": [
+            {
+                "sf_label": c.sf_label,
+                "checked": c.checked,
+                "target_trading_day": c.target_trading_day,
+                "skip_reason": c.skip_reason,
+                "executions_on_day": c.executions_on_day,
+                "succeeded_on_day": c.succeeded_on_day,
+                "marker_status": c.marker_status,
+                "alert_emitted": c.alert_emitted,
+                "alert_detail": c.alert_detail,
+            }
+            for c in failed_day
+        ],
     }
     logger.info("watchdog summary: %s", summary)
     return summary

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -320,6 +320,7 @@ def test_handler_passes_the_cadence_role_filter_for_the_saturday_check():
     _tc_mod.last_closed_trading_day.side_effect = [
         date(2026, 5, 29),
         date(2026, 5, 29),
+        date(2026, 5, 29),  # failed-day checks' target lookup (config#6732)
     ]
     # _eod_window_seconds runs even on a skipped EOD check (the window is an
     # argument), and the autouse fixture resets side_effect but not
@@ -469,6 +470,7 @@ def test_handler_on_trading_day_checks_weekday_and_eod_skips_saturday():
         date(2026, 5, 26),  # pre-open call at now
         date(2026, 5, 27),  # synthetic 22:00 UTC call → returns today
         date(2026, 5, 26),  # preopen-buffer canary's target-day lookup
+        date(2026, 5, 26),  # failed-day checks' target lookup (config#6732)
     ]
     # EOD window calc: previous_trading_day(2026-05-27) → 2026-05-26 (Tue)
     _tc_mod.previous_trading_day.return_value = date(2026, 5, 26)
@@ -503,6 +505,7 @@ def test_handler_on_saturday_skips_weekday_and_eod():
     _tc_mod.last_closed_trading_day.side_effect = [
         date(2026, 5, 29),  # Friday close
         date(2026, 5, 29),  # synthetic post-close still Friday
+        date(2026, 5, 29),  # failed-day checks' target lookup (config#6732)
     ]
     now = _frozen_now(2026, 5, 30, 14, 0)
     fake_client = _make_sfn_client({})
@@ -528,6 +531,7 @@ def test_handler_on_sunday_checks_saturday_sf_alone():
     _tc_mod.last_closed_trading_day.side_effect = [
         date(2026, 5, 29),  # Friday close
         date(2026, 5, 29),  # synthetic post-close still Friday (Sunday is not a session)
+        date(2026, 5, 29),  # failed-day checks' target lookup (config#6732)
     ]
     now = _frozen_now(2026, 5, 31, 14, 0)
     fake_client = _make_sfn_client({})  # no Saturday SF executions in last 7d → alert
@@ -647,6 +651,7 @@ def test_handler_post_holiday_eod_does_not_false_alert():
         date(2026, 5, 22),  # at 14:00 UTC pre-open, last close was Fri (Mon was holiday)
         date(2026, 5, 26),  # synthetic 22:00 UTC post-close, today is the session
         date(2026, 5, 22),  # preopen-buffer canary's target-day lookup
+        date(2026, 5, 22),  # failed-day checks' target lookup (config#6732)
     ]
     # EOD prev_trading_day → Fri 5/22
     _tc_mod.previous_trading_day.return_value = date(2026, 5, 22)
@@ -690,6 +695,7 @@ def test_handler_post_holiday_eod_alerts_when_friday_eod_missing():
         date(2026, 5, 22),
         date(2026, 5, 26),
         date(2026, 5, 22),  # preopen-buffer canary's target-day lookup
+        date(2026, 5, 22),  # failed-day checks' target lookup (config#6732)
     ]
     _tc_mod.previous_trading_day.return_value = date(2026, 5, 22)
     now = _frozen_now(2026, 5, 26, 14, 0)
@@ -998,6 +1004,7 @@ def test_handler_includes_preopen_buffer_check_in_summary():
         date(2026, 6, 2),  # pre-open call at now
         date(2026, 6, 3),  # synthetic 22:00 UTC call → today
         date(2026, 6, 2),  # preopen-buffer canary's target-day lookup
+        date(2026, 6, 2),  # failed-day checks' target lookup (config#6732)
     ]
     _tc_mod.previous_trading_day.return_value = date(2026, 6, 2)
     now = datetime(2026, 6, 3, 14, 0, tzinfo=timezone.utc)  # Wednesday
@@ -1023,3 +1030,170 @@ def test_handler_includes_preopen_buffer_check_in_summary():
     # same WKD_ARN rows for the canary's SUCCEEDED-only query too, but
     # those rows have no "stopDate" key → no data → deferred, not alerted.
     assert pbc["alert_emitted"] is False
+
+
+# ── _check_failed_day — prior-day failed-run check (config#6732) ─────────
+#
+# sf-pipeline-policy §4.1: independent of the SF's own notifier, sensitive
+# to started-but-never-succeeded. Zero-execution days belong to the
+# liveness checks; DEGRADED-marker days are Option-A visible degrades and
+# must not double-page; everything else without a SUCCEEDED execution
+# pages at severity=error (marker UNKNOWN ≠ pass).
+
+import json as _json
+
+
+class _FakeNoSuchKey(Exception):
+    def __init__(self):
+        super().__init__("NoSuchKey")
+        self.response = {"Error": {"Code": "NoSuchKey"}}
+
+
+def _make_status_aware_sfn_client(rows_by_status: dict) -> MagicMock:
+    """Unlike _make_sfn_client, honors statusFilter — required here because
+    _statuses_for_day's SUCCEEDED/FAILED distinction IS the check."""
+    client = MagicMock()
+
+    def _list_executions(**kwargs):
+        rows = rows_by_status.get(kwargs.get("statusFilter"), [])
+        return {"executions": rows, "nextToken": None}
+
+    client.list_executions.side_effect = _list_executions
+    return client
+
+
+def _make_s3_marker_client(*, marker: dict | None = None, error: Exception | None = None) -> MagicMock:
+    s3 = MagicMock()
+    if error is not None:
+        s3.get_object.side_effect = error
+    else:
+        body = MagicMock()
+        body.read.return_value = _json.dumps(marker).encode()
+        s3.get_object.return_value = {"Body": body}
+    return s3
+
+
+_TARGET = date(2026, 8, 5)
+_TARGET_START = datetime(2026, 8, 5, 12, 20, tzinfo=timezone.utc)  # 05:20 PT
+
+
+def test_failed_day_pages_when_all_executions_failed_and_no_marker():
+    client = _make_status_aware_sfn_client({"FAILED": [{"startDate": _TARGET_START}]})
+    s3 = _make_s3_marker_client(error=_FakeNoSuchKey())
+    result = index._check_failed_day(
+        sf_label="Weekday SF", sf_arn=WKD_ARN,
+        pipeline_name="ne-preopen-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is True
+    assert result.succeeded_on_day == 0
+    assert result.marker_status == "ABSENT"
+    assert _alerts_mod.publish.call_args.kwargs["severity"] == "error"
+    msg = _alerts_mod.publish.call_args.kwargs["message"]
+    assert "none SUCCEEDED" in msg
+    assert "no completion marker" in msg
+
+
+def test_failed_day_quiet_on_degraded_marker_option_a():
+    """Option-A (config#6692): a deliberate degraded terminal ends FAILED
+    with a DEGRADED marker — status-keyed watchers engaged; no double-page."""
+    client = _make_status_aware_sfn_client({"FAILED": [{"startDate": _TARGET_START}]})
+    s3 = _make_s3_marker_client(marker={"status": "DEGRADED"})
+    result = index._check_failed_day(
+        sf_label="Weekday SF", sf_arn=WKD_ARN,
+        pipeline_name="ne-preopen-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is False
+    assert result.marker_status == "DEGRADED"
+    _alerts_mod.publish.assert_not_called()
+
+
+def test_failed_day_quiet_when_day_succeeded_and_never_reads_marker():
+    client = _make_status_aware_sfn_client({
+        "SUCCEEDED": [{"startDate": _TARGET_START}],
+        "FAILED": [{"startDate": _TARGET_START + timedelta(minutes=5)}],
+    })
+    s3 = MagicMock()
+    result = index._check_failed_day(
+        sf_label="Weekday SF", sf_arn=WKD_ARN,
+        pipeline_name="ne-preopen-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is False
+    assert result.succeeded_on_day == 1
+    s3.get_object.assert_not_called()
+    _alerts_mod.publish.assert_not_called()
+
+
+def test_failed_day_skips_zero_execution_day_never_fired_is_livenesss_case():
+    client = _make_status_aware_sfn_client({})
+    result = index._check_failed_day(
+        sf_label="EOD SF", sf_arn=EOD_ARN,
+        pipeline_name="ne-postclose-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=MagicMock(),
+    )
+    assert result.alert_emitted is False
+    assert result.executions_on_day == 0
+    assert "liveness" in result.skip_reason
+    _alerts_mod.publish.assert_not_called()
+
+
+def test_failed_day_unreadable_marker_pages_unknown_is_not_pass():
+    client = _make_status_aware_sfn_client({"TIMED_OUT": [{"startDate": _TARGET_START}]})
+    s3 = _make_s3_marker_client(error=RuntimeError("s3 5xx"))
+    result = index._check_failed_day(
+        sf_label="EOD SF", sf_arn=EOD_ARN,
+        pipeline_name="ne-postclose-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is True
+    assert result.marker_status == "UNREADABLE"
+    assert _alerts_mod.publish.call_args.kwargs["severity"] == "error"
+
+
+def test_failed_day_non_degraded_marker_status_still_pages():
+    """A marker whose status is not DEGRADED on a day with zero SUCCEEDED
+    executions is contradictory state — page, do not trust it."""
+    client = _make_status_aware_sfn_client({"ABORTED": [{"startDate": _TARGET_START}]})
+    s3 = _make_s3_marker_client(marker={"status": "SUCCESS"})
+    result = index._check_failed_day(
+        sf_label="Weekday SF", sf_arn=WKD_ARN,
+        pipeline_name="ne-preopen-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is True
+    assert result.marker_status == "SUCCESS"
+
+
+def test_failed_day_running_execution_warns_not_errors():
+    client = _make_status_aware_sfn_client({
+        "RUNNING": [{"startDate": _TARGET_START}],
+        "FAILED": [{"startDate": _TARGET_START}],
+    })
+    result = index._check_failed_day(
+        sf_label="EOD SF", sf_arn=EOD_ARN,
+        pipeline_name="ne-postclose-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=MagicMock(),
+    )
+    assert result.alert_emitted is True
+    assert _alerts_mod.publish.call_args.kwargs["severity"] == "warning"
+
+
+def test_failed_day_ignores_executions_from_other_days():
+    """A FAILED execution from the day AFTER the target (e.g. today's
+    in-flight morning) must not condemn the target day."""
+    next_day_start = datetime(2026, 8, 6, 12, 20, tzinfo=timezone.utc)
+    client = _make_status_aware_sfn_client({
+        "FAILED": [{"startDate": next_day_start}, {"startDate": _TARGET_START}],
+        "SUCCEEDED": [{"startDate": _TARGET_START + timedelta(minutes=40)}],
+    })
+    s3 = MagicMock()
+    result = index._check_failed_day(
+        sf_label="Weekday SF", sf_arn=WKD_ARN,
+        pipeline_name="ne-preopen-trading-pipeline",
+        target_date=_TARGET, client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is False
+    assert result.succeeded_on_day == 1
+    assert result.executions_on_day == 2  # target-day rows only


### PR DESCRIPTION
## What & why
sf-pipeline-policy §4.1 (clause SFP-4.1-same-day-liveness) requires a liveness detector independent of the pipeline's own notifier, sensitive to started-but-never-succeeded. The watchdog's three liveness checks deliberately count FAILED as "fired" and delegate failure alerting to the SF's own HandleFailure path — the dependent channel — while the independent deadman (ExecutionsSucceeded, 7-day period) needs a week of silence to breach. A weekday pipeline that fires and fails with a broken notify path is invisible for up to 7 days.

New `_check_failed_day` (both weekday SFs, evaluated for the most recent closed trading day on every watchdog firing, weekends included — a Friday failure pages Saturday 14:00 UTC):
- ≥1 execution on the target PT trading day, none SUCCEEDED, no marker → **error** page with the rerun-helper command.
- Marker `status: DEGRADED` (Option-A, config#6692) → quiet: a deliberate visible degrade already engages status-keyed watchers; no double-page.
- Marker unreadable or non-DEGRADED on a failed day → **error** page (§2.3a: UNKNOWN ≠ pass).
- Still RUNNING from the prior day → **warning** (at/beyond the definition timeout horizon).
- Zero executions → skip; never-fired belongs to the existing `_check_sf` liveness checks.

Reuses `_publish_watchdog_alert` (no new notify call-sites — severity-taxonomy registry symmetric). Marker key = the definitions' WriteCompletionMarker convention (`_sf_completion/<pipeline>/<UTC-date>.json`, exact for every legal start time of both pipelines — see code comment).

**IAM (applied in-session before this PR opened, per pull-request-policy §4.2 form 2):** `CompletionMarkerRead` Sid added to `iam-policy.json` and applied live via `put-role-policy` under the admin identity; verified via `get-role-policy`. The merge deploys only the Lambda code (`deploy-pipeline-watchdog.yml`).

## Test plan (ran before opening)
- `infrastructure/lambdas/pipeline-watchdog/test_handler.py`: 54 passed (8 new tests covering page/quiet/skip/UNKNOWN/RUNNING/other-day isolation; existing handler tests extended for the one added `last_closed_trading_day` call).
- `tests/test_sf_liveness_watchdog_wiring.py` 5 passed; `tests/test_severity_taxonomy_chokepoint.py` + `test_watch_plane_alarms_script.py` + `test_krepis_fleet_events_floor.py` 56 passed.

Closes nousergon/alpha-engine-config#6732 (`alpha-engine-config-I6732`).

Prepared by: Claude Fable 5 (claude-fable-5) via [Claude Code](https://claude.com/claude-code)