### PR TITLE
feat(freshness-monitor): account-wide disabled-schedule inventory (config-I6817 D4)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -485,6 +485,20 @@ PRODUCER_SUPPRESSION_MAX_DAYS = int(
     os.environ.get("PRODUCER_SUPPRESSION_MAX_DAYS", "14")
 )
 PRODUCER_DISABLED_SINCE_KEY = "_freshness_monitor/producer_disabled_since.json"
+# alpha-engine-config-I6817 D4. The suppression path above answers "is THIS
+# artifact's producer off?" — it can only see triggers some registry row names.
+# The class defect is wider: a schedule switched off under a pause has no
+# release path, and NOTHING in the fleet enumerates what is currently off. The
+# 2026-08-07 pause disabled 23 rules; `alpha-research-thinktank-daily` stayed
+# off for three days after the condition that justified it was resolved,
+# because its tracking issue was CLOSED and no surface listed the rule.
+#
+# So this key is the inventory, written every daily sweep: every disabled
+# trigger in the account, whether or not any artifact row references it, with
+# how long it has been off. It is deliberately DATA and not an alert — deciding
+# whether a given pause has a release item needs the backlog, which this Lambda
+# has no credential for and should not. The join is a separate sweep's job.
+DISABLED_PRODUCER_INVENTORY_KEY = "_freshness_monitor/disabled_producers.json"
 
 _PRODUCER_SURFACES = ("events", "scheduler")
 
@@ -637,6 +651,130 @@ def apply_producer_suppression(
             "suppressed": suppressed,
         }
     return out
