### PR TITLE
fix(spot): the per-stage bootstrap installs python3.12 instead of asserting it

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -268,7 +268,25 @@ WDSH
   }
 fi
 
-command -v python3.12 >/dev/null || { echo "ERROR: python3.12 not found" >&2; exit 1; }
+# Install the interpreter — the AL2023 spot AMI does not ship python3.12.
+# The retired spot_data_weekly.sh monolith installed it here; the per-stage
+# split (#1122) replaced the install with a bare assertion, encoding an AMI
+# contract nothing provides. Latent until #1269 repointed the weekly SF onto
+# these scripts (2026-08-09); the first run over the new path died on
+# "ERROR: python3.12 not found" (watch-rerun-2026-08-10-3, 2026-08-11).
+# gcc + devel are needed by source-built wheels in requirements.txt; git for
+# the clone below. Measured on the monolith's own successful bootstraps
+# (2026-08-07 and 08-08): this whole step ran in 48-49s, well inside the 300s
+# budget, so the budget stays as it is.
+dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
+    dnf install -y -q python3 python3-pip python3-devel git gcc
+
+# Post-condition, not a precondition: the install above is what makes this
+# true, and a silent fallback to a system python3 is exactly the drift the
+# per-stage scripts must not inherit (requirements.txt is resolved against
+# 3.12).
+command -v python3.12 >/dev/null || { echo "ERROR: python3.12 not found after dnf install" >&2; exit 1; }
+echo "Using: $(python3.12 --version)"
 
 if [ ! -d /home/ec2-user/data/.git ]; then
   rm -rf /home/ec2-user/data

--- a/tests/test_spot_bootstrap_provides_what_it_asserts.py
+++ b/tests/test_spot_bootstrap_provides_what_it_asserts.py
@@ -1,0 +1,91 @@
+"""A spot bootstrap must INSTALL what it asserts is present.
+
+The failure this pins (2026-08-11, `watch-rerun-2026-08-10-3`): the per-stage
+bootstrap in ``infrastructure/_spot_common.sh`` carried
+
+    command -v python3.12 >/dev/null || { echo "ERROR: python3.12 not found"; exit 1; }
+
+and nothing that installs it. The retired ``spot_data_weekly.sh`` monolith ran
+``dnf install -y -q python3.12 …`` at exactly that point; the per-stage split
+(#1122) replaced the install with a bare assertion, encoding an AMI contract
+nothing provides. It stayed latent until #1269 repointed the weekly SF onto
+these scripts (2026-08-09) — MorningEnrich, DataPhase1 and RAGIngestion all
+inherit this helper, so all three were dead on the first run over the new path.
+
+An assertion that a tool exists is a PRECONDITION on the image. A bootstrap's
+job is to establish preconditions, not to require them — so every `command -v`
+guard here must be preceded, in the same script, by something that provides the
+binary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_COMMON = _REPO_ROOT / "infrastructure" / "_spot_common.sh"
+
+# How a bootstrap may legitimately provide a binary.
+_PROVIDERS = ("dnf install", "yum install", "apt-get install", "curl -", "pip install")
+
+
+def _bootstrap_block() -> str:
+    text = _COMMON.read_text()
+    m = re.search(r"bootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
+    assert m, "bootstrap_spot() not found in _spot_common.sh"
+    return m.group(1)
+
+
+def _fatal_command_v_guards(block: str) -> list[tuple[str, int]]:
+    """(binary, offset) for each `command -v X` guard that exits non-zero."""
+    out = []
+    for m in re.finditer(r"command -v (\S+)[^\n]*\|\|[^\n]*exit 1", block):
+        out.append((m.group(1), m.start()))
+    return out
+
+
+def test_every_asserted_binary_is_installed_first():
+    block = _bootstrap_block()
+    guards = _fatal_command_v_guards(block)
+    assert guards, (
+        "no fatal `command -v` guard found — if the bootstrap stopped asserting "
+        "its interpreter, this test has lost its subject and must be updated "
+        "deliberately, not deleted"
+    )
+    for binary, offset in guards:
+        before = block[:offset]
+        provided = any(
+            p in line and binary.split(".")[0] in line
+            for line in before.splitlines()
+            for p in _PROVIDERS
+        )
+        assert provided, (
+            f"_spot_common.sh bootstrap asserts `{binary}` is present but never "
+            f"installs it — a bootstrap establishes preconditions, it does not "
+            f"require them. This is the 2026-08-11 MorningEnrich failure "
+            f"(`ERROR: python3.12 not found`), inherited by DataPhase1 and "
+            f"RAGIngestion too."
+        )
+
+
+def test_bootstrap_installs_python312_explicitly():
+    """Anchored: 3.12 specifically, since requirements.txt resolves against it
+    and a silent fall back to the system python3 is its own drift class."""
+    block = _bootstrap_block()
+    assert re.search(r"dnf install[^\n]*python3\.12", block), (
+        "the bootstrap must install python3.12 explicitly"
+    )
+
+
+@pytest.mark.parametrize("tool", ["git", "gcc"])
+def test_bootstrap_installs_the_tools_the_later_steps_use(tool: str):
+    """`git clone` runs in this same block, and requirements.txt builds wheels
+    from source — both were in the monolith's install line."""
+    block = _bootstrap_block()
+    install_lines = [ln for ln in block.splitlines() if "dnf install" in ln]
+    assert any(tool in ln for ln in install_lines), (
+        f"{tool} is used by the bootstrap or the deps step but is not installed"
+    )


