### PR TITLE
fix(preflight): capability profile + packaged nousergon-lib — WeeklyPreflightGate halted the weekly SF

### DIFF
--- a/infrastructure/lambdas/weekly-preflight/deploy.sh
+++ b/infrastructure/lambdas/weekly-preflight/deploy.sh
@@ -54,6 +54,10 @@ python3 -c "import ast; ast.parse(open('${REPO_ROOT}/sf_preflight.py').read()); 
 # ----- Handler unit tests (shared gate) -------------------------------------
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
 run_handler_tests "${SCRIPT_DIR}" boto3
+# NOTE: run_handler_tests returns 0 when the lambda has no test_handler.py.
+# This lambda had none until 2026-08-10, so this gate reported green on a
+# function that could not execute a line of its own handler. Keep
+# test_handler.py present; deleting it silently disables this gate.
 
 # ----- 1. Package: copy sf_preflight.py + handler + deps --------------------
 
@@ -171,6 +175,50 @@ if ! $DRY_RUN; then
   fi
 else
   echo "DRY: publish-version + ensure 'live' alias for ${FUNCTION_NAME}"
+fi
+
+# ----- 6. Post-deploy smoke invoke (BLOCKING) --------------------------------
+# The gate's whole job is to run BEFORE the pipeline spends money, once a week.
+# Nothing else executes this code, so a packaging defect stays invisible from
+# the merge until the following Saturday — which is exactly what happened on
+# 2026-08-10 (`No module named 'nousergon_lib'`: sf_preflight.py was copied
+# into the zip but nousergon-lib was never in requirements.txt). Unit tests
+# cannot see it: they stub sf_preflight and run against the repo venv, where
+# every import resolves.
+#
+# So invoke the alias we just published, against the REAL runtime, and fail
+# the deploy on status=ERROR (handler could not execute — packaging, IAM, or
+# import defect). status=FAIL is a genuine preflight violation about system
+# state, not about this code: report it loudly and let the deploy succeed,
+# since blocking the deploy would block the fix for the very violation.
+# The handler is strictly read-only (Describe/Get/Simulate), so invoking it
+# on every deploy has no side effects and costs a sub-second Lambda run.
+if ! $DRY_RUN; then
+  echo "Smoke-invoking ${FUNCTION_NAME}:live..."
+  RESP=$(mktemp)
+  aws lambda invoke --function-name "${FUNCTION_NAME}:live" \
+    --cli-binary-format raw-in-base64-out --payload '{}' \
+    --region "${REGION}" "${RESP}" >/dev/null
+  SMOKE_STATUS=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('status','MALFORMED'))" "${RESP}")
+  echo "  smoke status: ${SMOKE_STATUS}"
+  case "${SMOKE_STATUS}" in
+    OK)
+      python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(f\"  ran {d.get('ran_count')} check(s), {d.get('skip_count')} skipped, {d.get('warn_count')} warning(s)\")" "${RESP}"
+      ;;
+    FAIL)
+      echo "  ⚠ preflight reports a genuine violation (system state, not this deploy):"
+      python3 -c "import json,sys; print('   ', json.load(open(sys.argv[1])).get('failures'))" "${RESP}"
+      ;;
+    *)
+      echo "  ✗ handler could not execute — the deployed gate is broken:"
+      cat "${RESP}"; echo ""
+      rm -f "${RESP}"
+      exit 1
+      ;;
+  esac
+  rm -f "${RESP}"
+else
+  echo "DRY: smoke-invoke ${FUNCTION_NAME}:live and fail on status=ERROR"
 fi
 
 echo "✓ ${FUNCTION_NAME} deployed."

--- a/infrastructure/lambdas/weekly-preflight/index.py
+++ b/infrastructure/lambdas/weekly-preflight/index.py
@@ -8,8 +8,16 @@ launch.
 
 The Lambda runs read-only API calls (IAM SimulatePrincipalPolicy, Lambda
 GetFunctionConfiguration, CloudWatch GetMetricStatistics, Step Functions
-DescribeStateMachine) and zero-cost static analysis. ArcticDB/Polygon
-checks gracefully skip (no VPC/database access from this Lambda).
+DescribeStateMachine) and zero-cost static analysis.
+
+Check selection is by CAPABILITY, not by hope. This Lambda declares
+``sf_preflight.LAMBDA_CAPABILITIES`` (the AWS control plane and nothing
+else); checks needing ArcticDB, the repo's collector modules, a Polygon key,
+or sibling checkouts on local disk are reported status="skip" and excluded
+from the failure count. Before 2026-08-10 this docstring claimed those checks
+"gracefully skip" while the handler in fact ran the FULL profile — they
+returned status="fail" (ModuleNotFoundError / "not checked out as sibling"),
+which would have halted the Saturday pipeline by construction.
 
 Usage:
     Invoked by Step Functions. Returns:
@@ -60,7 +68,9 @@ def handler(event: dict, context) -> dict:
         }
 
     try:
