### PR TITLE
ci(drift): SF-ARN drift check off the pull_request path — a drift red must never cloud a merge

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -3,11 +3,26 @@ name: SF-ARN Drift Check
 # Catches drift on four config#1464 axes: EventBridge rule stateMachineArn
 # drift, Step Function LoggingConfiguration drift, SF lambda:invoke
 # states referencing Lambdas that don't exist live, and SF definition drift
-# (codified vs live vs S3-staged — see check-definition-drift.py). Mirrors
-# iam-drift-check.yml's trigger/auth shape exactly
-# (same OIDC role, same PR-touching-path + daily + workflow_dispatch
-# trigger set) — see that workflow's header for why this shape (PR-time
-# catch + daily out-of-band sweep).
+# (codified vs live vs S3-staged — see check-definition-drift.py).
+#
+# NOT a pull_request check (Brian ruling 2026-08-10). Every step here
+# compares CODIFIED source against LIVE AWS. That comparison says nothing
+# about a PR's diff: it is red whenever live state has drifted, whoever
+# caused it and whenever — so a PR author sees a red X they did not cause
+# and cannot clear, and the merge decision gets clouded by a signal that is
+# not about the change under review. Four steps had already been carved off
+# the PR path one at a time for exactly this reason (weekly-cadence,
+# SF-definition, fleet-wide scheduler, manifest drift); the 2026-08-10
+# instance was the automation-pause step reddening #1291, whose diff was a
+# Lambda capability profile, because a thinktank EventBridge rule had been
+# re-enabled out of band. The trigger set is now the whole fix: drift is
+# graded post-merge (push to main, right after the deploy applies) and daily
+# out of band. Nothing is lost — no step ran on PRs that does not run here —
+# and no drift red can ever sit on an open PR again.
+#
+# Corollary for anything added below: if a step reads live AWS, it belongs
+# on this trigger set. If a future step grades the DIFF (codified vs
+# codified), it belongs in ci.yml, not here.
 #
 # infrastructure/eventbridge/check-drift.py and
 # infrastructure/step-functions/check-drift.py were merged code-complete
@@ -24,7 +39,8 @@ name: SF-ARN Drift Check
 # nousergon-data). Same identity iam-drift-check.yml already uses.
 
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - 'infrastructure/eventbridge/**'
       - 'infrastructure/step-functions/**'
@@ -51,8 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-        with:
-          fetch-depth: 0  # full history — needed for PR diff in scheduler step
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
@@ -64,8 +78,11 @@ jobs:
       # weekly/preopen/postclose SFs and the 24/7 box. This asserts the pause
       # still holds — the opposite direction from every other check here, and
       # the only surface that would notice a redeploy quietly switching a
-      # paused trigger back on. Runs unconditionally (not PR-scoped): the
-      # invariant is about live AWS, not about which files a PR touched.
+      # paused trigger back on. Runs unconditionally on every trigger this
+      # workflow has: the invariant is about live AWS, and tests/
+      # test_automation_pause.py::test_ci_runs_the_pause_check pins that it
+      # carries no `if:` — the 2026-08-10 fix was to the workflow's TRIGGER
+      # set, never to this step's reachability.
       # Read-only; needs nothing beyond the events:DescribeRule +
       # scheduler:GetSchedule this role already holds.
       - name: Scheduled-automation pause still holds (live)
@@ -76,12 +93,9 @@ jobs:
       # path runs --enforce; this catches drift BETWEEN deploys). AccessDenied
       # here means ops-PR538's grant has not been applied yet — the DAILY
       # scheduled run staying red is the form-3 detector for that
-      # operator-gated apply. Schedule/dispatch only: `drift-check` is a
-      # REQUIRED PR check, so running this on the pull_request path before the
-      # grant exists would block every PR on a red only an operator can clear
-      # (the gate-only-the-blocked-actor-can-clear trap).
+      # operator-gated apply. (This step carried the first `if:` excluding the
+      # PR path; the whole workflow now excludes it, so the guard is gone.)
       - name: Weekly exercise-cadence drift (manifest vs live SSM)
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: python3 infrastructure/weekly_cadence_drift.py --check
 
       - name: EventBridge SF-ARN drift (codified vs live)
@@ -93,19 +107,15 @@ jobs:
       - name: SF lambda:invoke Lambda-existence check (codified vs live)
         run: python3 infrastructure/step-functions/check-lambda-existence.py
 
