### PR TITLE
[P1/mid] fix(notifier): the digest renders weekday states instead of nothing (config-I6857)

### DIFF
--- a/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
@@ -13,17 +13,41 @@ logger = logging.getLogger(__name__)
 S3_BUCKET = "alpha-engine-research"
 
 # Minimum plausible wall-clock duration (seconds) for spot workload Task states.
+#
+# A FLOOR IS AN ANNOTATION, NOT AN ADMISSION TICKET (alpha-engine-config-I6857).
+# A state absent from this mapping renders with no floor; it is never dropped.
+# The reverse — treating this mapping and DIGEST_STATE_ORDER below as a
+# whitelist — is why every weekday alert read "(no workload states in
+# history)" on every run, success or failure: both collections list weekly
+# pipeline state names only, and not one preopen or postclose state appears
+# in either.
 STATE_DURATION_FLOORS_SEC: Mapping[str, int] = {
+    # Weekly — ne-weekly-freshness-pipeline
     "MorningEnrich": 15 * 60,
     "DataPhase1": 15 * 60,
     "RAGIngestion": 10 * 60,
     "PredictorTraining": 20 * 60,
     "Backtester": 10 * 60,
-    "ModelZooRotation": 8 * 60,
+    # Was "ModelZooRotation", a state no definition has had for some time —
+    # the rotation is ModelZooSelect -> ModelZooTrainMap ("ModelZooResolve"
+    # is a phase LABEL in an error extractor, not a state),
+    # and the floor sat on the training map's old name, annotating nothing.
+    # Same drift class as I6857 itself, caught by
+    # test_every_weekday_state_name_in_the_order_list_exists_in_a_definition.
+    "ModelZooTrainMap": 8 * 60,
+    # Weekday — ne-preopen-trading-pipeline. Floors sit on the POLL states,
+    # not the Launch states: a Launch returns in ~20s having only dispatched
+    # the spot request, so a floor there would fire on every healthy run,
+    # while the poll loop is what actually spans the workload.
+    "PollMorningEnrichSpot": 8 * 60,
+    "PollMorningArcticAppendSpot": 8 * 60,
+    "Scanner": 60,
 }
 