-        n_fail, results = sfp.run_preflight(bucket=bucket)
+        n_fail, results = sfp.run_preflight(
+            bucket=bucket, capabilities=sfp.LAMBDA_CAPABILITIES
+        )
     except Exception as exc:
         return {
             "status": "ERROR",
@@ -72,6 +82,8 @@ def handler(event: dict, context) -> dict:
     result_dicts = [asdict(r) for r in results]
     fail_results = [r for r in result_dicts if r.get("status") == "fail"]
     warn_results = [r for r in result_dicts if r.get("status") == "warn"]
+    skip_results = [r for r in result_dicts if r.get("status") == "skip"]
+    ran_count = len(result_dicts) - len(skip_results)
 
     if n_fail > 0:
         return {
@@ -79,7 +91,25 @@ def handler(event: dict, context) -> dict:
             "has_violation": True,
             "fail_count": n_fail,
             "warn_count": len(warn_results),
+            "skip_count": len(skip_results),
+            "ran_count": ran_count,
             "failures": [r["name"] for r in fail_results],
+            "results": result_dicts,
+        }
+
+    # A gate that ran ZERO checks is not a pass — it is an unobserved
+    # system reporting green (principles.md §2.7). Fail closed: this can
+    # only happen if CHECKS or CHECK_CAPABILITIES drifted such that no
+    # check is eligible under LAMBDA_CAPABILITIES.
+    if ran_count == 0:
+        return {
+            "status": "ERROR",
+            "has_violation": True,
+            "error": (
+                "preflight ran 0 checks — every check was skipped for missing "
+                "capabilities; the gate observed nothing"
+            ),
+            "skip_count": len(skip_results),
             "results": result_dicts,
         }
 
@@ -87,5 +117,7 @@ def handler(event: dict, context) -> dict:
         "status": "OK",
         "has_violation": False,
         "warn_count": len(warn_results),
+        "skip_count": len(skip_results),
+        "ran_count": ran_count,
         "results": result_dicts,
     }

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -1,6 +1,19 @@
 # Lambda deps for weekly-preflight — minimal set.
 # boto3 and jmespath are available in the Lambda runtime.
 # sf_preflight.py is copied from the repo root during deploy.
-# ArcticDB/polygon/secrets deps are NOT needed: checks that require
-# them gracefully skip/fail with an explanatory message.
+#
+# nousergon-lib is NOT optional: sf_preflight.run_preflight() resolves the
+# prior trading day via nousergon_lib.trading_calendar in its PROLOGUE —
+# before the per-check try/except exists — so a missing pin is not a degraded
+# check, it is the whole gate returning status=ERROR. That is exactly what
+# halted ne-weekly-freshness-pipeline on 2026-08-10, the first Saturday the
+# I4494 gate actually fired (`ModuleNotFoundError: No module named
+# 'nousergon_lib'` out of _previous_trading_day_str). The earlier comment here
+# claimed the nousergon_lib-dependent checks "gracefully skip/fail" — true of
+# the four in-check imports, false of the prologue.
+#
+# ArcticDB/polygon/collectors deps remain absent BY DESIGN: the Lambda runs
+# only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
+# needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.44

--- a/infrastructure/lambdas/weekly-preflight/test_handler.py
+++ b/infrastructure/lambdas/weekly-preflight/test_handler.py
@@ -1,0 +1,129 @@
+"""Handler tests for the WeeklyPreflight pre-spend gate.
+
+Why this file exists (2026-08-10): it did not, and `_shared/run_handler_tests.sh`
+returns 0 when a lambda has no `test_handler.py`, so BOTH pre-merge gates —
+ci.yml's glob step and deploy.sh's pytest gate — reported green on a Lambda
+that could not execute a single line of its own gate logic. The first real
+Saturday invocation returned
+``ModuleNotFoundError: No module named 'nousergon_lib'`` and halted
+ne-weekly-freshness-pipeline.
+
+These tests stub ``sf_preflight`` in ``sys.modules``, so they pin the
+handler's CONTRACT (which capability profile it asks for, how it classifies
+skips, that an all-skipped run is not a pass). They deliberately cannot catch
+a packaging gap — that is the job of
+``tests/test_sf_preflight.py::test_lambda_profile_imports_are_packaged`` and of
+deploy.sh's post-deploy smoke invoke against the real runtime.
+"""
+
+import os
+import sys
+import types
+import unittest
+from dataclasses import dataclass, field
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+@dataclass
+class _Result:
+    name: str
+    status: str
+    message: str = ""
+    details: dict = field(default_factory=dict)
+    elapsed_seconds: float = 0.0
+
+
+def _install_stub(results, n_fail=None, raises=None):
+    """Install a stub sf_preflight module and return the recorded call kwargs."""
+    recorded = {}
+    stub = types.ModuleType("sf_preflight")
+    stub.LAMBDA_CAPABILITIES = frozenset({"aws"})
+    stub.FULL_CAPABILITIES = frozenset({"aws", "arctic", "repo_modules", "checkout", "polygon"})
+
+    def run_preflight(bucket=None, capabilities=None):
+        recorded["bucket"] = bucket
+        recorded["capabilities"] = capabilities
+        if raises is not None:
+            raise raises
+        fails = n_fail if n_fail is not None else sum(1 for r in results if r.status == "fail")
+        return fails, results
+
+    stub.run_preflight = run_preflight
+    sys.modules["sf_preflight"] = stub
+    return recorded
+
+
+class WeeklyPreflightHandlerTests(unittest.TestCase):
+    def tearDown(self):
+        sys.modules.pop("sf_preflight", None)
+        sys.modules.pop("index", None)
+
+    def _handler(self):
+        sys.modules.pop("index", None)
+        import index
+        return index.handler
+
+    def test_requests_the_lambda_capability_profile(self):
+        """The gate must NOT run the full laptop/spot profile.
+
+        Running it is not a degraded gate: check_arctic_connectivity and
+        check_tool_contracts return status="fail" in a Lambda by
+        construction, so the pipeline halts however healthy the system is.
+        """
+        recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
+        out = self._handler()({}, None)
+        self.assertEqual(recorded["capabilities"], frozenset({"aws"}))
+        self.assertEqual(out["status"], "OK")
+        self.assertFalse(out["has_violation"])
+
+    def test_skips_are_not_violations(self):
+        recorded = _install_stub([
+            _Result("sf_iam_reachability", "ok"),
+            _Result("arctic_connectivity", "skip", "Not run: ... arctic"),
+            _Result("tool_contracts", "skip", "Not run: ... checkout"),
+        ])
+        out = self._handler()({}, None)
+        self.assertEqual(out["status"], "OK")
+        self.assertFalse(out["has_violation"])
+        self.assertEqual(out["skip_count"], 2)
+        self.assertEqual(out["ran_count"], 1)
+        self.assertEqual(recorded["capabilities"], frozenset({"aws"}))
+
+    def test_all_skipped_is_an_error_not_a_pass(self):
+        """Zero checks run is an unobserved gate, never a green one."""
+        _install_stub([
+            _Result("arctic_connectivity", "skip"),
+            _Result("tool_contracts", "skip"),
+        ])
+        out = self._handler()({}, None)
+        self.assertEqual(out["status"], "ERROR")
+        self.assertTrue(out["has_violation"])
+        self.assertIn("0 checks", out["error"])
+
+    def test_real_failure_still_halts(self):
+        _install_stub([
+            _Result("sf_iam_reachability", "fail", "role cannot invoke"),
+            _Result("arctic_connectivity", "skip"),
+        ])
+        out = self._handler()({}, None)
+        self.assertEqual(out["status"], "FAIL")
+        self.assertTrue(out["has_violation"])
+        self.assertEqual(out["failures"], ["sf_iam_reachability"])
+
+    def test_run_preflight_raising_is_reported_as_error(self):
+        """The 2026-08-10 shape: a missing dependency in the PROLOGUE."""
+        _install_stub([], raises=ModuleNotFoundError("No module named 'nousergon_lib'"))
+        out = self._handler()({}, None)
+        self.assertEqual(out["status"], "ERROR")
+        self.assertTrue(out["has_violation"])
+        self.assertIn("nousergon_lib", out["error"])
+
+    def test_bucket_override_from_event(self):
+        recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
+        self._handler()({"bucket": "some-other-bucket"}, None)
+        self.assertEqual(recorded["bucket"], "some-other-bucket")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -105,7 +105,7 @@ _UNIVERSE_SAMPLE_SIZE = 20
 @dataclass
 class CheckResult:
     name: str
