### PR TITLE
fix(spot): the spot watchdog is a daemon, not a oneshot — it hung every per-stage bootstrap

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -217,7 +217,18 @@ bootstrap_spot() {
 set -eo pipefail
 export HOME=/home/ec2-user XDG_CACHE_HOME=/tmp AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1
 
-# systemd watchdog (config#2693)
+# systemd watchdog (config#2693). Type=simple, NOT oneshot: ExecStart is an
+# endless supervision loop, and `systemctl start` on a Type=oneshot unit BLOCKS
+# until ExecStart exits (TimeoutStartSec defaults to infinity for oneshot). The
+# original unit declared Type=oneshot + RemainAfterExit=yes, so every bootstrap
+# hung here until SSM SIGKILLed the command at its budget — rc=137 at exactly
+# PT5M0.1S, stderr ending on the `systemctl enable` symlink line with nothing
+# after it. Latent from #1122 until #1269 repointed the weekly SF onto these
+# per-stage scripts on 2026-08-09; the first weekly run on the new path
+# (2026-08-10) failed at MorningEnrich twice, and DataPhase1 + RAGIngestion
+# would have failed identically. The retired spot_data_weekly.sh monolith never
+# hit it: it arms its watchdog with a transient `systemd-run --on-active` timer,
+# not a unit file.
 if ! systemctl is-enabled ec2-spot-watchdog 2>/dev/null; then
   cat > /tmp/ec2-spot-watchdog.service <<'UNIT'
 [Unit]
@@ -225,9 +236,10 @@ Description=EC2 Spot Watchdog
 After=amazon-ssm-agent.service
 Requires=amazon-ssm-agent.service
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/local/bin/ec2-spot-watchdog.sh
-RemainAfterExit=yes
+Restart=always
+RestartSec=30
 [Install]
 WantedBy=multi-user.target
 UNIT
@@ -246,8 +258,14 @@ done
 WDSH
   chmod +x /usr/local/bin/ec2-spot-watchdog.sh
   cp /tmp/ec2-spot-watchdog.service /etc/systemd/system/
-  systemctl enable ec2-spot-watchdog
-  systemctl start ec2-spot-watchdog
+  # `timeout` so a future unit-shape regression fails in seconds WITH a message,
+  # instead of consuming the whole SSM budget and dying under SIGKILL with no
+  # output — that silence is what made the 2026-08-10 hang read as "bootstrap
+  # is slow" rather than "systemctl is blocked forever".
+  timeout 60 systemctl enable --now ec2-spot-watchdog || {
+    echo "ERROR: enabling ec2-spot-watchdog did not return within 60s — the unit is misdeclared (an endless ExecStart under Type=oneshot blocks systemctl start forever)" >&2
+    exit 1
+  }
 fi
 
 command -v python3.12 >/dev/null || { echo "ERROR: python3.12 not found" >&2; exit 1; }

--- a/tests/test_embedded_systemd_unit_shapes.py
+++ b/tests/test_embedded_systemd_unit_shapes.py
@@ -1,0 +1,123 @@
+"""A systemd unit whose ExecStart never returns must not be Type=oneshot.
+
+The failure this pins (2026-08-10, `ne-weekly-freshness-pipeline` runs
+`watch-rerun-2026-08-10-1` and `-2`): ``infrastructure/_spot_common.sh``'s
+bootstrap wrote an ``ec2-spot-watchdog.service`` declaring::
+
+    Type=oneshot
+    ExecStart=/usr/local/bin/ec2-spot-watchdog.sh   # while true; do ... done
+    RemainAfterExit=yes
+
+``systemctl start`` on a ``Type=oneshot`` unit BLOCKS until ExecStart exits,
+and for oneshot units ``TimeoutStartSec`` defaults to infinity — so the
+bootstrap step hung until SSM SIGKILLed it at its budget: rc=137 at exactly
+``PT5M0.1S``, stderr ending on the ``systemctl enable`` symlink line with
+nothing after it. Latent from #1122 until #1269 repointed the weekly SF onto
+the per-stage spot scripts (2026-08-09); MorningEnrich failed twice on the
+first weekly run over the new path, and DataPhase1 + RAGIngestion embed the
+same helper, so all three stages were dead.
+
+Unit files here are written INSIDE bash heredocs, so no systemd linter sees
+them. This test parses them out of the shell scripts and checks the one
+property whose violation hangs a pipeline: an endless ExecStart under a
+service type that waits for it to finish.
+
+Scope note: a genuinely one-shot job (a timer-driven backup, a drift check)
+is correctly ``Type=oneshot`` and is not flagged — the test keys on the
+ExecStart script's own body containing an unbounded loop, not on the type.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+
+# A service type whose `systemctl start` waits for ExecStart to exit.
+_BLOCKING_TYPES = {"oneshot"}
+# Shapes that never return on their own.
+_ENDLESS = (
+    re.compile(r"while\s+true"),
+    re.compile(r"while\s+:\s*;"),
+    re.compile(r"for\s*\(\(\s*;\s*;\s*\)\)"),
+)
+
+
+def _shell_scripts() -> list[Path]:
+    return sorted(p for p in _INFRA.rglob("*.sh") if p.is_file())
+
+
+def _units_in(text: str) -> list[tuple[str, str]]:
+    """Return (unit_body, whole_file_text) for each embedded unit file."""
+    return [(m.group(0), text) for m in re.finditer(r"\[Unit\].*?\[Install\]", text, re.S)]
+
+
+def _execstart_target(unit: str) -> str | None:
+    m = re.search(r"^ExecStart=(\S+)", unit, re.M)
+    return m.group(1) if m else None
+
+
+def _service_type(unit: str) -> str:
+    m = re.search(r"^Type=(\S+)", unit, re.M)
+    return m.group(1) if m else "simple"
+
+
+def _body_of(script_path: str, text: str) -> str:
+    """The inline heredoc body written to *script_path* in the same file.
+
+    Bootstrap scripts write their ExecStart target in the same heredoc that
+    declares the unit, e.g. ``cat > /usr/local/bin/x.sh <<'WDSH' ... WDSH``.
+    """
+    name = re.escape(script_path)
+    m = re.search(rf"cat\s*>\s*{name}\s*<<'?(\w+)'?\n(.*?)\n\1", text, re.S)
+    return m.group(2) if m else ""
+
+
+@pytest.mark.parametrize("script", _shell_scripts(), ids=lambda p: p.name)
+def test_endless_execstart_is_never_a_blocking_service_type(script: Path):
+    text = script.read_text()
+    for unit, whole in _units_in(text):
+        target = _execstart_target(unit)
+        if not target:
+            continue
+        body = _body_of(target, whole)
+        if not body:
+            continue  # ExecStart lives outside this file — nothing to assert
+        if not any(rx.search(body) for rx in _ENDLESS):
+            continue
+        stype = _service_type(unit)
+        assert stype not in _BLOCKING_TYPES, (
+            f"{script.name}: {target} runs an unbounded loop but its unit "
+            f"declares Type={stype}. `systemctl start` will block until "
+            f"ExecStart exits — which it never does — and the caller dies "
+            f"when its own timeout kills it (2026-08-10: the weekly SF's "
+            f"MorningEnrich bootstrap, rc=137 at PT5M0.1S). Use Type=simple."
+        )
+
+
+def test_the_spot_watchdog_unit_is_a_simple_service():
+    """Anchored assertion on the specific unit that hung the pipeline."""
+    text = (_INFRA / "_spot_common.sh").read_text()
+    units = [u for u, _ in _units_in(text) if "ec2-spot-watchdog" in u or "EC2 Spot Watchdog" in u]
+    assert units, "ec2-spot-watchdog unit not found in _spot_common.sh"
+    for unit in units:
+        assert _service_type(unit) == "simple", unit
+        assert "RemainAfterExit" not in unit, (
+            "RemainAfterExit belongs to oneshot units; a supervised daemon "
+            "uses Restart= instead"
+        )
+
+
+def test_the_watchdog_enable_call_is_time_bounded():
+    """A future regression must fail loudly in seconds, not silently at the
+    SSM budget. The 2026-08-10 hang produced NO stderr past the symlink line,
+    which is why it read as a slow bootstrap rather than a blocked systemctl."""
+    text = (_INFRA / "_spot_common.sh").read_text()
+    assert re.search(r"timeout\s+\d+\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog", text), (
+        "the watchdog enable call must be wrapped in `timeout N systemctl "
+        "enable --now ec2-spot-watchdog` with an explicit error message"
+    )


### PR DESCRIPTION
## What broke

`ne-weekly-freshness-pipeline` failed twice tonight at **MorningEnrich** — `watch-rerun-2026-08-10-1` and `-2` — with the SSM bootstrap step killed at **exactly `PT5M0.108S`, rc=137**, stderr ending on:

```
Created symlink /etc/systemd/system/multi-user.target.wants/ec2-spot-watchdog.service → /etc/systemd/system/ec2-spot-watchdog.service.
```

and nothing after it.

## Root cause

`infrastructure/_spot_common.sh` writes `ec2-spot-watchdog.service` as `Type=oneshot` + `RemainAfterExit=yes`, but its `ExecStart` is an endless supervision loop (`while true; do … sleep 60; done`). **`systemctl start` on a oneshot unit blocks until ExecStart exits**, and `TimeoutStartSec` defaults to infinity for oneshot — so every bootstrap hung on that line until SSM's own budget SIGKILLed the command.

Not a slow bootstrap, not spot capacity, and **not the 300s budget** — the command was blocked forever; the budget is merely what ended it. The budget is left at 300s deliberately: raising it would have masked this.

## Why now, and why it is three stages, not one

| | |
|---|---|
| #1122 | created the shared `_spot_common.sh` helper with this unit — latent |
| #1269 | repointed the weekly SF's MorningEnrich / DataPhase1 / RAGIngestion onto the per-stage scripts, **2026-08-09** |
| 2026-08-10 | first weekly run over the new path — MorningEnrich fails, twice |

DataPhase1 and RAGIngestion embed the same helper and were dead identically. The retired `spot_data_weekly.sh` monolith never hit this — it arms its watchdog with a transient `systemd-run --on-active` timer, not a unit file — which is why 08-07 and 08-08 ran clean. Verified against SSM directly: those bootstraps carried `TimeoutSeconds=600 / executionTimeout=600` and **succeeded**; tonight's carried 300 and were killed at exactly 300.

## The fix

- `Type=simple`, `Restart=always`, `RestartSec=30`; `RemainAfterExit` removed (it belongs to oneshot units).
- `timeout 60 systemctl enable --now ec2-spot-watchdog` with an explicit error message, so a future unit-shape regression fails in seconds **with output** rather than consuming the SSM budget and dying under SIGKILL silently. That silence is precisely what made this read as "the bootstrap is slow".
- `tests/test_embedded_systemd_unit_shapes.py` — these units live inside bash heredocs, so no systemd linter ever sees them. The test parses them out and fails any unbounded `ExecStart` declared under a blocking service type. A genuinely one-shot timer job is not flagged: the check keys on the ExecStart script's own body, not on the type.

## Test plan

- **Negative control** (the check is a real detector, not decoration): against the pre-fix file it produces **3 failures**; after the fix, **0**. Both measured, not assumed.
- `pytest tests/` → **4868 passed, 8 skipped**, run against the pinned `nousergon-lib` v0.124.44 (the shared venv carries v0.124.43, which false-fails `test_pipeline_status_registry_source_check`).
- Swept every embedded and standalone systemd unit across `nousergon-data`, `crucible-dashboard`, `nous-ergon-ops`, `krepis`, `nousergon-lib`: this was the only oneshot-with-endless-ExecStart. `morning-signal-watchdog` looked similar and is correctly timer-driven.

## Verification after merge

The next `weekly_sf_rerun.py --start` is the real proof — MorningEnrich reaching `Bootstrap complete.` rather than rc=137. Tracked with the recovery run in alpha-engine-config-I6822.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