### PR DESCRIPTION
## What

The defect underneath the one nousergon-data-PR1294 fixed. With the watchdog hang gone, the bootstrap reaches its next line and dies in **0.45s**:

```
ERROR: python3.12 not found
```

`infrastructure/_spot_common.sh` carried `command -v python3.12 >/dev/null || exit 1` and nothing that installs it — an AMI precondition nothing provides, since the AL2023 spot AMI does not ship 3.12. The retired `spot_data_weekly.sh` monolith ran `dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc` at exactly that point; the per-stage split (#1122) replaced the install with a bare assertion.

Same shape as PR1294: latent from #1122, made live by #1269's repoint on 2026-08-09, and shared by **MorningEnrich, DataPhase1 and RAGIngestion** — all three were dead.

## Fix

- `dnf install` restored with the monolith's `python3` fallback. `git` and `gcc` ride along: the clone in this same block needs git, and `requirements.txt` builds wheels from source.
- The `command -v` guard stays as a **post-condition** ("not found after dnf install"). A silent fall back to the system python3 is its own drift class — `requirements.txt` resolves against 3.12.
- **Budget untouched.** Measured on the monolith's own successful bootstraps (2026-08-07, 08-08) via `ssm get-command-invocation`: the whole step, dnf included, ran in **48–49s** against a 300s budget. The 300s was never the problem; PR1294's hang merely consumed it.

## Test plan

- `tests/test_spot_bootstrap_provides_what_it_asserts.py` fails any fatal `command -v` guard in the bootstrap not preceded by something providing the binary. **Negative control:** 4 failures against the pre-fix file, 0 after — measured both ways.
- `pytest tests/` → **4916 passed, 8 skipped** (against the pinned `nousergon-lib` v0.124.44).

## Sweep

Compared the rest of the per-stage rewrite against the monolith it replaced. One other step differs — the monolith's `pip install 'numpy<2'` — and its absence is **correct**, not a second drop: `requirements.txt` now pins `numpy>=2.4.6`, so re-adding it would be an uninstallable conflict.

## Verification after merge

`weekly_sf_rerun.py --start`; MorningEnrich should reach `Bootstrap complete.` and then `Dependencies installed.` Tracked with the recovery run in alpha-engine-config-I6822.

Related: nousergon-data-PR1294 (merged), nousergon-data-PR1295 (the alert that failed to name any of this).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