-      # PR-time only, this check compares the PR BRANCH's bytes against
-      # live/S3 — but a PR that changes infrastructure/step_function*.json
-      # (the legitimate change mechanism) IS the divergence, and the
-      # restamp only happens at deploy, post-merge (config#2273). It can
-      # never pass on such PRs and blocked the Director-terminal-failure PR
-      # through three escalation cycles (alpha-engine-config-I6591). The
-      # invariant this check enforces is "deployed truth == repo source",
-      # which only exists on the pushed branch: fleet-wide runs happen on
-      # every merge (deploy-infrastructure.yml, right after the deploy
-      # applies) and daily via the schedule below — same shape as the
-      # scheduler checks.
+      # The invariant here is "deployed truth == repo source", which only
+      # exists once the branch is pushed: on a PR that changes
+      # infrastructure/step_function*.json — the legitimate change mechanism —
+      # the diff IS the divergence, and the restamp happens at deploy,
+      # post-merge (config#2273). This check blocked the Director-terminal-
+      # failure PR through three escalation cycles before it was carved off
+      # the PR path (alpha-engine-config-I6591). Fleet-wide runs also happen
+      # on every merge via deploy-infrastructure.yml, right after the deploy.
       - name: SF definition drift (codified vs live vs S3-staged)
-        if: github.event_name != 'pull_request'
         run: python3 infrastructure/step-functions/check-definition-drift.py
 
       # alpha-engine-config-I5805. The out-of-band half of schedule coverage.
@@ -114,49 +124,17 @@ jobs:
       # can see — a rule disabled or retimed in the console, or one belonging to
       # a dispatcher whose repo has no deploy workflow at all.
       #