+
+
+def enumerate_disabled_schedules(
+    events_client: Any = None,
+    scheduler_client: Any = None,
+) -> list[dict[str, str]]:
+    """Every DISABLED EventBridge rule and EventBridge Scheduler schedule.
+
+    Unlike :func:`resolve_disabled_producers`, this takes no trigger set — it
+    walks the account. That is the point: a rule nothing in ARTIFACT_REGISTRY
+    references is exactly the one no surface can currently see, and the two
+    probes paused on 2026-08-07 (`alpha-engine-router-exposure-probe-15min`,
+    `alpha-engine-ssm-reachability-probe-5min`) are both in that class.
+
+    A surface that cannot be enumerated is reported as an ERROR row rather
+    than omitted. Silence here would reproduce the defect this exists to
+    close — an empty inventory must mean "nothing is disabled", never
+    "the walk failed".
+    """
+    out: list[dict[str, str]] = []
+    try:
+        client = events_client or boto3.client("events")
+        paginator = client.get_paginator("list_rules")
+        for page in paginator.paginate():
+            for rule in page.get("Rules", []):
+                if rule.get("State") == "DISABLED":
+                    out.append({
+                        "trigger": f"events:{rule['Name']}",
+                        "name": rule["Name"],
+                        "surface": "events",
+                        "schedule": rule.get("ScheduleExpression", ""),
+                    })
+    except Exception as exc:  # noqa: BLE001 — recorded, never silently empty
+        logger.error(
+            "DISABLED_INVENTORY_ENUMERATION_FAILED for events (%s: %s) — the "
+            "inventory is INCOMPLETE and says so", type(exc).__name__, exc,
+        )
+        out.append({"trigger": "", "name": "", "surface": "events",
+                    "schedule": "", "error": f"{type(exc).__name__}: {exc}"})
+    try:
+        client = scheduler_client or boto3.client("scheduler")
+        paginator = client.get_paginator("list_schedules")
+        for page in paginator.paginate():
+            for sch in page.get("Schedules", []):
+                if sch.get("State") == "DISABLED":
+                    out.append({
+                        "trigger": f"scheduler:{sch['Name']}",
+                        "name": sch["Name"],
+                        "surface": "scheduler",
+                        "schedule": sch.get("ScheduleExpression", ""),
+                    })
+    except Exception as exc:  # noqa: BLE001 — recorded, never silently empty
+        logger.error(
+            "DISABLED_INVENTORY_ENUMERATION_FAILED for scheduler (%s: %s) — "
+            "the inventory is INCOMPLETE and says so", type(exc).__name__, exc,
+        )
+        out.append({"trigger": "", "name": "", "surface": "scheduler",
+                    "schedule": "", "error": f"{type(exc).__name__}: {exc}"})
+    return out
+
+
+def write_disabled_producer_inventory(
+    s3_client: Any,
+    now: datetime,
+    referenced_triggers: set[str],
+    events_client: Any = None,
+    scheduler_client: Any = None,
+) -> dict[str, Any]:
+    """Write the account-wide disabled-schedule inventory (config-I6817 D4).
+
+    Reuses ``producer_disabled_since`` for the age of triggers the suppression
+    path already tracks, and stamps today for the rest. ``referenced`` says
+    whether ANY artifact row names the trigger — an unreferenced disabled rule
+    is invisible to every other surface in the fleet, which is why the flag is
+    on the row rather than left to the consumer to derive.
+
+    Returns the payload. Never raises: this is an observability side effect and
+    must not take down a sweep whose alerting already ran.
+    """
+    today = now.date().isoformat()
+    rows = enumerate_disabled_schedules(events_client, scheduler_client)
+    since = _load_producer_disabled_since(s3_client)
+    incomplete = any(r.get("error") for r in rows)
+    for row in rows:
+        if row.get("error"):
+            continue
+        first_seen = since.get(row["trigger"], today)
+        row["disabled_since"] = first_seen
+        try:
+            row["days_disabled"] = (
+                now.date() - date.fromisoformat(first_seen)
+            ).days
+        except ValueError:
+            row["days_disabled"] = 0
+        row["referenced_by_registry"] = row["trigger"] in referenced_triggers
+    payload = {
+        "generated_at": now.isoformat(),
+        "complete": not incomplete,
+        "disabled_count": len([r for r in rows if not r.get("error")]),
+        "unreferenced_count": len(
+            [r for r in rows
+             if not r.get("error") and not r.get("referenced_by_registry")]
+        ),
+        "rows": rows,
+    }
+    try:
+        s3_client.put_object(
+            Bucket=REGISTRY_BUCKET,
+            Key=DISABLED_PRODUCER_INVENTORY_KEY,
+            Body=json.dumps(payload, indent=2).encode(),
+            ContentType="application/json",
+        )
+        logger.info(
+            "disabled-producer inventory: %d disabled (%d unreferenced by any "
+            "artifact row), complete=%s",
+            payload["disabled_count"], payload["unreferenced_count"],
+            payload["complete"],
+        )
+    except Exception as exc:  # noqa: BLE001 — see docstring; the ERROR is the surface
+        logger.error(
+            "DISABLED_INVENTORY_WRITE_FAILED (non-fatal, the sweep's alerting "
+            "already ran): %s: %s", type(exc).__name__, exc,
+        )
+    return payload
 
 
 def _load_prev_miss_counts(s3_client: Any) -> dict[str, int]:
@@ -2093,6 +2231,15 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 for a, v in suppression_by_id.items()
             ),
         )