-    status: str  # "ok" | "warn" | "fail"
+    status: str  # "ok" | "warn" | "fail" | "skip" (capability absent — see CHECK_CAPABILITIES)
     message: str
     details: dict = field(default_factory=dict)
     elapsed_seconds: float = 0.0
@@ -1037,6 +1037,73 @@ def _collect_jsonpath_refs(node, path: str = "") -> list[tuple[str, str]]:
     return refs
 
 
+def _collect_produced_roots(node) -> "set[str]":
+    """Top-level keys the definition WRITES somewhere, from three shapes.
+
+    A ref rooted in one of these does not resolve against the execution
+    input by design — the value appears mid-flow — so it is undecidable for
+    ``check_definition_input_coherence`` rather than a violation.
+
+      * ``ResultPath: "$.foo"``            → ``foo``
+      * a state's ``Parameters`` keys      → ``foo`` (``foo.$`` stripped)
+      * JSON object literals built inside intrinsic functions, e.g.
+        ``States.JsonMerge($, States.StringToJson(States.Format(
+        '{"ec2_instance_id":["{}"]}', ...)), false)`` → ``ec2_instance_id``.
+        WrapEc2InstanceIdInArray writes the field this way and NO key walk
+        can see it — the field name lives inside a format string. Missing it
+        is what made ``$.ec2_instance_id[0]`` look like a violation.
+
+    Deliberately over-collects: a spurious entry only narrows coverage (the
+    check reports how much), while a miss produces a false gate failure.
+    """
+    import re as _re
+
+    roots: set[str] = set()
+    if isinstance(node, dict):
+        for key, val in node.items():
+            if key == "ResultPath" and isinstance(val, str) and val.startswith("$."):
+                roots.add(val[2:].split(".")[0].split("[")[0])
+            if key == "Parameters" and isinstance(val, dict):
+                for pkey in val:
+                    roots.add(pkey[:-2] if pkey.endswith(".$") else pkey)
+            if isinstance(val, str):
+                roots.update(
+                    _re.findall(r'\{\s*\\?"([A-Za-z_][A-Za-z0-9_]*)\\?"\s*:', val)
+                )
+            roots.update(_collect_produced_roots(val))
+    elif isinstance(node, list):
+        for item in node:
+            roots.update(_collect_produced_roots(item))
+    return roots
+
+
+def _has_output_replacing_state(node) -> bool:
+    """True if any state REPLACES its output with something the definition
+    does not name — an AWS API response.
+
+    ``Type: Task`` with no ``ResultPath`` (or ``ResultPath: "$"``) discards
+    the state's input and emits the raw service response: SSM
+    GetCommandInvocation is where ``$.Status`` / ``$.ResponseCode`` /
+    ``$.StandardErrorContent`` come from. Those roots are named nowhere in
+    the definition, so in a definition containing such a state an unknown
+    root is UNDECIDABLE, not a violation.
+
+    In a definition WITHOUT one, every root is accounted for — the
+    execution input or a written key — so an unknown root is a genuine
+    unresolvable reference and is reported as a failure.
+    """
+    if isinstance(node, dict):
+        stype = node.get("Type")
+        replaces_by_default = stype in ("Task", "Map", "Parallel")
+        pass_replaces = stype == "Pass" and ("Result" in node or "Parameters" in node)
+        if (replaces_by_default or pass_replaces) and node.get("ResultPath", "$") == "$":
+            return True
+        return any(_has_output_replacing_state(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_output_replacing_state(v) for v in node)
+    return False
+
+
 def _build_proposed_input(skip_flags: dict[str, bool] | None = None) -> dict:
     """Build a proposed execution input that exercises all code paths.
 
@@ -1087,14 +1154,33 @@ def _build_proposed_input(skip_flags: dict[str, bool] | None = None) -> dict:
 
 
 def check_definition_input_coherence(ctx: PreflightContext) -> CheckResult:
-    """Every JSONPath referenced by a SF state resolves against a proposed
-    execution input, including under each skip_* combination.
+    """Every JSONPath rooted in the EXECUTION INPUT resolves against a
+    proposed input, including under each skip_* combination.
 
     Walks the live SF definition, collects every ``.$``-suffixed JSONPath
-    reference, and validates each against the proposed input using jmespath.
-    Also tests each individual skip_* flag set to True (the input shape
-    changes under skip gates — a path that resolves with skip=false may not
-    resolve with skip=true if a prior state was bypassed).
+    reference, and validates the decidable subset against the proposed input
+    using jmespath. Also tests each individual skip_* flag set to True (the
+    input shape changes under skip gates — a path that resolves with
+    skip=false may not resolve with skip=true if a prior state was bypassed).
+
+    Scope, and why it is narrower than "every reference" (2026-08-10)
+    ----------------------------------------------------------------
+    A state's JSONPaths resolve against THAT STATE's effective input, which
+    for most states is a prior state's output, not the execution input. The
+    original implementation resolved all ~80 refs against the execution
+    input and reported 177 "unresolvable" — every one of them a false
+    positive (``$.libpin_drift_result.Payload``, ``$.Status``,
+    ``$.ec2_instance_id[0]``: values produced mid-flow, by construction
+    absent from the execution input). A check whose every finding is noise
+    fails the gate permanently and teaches operators to ignore it; the check
+    had never run against the live definition, only against mocks.
+
+    So this validates only the DECIDABLE subset — refs whose root key the
+    execution input owns and no state overwrites — and REPORTS the
+    undecidable remainder as a coverage number rather than passing silently
+    over it. Modelling mid-flow state (ResultPath/ResultSelector/InputPath
+    through Parallel and Map branches) is real dataflow analysis; until that
+    exists, this check must not claim it.
 
     Static analysis — zero network calls, runs in <1s.
     """
@@ -1134,11 +1220,34 @@ def check_definition_input_coherence(ctx: PreflightContext) -> CheckResult:
     # Build the base proposed input (all skip flags false).
     base_input = _build_proposed_input()
 
-    failures: list[str] = []
+    # Partition the refs: only those rooted in an execution-input key that no
+    # state overwrites are decidable from the input model alone.
+    produced_roots = _collect_produced_roots(live)
+    input_roots = set(base_input)
+    # Only where NO state emits an unnamed API response is an unknown root
+    # provably unresolvable rather than merely unmodelled.
+    unknown_root_is_a_violation = not _has_output_replacing_state(live)
+    decidable_refs = []
+    undecidable_roots: set[str] = set()
+    unresolvable_roots: list[str] = []
+    for ref in input_refs:
+        root = ref[2:].split(".")[0].split("[")[0]
+        if root in input_roots and root not in produced_roots:
+            decidable_refs.append(ref)
+        elif root not in input_roots and root not in produced_roots and unknown_root_is_a_violation:
+            unresolvable_roots.append(ref)
+        else:
+            undecidable_roots.add(root)
+
+    failures: list[str] = [
+        f"{ref}: root key is neither an execution-input field nor written by "
+        f"any state — unresolvable at run time"
+        for ref in unresolvable_roots
+    ]
     checked = 0
 
-    # Resolve each JSONPath against the base input.
-    for ref in input_refs:
+    # Resolve each decidable JSONPath against the base input.
+    for ref in decidable_refs:
         checked += 1
         # Strip the leading "$" for jmespath (it uses bare paths)
         jmes_expr = ref.lstrip("$").lstrip(".")
@@ -1160,7 +1269,7 @@ def check_definition_input_coherence(ctx: PreflightContext) -> CheckResult:
     skip_flags = [k for k in base_input if k.startswith("skip_")]
     for skip_flag in skip_flags:
         skip_input = _build_proposed_input({skip_flag: True})
-        for ref in input_refs:
+        for ref in decidable_refs:
             jmes_expr = ref.lstrip("$").lstrip(".")
             try:
                 result = jmespath.search(jmes_expr, skip_input)
@@ -1182,6 +1291,8 @@ def check_definition_input_coherence(ctx: PreflightContext) -> CheckResult:
                 "failures": failures,
                 "checked": checked,
                 "skip_combinations_tested": len(skip_flags),
+                "undecidable_refs": len(input_refs) - len(decidable_refs),
+                "undecidable_roots": sorted(undecidable_roots),
             },
             elapsed_seconds=elapsed,
         )
