### PR TITLE
[P1/low] fix(spot): stage config.yaml where the resolver looks (config#6846)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -293,8 +293,22 @@ if [ ! -d /home/ec2-user/data/.git ]; then
   git clone --depth 1 --branch "${BRANCH:-main}" https://github.com/nousergon/nousergon-data.git /home/ec2-user/data
 fi
 
-mkdir -p /home/ec2-user/data/config
-aws s3 cp "${S3_STAGING}/config.yaml" "/home/ec2-user/data/config/config.yaml" --region "${AWS_REGION:-us-east-1}" --quiet
+# Destination must be a path weekly_collector.load_config actually searches.
+# It delegates to nousergon_lib.config.resolve_experiment_config("data",
+# "config.yaml", repo_root=<checkout>, repo_local_fallback=Path("config.yaml")),
+# so with the clone at /home/ec2-user/data the candidates are
+# /home/ec2-user/alpha-engine-config/{experiments/reference/,}data/config.yaml
+# plus the CWD-relative config.yaml — /home/ec2-user/data/config/config.yaml is
+# in none of them. The retired spot_data_weekly.sh monolith staged to the
+# alpha-engine-config path below; the per-stage split (#1122) changed the
+# destination and #1269 made that live, so MorningEnrich died on
+# FileNotFoundError (config#6846). No per-stage workload reads the old path —
+# it is dropped rather than written twice. tests/test_spot_bootstrap_config_
+# lands_where_the_resolver_looks.py derives the candidate list from the
+# resolver, so a resolver change fails CI instead of production.
+mkdir -p /home/ec2-user/alpha-engine-config/data
+aws s3 cp "${S3_STAGING}/config.yaml" "/home/ec2-user/alpha-engine-config/data/config.yaml" --region "${AWS_REGION:-us-east-1}" --quiet
+chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-config
 BOOTSTRAP
 )" 300
   echo "  Bootstrap complete."