+
+    # config-I6817 D4 — the account-wide inventory, written every daily sweep.
+    # Distinct from suppression above: that answers "is this row's producer
+    # off?", this answers "what is off at all?", including schedules no
+    # artifact row names. Written before the probe pass so a pass that raises
+    # still leaves the inventory current.
+    write_disabled_producer_inventory(
+        s3, now, set(producer_trigger_by_id.values())
+    )
 
     pairs, alerted, dispatched, per_spec_exceptions, miss_counts = _run_probe_pass(
         s3, specs, recovery_by_id, now, prev_miss_counts,

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -2705,3 +2705,141 @@ def test_check_results_row_defaults_are_inert_without_suppression(fixed_now):
     assert row["alert_suppressed"] is False
     assert row["producer_trigger"] is None
     assert row["producer_disabled_since"] is None
+
+
+# ── config-I6817 D4: the account-wide disabled-schedule inventory ───────────
+#
+# The 2026-08-07 pause disabled 23 EventBridge rules. `alpha-research-thinktank
+# -daily` then stayed off for three days after the provider-balance condition
+# that justified it was resolved, because I6617 was CLOSED and NO SURFACE
+# ANYWHERE listed which rules were off. The suppression path could not have
+# caught it: it only walks triggers some ARTIFACT_REGISTRY row names.
+
+
+class _FakeEventsPaginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self):
+        return iter(self._pages)
+
+
+class _FakeEvents:
+    def __init__(self, rules, raises=False):
+        self._rules = rules
+        self._raises = raises
+
+    def get_paginator(self, _name):
+        if self._raises:
+            raise RuntimeError("AccessDenied enumerating rules")
+        return _FakeEventsPaginator([{"Rules": self._rules}])
+
+
+class _FakeScheduler:
+    def __init__(self, schedules=None):
+        self._schedules = schedules or []
+
+    def get_paginator(self, _name):
+        return _FakeEventsPaginator([{"Schedules": self._schedules}])
+
+
+def test_inventory_enumerates_disabled_rules_no_registry_row_names():
+    """The load-bearing case. A disabled rule that no artifact row references
+    is invisible to every other surface in the fleet — both probes paused on
+    2026-08-07 are in that class."""
+    import importlib
+    import index
+    importlib.reload(index)
+    events = _FakeEvents([
+        {"Name": "alpha-research-thinktank-daily", "State": "DISABLED",
+         "ScheduleExpression": "cron(30 14 * * ? *)"},
+        {"Name": "alpha-engine-ssm-reachability-probe-5min", "State": "DISABLED",
+         "ScheduleExpression": "rate(5 minutes)"},
+        {"Name": "alpha-engine-saturday", "State": "ENABLED",
+         "ScheduleExpression": "cron(0 9 * * 6 *)"},
+    ])
+    rows = index.enumerate_disabled_schedules(events, _FakeScheduler())
+    names = {r["name"] for r in rows}
+    assert names == {
+        "alpha-research-thinktank-daily",
+        "alpha-engine-ssm-reachability-probe-5min",
+    }, "ENABLED rules must not appear; both DISABLED ones must"
+
+
+def test_an_unenumerable_surface_is_an_error_row_never_an_empty_inventory():
+    """An empty inventory must mean 'nothing is disabled', never 'the walk
+    failed' — that conflation is the defect this whole feature exists to
+    close, reproduced one level up."""
+    import importlib
+    import index
+    importlib.reload(index)
+    rows = index.enumerate_disabled_schedules(
+        _FakeEvents([], raises=True), _FakeScheduler()
+    )
+    errs = [r for r in rows if r.get("error")]
+    assert errs, "a failed enumeration produced no error row — silent empty"
+    assert "AccessDenied" in errs[0]["error"]
+
+
+def test_the_payload_flags_rows_no_artifact_row_references(monkeypatch):
+    import importlib
+    import index
+    importlib.reload(index)
+    events = _FakeEvents([
+        {"Name": "alpha-research-thinktank-daily", "State": "DISABLED",
+         "ScheduleExpression": "cron(30 14 * * ? *)"},
+        {"Name": "alpha-engine-router-exposure-probe-15min", "State": "DISABLED",
+         "ScheduleExpression": "rate(15 minutes)"},
+    ])
+    monkeypatch.setattr(
+        index, "_load_producer_disabled_since",
+        lambda _s: {"events:alpha-research-thinktank-daily": "2026-08-07"},
+    )
+
+    class _S3:
+        def __init__(self):
+            self.put = None
+
+        def put_object(self, **kw):
+            self.put = kw
+
+    s3 = _S3()
+    now = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    payload = index.write_disabled_producer_inventory(
+        s3, now, {"events:alpha-research-thinktank-daily"}, events, _FakeScheduler()
+    )
+
+    assert payload["complete"] is True
+    assert payload["disabled_count"] == 2
+    assert payload["unreferenced_count"] == 1, (
+        "the router-exposure probe is named by no artifact row and must be "
+        "counted as unreferenced — that is the class the thinktank rule's "
+        "three-day overrun belongs to"
+    )
+    by_name = {r["name"]: r for r in payload["rows"]}
+    tt = by_name["alpha-research-thinktank-daily"]
+    assert tt["disabled_since"] == "2026-08-07"
+    assert tt["days_disabled"] == 3, "age must come from producer_disabled_since"
+    assert tt["referenced_by_registry"] is True
+    assert by_name["alpha-engine-router-exposure-probe-15min"][
+        "referenced_by_registry"] is False
+    assert s3.put is not None, "the inventory was not written"
+    assert s3.put["Key"] == index.DISABLED_PRODUCER_INVENTORY_KEY
+
+
+def test_a_failed_write_does_not_take_down_the_sweep():
+    """This is an observability side effect. The sweep's alerting has already
+    run by the time it is called; raising here would trade a real page for a
+    bookkeeping failure."""
+    import importlib
+    import index
+    importlib.reload(index)
+    class _S3:
+        def put_object(self, **kw):
+            raise RuntimeError("s3 down")
+
+    payload = index.write_disabled_producer_inventory(
+        _S3(), datetime(2026, 8, 10, tzinfo=timezone.utc), set(),
+        _FakeEvents([]), _FakeScheduler(),
+    )
+    assert payload["disabled_count"] == 0


