### PR TITLE
feat(overseer): alert_classes row for executor_zero_entries_alarm (config-I6753 straggler)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -942,6 +942,14 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: executor_zero_entries_alarm
+    # In-process emitter merged to crucible-executor while the drift
+    # chokepoint was dead on infra (config-I6753) — caught by the revived
+    # check's first post-merge run.
+    source: "alpha-engine/executor/zero_entries_alarm.py"
+    severities: [error]
+    intake: bus
+    response: drain-queue
 
   # ── laptop LLM-routing plane (claude-code-config, config-I6753) ──
   # All four call sites previously omitted the REQUIRED `publish` subcommand,


### PR DESCRIPTION
## Deploy mechanism
**Deploy-mechanism:** N/A — read from the repo checkout at drain/check run time.

## What

One registry row: `executor_zero_entries_alarm` (source `alpha-engine/executor/zero_entries_alarm.py`, error/bus/drain-queue). The emitter merged to crucible-executor while the drift chokepoint was dead-red on infra (config-I6753); the revived check's first post-merge run flagged it. Completes the I6753 sweep alongside nousergon-data-PR1284.

## Testing

`tests/test_overseer_playbook_registry.py` — 42 passed locally.

---

**Prepared by:** claude-fable-5 via [Claude Code](https://claude.com/claude-code)