-# Display order for digest lines (unknown states sort after, alphabetically).
+# Display order for digest lines. States NOT listed here still render — they
+# sort after these, longest-running first. See _sort_key.
 DIGEST_STATE_ORDER: Tuple[str, ...] = (
+    # Weekly
     "MorningEnrich",
     "DataPhase1",
     "RAGIngestion",
@@ -31,11 +55,36 @@ DIGEST_STATE_ORDER: Tuple[str, ...] = (
     "PredictorTraining",
     "DataPhase2",
     "Backtester",
-    "Parity",
-    "ModelZooRotation",
+    # "Parity" and "ModelZooRotation" were stale: the states were split into
+    # the names below and this list was never updated, so both entries
+    # ordered nothing for however long that has been true.
+    "ParityParallel",
+    "PitParityCompare",
+    "ModelZooSelect",
+    "ModelZooTrainMap",
     "Evaluator",
     "ReportCard",
+    # Weekday preopen, in pipeline order
+    "StartExecutorEC2",
+    "CodeFreshnessGate",
+    "LaunchMorningEnrichSpot",
+    "PollMorningEnrichSpot",
+    "LaunchMorningArcticAppendSpot",
+    "PollMorningArcticAppendSpot",
+    "Scanner",
+    "PredictorInference",
+    "CheckPredictorCoverage",
+    "RunMorningPlanner",
+    "RunDaemon",
 )
+
+# Digest rows kept, before the elision line. Telegram messages are read on a
+# phone; a preopen execution touches ~25 distinct Task states and dumping all
+# of them buries the one that mattered. Truncation is by RELEVANCE (anomalies
+# first, then pipeline order, then longest-running) and is always ANNOUNCED —
+# a bound that renders as though it were the whole list is how "covered
+# everything" gets asserted about a sample.
+_MAX_DIGEST_ROWS = 14
 
 _HISTORY_EVENT_TYPES = (
     "TaskStateEntered",
@@ -92,8 +141,15 @@ def last_workload_state_entered(events: Sequence[dict]) -> Optional[str]:
 
     Entered-but-never-exited is exactly the signature of the interesting
     failure — a hang, a timeout, a kill — so it is the one the digest must
-    name. Untracked states (gates, Pass, poll loops) are ignored: naming
-    "CheckMorningEnrichStatus" would be true and useless.
+    name.
+
+    Every Task state is eligible, not only those in DIGEST_STATE_ORDER
+    (alpha-engine-config-I6857). Restricting it to known names meant that on
+    the weekday pipelines — whose states appear in neither collection — this
+    fallback could never fire either, so a run dying before its first exit
+    named nothing on the two pipelines that trade real money. Choice and Pass
+    states are still excluded, by _state_name_from_event: naming
+    "CheckMorningEnrichSpotStatus" would be true and useless.
     """
     last: Optional[str] = None
     for event in events:
@@ -102,15 +158,29 @@ def last_workload_state_entered(events: Sequence[dict]) -> Optional[str]:
         name = _state_name_from_event(event)
         if not name:
             continue
-        if name in STATE_DURATION_FLOORS_SEC or name in DIGEST_STATE_ORDER:
-            last = name
+        last = name
     return last
 
 
 def parse_task_state_durations(events: Sequence[dict]) -> Dict[str, int]:
-    """Return max wall-clock seconds per Task state name from history events."""
-    entered_at: Dict[str, datetime] = {}
-    durations: Dict[str, int] = {}
+    """Wall-clock seconds per Task state name: FIRST entry to LAST exit.
+
+    The span, not the longest single entry/exit pair (alpha-engine-config-I6857).
+
+    The weekday pipelines poll: ``PollMorningEnrichSpot`` is entered and
+    exited every 15 seconds for as long as the spot workload runs. Under
+    max-per-pair that 15-minute stage reported ``0s`` — technically a row,
+    and worse than none, because it says the stage was instant. Under the
+    span it reports the elapsed time an operator would recognise.
+
+    For a state entered once the two are identical, so nothing about the
+    weekly digest changes. For a RETRIED state the span includes the gap
+    between attempts, which is the honest number: the pipeline really did
+    spend that wall-clock inside the stage, and the floor comparison should
+    see it.
+    """
+    first_entry: Dict[str, datetime] = {}
+    last_exit: Dict[str, datetime] = {}
 
     for event in events:
         etype = event.get("type")
@@ -121,20 +191,36 @@ def parse_task_state_durations(events: Sequence[dict]) -> Dict[str, int]:
         if not isinstance(ts, datetime):
             continue
         if etype == "TaskStateEntered":
-            entered_at[name] = ts
-        elif etype == "TaskStateExited" and name in entered_at:
-            delta = int((ts - entered_at[name]).total_seconds())
-            durations[name] = max(durations.get(name, 0), delta)
-            entered_at.pop(name, None)
+            first_entry.setdefault(name, ts)
+        elif etype == "TaskStateExited":
+            last_exit[name] = ts
 
-    return durations
+    return {
+        name: max(0, int((last_exit[name] - entered).total_seconds()))
+        for name, entered in first_entry.items()
+        if name in last_exit
+    }
 
 
-def _sort_key(name: str) -> Tuple[int, str]:
-    try:
-        return (DIGEST_STATE_ORDER.index(name), name)
-    except ValueError:
-        return (len(DIGEST_STATE_ORDER), name)
+def _sort_key(row: "StateDuration") -> Tuple[int, int, int, str]:
+    """Relevance order: anomalies, then pipeline order, then longest-running.
+
+    Anomalies lead because the digest is read on a phone under a red alert,
+    and because _MAX_DIGEST_ROWS truncates the tail — a bound that can drop a
+    floor breach while keeping a healthy state has inverted its own purpose.
+
+    States outside DIGEST_STATE_ORDER sort after those in it, longest-running
+    first. This is the branch the old code's comment promised ("unknown states
+    sort after, alphabetically") and the whitelist filter one function away
+    made unreachable: nothing unknown ever arrived here to be sorted.
+    """
+    known = DIGEST_STATE_ORDER.index(row.name) if row.name in DIGEST_STATE_ORDER else None
+    return (
+        0 if row.anomaly else 1,
+        len(DIGEST_STATE_ORDER) if known is None else known,
+        -row.duration_sec,
+        row.name,
+    )
 
 
 def _ms_to_datetime(ms: int | None) -> Optional[datetime]:
@@ -196,8 +282,10 @@ def build_state_durations(
 ) -> List[StateDuration]:
     rows: List[StateDuration] = []
     for name, secs in durations_sec.items():
-        if name not in STATE_DURATION_FLOORS_SEC and name not in DIGEST_STATE_ORDER:
-            continue
+        # NO whitelist filter. Every tracked Task state renders; the two
+        # module-level collections supply the floor and the sort position
+        # when they happen to know the state, and nothing when they do not
+        # (alpha-engine-config-I6857).
         floor = None if is_preflight else STATE_DURATION_FLOORS_SEC.get(name)
         floor_breach = bool(floor is not None and secs < floor)
         attestation_failed = False
@@ -221,7 +309,7 @@ def build_state_durations(
                 attestation_failed=attestation_failed,
             )
         )
-    rows.sort(key=lambda r: _sort_key(r.name))
+    rows.sort(key=_sort_key)
     return rows
 
 
@@ -232,8 +320,9 @@ def format_digest_lines(
         if last_entered:
             return [f"{last_entered} — entered, never completed ⚠️"]
         return ["_(no workload states in history)_"]
+    kept, elided = list(rows[:_MAX_DIGEST_ROWS]), len(rows) - _MAX_DIGEST_ROWS
     lines: List[str] = []
-    for row in rows:
+    for row in kept:
         dur = format_duration_short(row.duration_sec)
         if row.anomaly:
             detail = "⚠️"
@@ -244,6 +333,10 @@ def format_digest_lines(
         else:
             detail = "✓"
         lines.append(f"{row.name} {dur} {detail}")
+    if elided > 0:
+        # Announced, never silent. A truncated list rendered as a whole one
+        # is an assertion that nothing else ran.
+        lines.append(f"_(+{elided} more state{'s' if elided > 1 else ''}, shortest-running, elided)_")
     return lines
 
 

--- a/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
@@ -173,12 +173,47 @@ def test_last_workload_state_entered_finds_the_unexited_state():
 
 
 def test_last_workload_state_entered_ignores_untracked_states():
-    """Naming a poll or gate state would be true and useless."""
+    """Naming a gate or wait state would be true and useless.
+
+    The exclusion is by EVENT TYPE, not by a name whitelist
+    (alpha-engine-config-I6857). Choice and Wait states emit
+    ChoiceStateEntered / WaitStateEntered, which _state_name_from_event does
+    not read, so they cannot reach this function whatever they are called.
+
+    This test previously fed CheckMorningEnrichStatus in as a
+    TaskStateEntered and asserted it was dropped — which passed only because
+    the name was missing from DIGEST_STATE_ORDER, and asserted a shape Step
+    Functions never emits. Under the whitelist that also meant every genuine
+    weekday Task state was dropped with it, which is the defect I6857 fixed.
+    """
     from execution_digest import last_workload_state_entered
 
     base = datetime(2026, 8, 10, 23, 58, 0, tzinfo=timezone.utc)
-    events = [_entered(base, "CheckMorningEnrichStatus", 0), _entered(base, "WaitForMorningEnrich", 5)]
+    events = [
+        {
+            "type": "ChoiceStateEntered",
+            "timestamp": _ts(base, 0),
+            "stateEnteredEventDetails": {"name": "CheckMorningEnrichStatus"},
+        },
+        {
+            "type": "WaitStateEntered",
+            "timestamp": _ts(base, 5),
+            "stateEnteredEventDetails": {"name": "MorningEnrichWait"},
+        },
+    ]
     assert last_workload_state_entered(events) is None
+
+
+def test_last_workload_state_entered_names_a_weekday_task_state():
+    """The counterpart: a Task state absent from DIGEST_STATE_ORDER is named.
+
+    Under the old whitelist this returned None for every weekday pipeline
+    state, so a preopen run dying before its first exit named nothing.
+    """
+    from execution_digest import last_workload_state_entered
+
+    base = datetime(2026, 8, 11, 12, 15, 0, tzinfo=timezone.utc)
+    assert last_workload_state_entered([_entered(base, "SomeBrandNewState", 0)]) == "SomeBrandNewState"
 
 
 def test_digest_names_the_entered_state_instead_of_saying_nothing():
@@ -216,3 +251,176 @@ def test_build_execution_digest_names_the_hung_state_end_to_end():
     )
     assert lines == ["MorningEnrich — entered, never completed ⚠️"]
     assert hollow is False
+
+
+# ── Weekday pipelines render at all (alpha-engine-config-I6857) ───────────
+#
+# The 2026-08-11 preopen alert rendered "_(no workload states in history)_"
+# for an execution with 1403 events across 18 distinct Task states. Not a
+# one-off: DIGEST_STATE_ORDER and STATE_DURATION_FLOORS_SEC listed weekly
+# state names only, and build_state_durations dropped everything in neither,
+# so EVERY weekday alert rendered an empty list on EVERY run.
+#
+# nousergon-data-PR1295 had shipped that morning and did not prevent it — it
+# covered a run dying before its first TaskStateExited. This run exited many.
+
+import execution_digest as ed
+import json as _json
+from pathlib import Path as _Path
+
+_FIXTURE = _Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "sf_history_preopen_2026-08-11.json"
+
+
+def _preopen_history() -> list[dict]:
+    """The real 2026-08-11 preopen execution, trimmed to Task state events.
+
+    Execution 021b85f7-4814-477e-9fe0-05c77f4296d6 — the one whose alert
+    named no states. Timestamps are parsed back to datetimes because that is
+    what botocore hands the digest.
+    """
+    from datetime import datetime
+
+    events = _json.loads(_FIXTURE.read_text())
+    for e in events:
+        e["timestamp"] = datetime.fromisoformat(e["timestamp"])
+    return events
+
+
+def test_the_real_2026_08_11_preopen_history_renders_states():
+    """The regression, against the execution that produced it."""
+    events = _preopen_history()
+    durations = ed.parse_task_state_durations(events)
+    rows = ed.build_state_durations(
+        durations,
+        is_preflight=False,
+        execution_start=events[0]["timestamp"],
+        run_date="2026-08-11",
+        s3_client=None,
+    )
+    lines = ed.format_digest_lines(rows, last_entered=ed.last_workload_state_entered(events))
+
+    assert lines != ["_(no workload states in history)_"]
+    assert any("Scanner" in line for line in lines), (
+        "the state that degraded the run must appear in the digest of that run"
+    )
+
+
+def test_the_preopen_poll_loop_reports_its_elapsed_not_zero():
+    """PollMorningEnrichSpot spans ~15 min across ~60 entry/exit pairs.
+
+    Max-per-pair reported 0s, which is worse than omitting it: it asserts the
+    stage was instant.
+    """
+    durations = ed.parse_task_state_durations(_preopen_history())
+    assert durations["PollMorningEnrichSpot"] > 10 * 60
+    assert durations["PollMorningArcticAppendSpot"] > 10 * 60
+
+
+def test_a_state_in_neither_collection_still_renders():
+    """The filter is gone; the collections annotate and order only."""
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    rows = ed.build_state_durations(
+        {"TotallyUnknownState": 42},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-08-11",
+        s3_client=None,
+    )
+    assert [r.name for r in rows] == ["TotallyUnknownState"]
+    assert rows[0].floor_sec is None
+    assert not rows[0].anomaly
+
+
+def test_unknown_states_sort_after_known_ones_longest_first():
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    rows = ed.build_state_durations(
+        {"ZebraState": 10, "AardvarkState": 900, "Scanner": 700},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-08-11",
+        s3_client=None,
+    )
+    rows.sort(key=ed._sort_key)
+    assert [r.name for r in rows] == ["Scanner", "AardvarkState", "ZebraState"]
+
+
+def test_anomalous_states_lead_so_truncation_cannot_drop_them():
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    rows = ed.build_state_durations(
+        {"Scanner": 5, "MorningEnrich": 20 * 60},  # Scanner breaches its 60s floor
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-08-11",
+        s3_client=None,
+    )
+    rows.sort(key=ed._sort_key)
+    assert rows[0].name == "Scanner"
+    assert rows[0].floor_breach
+
+
+def test_truncation_is_announced_never_silent():
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    many = {f"State{i:02d}": 100 - i for i in range(ed._MAX_DIGEST_ROWS + 3)}
+    rows = ed.build_state_durations(
+        many, is_preflight=False, execution_start=start, run_date=None, s3_client=None
+    )
+    rows.sort(key=ed._sort_key)
+    lines = ed.format_digest_lines(rows)
+
+    assert len(lines) == ed._MAX_DIGEST_ROWS + 1
+    assert "+3 more states" in lines[-1]
+
+
+def test_no_truncation_line_when_everything_fits():
+    from datetime import datetime, timezone
+
+    start = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+    rows = ed.build_state_durations(
+        {"Scanner": 700}, is_preflight=False, execution_start=start, run_date=None, s3_client=None
+    )
+    lines = ed.format_digest_lines(rows)
+    assert len(lines) == 1
+    assert "elided" not in lines[0]
+
+
+def test_every_weekday_state_name_in_the_order_list_exists_in_a_definition():
+    """A misspelled state name is a silent no-op — it orders nothing.
+
+    The old collections were not wrong about spelling, they were wrong about
+    WHICH pipeline; this guard catches the other way of being wrong.
+    """
+    def _walk(states: dict) -> set[str]:
+        """State names including those nested in Parallel branches / Map iterators.
+
+        A flat scan of the top-level States map misses PredictorTraining,
+        Parity and the rest, which live inside ResearchPredictorParallel's
+        branches — and would then declare the digest's own weekly names
+        phantom.
+        """
+        found = set(states)
+        for body in states.values():
+            for branch in body.get("Branches") or []:
+                found |= _walk(branch.get("States") or {})
+            iterator = body.get("Iterator") or body.get("ItemProcessor")
+            if iterator:
+                found |= _walk(iterator.get("States") or {})
+        return found
+
+    infra = _Path(__file__).resolve().parents[3] / "infrastructure"
+    known: set[str] = set()
+    for name in ("step_function.json", "step_function_daily.json", "step_function_eod.json"):
+        known |= _walk(_json.loads((infra / name).read_text())["States"])
+
+    unknown = sorted(s for s in ed.DIGEST_STATE_ORDER if s not in known)
+    assert not unknown, f"DIGEST_STATE_ORDER names states no definition has: {unknown}"
+
+    unknown_floors = sorted(s for s in ed.STATE_DURATION_FLOORS_SEC if s not in known)
+    assert not unknown_floors, f"STATE_DURATION_FLOORS_SEC names states no definition has: {unknown_floors}"

--- a/tests/fixtures/sf_history_preopen_2026-08-11.json
+++ b/tests/fixtures/sf_history_preopen_2026-08-11.json
@@ -1,0 +1,2200 @@
+[
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:15:41.107000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "AcquireMutex"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:15:41.238000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "AcquireMutex"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:15:41.238000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "DeployDriftCheck"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:15:44.703000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "DeployDriftCheck"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:15:44.703000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "TradingDayGate"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:15:44.858000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "TradingDayGate"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:15:44.858000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "StartExecutorEC2"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:15:45.767000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "StartExecutorEC2"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:00.816000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:00.951000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:15.998000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:16.187000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:31.238000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:31.364000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:46.420000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:46.522000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "DescribeInstanceInfo"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:46.522000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "CodeFreshnessGate"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:46.740000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "CodeFreshnessGate"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:46.740000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:47.979000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:16:58.057000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:16:58.279000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:17:08.364000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:17:08.631000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForCodeFreshness"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:17:08.631000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "LaunchMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:17:29.289000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "LaunchMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:17:29.289000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:17:29.426000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:17:44.493000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:17:44.615000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:17:59.688000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:17:59.811000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:18:14.873000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:18:15.025000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:18:30.088000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:18:30.217000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:18:45.281000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:18:45.430000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:19:00.491000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:19:00.632000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:19:15.676000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:19:15.829000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:19:30.893000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:19:31.039000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:19:46.147000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:19:46.260000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:20:01.320000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:20:01.468000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:20:16.540000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:20:16.675000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:20:31.730000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:20:31.865000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:20:46.926000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:20:47.066000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:21:02.131000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:21:02.255000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:21:17.323000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:21:17.551000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:21:32.607000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:21:32.749000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:21:47.889000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:21:48.005000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:22:03.057000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:22:03.228000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:22:18.297000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:22:18.427000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:22:33.489000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:22:33.622000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:22:48.695000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:22:48.837000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:23:03.949000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:23:04.114000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:23:19.178000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:23:19.307000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:23:34.341000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:23:34.479000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:23:49.528000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:23:49.642000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:24:04.691000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:24:04.815000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:24:19.865000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:24:19.998000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:24:35.056000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:24:35.187000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:24:50.246000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:24:50.378000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:25:05.462000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:25:05.629000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:25:20.690000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:25:20.823000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:25:35.875000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:25:36.027000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:25:51.094000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:25:51.232000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:26:06.287000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:26:06.433000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:26:21.485000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:26:21.632000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:26:36.693000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:26:36.817000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:26:51.878000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:26:52.005000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:27:07.103000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:27:07.225000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:27:22.277000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:27:22.418000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:27:37.474000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:27:37.602000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:27:52.678000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:27:52.821000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:28:07.876000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:28:07.999000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:28:23.064000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:28:23.200000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:28:38.293000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:28:38.511000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:28:53.568000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:28:53.722000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:29:08.772000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:29:08.910000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:29:23.971000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:29:24.105000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:29:39.185000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:29:39.320000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:29:54.383000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:29:54.519000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:30:09.580000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:30:09.725000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:30:24.778000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:30:24.899000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:30:39.959000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:30:40.095000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:30:55.211000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:30:55.364000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:31:10.423000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:31:10.568000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:31:25.630000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:31:25.767000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:31:40.829000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:31:41.004000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:31:56.054000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:31:56.176000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:32:11.229000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:32:11.415000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:32:26.475000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:32:26.642000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:32:41.696000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:32:41.821000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:32:56.872000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:32:57.135000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningEnrichSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:32:57.135000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "LaunchMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:33:17.662000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "LaunchMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:33:17.662000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:33:17.814000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:33:37.874000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:33:38-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:33:58.052000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:33:58.204000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:34:18.269000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:34:18.379000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:34:38.427000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:34:38.592000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:34:58.657000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:34:58.767000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:35:18.833000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:35:19.044000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:35:39.101000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:35:39.235000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:35:59.296000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:35:59.434000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:36:19.507000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:36:19.608000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:36:39.656000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:36:39.794000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:36:59.858000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:36:59.992000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:37:20.049000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:37:20.199000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:37:40.258000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:37:40.402000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:38:00.452000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:38:00.592000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:38:20.659000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:38:20.807000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:38:40.868000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:38:40.980000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:39:01.087000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:39:01.238000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:39:21.295000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:39:21.428000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:39:41.487000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:39:41.632000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:40:01.702000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:40:01.837000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:40:21.896000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:40:22.051000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:40:42.137000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:40:42.280000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:41:02.339000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:41:02.490000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:41:22.590000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:41:22.714000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:41:42.746000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:41:42.855000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:42:02.912000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:42:03.045000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:42:23.098000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:42:23.238000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:42:43.300000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:42:43.438000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:43:03.492000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:43:03.623000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:43:23.685000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:43:23.820000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:43:43.877000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:43:44.028000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:44:04.089000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:44:04.227000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:44:24.297000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:44:24.456000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:44:44.513000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:44:44.651000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:45:04.711000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:45:04.857000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:45:24.918000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:45:25.038000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:45:45.099000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:45:45.241000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:46:05.294000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:46:05.425000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:46:25.479000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:46:25.629000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:46:45.688000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:46:45.834000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:47:05.894000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:47:06.032000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:47:26.085000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:47:26.226000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:47:46.289000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:47:46.441000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:48:06.502000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:48:06.674000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:48:26.739000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:48:26.931000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:48:46.993000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:48:47.139000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:49:07.213000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:49:07.411000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:49:27.508000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:49:27.659000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:49:47.709000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:49:47.836000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:50:07.897000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:50:08.034000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:50:28.095000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:50:28.236000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:50:48.314000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:50:48.442000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:51:08.504000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:51:08.677000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:51:28.746000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:51:28.876000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:51:48.947000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:51:49.111000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:52:09.174000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:52:09.317000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:52:29.377000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:52:29.515000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:52:49.616000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:52:49.763000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:53:09.822000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:53:09.950000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:53:30-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:53:30.137000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:53:50.193000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:53:50.327000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:54:10.382000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:54:10.530000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:54:30.585000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:54:30.723000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:54:50.789000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:54:50.935000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:55:10.988000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:55:11.124000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:55:31.187000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:55:31.304000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:55:51.357000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:55:51.489000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:56:11.545000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:56:11.688000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:56:31.739000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:56:31.880000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:56:51.938000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:56:52.069000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:57:12.135000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T05:57:12.316000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PollMorningArcticAppendSpot"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T05:57:12.316000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "Scanner"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:08:23.479000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "Scanner"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:08:23.479000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "PredictorInference"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:22.581000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "PredictorInference"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:22.581000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "CheckPredictorCoverage"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:23.189000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "CheckPredictorCoverage"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:23.189000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "RunMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:23.377000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "RunMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:23.377000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:24.487000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:39.566000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:39.769000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:54.846000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:55.120000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WaitForMorningPlanner"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:55.120000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "RunDaemon"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:55.383000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "RunDaemon"
+  }
+ },
+ {
+  "type": "TaskStateEntered",
+  "timestamp": "2026-08-11T06:09:55.383000-07:00",
+  "taskStateEnteredEventDetails": {
+   "name": "WriteCompletionMarkerDegraded"
+  }
+ },
+ {
+  "type": "TaskStateExited",
+  "timestamp": "2026-08-11T06:09:55.575000-07:00",
+  "taskStateExitedEventDetails": {
+   "name": "WriteCompletionMarkerDegraded"
+  }
+ }
+]


### PR DESCRIPTION
## What broke

The 2026-08-11 preopen alert rendered:

```
States:
-(no workload states in history)-
```

for an execution carrying **1403 events across 18 distinct Task states**.

Not a one-off, and not a failure-path quirk. `build_state_durations` filtered every state through `STATE_DURATION_FLOORS_SEC` / `DIGEST_STATE_ORDER`, and both listed **weekly** pipeline state names only. Not one preopen or postclose state appeared in either — so **every weekday alert rendered an empty state list, on every run, success or failure**. The nearest match, `MorningEnrich`, is not a state name in `step_function_daily.json` either; that pipeline uses `LaunchMorningEnrichSpot` / `PollMorningEnrichSpot`.

`nousergon-data-PR1295` deployed at 03:53Z that morning, nine hours before the run, and could not have prevented it: it covered a run dying before any state *exits*. This run exited many.

The file already contradicted itself. `_sort_key`'s `ValueError` branch handled unrecognised states and its comment promised *"unknown states sort after, alphabetically"* — a branch the filter one function away made unreachable, because nothing unknown ever arrived to be sorted. The intended design was allow-unknown-and-sort-last; the filter enforced deny-unknown.

## Changes

| | |
|---|---|
| **Filter removed** | Every tracked Task state renders. The two collections supply a floor and a sort position where they know the state, and nothing where they do not. Same inversion fixed in `last_workload_state_entered`. Choice and Wait states are still excluded — by **event type**, which is what actually distinguishes them, not by absence from a list. |
| **Duration is now the span** | First entry → last exit, not the longest single entry/exit pair. The weekday pipelines poll: `PollMorningEnrichSpot` is entered and exited every 15s for the life of the spot workload, so max-per-pair reported **0s** for a 15-minute stage — a row worse than no row, because it asserts the stage was instant. For a state entered once the two are identical, so the weekly digest is unchanged. |
| **Relevance ordering + announced cap** | ~25 Task states in a preopen execution, read on a phone. Anomalies sort **first**, precisely so truncation cannot drop a floor breach while keeping a healthy state; then pipeline order; then longest-running. Elision always states how many were dropped — a truncated list rendered as a whole one asserts that nothing else ran. |
| **Weekday floors** | On the **poll** states, not the Launch states: a Launch returns in ~20s having only dispatched the spot request, so a floor there would fire on every healthy run. |

## Two things the new guard test found

1. **`Parity` and `ModelZooRotation` name states no definition has.** They were split into `ParityParallel` / `PitParityCompare` and `ModelZooSelect` / `ModelZooTrainMap`, and this file was never updated — so both entries, and the `ModelZooRotation` floor, had been ordering and annotating nothing on the **weekly** side. Same drift class as the bug itself. Corrected against the live definitions; the guard walks `Parallel` branches so nested states are not falsely reported missing.

2. **A test was certifying the defect.** `test_last_workload_state_entered_ignores_untracked_states` fed a Choice state in as a `TaskStateEntered` and passed only because the name was missing from `DIGEST_STATE_ORDER` — asserting a shape Step Functions never emits, while the mechanism it certified was silently dropping every real weekday state. Rewritten to use the event types the service actually sends, plus a counterpart asserting an unknown Task state **is** named.

## Validation

- `1865 passed, 5 skipped` across the SF suite.
- `24 passed` in the handler suite; `run_handler_tests.sh sf-telegram-notifier` (the deploy gate) exits 0.
- The regression test replays the **real** 2026-08-11 history — `tests/fixtures/sf_history_preopen_2026-08-11.json`, execution `021b85f7-4814-477e-9fe0-05c77f4296d6` — and asserts `Scanner`, the state that degraded that run, appears in that run's digest.

**Rehearsal-path:** `infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py` over the captured history fixture. No live run needed.

**Verified-when:** the next weekday terminal alert renders a non-empty state list.

## Cross-repo

- `nousergon-data-PR1299` — the terminal that named the wrong degraded cause (`I6856`). Same alert, different half; independent, either order.
- `crucible-research-PR601` — the scanner timeout that degraded the run (`I6855`). Independent, either order.

Closes nousergon/alpha-engine-config#6857

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)