### PR DESCRIPTION
## The incident this comes from

The 2026-08-07 automation pause disabled 23 EventBridge rules. `alpha-research-thinktank-daily` then sat DISABLED for **three days after the condition that justified it was resolved** — the DeepSeek balance was restored and verified 2026-08-09; the Think Tank produced nothing until it was re-enabled by hand on 2026-08-10.

Nothing caught it because `-I6617`, the issue codifying the pause, was **CLOSED**, and no surface anywhere in the fleet lists which rules are off. That is the registered `one-way-latch-with-no-release-path` class — and it is the same class whose existence was the written rationale for **declining** a schedule circuit breaker on `-I6613` D4. The decline was correct. This is the half that was never built.

## Why the existing suppression path could not have caught it

`apply_producer_suppression` answers *"is THIS artifact's producer off?"*. It walks `producer_trigger_by_id` — only triggers some `ARTIFACT_REGISTRY` row names. A disabled rule that no row references is invisible to it **by construction**, and that is the case for both probes paused on 2026-08-07 (`alpha-engine-router-exposure-probe-15min`, `alpha-engine-ssm-reachability-probe-5min`).

Worse, suppression working correctly makes the latch *quieter*: it annotates `alert_suppressed: true` on exactly the rows whose producer is off, so the fleet stops paging about the thing nobody is tracking.

## This PR

- **`enumerate_disabled_schedules()`** walks the account rather than a trigger set, across both EventBridge rules and Scheduler schedules.
- **`write_disabled_producer_inventory()`** joins it to the existing `producer_disabled_since` state for age, flags each row `referenced_by_registry`, and writes `_freshness_monitor/disabled_producers.json` on every daily sweep. Written **before** the probe pass, so a pass that raises still leaves the inventory current.

**Deliberately data, not an alert.** Deciding whether a pause has a release item needs the backlog, and this Lambda has no GitHub credential and should not acquire one — its blast radius is already the fleet's alerting. The join is a separate sweep's job, filed as **`alpha-engine-config-I6828`**. What this PR closes is that nothing enumerates the population at all.

## Two failure modes pinned by test

- **An unenumerable surface produces an ERROR row and `complete: false`, never a silently empty inventory.** An empty inventory must mean "nothing is disabled", never "the walk failed" — that conflation is this defect reproduced one level up.
- **A failed write logs and returns rather than raising.** The sweep's alerting has already run by then; trading a real page for a bookkeeping failure is the wrong direction. Rationale per the fail-loud rule: (a) the failure swallowed is the S3 put; (b) the primary deliverable — pages — is already delivered; (c) the recording surface is `DISABLED_INVENTORY_WRITE_FAILED` at ERROR, and the stale `generated_at` on the artifact, which `-I6828` D5 requires its consumer to fail on.

## Testing

- `python3 -m pytest test_handler.py -q` — **102 passed** (4 new, covering: a disabled rule no registry row names is enumerated; ENABLED rules are excluded; a failed enumeration yields an error row rather than an empty result; age comes from `producer_disabled_since` and `referenced_by_registry` is set correctly; a failed write does not raise).
- Full repo suite on a clean Python 3.12 venv from `requirements.txt` — **4789 passed, 8 skipped, 0 failed**.

## Related

- `alpha-engine-config-I6817` — the incident and D4; this is D4's first half
- `alpha-engine-config-I6828` — the backlog join (second half), filed by this arc
- `alpha-engine-config-I6613` D4 — where the circuit breaker was declined and this class named

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)