-      # On PRs: scope to only the deploy.sh files this PR changed
-      # (HEAD^1 = base, HEAD^2 = PR head — the merge commit gives us both).
-      # The fleet-wide check still runs daily via the schedule trigger.
-      - name: Find changed deploy.sh files (PR only)
-        if: github.event_name == 'pull_request'
-        id: changed-deploys
-        run: |
-          FILES=$(git diff --name-only HEAD^1...HEAD^2 -- 'infrastructure/lambdas/*/deploy.sh' || true)
-          if [ -n "$FILES" ]; then
-            {
-              echo "files<<DEPLOY_EOF"
-              echo "$FILES"
-              echo "DEPLOY_EOF"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: EventBridge Scheduler rule drift (PR-scoped, codified vs live)
-        if: github.event_name == 'pull_request' && steps.changed-deploys.outputs.files != ''
-        run: |
-          echo "${{ steps.changed-deploys.outputs.files }}" | while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            echo "::group::check-schedule-drift --source-file $f"
-            # --ignore-kind missing-in-aws: on a PR, schedules that do not exist
-            # live yet (because the PR that declares them hasn't merged) are
-            # expected — the deploy workflow's own post-deploy assertion catches
-            # them after merge.  The daily fleet-wide sweep (which does NOT pass
-            # this flag) still hard-fails on every kind, so real drift (a rule
-            # deleted or disabled in the console post-deploy) is still caught.
-            python3 infrastructure/scheduler/check-schedule-drift.py \
-              --source-file "$f" --ignore-kind missing-in-aws
-            echo "::endgroup::"
-          done
-
+      # The PR-scoped variant of this step (changed deploy.sh files only,
+      # --ignore-kind missing-in-aws) is deleted with the PR trigger: every
+      # rule it covered is covered here unscoped, on merge and daily.
       - name: EventBridge Scheduler rule drift (fleet-wide, codified vs live)
-        if: github.event_name != 'pull_request'
         run: python3 infrastructure/scheduler/check-schedule-drift.py
 
       # alpha-engine-config-I6461: the manifest-vs-live leg check-schedule-
       # drift.py above does not cover (manifest completeness — reason +
       # actuation_tier + attended_window present — and manifest cron vs LIVE
-      # AWS state, not just vs the deploy.sh literal). Daily-only, like the
-      # fleet-wide check above: --live makes an AWS call per manifest entry,
-      # too costly to run on every PR.
+      # AWS state, not just vs the deploy.sh literal). --live makes an AWS
+      # call per manifest entry, which is why it belongs on merge and the
+      # daily sweep rather than on every push of a branch.
       - name: schedule-manifest.json drift (fleet-wide, vs live AWS)
-        if: github.event_name != 'pull_request'
         run: python3 infrastructure/scheduler/check-manifest-drift.py --live

--- a/tests/test_drift_checks_are_not_pr_gated.py
+++ b/tests/test_drift_checks_are_not_pr_gated.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""A live-AWS drift check may never run on the ``pull_request`` path.
+
+Brian ruling 2026-08-10: a pull request whose only failing check is a drift
+check must read GREEN, so that the merge decision is never clouded by a signal
+that is not about the diff under review.
+
+The reasoning, so a later change does not re-add one:
+
+  A drift check compares CODIFIED source against LIVE AWS. Its answer is a
+  property of the account at the moment it runs — not of the branch. On a pull
+  request that produces two distinct failure modes, and BOTH are wrong there:
+
+    * Someone else's out-of-band change (a console edit, a paused rule
+      re-enabled, an un-deployed merge) reddens a PR whose author did not cause
+      it and cannot clear it — the gate-only-the-blocked-actor-can-clear trap.
+    * The PR's OWN intended change is the divergence, because the apply or
+      restamp happens at deploy, post-merge. The check is then red exactly when
+      the author did the right thing (alpha-engine-config-I6591, ops-I305).
+
+  Both train the reader to merge past a red X, which is how a real drift
+  finding goes unread (nous-ergon-ops-I563, alarm-red-by-construction).
+
+Nothing is lost by moving these to ``push: [main]`` + ``schedule``: the merge
+arm grades the same comparison minutes later, with a deploy behind it, and the
+daily sweep catches what no merge can see. What IS lost by leaving them on the
+PR path is the meaning of a red check.
+
+This file is the class-level guard. ``sf-arn-drift-check.yml`` is pinned by
+name because it is the workflow the 2026-08-10 instance came from; the generic
+test covers every workflow added later.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# A step matching any of these reads live AWS and compares it against codified
+# source. Substring match against the step's `run:` block.
+LIVE_DRIFT_INVOCATIONS = (
+    "automation_pause.py --check",
+    "check-drift.py",
+    "check-definition-drift.py",
+    "check-schedule-drift.py",
+    "check-manifest-drift.py",
+    "check-lambda-existence.py",
+    "weekly_cadence_drift.py",
+)
+
+
+def _workflows() -> list[Path]:
+    return sorted(p for p in WORKFLOWS.glob("*.yml"))
+
+
+def _triggers(doc: dict) -> dict:
+    # PyYAML parses the bare key `on` as the boolean True (YAML 1.1).
+    return doc.get("on") or doc.get(True) or {}
+
+
+def _run_blocks(doc: dict):
+    for job in (doc.get("jobs") or {}).values():
+        for step in (job or {}).get("steps") or []:
+            run = (step or {}).get("run")
+            if isinstance(run, str):
+                yield (step.get("name") or "<unnamed>"), run, step.get("if")
+
+
+def test_sf_arn_drift_check_has_no_pull_request_trigger():
+    """The 2026-08-10 instance, pinned by name.
+
+    #1291 was a Lambda capability-profile fix. Its only red check was this
+    workflow's automation-pause step, reporting that
+    `alpha-research-thinktank-daily` had been re-enabled out of band hours
+    earlier. Nothing in the diff could have made it green.
+    """
+    doc = yaml.safe_load((WORKFLOWS / "sf-arn-drift-check.yml").read_text(encoding="utf-8"))
+    triggers = _triggers(doc)
+    assert "pull_request" not in triggers, (
+        "sf-arn-drift-check.yml grades live AWS against codified source; on a "
+        "pull_request it reports drift the author did not cause and cannot "
+        "clear. Keep it on push:[main] + schedule."
+    )
+    # And the coverage it moved to must actually exist.
+    assert "push" in triggers and "main" in (triggers["push"].get("branches") or [])
+    assert "schedule" in triggers
+
+
+@pytest.mark.parametrize("path", _workflows(), ids=lambda p: p.name)
+def test_no_live_drift_step_runs_on_pull_request(path: Path):
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict):
+        pytest.skip(f"{path.name} is not a mapping")
+    if "pull_request" not in _triggers(doc):
+        return
+
+    for name, run, guard in _run_blocks(doc):
+        hit = next((s for s in LIVE_DRIFT_INVOCATIONS if s in run), None)
+        if hit is None:
+            continue
+        # A step explicitly excluded from the PR path is fine — that is the
+        # same fix, applied per step instead of per workflow.
+        if guard and re.search(r"github\.event_name\s*!=\s*'pull_request'", str(guard)):
+            continue
+        if guard and "pull_request" not in str(guard) and "schedule" in str(guard):
+            continue
+        pytest.fail(
+            f"{path.name} step {name!r} runs {hit} on the pull_request path. "
+            "A live-AWS drift comparison says nothing about a PR's diff and "
+            "reddens PRs their authors cannot fix (Brian ruling 2026-08-10). "
+            "Move the workflow to push:[main] + schedule, or guard the step "
+            "with `if: github.event_name != 'pull_request'`."
+        )