@@ -1189,10 +1300,17 @@ def check_definition_input_coherence(ctx: PreflightContext) -> CheckResult:
         name="definition_input_coherence",
         status="ok",
         message=(
-            f"All {checked} input JSONPath reference(s) resolve against base input "
-            f"and {len(skip_flags)} individual skip-flag combinations"
+            f"All {checked} execution-input JSONPath reference(s) resolve against "
+            f"base input and {len(skip_flags)} individual skip-flag combinations "
+            f"({len(input_refs) - len(decidable_refs)} mid-flow ref(s) not covered — "
+            f"they resolve against prior-state output, not the execution input)"
         ),
-        details={"checked": checked, "skip_flags_tested": len(skip_flags)},
+        details={
+            "checked": checked,
+            "skip_flags_tested": len(skip_flags),
+            "undecidable_refs": len(input_refs) - len(decidable_refs),
+            "undecidable_roots": sorted(undecidable_roots),
+        },
         elapsed_seconds=elapsed,
     )
 
@@ -1798,6 +1916,59 @@ CHECKS = [
 ]
 
 
+# ── Environment capabilities ──────────────────────────────────────────────────
+#
+# sf_preflight.py was written for a host that HAS the data plane and the
+# sibling checkouts: the laptop and the weekly spot box. The WeeklyPreflight
+# Lambda (I4494) has neither — no arcticdb wheel, no ``collectors``/
+# ``features``/``builders`` repo modules, no ``~/Development/alpha-engine-*``
+# checkouts, no Polygon key. Running the full CHECKS list there does not
+# "gracefully skip": ``check_arctic_connectivity`` returns status="fail" on
+# ``ModuleNotFoundError``, ``check_tool_contracts`` returns status="fail" on
+# "not checked out as sibling", and every downstream check that reads
+# ``ctx.universe_lib`` fails on the unpopulated context — so the gate returns
+# has_violation=true and halts the Saturday pipeline by construction, no
+# matter how healthy the system is.
+#
+# Fix: each check declares what its ENVIRONMENT must provide. A caller passes
+# the capability set its environment actually has; checks that need more are
+# reported status="skip" (never "fail" — an unavailable capability is not a
+# violation) and excluded from the failure count.
+CAP_AWS = "aws"                    # AWS control-plane APIs (always available)
+CAP_ARCTIC = "arctic"              # arcticdb wheel + ArcticDB data plane
+CAP_REPO_MODULES = "repo_modules"  # collectors/ features/ builders/ polygon_client
+CAP_CHECKOUT = "checkout"          # sibling alpha-engine-* checkouts on local disk
+CAP_POLYGON = "polygon"            # POLYGON_API_KEY resolvable
+
+# Every environment has the AWS control plane; the Lambda has nothing else.
+LAMBDA_CAPABILITIES = frozenset({CAP_AWS})
+# The laptop and the weekly spot box carry the full set.
+FULL_CAPABILITIES = frozenset({
+    CAP_AWS, CAP_ARCTIC, CAP_REPO_MODULES, CAP_CHECKOUT, CAP_POLYGON,
+})
+
+# Every entry in CHECKS MUST appear here — tests/test_sf_preflight.py pins
+# it, so a new check cannot silently inherit (or silently lose) Lambda
+# eligibility. State what the check's ENVIRONMENT must provide, not what it
+# happens to import today.
+CHECK_CAPABILITIES: "dict[str, frozenset[str]]" = {
+    "check_sf_iam_reachability": frozenset({CAP_AWS}),
+    "check_arctic_connectivity": frozenset({CAP_AWS, CAP_ARCTIC}),
+    "check_constituents_fetch": frozenset({CAP_REPO_MODULES}),
+    "check_universe_drift": frozenset({CAP_AWS, CAP_ARCTIC, CAP_REPO_MODULES}),
+    "check_universe_sample_freshness": frozenset({CAP_AWS, CAP_ARCTIC}),
+    "check_polygon_grouped_coverage": frozenset({CAP_REPO_MODULES, CAP_POLYGON}),
+    "check_predicted_missing_from_closes": frozenset({CAP_AWS, CAP_ARCTIC, CAP_POLYGON}),
+    "check_backfill_source_freshness": frozenset({CAP_AWS, CAP_REPO_MODULES}),
+    "check_postflight_contracts": frozenset({CAP_AWS}),
+    "check_price_cards_cover_all_models": frozenset({CAP_CHECKOUT}),
+    "check_recursion_budget_for_response_format": frozenset({CAP_CHECKOUT}),
+    "check_tool_contracts": frozenset({CAP_AWS, CAP_CHECKOUT}),
+    "check_definition_input_coherence": frozenset({CAP_AWS}),
+    "check_lambda_memory_headroom": frozenset({CAP_AWS}),
+}
+
+
 def _previous_trading_day_str() -> str:
     """Resolve the prior trading day. Avoids importing weekly_collector
     (which transitively imports boto3 + every collector module) so
@@ -1815,18 +1986,46 @@ def _previous_trading_day_str() -> str:
     raise RuntimeError("Could not find a trading day within the last 10 days")
 
 
-def run_preflight(bucket: str = DEFAULT_BUCKET) -> tuple[int, list[CheckResult]]:
-    """Execute all checks against real state. Returns (n_failures, results).
+def run_preflight(
+    bucket: str = DEFAULT_BUCKET,
+    capabilities: "frozenset[str] | set[str] | None" = None,
+) -> tuple[int, list[CheckResult]]:
+    """Execute the checks this environment can run. Returns (n_failures, results).
+
+    ``capabilities`` declares what the HOST provides (see CHECK_CAPABILITIES).
+    Checks needing a capability the host lacks are reported status="skip" and
+    are not counted as failures — the WeeklyPreflight Lambda has only
+    ``LAMBDA_CAPABILITIES``, the laptop and spot box have FULL_CAPABILITIES
+    (the default, so the CLI and every existing caller are unchanged).
 
     Each check runs in its own try/except — a single check raising must
     not abort the others (we want the full picture, not first-fail-bail).
     """