--- a/tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py
+++ b/tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py
@@ -1,0 +1,89 @@
+"""The spot bootstrap must stage config.yaml where the resolver actually looks.
+
+Bug class (config#6846, live failure ``watch-rerun-2026-08-10-4``,
+2026-08-11T04:44Z): the bootstrap staged the config to a path that
+``weekly_collector.load_config`` never searches, so MorningEnrich died on::
+
+    FileNotFoundError: Config data/config.yaml not found. Searched:
+      ['/home/ec2-user/alpha-engine-config/experiments/reference/data/config.yaml',
+       '/home/ec2-user/alpha-engine-config/data/config.yaml',
+       'config.yaml']
+
+The retired ``spot_data_weekly.sh`` monolith staged to the second candidate.
+The per-stage split (#1122) changed the destination and #1269 repointed the
+weekly SF onto the per-stage scripts, so the mismatch only became observable in
+production — a shell heredoc and a Python resolver agreeing on a literal path
+is exactly the coupling nothing else checks.
+
+The candidate list here is DERIVED from
+``nousergon_lib.config.resolve_experiment_config`` rather than hardcoded: if the
+resolver's search order changes, this test fails instead of the pipeline.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from nousergon_lib.config import resolve_experiment_config
+
+# Where the bootstrap clones nousergon-data on the spot box, and the working
+# directory every stage's SSM heredoc cds into before invoking python.
+_REMOTE_CHECKOUT = Path("/home/ec2-user/data")
+
+_SPOT_COMMON = Path(__file__).resolve().parents[1] / "infrastructure" / "_spot_common.sh"
+_SRC = _SPOT_COMMON.read_text(encoding="utf-8")
+
+# `aws s3 cp "${S3_STAGING}/config.yaml" "<dest>"` inside the bootstrap heredoc.
+_STAGE_CP = re.compile(
+    r'aws\s+s3\s+cp\s+"\$\{S3_STAGING\}/config\.yaml"\s+"?(?P<dest>[^"\s]+)"?'
+)
+
+
+def _resolver_candidates() -> list[str]:
+    """The exact paths load_config would try on the spot box.
+
+    Mirrors ``weekly_collector.load_config``: same subdir, filename, repo_root
+    and CWD-relative repo_local_fallback, with ``resolve=False`` so we get the
+    candidate list rather than a FileNotFoundError.
+    """
+    candidates = resolve_experiment_config(
+        "data",
+        "config.yaml",
+        repo_root=_REMOTE_CHECKOUT,
+        repo_local_fallback=Path("config.yaml"),
+        resolve=False,
+    )
+    # CWD-relative candidates resolve against the checkout the stages cd into.
+    return [str(_REMOTE_CHECKOUT / c) if not Path(c).is_absolute() else str(c) for c in candidates]
+
+
+def test_bootstrap_stages_config_to_a_resolver_candidate():
+    dests = [m.group("dest") for m in _STAGE_CP.finditer(_SRC)]
+    assert dests, (
+        f"{_SPOT_COMMON.name} no longer stages config.yaml in its bootstrap — if that "
+        "is deliberate (prebaked image), delete this test with the reason; otherwise "
+        "the stages will fail on a fresh box."
+    )
+
+    candidates = _resolver_candidates()
+    assert any(d in candidates for d in dests), (
+        f"the bootstrap stages config.yaml to {dests}, none of which "
+        f"weekly_collector.load_config searches on a box with the checkout at "
+        f"{_REMOTE_CHECKOUT}. Resolver candidates: {candidates}. This is config#6846: "
+        "the copy succeeds, the box looks healthy, and the workload dies on "
+        "FileNotFoundError several minutes later."
+    )
+
+
+def test_staged_config_is_readable_by_the_stage_user():
+    """The bootstrap runs as root; every stage workload runs as ec2-user."""
+    dests = [m.group("dest") for m in _STAGE_CP.finditer(_SRC)]
+    for dest in dests:
+        owner_root = str(Path(dest).parent.parent)
+        assert re.search(
+            rf"chown -R ec2-user:ec2-user {re.escape(owner_root)}\b", _SRC
+        ) or re.search(rf"chown -R ec2-user:ec2-user {re.escape(str(Path(dest).parent))}\b", _SRC), (
+            f"config staged to {dest} by the root bootstrap is never chowned to "
+            "ec2-user, which is the uid every stage's SSM heredoc runs under"
+        )


### PR DESCRIPTION
## What

The per-stage spot bootstrap staged `config.yaml` to `/home/ec2-user/data/config/config.yaml` — a path `weekly_collector.load_config` never searches. Stage to the path the resolver actually resolves, and add a guard test that derives the candidate list from the resolver.

## Why

`ne-weekly-freshness-pipeline` failed four consecutive times on 2026-08-10 (`watch-rerun-2026-08-10-{1..4}`), each at MorningEnrich:

```
FileNotFoundError: Config data/config.yaml not found. Searched:
  ['/home/ec2-user/alpha-engine-config/experiments/reference/data/config.yaml',
   '/home/ec2-user/alpha-engine-config/data/config.yaml', 'config.yaml']
```

`load_config` delegates to `nousergon_lib.config.resolve_experiment_config("data", "config.yaml", repo_root=Path(__file__).parent, repo_local_fallback=Path(path))`. With the clone at `/home/ec2-user/data`, the staged path is in none of the candidates. The copy succeeds and the box looks healthy; the workload dies minutes later, having already burned a spot instance.

The retired `spot_data_weekly.sh` monolith staged to `/home/ec2-user/alpha-engine-config/data/config.yaml`, which IS a candidate. The per-stage split (#1122) changed the destination; #1269 repointed the weekly SF onto the per-stage scripts on 2026-08-09 and made it live. Third instance of the same class this week, after #1294 (watchdog `Type=oneshot`) and #1296 (bare `python3.12` assertion) — a rewrite silently dropping a property the monolith had, visible only once the consumer was repointed.

## Changes

- `infrastructure/_spot_common.sh` — bootstrap stages to `/home/ec2-user/alpha-engine-config/data/config.yaml`, with `chown -R ec2-user:ec2-user` (bootstrap runs as root, every stage heredoc runs as ec2-user). Old path dropped, not dual-written: grepped `spot_morning_enrich.sh`, `spot_data_phase1.sh`, `spot_rag_ingestion.sh` — no per-stage workload reads it.
- `tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py` — parses the bootstrap's `aws s3 cp` destination and asserts it is in the list `resolve_experiment_config` returns for a checkout at `/home/ec2-user/data`. Derived, not hardcoded, so a resolver-order change fails CI instead of production.

## Verification

- Guard test verified as a real detector: both tests FAIL against the pre-fix file, PASS after.
- Full suite against the pinned lib (`v0.124.44`): **4909 passed, 8 skipped**.
- Live verification is the rerun itself. Brian authorized the operator step in-session (2026-08-11), so `scripts/weekly_sf_rerun.py --start` is run by the agent once this merges and the ARN is posted to config#6846 — no post-merge action falls to the merger.

## Out of scope (filed)

- `alpha-engine-config#5688` — the three `*RetryGate` re-issues target the already-terminated instance id, so the bounded auto-retry is a no-op after substrate loss. Untouched here.

Closes nousergon/alpha-engine-config#6846

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