### PR DESCRIPTION
## What

Moves `sf-arn-drift-check.yml` from `pull_request` to `push: [main]`, keeping the daily 09:30 schedule and `workflow_dispatch`. Adds a class-level guard test.

**Brian ruling 2026-08-10:** a PR whose only failing check is a drift check must read green for merging.

## Why

A drift check compares **codified source against live AWS**. Its answer is a property of the account at the moment it runs — not of the branch. On a PR that yields exactly two failure modes, and both are wrong there:

| Failure mode | Why it is wrong on a PR |
|---|---|
| Someone else's out-of-band change (console edit, un-deployed merge, a paused rule re-enabled) | The author did not cause it and cannot clear it — the gate-only-the-blocked-actor-can-clear trap |
| The PR's own intended change | The apply/restamp happens at deploy, post-merge, so the check is red exactly when the author did the right thing (`alpha-engine-config-I6591`, `nous-ergon-ops-I305`) |

Both train the reader to merge past a red X, which is how a genuine drift finding goes unread (`nous-ergon-ops-I563`, `alarm-red-by-construction`).

The concrete instance: **#1291** was a `WeeklyPreflightGate` capability-profile fix. Its only red check was this workflow's `Scheduled-automation pause still holds (live)` step:

```
✗ [unexpectedly-enabled] events:alpha-research-thinktank-daily
```

Verified live — the rule is `ENABLED`, and CloudTrail shows `EnableRule` at 2026-08-10 14:18 PT by the SSO admin identity, with `infrastructure/automation_pause.json` never updated. Real drift, zero relation to the diff.

Four steps in this same workflow had already been carved off the PR path one at a time for this reason (weekly-cadence, SF-definition, fleet-wide scheduler, manifest drift), each with its own comment explaining the trap. This applies the fix at the trigger, once.

## Changes

- `pull_request:` → `push: branches: [main]`, same path filter
- delete the two now-dead PR-only steps (changed-`deploy.sh` discovery; the PR-scoped `check-schedule-drift.py --source-file … --ignore-kind missing-in-aws` run). Every rule they covered is covered by the unscoped fleet-wide invocation that remains — `test_daily_sweep_stays_unscoped` still passes
- drop the four `if: github.event_name != 'pull_request'` guards, now no-ops
- **corrected a stale comment**: it claimed `drift-check` is a REQUIRED PR check. Measured 2026-08-10 — the required set on `nousergon-data` is `test`, `gate-label-guard`, `iam-policy-change-guard`, `rehearsal-path-guard`. `drift-check` is not among them, which is why #1291 was `UNSTABLE` and still mergeable
- new `tests/test_drift_checks_are_not_pr_gated.py` — pins this workflow by name, and parametrically fails **any** workflow in the repo that invokes a live-AWS drift comparison on a `pull_request` trigger without an explicit non-PR guard. That is the class fix: the next drift step added cannot land on the PR path silently

## Coverage delta

None lost. No step ran on PRs that does not run on the merge arm. The exposure window widens from "at PR open" to "at merge, plus daily" — on a day with no merge to `infrastructure/**`, out-of-band drift is caught by the 09:30 sweep instead of by whichever PR happened to be open.

## Test plan

- `tests/test_drift_checks_are_not_pr_gated.py` + `test_automation_pause.py` + `test_scheduler_reconcile_is_ci_runnable.py` → **81 passed**
- `pytest tests/ -k "workflow or drift or pause or schedule or yaml"` → **358 passed, 2 skipped**
- `test_automation_pause.py::test_ci_runs_the_pause_check` (asserts the pause step carries no `if:`) still passes — the fix is to the trigger set, never to that step's reachability

## Related

- Same ruling, one PR per repo, no merge-order dependency between them: `nous-ergon-ops-PR386` (base-tree IAM comparison deleted from its PR path) and `crucible-predictor-PR460` (IAM drift check moved to `push: [main]`).
- The `alpha-research-thinktank-daily` drift itself is a separate disposition (re-enforce the pause, or record the un-pause in the manifest) — not fixed here, and the daily sweep stays red until it is.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