+    caps = frozenset(capabilities) if capabilities is not None else FULL_CAPABILITIES
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     prior = _previous_trading_day_str()
     ctx = PreflightContext(bucket=bucket, today=today, prior_trading_day=prior)
 
     results: list[CheckResult] = []
     for check_fn in CHECKS:
+        # An undeclared check defaults to the FULL set: it can never silently
+        # gain Lambda eligibility, and an undeclared check can never abort the
+        # run (raising here would re-create the prologue-abort failure mode
+        # this profile exists to fix). CI pins the declaration —
+        # tests/test_sf_preflight.py::test_every_check_declares_its_capabilities.
+        required = CHECK_CAPABILITIES.get(check_fn.__name__, FULL_CAPABILITIES)
+        missing = required - caps
+        if missing:
+            results.append(CheckResult(
+                name=check_fn.__name__.replace("check_", ""),
+                status="skip",
+                message=(
+                    "Not run: this environment does not provide "
+                    f"{', '.join(sorted(missing))}"
+                ),
+                details={"required": sorted(required), "missing": sorted(missing)},
+            ))
+            continue
         try:
             results.append(check_fn(ctx))
         except Exception as exc:
@@ -1844,7 +2043,7 @@ def run_preflight(bucket: str = DEFAULT_BUCKET) -> tuple[int, list[CheckResult]]
 
 def _format_human(results: list[CheckResult]) -> str:
     lines = ["", "=" * 70, " Saturday SF Preflight ", "=" * 70, ""]
-    icons = {"ok": "[OK]  ", "warn": "[WARN]", "fail": "[FAIL]"}
+    icons = {"ok": "[OK]  ", "warn": "[WARN]", "fail": "[FAIL]", "skip": "[SKIP]"}
     for r in results:
         lines.append(f"{icons.get(r.status, '[?]   ')} {r.name:<32} {r.message}")
         if r.status == "fail" and r.details:

--- a/tests/test_sf_preflight.py
+++ b/tests/test_sf_preflight.py
@@ -883,3 +883,210 @@ def test_simulate_requires_every_result_allowed():
         ]
     }
     assert sfp._simulate(iam, "arn:role", "ssm:SendCommand", "arn:inst") is False
+
+
+# ── Environment capability profile (the 2026-08-10 WeeklyPreflight outage) ────
+#
+# ne-weekly-freshness-pipeline halted on its first real WeeklyPreflightGate
+# invocation with ``ModuleNotFoundError: No module named 'nousergon_lib'``,
+# raised out of run_preflight's PROLOGUE (_previous_trading_day_str) — before
+# the per-check try/except exists, so the whole gate returned status=ERROR.
+# Two defects behind it, both pinned here:
+#   1. weekly-preflight/requirements.txt did not declare nousergon-lib even
+#      though the packaged sf_preflight.py imports it in five places;
+#   2. the Lambda ran the FULL check list, which includes checks that require
+#      arcticdb, the repo's collector modules and sibling checkouts on local
+#      disk — none of which a Lambda has. Those return status="fail", so the
+#      gate could not have returned OK even with (1) fixed.
+
+import ast as _ast
+import pathlib as _pathlib
+import sys as _sys
+
+_REPO_ROOT = _pathlib.Path(sfp.__file__).resolve().parent
+_LAMBDA_DIR = _REPO_ROOT / "infrastructure" / "lambdas" / "weekly-preflight"
+
+# Modules the python3.12 Lambda runtime provides without a requirements entry.
+_LAMBDA_RUNTIME_MODULES = {"boto3", "botocore", "jmespath", "dateutil", "urllib3", "s3transfer"}
+# import name -> distribution name, for the specs weekly-preflight declares.
+_DIST_FOR_MODULE = {
+    "nousergon_lib": "nousergon-lib",
+    "aws_assume_role_lib": "aws-assume-role-lib",
+}
+
+
+def _fn_node(name: str) -> _ast.FunctionDef:
+    tree = _ast.parse(_REPO_ROOT.joinpath("sf_preflight.py").read_text())
+    for node in tree.body:
+        if isinstance(node, _ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in sf_preflight.py")
+
+
+def _imports_of(node: _ast.AST) -> set[str]:
+    found: set[str] = set()
+    for sub in _ast.walk(node):
+        if isinstance(sub, _ast.Import):
+            found.update(a.name.split(".")[0] for a in sub.names)
+        elif isinstance(sub, _ast.ImportFrom) and sub.module and sub.level == 0:
+            found.add(sub.module.split(".")[0])
+    return found
+
+
+def _declared_distributions() -> set[str]:
+    out: set[str] = set()
+    for line in _LAMBDA_DIR.joinpath("requirements.txt").read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # "nousergon-lib[extra] @ git+https://..." / "pkg==1.2" / "pkg"
+        out.add(line.split("@")[0].split("[")[0].split("=")[0].split(">")[0].strip())
+    return out
+
+
+def test_every_check_declares_its_capabilities():
+    """A new check may not silently inherit or lose Lambda eligibility."""
+    listed = {fn.__name__ for fn in sfp.CHECKS}
+    declared = set(sfp.CHECK_CAPABILITIES)
+    assert listed == declared, (
+        "CHECKS and CHECK_CAPABILITIES disagree; add the missing entry "
+        f"(only in CHECKS: {sorted(listed - declared)}; "
+        f"only in CHECK_CAPABILITIES: {sorted(declared - listed)})"
+    )
+    known = sfp.FULL_CAPABILITIES
+    for name, caps in sfp.CHECK_CAPABILITIES.items():
+        assert caps, f"{name}: declare at least one capability"
+        assert caps <= known, f"{name}: unknown capability {sorted(caps - known)}"
+
+
+def test_lambda_profile_runs_at_least_one_check():
+    """A gate observing nothing is not a gate (principles.md §2.7)."""
+    eligible = [
+        fn for fn in sfp.CHECKS
+        if sfp.CHECK_CAPABILITIES[fn.__name__] <= sfp.LAMBDA_CAPABILITIES
+    ]
+    assert eligible, "no check is runnable under LAMBDA_CAPABILITIES"
+
+
+def test_lambda_profile_imports_are_packaged():
+    """Every module the Lambda-eligible code path imports must be in the zip.
+
+    This is the test that would have caught the 2026-08-10 outage: the
+    prologue's nousergon_lib import against a requirements.txt that never
+    declared it. Scans the prologue plus every Lambda-eligible check.
+    """
+    packaged = _declared_distributions() | _LAMBDA_RUNTIME_MODULES
+    scanned = ["_previous_trading_day_str", "run_preflight"] + [
+        fn.__name__ for fn in sfp.CHECKS
+        if sfp.CHECK_CAPABILITIES[fn.__name__] <= sfp.LAMBDA_CAPABILITIES
+    ]
+    for fn_name in scanned:
+        for mod in _imports_of(_fn_node(fn_name)):
+            if mod in _sys.stdlib_module_names or mod == "sf_preflight":
+                continue
+            dist = _DIST_FOR_MODULE.get(mod, mod)
+            assert dist in packaged or mod in packaged, (
+                f"{fn_name} imports {mod!r}, which weekly-preflight's "
+                f"requirements.txt does not provide — the Lambda will raise "
+                f"ModuleNotFoundError at run time, and the gate will halt the "
+                f"Saturday pipeline"
+            )
+
+
+def test_lambda_profile_checks_need_no_local_checkout():
+    """_sibling_repo returns None in a Lambda — the check then FAILS, not skips."""
+    for fn in sfp.CHECKS:
+        if sfp.CHECK_CAPABILITIES[fn.__name__] <= sfp.LAMBDA_CAPABILITIES:
+            src = _ast.dump(_fn_node(fn.__name__))
+            assert "_sibling_repo" not in src, (
+                f"{fn.__name__} reads a sibling checkout but is declared "
+                f"Lambda-eligible; add CAP_CHECKOUT to its capabilities"
+            )
+
+
+def test_run_preflight_skips_rather_than_fails_on_missing_capability():
+    n_fail, results = sfp.run_preflight(
+        bucket="test-bucket", capabilities=frozenset()
+    )
+    assert n_fail == 0, "an absent capability is not a violation"
+    assert results and all(r.status == "skip" for r in results)
+    assert all("Not run" in r.message for r in results)
+
+
+def test_run_preflight_defaults_to_the_full_profile():
+    """The CLI and the spot box must keep running every check."""
+    def check_sf_iam_reachability(ctx):  # name matters: CHECK_CAPABILITIES key
+        return sfp.CheckResult(name="sf_iam_reachability", status="ok", message="ran")
+
+    def check_tool_contracts(ctx):  # requires CAP_CHECKOUT — absent in a Lambda
+        return sfp.CheckResult(name="tool_contracts", status="ok", message="ran")
+
+    with patch.object(sfp, "CHECKS", [check_sf_iam_reachability, check_tool_contracts]):
+        n_fail, results = sfp.run_preflight(bucket="test-bucket")
+        assert n_fail == 0
+        assert [r.status for r in results] == ["ok", "ok"]
+
+        _, lambda_results = sfp.run_preflight(
+            bucket="test-bucket", capabilities=sfp.LAMBDA_CAPABILITIES
+        )
+    assert [r.status for r in lambda_results] == ["ok", "skip"]
+
+
+def test_definition_input_coherence_ignores_mid_flow_refs():
+    """A ref to a value a PRIOR STATE produces is not an input violation.
+
+    The 2026-08-10 false-positive class: resolving every ``.$`` ref against
+    the execution input reported 177 unresolvable paths on a live, working
+    definition ($.libpin_drift_result.Payload, $.Status, $.ec2_instance_id[0]),
+    which would have failed the pre-spend gate every Saturday forever.
+    """
+    import json
+    from unittest.mock import patch, MagicMock
+
+    sf_def = {
+        "StartAt": "Launch",
+        "States": {
+            "Launch": {
+                "Type": "Task",
+                "Resource": "arn:aws:states:::lambda:invoke",
+                "Parameters": {"FunctionName": "launcher"},
+                "ResultPath": "$.launch_result",
+                "Next": "Wrap",
+            },
+            # Writes ec2_instance_id inside an intrinsic format string —
+            # invisible to any key walk (WrapEc2InstanceIdInArray's shape).
+            "Wrap": {
+                "Type": "Pass",
+                "Parameters": {
+                    "merged.$": "States.JsonMerge($, States.StringToJson("
+                                "States.Format('{\"ec2_instance_id\":[\"{}\"]}', "
+                                "$.launch_result.instance_id)), false)"
+                },
+                "OutputPath": "$.merged",
+                "Next": "Poll",
+            },
+            "Poll": {  # output-replacing Task: emits the raw SSM response
+                "Type": "Task",
+                "Resource": "arn:aws:states:::aws-sdk:ssm:getCommandInvocation",
+                "Parameters": {"InstanceIds.$": "$.ec2_instance_id[0]"},
+                "Next": "Done",
+            },
+            "Done": {
+                "Type": "Pass",
+                "Parameters": {
+                    "status.$": "$.Status",                     # SSM response field
+                    "payload.$": "$.launch_result.Payload",     # prior state's result
+                    "instance.$": "$.ec2_instance_id[0]",       # intrinsic-written
+                    "role.$": "$.pipeline_role",                # execution input
+                },
+                "End": True,
+            },
+        },
+    }
+    fake_sfn = MagicMock()
+    fake_sfn.describe_state_machine.return_value = {"definition": json.dumps(sf_def)}
+    with patch("boto3.client", return_value=fake_sfn):
+        result = sfp.check_definition_input_coherence(_ctx())
+    assert result.status == "ok", result.details
+    assert result.details["undecidable_refs"] >= 3
+    assert result.details["checked"] >= 1  # $.pipeline_role still verified


### PR DESCRIPTION
## What

Makes `WeeklyPreflightGate` executable. It halted `ne-weekly-freshness-pipeline` on 2026-08-10 at 14:02 PT with `ModuleNotFoundError: No module named 'nousergon_lib'`, on its first real invocation since #1230 wired it in.

Three defects, all in this PR:

| # | Defect | Fix |
|---|---|---|
| 1 | `weekly-preflight/requirements.txt` never declared `nousergon-lib`, though the `sf_preflight.py` copied into the zip imports it in five places. The fifth import is in `run_preflight`'s **prologue** (`_previous_trading_day_str`), before any per-check try/except — so it was not a degraded check, it was `status: ERROR` for the whole gate. | pin added (v0.124.44, matching root) |
| 2 | The handler ran all 14 checks. Ten need the `arcticdb` wheel, the `collectors`/`features`/`builders` modules, a Polygon key, or sibling checkouts on local disk. They return `status="fail"`, not skip — so the gate could not have passed even with #1 fixed. `index.py`'s docstring claimed otherwise. | `CHECK_CAPABILITIES` per check; the Lambda passes `LAMBDA_CAPABILITIES`; unrunnable checks report `status="skip"` and are not counted as failures |
| 3 | `check_definition_input_coherence` resolved every `.$` ref against the execution input, but most refs resolve against a prior state's output — **177 findings on a healthy live definition, all false positives** (`$.libpin_drift_result.Payload`, `$.Status`, `$.ec2_instance_id[0]`). It had only ever run against mocks. | validates the decidable subset, reports the undecidable remainder as a coverage number, still flags a genuinely unknown root where no state emits an unnamed API response |

Default stays `FULL_CAPABILITIES`, so `python3 sf_preflight.py` and the weekly spot box behave exactly as before.

## Why nothing caught it

The lambda had no `test_handler.py`, and `_shared/run_handler_tests.sh` returns 0 when that file is absent — so `ci.yml`'s glob gate and `deploy.sh`'s pytest gate both reported green on a function that could not execute a line of its own handler. The repo suite runs `sf_preflight.py` in a venv where `nousergon_lib` is installed, so it structurally cannot see a packaging gap. And the component runs once a week.

Added:
- `weekly-preflight/test_handler.py` (picked up automatically by ci.yml's glob and by deploy.sh);
- `test_lambda_profile_imports_are_packaged` — derives the Lambda's required distributions from the imports of the code actually packaged and asserts each is in `requirements.txt`. Fails on the exact 2026-08-10 shape;
- `test_every_check_declares_its_capabilities` — a new check can neither silently gain nor silently lose Lambda eligibility;
- **a blocking post-deploy smoke invoke** (`deploy.sh` step 6): invokes the alias just published and fails the deploy on `status: ERROR`. `status: FAIL` reports loudly and does not block, since that is a violation about system state and blocking would block its own fix. The handler is read-only; `github-actions-lambda-deploy` already holds `lambda:InvokeFunction` on `alpha-engine-*:*` (`LambdaInvokeCanary`), so no IAM change is needed.

Swept the two sibling lambdas that also `cp` a repo module into their zip — `crypto-balances` (`embit`) and `pipeline-watchdog` (`nousergon_lib`, `krepis`): both declare their imports. This was the only instance.

## Test plan

- `pytest tests/` → **4795 passed, 8 skipped**, 1 failure (`test_pipeline_status_registry_source_check`) traced to the local `.venv` carrying nousergon-lib v0.124.43 while the repo pins v0.124.44; re-run with the v0.124.44 worktree on `PYTHONPATH` → **passes**. Not related to this change.
- `pytest tests/test_sf_preflight.py infrastructure/lambdas/weekly-preflight/test_handler.py tests/test_lib_pin_lockstep.py` → 72 passed.
- **End-to-end against live AWS**, package built exactly as `deploy.sh` builds it (`cp sf_preflight.py` + `pip install -r requirements.txt`), handler run with only the package on `sys.path`:

```
{"status": "OK", "has_violation": false, "warn_count": 0, "skip_count": 10, "ran_count": 4}
  ok  sf_iam_reachability          22 identity/target pair(s) reachable
  ok  postflight_contracts         All postflight contract files present + parseable
  ok  definition_input_coherence   All 36 execution-input refs resolve ... (204 mid-flow refs not covered)
  ok  lambda_memory_headroom       All 20 Lambda(s) above 128 MB headroom margin
```

The same run before this PR: `status: ERROR` on the import; with only defect 1 fixed: `status: FAIL`, 177 unresolvable JSONPaths.

## Related

- Incident records: nous-ergon-ops-I562 (sev2, `import-missing-from-build-manifest`), nous-ergon-ops-I563 (sev4, `alarm-red-by-construction`), registry instances in nous-ergon-ops-PR564.
- Follow-up filed: alpha-engine-config-I6821 — full ASL dataflow modelling so `check_definition_input_coherence` covers mid-flow refs (today it verifies 4 of 80 distinct refs and says so). Recovery run tracked as alpha-engine-config-I6822.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)