### PR TITLE
[P2/mid] test(sf): a stage timeout that can never bind is not a budget (config-I6855)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -405,7 +405,7 @@
     },
     "WeeklyPreflight": {
       "Type": "Task",
-      "Comment": "I4494: pre-spend gate — runs sf_preflight.py checks against live AWS state before the pipeline spends on any spot or mutex acquisition. Checks: IAM reachability, tool contracts, definition input coherence, Lambda memory headroom. Fail-hard on assertion failure (preflight is cheaper than a Saturday spot run that would die for the same reason). Routes failures through ExtractWeeklyPreflightError → NormalizeFailureContext (the same chokepoint all pre-spend gate failures use), NOT directly to HandleFailure. Reads-only: no writes, no cost, no side effects. <60s target.",
+      "Comment": "I4494: pre-spend gate \u2014 runs sf_preflight.py checks against live AWS state before the pipeline spends on any spot or mutex acquisition. Checks: IAM reachability, tool contracts, definition input coherence, Lambda memory headroom. Fail-hard on assertion failure (preflight is cheaper than a Saturday spot run that would die for the same reason). Routes failures through ExtractWeeklyPreflightError \u2192 NormalizeFailureContext (the same chokepoint all pre-spend gate failures use), NOT directly to HandleFailure. Reads-only: no writes, no cost, no side effects. <60s target.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "TimeoutSeconds": 60,
       "Parameters": {
@@ -440,7 +440,7 @@
     },
     "WeeklyPreflightGate": {
       "Type": "Choice",
-      "Comment": "I4494: hard-fail when the preflight reports any failing check. Stops the pipeline before any spot spend, naming the failing assertion. Routes via ExtractWeeklyPreflightError (NOT straight to HandleFailure), mirroring the other pre-spend gate conventions: a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) — a direct Choice→HandleFailure jump would die with States.Runtime, swallowing the violation list behind an opaque meta-error. config#1819: ExtractWeeklyPreflightError hands off to NormalizeFailureContext, not HandleFailure directly.",
+      "Comment": "I4494: hard-fail when the preflight reports any failing check. Stops the pipeline before any spot spend, naming the failing assertion. Routes via ExtractWeeklyPreflightError (NOT straight to HandleFailure), mirroring the other pre-spend gate conventions: a Choice transition does not populate $.error the way a Task Catch (ResultPath $.error) does, and HandleFailure's Message template calls States.JsonToString($.error) \u2014 a direct Choice\u2192HandleFailure jump would die with States.Runtime, swallowing the violation list behind an opaque meta-error. config#1819: ExtractWeeklyPreflightError hands off to NormalizeFailureContext, not HandleFailure directly.",
       "Choices": [
         {
           "And": [
@@ -453,7 +453,7 @@
               "BooleanEquals": true
             }
           ],
-          "Comment": "Preflight found one or more failing checks — stop before spend. The Payload carries the violation list for the SNS alert.",
+          "Comment": "Preflight found one or more failing checks \u2014 stop before spend. The Payload carries the violation list for the SNS alert.",
           "Next": "ExtractWeeklyPreflightError"
         },
         {
@@ -461,7 +461,7 @@
             "Variable": "$.weekly_preflight_result.Payload.has_violation",
             "IsPresent": true
           },
-          "Comment": "Preflight returned a payload WITHOUT has_violation (partial/malformed result). Fail-closed: a preflight that cannot produce a verdict must not proceed, unlike the advisory gates (LibPinDriftCheck/PipelineContractCheck) which fail-open. The preflight is the last check before spend — failing open here defeats its purpose.",
+          "Comment": "Preflight returned a payload WITHOUT has_violation (partial/malformed result). Fail-closed: a preflight that cannot produce a verdict must not proceed, unlike the advisory gates (LibPinDriftCheck/PipelineContractCheck) which fail-open. The preflight is the last check before spend \u2014 failing open here defeats its purpose.",
           "Next": "ExtractWeeklyPreflightError"
         }
       ],
@@ -469,7 +469,7 @@
     },
     "ExtractWeeklyPreflightError": {
       "Type": "Pass",
-      "Comment": "Normalize a confirmed preflight failure (WeeklyPreflightGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so — unlike a Task Catch (ResultPath $.error) — it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the preflight failure details. Carries the whole preflight Payload (failures/warnings) so the FAILED SNS alert names the exact check that must pass before redrive. References only $.weekly_preflight_result.Payload — guaranteed present because the gate already dereferenced Payload.has_violation to route here. Mirrors ExtractPipelineContractError's convention.",
+      "Comment": "Normalize a confirmed preflight failure (WeeklyPreflightGate has_violation==true) into $.error for HandleFailure's States.Format/JsonToString template. The gate is a Choice, so \u2014 unlike a Task Catch (ResultPath $.error) \u2014 it does NOT populate $.error; without this normalizer HandleFailure's States.JsonToString($.error) raises States.Runtime and the SF dies with an opaque meta-error instead of surfacing the preflight failure details. Carries the whole preflight Payload (failures/warnings) so the FAILED SNS alert names the exact check that must pass before redrive. References only $.weekly_preflight_result.Payload \u2014 guaranteed present because the gate already dereferenced Payload.has_violation to route here. Mirrors ExtractPipelineContractError's convention.",
       "Parameters": {
         "phase": "WeeklyPreflightGate",
         "source": "WeeklyPreflightGate.has_violation",
@@ -578,7 +578,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review. alpha-engine-config#6722: this fail-open previously proceeded with no degraded flag at all — now routes through SetMutexAcquireDegradedFlag (mirrors LibPinGateDegraded/PipelineContractGateDegraded exactly: this IS a pre-spend precondition check, same family as the other two gate-infra fail-opens) so the completion email says so via CheckGateDegradedNotify.",
+          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review. alpha-engine-config#6722: this fail-open previously proceeded with no degraded flag at all \u2014 now routes through SetMutexAcquireDegradedFlag (mirrors LibPinGateDegraded/PipelineContractGateDegraded exactly: this IS a pre-spend precondition check, same family as the other two gate-infra fail-opens) so the completion email says so via CheckGateDegradedNotify.",
           "Next": "SetMutexAcquireDegradedFlag",
           "ResultPath": "$.mutex_error"
         }
@@ -588,7 +588,7 @@
     },
     "SetMutexAcquireDegradedFlag": {
       "Type": "Pass",
-      "Comment": "alpha-engine-config#6722: the mutex-acquire infra-error Catch (DynamoDB outage / IAM drift / transient SDK error — NOT the ConditionalCheckFailedException conflict case, which the separate MutexConflict Fail already handles) previously proceeded to CheckSpotDispatchNeeded with zero visibility. Mirrors LibPinGateDegraded's shape exactly: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishMutexAcquireDegraded alerts NOW.",
+      "Comment": "alpha-engine-config#6722: the mutex-acquire infra-error Catch (DynamoDB outage / IAM drift / transient SDK error \u2014 NOT the ConditionalCheckFailedException conflict case, which the separate MutexConflict Fail already handles) previously proceeded to CheckSpotDispatchNeeded with zero visibility. Mirrors LibPinGateDegraded's shape exactly: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishMutexAcquireDegraded alerts NOW.",
       "Result": true,
       "ResultPath": "$.gate_degraded",
       "Next": "PublishMutexAcquireDegraded"
@@ -599,7 +599,7 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekly Pipeline — Mutex Acquire DEGRADED (Proceeding Unchecked)",
+        "Subject": "Alpha Engine Weekly Pipeline \u2014 Mutex Acquire DEGRADED (Proceeding Unchecked)",
         "Message": "AcquireMutex could not complete its DynamoDB conditional PUT (infra error, not a genuine duplicate-run conflict). Proceeding FAIL-OPEN: this run's duplicate-execution protection is unchecked for this run_date. The completion email will carry the gates-degraded marker. View pipeline status: https://console.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.mutex_acquire_degraded_notify",
@@ -608,7 +608,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Best-effort alert — a publish failure must not halt the fail-open path.",
+          "Comment": "Best-effort alert \u2014 a publish failure must not halt the fail-open path.",
           "ResultPath": "$.mutex_acquire_degraded_notify_error",
           "Next": "CheckSpotDispatchNeeded"
         }
@@ -1038,7 +1038,7 @@
           "States": {
             "InitResearchDegradedFlag": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config#6722: seeds the branch-local $.research_degraded_local marker every fail-open Catch inside Branch A threads through (the Scanner/RegimeSubstrate/ChallengerShadow/RegimeRetrospectiveEval research-substep group, ThinkTankDegraded's flag, the eval-judge chain, and AggregateCosts's named sf-pipeline-policy.md §5 cost-aggregation carve-out). Must be seeded BEFORE any Mark*Degraded state or BranchAComplete's Parameters.$ extraction would throw States.Runtime on a clean run that never sets it. Folded into the top-level $.research_predictor_degraded at AggregateBranchOutcomes/CheckResearchPredictorDegraded (mirrors CheckParityBranchOutcomes' branch-status fold, alpha-engine-config#6030) since a Parallel branch cannot write an outer-scope JSONPath directly — ASL scopes each branch to its own copy of the state.",
+              "Comment": "alpha-engine-config#6722: seeds the branch-local $.research_degraded_local marker every fail-open Catch inside Branch A threads through (the Scanner/RegimeSubstrate/ChallengerShadow/RegimeRetrospectiveEval research-substep group, ThinkTankDegraded's flag, the eval-judge chain, and AggregateCosts's named sf-pipeline-policy.md \u00a75 cost-aggregation carve-out). Must be seeded BEFORE any Mark*Degraded state or BranchAComplete's Parameters.$ extraction would throw States.Runtime on a clean run that never sets it. Folded into the top-level $.research_predictor_degraded at AggregateBranchOutcomes/CheckResearchPredictorDegraded (mirrors CheckParityBranchOutcomes' branch-status fold, alpha-engine-config#6030) since a Parallel branch cannot write an outer-scope JSONPath directly \u2014 ASL scopes each branch to its own copy of the state.",
               "Result": false,
               "ResultPath": "$.research_degraded_local",
               "Next": "CheckSkipScanner"
@@ -1065,7 +1065,7 @@
             },
             "Scanner": {
               "Type": "Task",
-              "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 \u2014 alpha-engine-research #235). Reads constituents.json + feature store, runs run_quant_filter, writes the candidates.json universe-board artifact for THIS run_date (crucible-research PR425, merged). alpha-engine-config-I2515 Phase B: this write is now LOAD-BEARING \u2014 SignalsEnvelope, ChallengerShadow, and the relocated (post-RAG) ThinkTankCoverage all read the SAME-DAY board, closing the no-week-old-data invariant (config#1580 ruling). The multi-agent Research graph runner that previously consumed this artifact has been REMOVED from this SF; the champion path is scanner \u2192 predictor direct. Status contract OK / ERROR \u2014 no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true.",
+              "Comment": "Standalone scanner Lambda (ROADMAP L1995 Phase 1 \u2014 alpha-engine-research #235). Reads constituents.json + feature store, runs run_quant_filter, writes the candidates.json universe-board artifact for THIS run_date (crucible-research PR425, merged). alpha-engine-config-I2515 Phase B: this write is now LOAD-BEARING \u2014 SignalsEnvelope, ChallengerShadow, and the relocated (post-RAG) ThinkTankCoverage all read the SAME-DAY board, closing the no-week-old-data invariant (config#1580 ruling). The multi-agent Research graph runner that previously consumed this artifact has been REMOVED from this SF; the champion path is scanner \u2192 predictor direct. Status contract OK / ERROR \u2014 no SKIPPED today (constituents.json + feature store are hard preconditions). dry_run_llm threads the Friday-Preflight shell-run signal so the Lambda boots+imports without S3 read on $.research_dry=true. alpha-engine-config-I6855: 600 -> 440. The SF budget must sit BELOW the function timeout or it can never bind \u2014 on 2026-08-11 this state declared 600s while alpha-engine-research-scanner carried 300s, so both preopen invocations died at 300s with Sandbox.Timedout and the 600 described nothing. The function is now 450s (crucible-research-PR601, p95 x 1.5); 440 keeps the SF the effective budget, so a scanner overrun surfaces as States.Timeout naming this state rather than as an opaque Lambda error.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-research-scanner:live",
@@ -1074,7 +1074,7 @@
                   "dry_run_llm.$": "$.research_dry"
                 }
               },
-              "TimeoutSeconds": 600,
+              "TimeoutSeconds": 440,
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -1155,7 +1155,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "alpha-engine-config#6722: routes through MarkRegimeSubstrateDegraded before converging on CheckSkipSignalsEnvelope — this fail-open previously set no degraded flag.",
+                  "Comment": "alpha-engine-config#6722: routes through MarkRegimeSubstrateDegraded before converging on CheckSkipSignalsEnvelope \u2014 this fail-open previously set no degraded flag.",
                   "Next": "MarkRegimeSubstrateDegraded",
                   "ResultPath": "$.regime_substrate_error"
                 }
@@ -2461,7 +2461,7 @@
           "States": {
             "InitPredictorDegradedFlag": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config#6722: seeds the branch-local $.research_degraded_local marker Branch B's model-zoo rotation fail-open group (ResolveZooSpecs/WaitResolveZoo/ModelZooTrainMap/ModelZooSelect/WaitForModelZoo, all converging on PublishModelZooFailureImmediate) threads through. Must be seeded BEFORE BranchBComplete's Parameters.$ extraction would throw States.Runtime on a clean run that never sets it. Same field name as Branch A's InitResearchDegradedFlag — branches are isolated JSONPath scopes, so no collision — folded into the top-level $.research_predictor_degraded at AggregateBranchOutcomes/CheckResearchPredictorDegraded.",
+              "Comment": "alpha-engine-config#6722: seeds the branch-local $.research_degraded_local marker Branch B's model-zoo rotation fail-open group (ResolveZooSpecs/WaitResolveZoo/ModelZooTrainMap/ModelZooSelect/WaitForModelZoo, all converging on PublishModelZooFailureImmediate) threads through. Must be seeded BEFORE BranchBComplete's Parameters.$ extraction would throw States.Runtime on a clean run that never sets it. Same field name as Branch A's InitResearchDegradedFlag \u2014 branches are isolated JSONPath scopes, so no collision \u2014 folded into the top-level $.research_predictor_degraded at AggregateBranchOutcomes/CheckResearchPredictorDegraded.",
               "Result": false,
               "ResultPath": "$.research_degraded_local",
               "Next": "CheckSkipPredictorTraining"

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -91,7 +91,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability hung off a primary path' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review via SF execution history; CW alarm wiring deferred (operator-decision when first non-Conditional-Check mutex error appears). alpha-engine-config#6722: previously proceeded with no degraded flag at all — now routes through SetMutexAcquireDegradedFlag (Option-A parity with SetDataSpotDegradedFlag/SetDaemonDegradedFlag/SetDeployDriftDegradedFlag) so CheckDegradedOutcome's terminal reflects it.",
+          "Comment": "Fail-open: DynamoDB outage / IAM drift / transient SDK error must NOT block a real trading cadence run. The mutex is best-effort architectural insurance; per feedback_no_silent_fails 'secondary observability hung off a primary path' carve-out, the primary deliverable survives a mutex-side failure. The error is captured in $.mutex_error for forensic review via SF execution history; CW alarm wiring deferred (operator-decision when first non-Conditional-Check mutex error appears). alpha-engine-config#6722: previously proceeded with no degraded flag at all \u2014 now routes through SetMutexAcquireDegradedFlag (Option-A parity with SetDataSpotDegradedFlag/SetDaemonDegradedFlag/SetDeployDriftDegradedFlag) so CheckDegradedOutcome's terminal reflects it.",
           "Next": "SetMutexAcquireDegradedFlag",
           "ResultPath": "$.mutex_error"
         }
@@ -101,7 +101,7 @@
     },
     "SetMutexAcquireDegradedFlag": {
       "Type": "Pass",
-      "Comment": "alpha-engine-config#6722 (Option-A parity with SetDataSpotDegradedFlag/SetDaemonDegradedFlag/SetDeployDriftDegradedFlag, config#6692 shape): threads $.degraded_summary onto the mutex-acquire infra-error fail-open path (DynamoDB outage / IAM drift / transient SDK error — NOT the ConditionalCheckFailedException conflict case, which the separate MutexConflict Fail already handles) WITHOUT changing its fail-open continuation — Next still leads to DeployDriftCheck exactly as before. Last-write-wins if a later stage also degrades (same convention SetDaemonDegradedFlag documents); does not clobber $.mutex_error (set by AcquireMutex's own Catch ResultPath).",
+      "Comment": "alpha-engine-config#6722 (Option-A parity with SetDataSpotDegradedFlag/SetDaemonDegradedFlag/SetDeployDriftDegradedFlag, config#6692 shape): threads $.degraded_summary onto the mutex-acquire infra-error fail-open path (DynamoDB outage / IAM drift / transient SDK error \u2014 NOT the ConditionalCheckFailedException conflict case, which the separate MutexConflict Fail already handles) WITHOUT changing its fail-open continuation \u2014 Next still leads to DeployDriftCheck exactly as before. Last-write-wins if a later stage also degrades (same convention SetDaemonDegradedFlag documents); does not clobber $.mutex_error (set by AcquireMutex's own Catch ResultPath).",
       "Parameters": {
         "degraded": true,
         "reason": "daily_mutex_acquire_fail_open",
@@ -1186,7 +1186,7 @@
     },
     "Scanner": {
       "Type": "Task",
-      "Comment": "Weekday invoke of the SAME standalone scanner Lambda the Saturday SF runs (alpha-engine-research-scanner:live \u2014 ROADMAP L1995 / alpha-engine-config-I6494). Placed AFTER MorningArcticAppend so ArcticDB technicals for the trading day are present, and BEFORE PredictorInference so universe_membership/{date} + factor profiles (+ provenance) are fresh for the membership consumer (I6495). Features are daily-capable (I5360 / research-PR545; SCANNER_FEATURE_SOURCE default arcticdb). Status contract OK / ERROR \u2014 Catch is non-blocking at the SF layer (mirrors Saturday): Catch and Next converge on CheckSkipPredictorInference; a missing/stale membership surfaces at the predictor's own age gate rather than hard-failing preopen. dry_run_llm omitted \u2014 weekday cadence has no Friday-Preflight research_dry shell path.",
+      "Comment": "Weekday invoke of the SAME standalone scanner Lambda the Saturday SF runs (alpha-engine-research-scanner:live \u2014 ROADMAP L1995 / alpha-engine-config-I6494). Placed AFTER MorningArcticAppend so ArcticDB technicals for the trading day are present, and BEFORE PredictorInference so universe_membership/{date} + factor profiles (+ provenance) are fresh for the membership consumer (I6495). Features are daily-capable (I5360 / research-PR545; SCANNER_FEATURE_SOURCE default arcticdb). Status contract OK / ERROR \u2014 Catch is non-blocking at the SF layer (mirrors Saturday): Catch and Next converge on CheckSkipPredictorInference; a missing/stale membership surfaces at the predictor's own age gate rather than hard-failing preopen. dry_run_llm omitted \u2014 weekday cadence has no Friday-Preflight research_dry shell path. alpha-engine-config-I6855: 600 -> 440. The SF budget must sit BELOW the function timeout or it can never bind \u2014 on 2026-08-11 this state declared 600s while alpha-engine-research-scanner carried 300s, so both preopen invocations died at 300s with Sandbox.Timedout and the 600 described nothing. The function is now 450s (crucible-research-PR601, p95 x 1.5); 440 keeps the SF the effective budget, so a scanner overrun surfaces as States.Timeout naming this state rather than as an opaque Lambda error.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-research-scanner:live",
@@ -1194,7 +1194,7 @@
           "run_date.$": "$.run_date"
         }
       },
-      "TimeoutSeconds": 600,
+      "TimeoutSeconds": 440,
       "Retry": [
         {
           "ErrorEquals": [

--- a/tests/test_sf_daily_scanner_wiring.py
+++ b/tests/test_sf_daily_scanner_wiring.py
@@ -77,7 +77,14 @@ class TestSameEntrypointAsWeekly:
         )
 
     def test_timeout_matches_weekly(self, states, weekly_scanner):
-        assert states["Scanner"]["TimeoutSeconds"] == weekly_scanner["TimeoutSeconds"] == 600
+        # 600 -> 440 (alpha-engine-config-I6855). 600 could never bind: the
+        # function's own timeout was 300s, so both 2026-08-11 preopen
+        # invocations died at 300.00s with Sandbox.Timedout and the pipeline
+        # terminated DEGRADED. The function is now 450s (p95 x 1.5,
+        # crucible-research-PR601) and the SF budget sits below it, so an
+        # overrun surfaces as States.Timeout naming this state.
+        # Ordering guard: tests/test_sf_lambda_timeout_ordering.py.
+        assert states["Scanner"]["TimeoutSeconds"] == weekly_scanner["TimeoutSeconds"] == 440
 
 
 class TestPayloadAndRunDate:

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -1,0 +1,246 @@
+"""A stage timeout that can never bind is not a budget (config-I6855).
+
+`sf-pipeline-policy.md` §4: every stage carries a declared timeout sized to
+observed p95 x 1.5, and a stage with no declared timeout is a defect.
+
+There is a second way to have no budget, and it is invisible: declare one the
+service can never reach. A `lambda:invoke` task has TWO ceilings — the state's
+`TimeoutSeconds` and the function's own `Timeout` — and only the SMALLER one
+ever fires. Where the state's value is the larger, it describes nothing.
+
+Measured 2026-08-11 on `ne-preopen-trading-pipeline`. The `Scanner` state
+declared `TimeoutSeconds: 600`; `alpha-engine-research-scanner` carried a
+300s function timeout. Both invocations died at exactly 300.00s with
+`Sandbox.Timedout`, the preopen pipeline terminated DEGRADED, and that day's
+universe board, membership, leaderboard and trajectory were never written.
+The 600 had never been reachable, so nobody reviewing the definition could
+see the real budget — it lived in another repo's deploy script.
+
+Which direction is correct is not symmetric:
+
+  SF <  function   LEGITIMATE. The state's value binds, and a shared
+                   multi-purpose Lambda (alpha-engine-predictor-inference is
+                   invoked by nine states at budgets from 60s to 900s)
+                   deliberately carries per-call budgets below its ceiling.
+                   An overrun surfaces as States.Timeout naming the state.
+  SF == function   RACE. Whichever fires first is undefined, so the error
+                   type an operator sees is not reproducible.
+  SF >  function   DEFECT. The declaration is decorative; the function's
+                   ceiling silently governs.
+
+So this file asserts `TimeoutSeconds < function timeout`, and that one is
+declared at all.
+
+WHY THE FUNCTION TIMEOUTS ARE CODIFIED HERE rather than read from AWS: this
+runs in CI without credentials, and the functions are deployed from four
+other repositories. `_FUNCTION_TIMEOUTS_SEC` is therefore a claim about the
+live account that can go stale — `test_the_codified_function_timeouts_match_live`
+is skipped without credentials and is what proves it has not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+_DEFS = ("step_function.json", "step_function_daily.json", "step_function_eod.json")
+
+# Live function timeouts, measured 2026-08-11 via
+# `aws lambda get-function-configuration --query Timeout`.
+_FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
+    "alpha-engine-data-spot-dispatcher": 600,
+    "alpha-engine-eod-precondition-probe": 30,
+    "alpha-engine-evaluator": 300,
+    "alpha-engine-evaluator-director": 900,
+    "alpha-engine-predictor-inference": 900,
+    "alpha-engine-predictor-regime-retrospective-eval": 600,
+    "alpha-engine-predictor-regime-substrate": 300,
+    "alpha-engine-replay-concordance": 900,
+    "alpha-engine-replay-counterfactual": 600,
+    "alpha-engine-research-aggregate-costs": 300,
+    "alpha-engine-research-eval-judge-poll": 60,
+    "alpha-engine-research-eval-judge-process": 900,
+    "alpha-engine-research-eval-judge-submit": 300,
+    "alpha-engine-research-eval-rolling-mean": 300,
+    "alpha-engine-research-rationale-clustering": 900,
+    "alpha-engine-research-runner": 900,
+    # 300 -> 450 by crucible-research-PR601 (p95 x 1.5). The Scanner states
+    # moved 600 -> 440 in the same arc so the SF budget binds again.
+    "alpha-engine-research-scanner": 450,
+    "alpha-engine-research-signals-envelope": 300,
+    "alpha-engine-weekly-freshness-spot-dispatcher": 600,
+    "alpha-engine-weekly-preflight": 120,
+}
+
+# States whose SF budget is >= the function timeout, measured 2026-08-11.
+#
+# NOT fixed here. Each needs its stage runtime looked at before a number is
+# chosen — sf-pipeline-policy.md §4: "Timeouts are budgets, not
+# accommodations. Raise only with a stated reason for the new baseline."
+# Picking values to make a test pass is the move that policy forbids, and
+# most of these sit on the weekly pipeline, whose behaviour this arc did not
+# measure. Tracked as alpha-engine-config-I6897 with the full table.
+#
+# Pinned as an exact set: the gap cannot widen while that issue is open, and
+# an entry cannot outlive its fix without failing.
+_KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("step_function.json", "WeeklyRunDayGate"),  # no TimeoutSeconds at all
+        ("step_function.json", "SignalsEnvelope"),
+        ("step_function.json", "ChallengerShadow"),
+        ("step_function.json", "EvalJudgeSubmitFirstSaturday"),
+        ("step_function.json", "EvalJudgeSubmitWeekly"),
+        ("step_function.json", "EvalJudgePoll"),
+        ("step_function.json", "EvalJudgeProcess"),
+        ("step_function.json", "EvalRollingMean"),
+        ("step_function.json", "RationaleClustering"),
+        ("step_function.json", "ReplayConcordance"),
+        ("step_function.json", "Counterfactual"),
+        ("step_function.json", "ReportCard"),
+        ("step_function.json", "DispatchWeeklyFreshnessSpot"),
+        # SF > function: the declaration is decorative, the function governs.
+        ("step_function.json", "RegimeSubstrate"),
+        ("step_function.json", "RegimeRetrospectiveEval"),
+        ("step_function.json", "AggregateCosts"),
+        ("step_function.json", "Director"),
+        ("step_function_daily.json", "PredictorInference"),
+        ("step_function_daily.json", "ReinvokePredictor"),
+        ("step_function_eod.json", "ProbeEODReconcilePrecondition"),
+        ("step_function_eod.json", "HealReProbe"),
+    }
+)
+
+
+def _lambda_invoke_states(states: dict) -> Iterator[tuple[str, str, int | None]]:
+    """``(state_name, function_base_name, TimeoutSeconds)`` for every lambda:invoke.
+
+    Recurses into Parallel branches and Map iterators — the weekly Scanner
+    lives inside ``ResearchPredictorParallel``, and a top-level-only scan
+    would silently exempt it, which is the state this test exists for.
+    """
+    for name, body in states.items():
+        resource = body.get("Resource")
+        if isinstance(resource, str) and resource.endswith(":lambda:invoke"):
+            raw = str((body.get("Parameters") or {}).get("FunctionName") or "")
+            # Either "name:alias" or a full ARN with an optional alias suffix.
+            base = raw.split(":")[-2] if raw.startswith("arn:") else raw.split(":")[0]
+            yield name, base, body.get("TimeoutSeconds")
+        for branch in body.get("Branches") or []:
+            yield from _lambda_invoke_states(branch.get("States") or {})
+        iterator = body.get("Iterator") or body.get("ItemProcessor")
+        if iterator:
+            yield from _lambda_invoke_states(iterator.get("States") or {})
+
+
+def _states(definition: str) -> dict:
+    return json.loads((_INFRA / definition).read_text(encoding="utf-8"))["States"]
+
+
+@pytest.mark.parametrize("definition", _DEFS)
+def test_every_lambda_invoke_declares_a_timeout(definition: str) -> None:
+    """§4: a stage with no declared timeout inherits the definition ceiling.
+
+    Its hang is then indistinguishable from a slow run until everything
+    times out together.
+    """
+    missing = sorted(
+        name
+        for name, _, timeout in _lambda_invoke_states(_states(definition))
+        if timeout is None and (definition, name) not in _KNOWN_UNBOUND
+    )
+    assert not missing, f"{definition}: lambda:invoke states with no TimeoutSeconds: {missing}"
+
+
+@pytest.mark.parametrize("definition", _DEFS)
+def test_the_declared_stage_timeout_is_the_one_that_binds(definition: str) -> None:
+    """`TimeoutSeconds` strictly below the function's own timeout.
+
+    Equal is a race — whichever ceiling fires first is undefined, so the
+    error an operator sees is not reproducible. Greater is decorative.
+    """
+    violations: list[str] = []
+    for name, fn, timeout in _lambda_invoke_states(_states(definition)):
+        if (definition, name) in _KNOWN_UNBOUND:
+            continue
+        fn_timeout = _FUNCTION_TIMEOUTS_SEC.get(fn)
+        if fn_timeout is None:
+            continue  # covered by test_every_invoked_function_has_a_codified_timeout
+        if timeout is None:
+            continue  # covered by test_every_lambda_invoke_declares_a_timeout
+        if timeout >= fn_timeout:
+            violations.append(
+                f"{name}: TimeoutSeconds={timeout} >= {fn}'s own {fn_timeout}s "
+                f"({'race' if timeout == fn_timeout else 'never binds'})"
+            )
+    assert not violations, f"{definition}:\n  " + "\n  ".join(violations)
+
+
+@pytest.mark.parametrize("definition", _DEFS)
+def test_every_invoked_function_has_a_codified_timeout(definition: str) -> None:
+    """A function missing from the map is an unchecked stage, not a passing one.
+
+    Without this, adding a Lambda no one codified would make the ordering
+    test silently skip it — the same shape as the whitelist that made the
+    weekday notifier render nothing (config-I6857).
+    """
+    unknown = sorted(
+        {
+            fn
+            for _, fn, _ in _lambda_invoke_states(_states(definition))
+            if fn not in _FUNCTION_TIMEOUTS_SEC and not fn.startswith("function")
+        }
+    )
+    assert not unknown, (
+        f"{definition} invokes functions absent from _FUNCTION_TIMEOUTS_SEC: {unknown}. "
+        "Add each with its measured `aws lambda get-function-configuration --query Timeout`."
+    )
+
+
+def test_the_known_unbound_set_contains_no_stale_entries() -> None:
+    """An exception that outlives its fix silently exempts a healthy stage."""
+    live = {(d, name) for d in _DEFS for name, _, _ in _lambda_invoke_states(_states(d))}
+    stale = sorted(entry for entry in _KNOWN_UNBOUND if entry not in live)
+    assert not stale, f"_KNOWN_UNBOUND names states that no longer exist: {stale}"
+
+    still_broken = set()
+    for definition, name in _KNOWN_UNBOUND:
+        for state, fn, timeout in _lambda_invoke_states(_states(definition)):
+            if state != name:
+                continue
+            fn_timeout = _FUNCTION_TIMEOUTS_SEC.get(fn)
+            if timeout is None or (fn_timeout is not None and timeout >= fn_timeout):
+                still_broken.add((definition, name))
+    fixed = sorted(set(_KNOWN_UNBOUND) - still_broken)
+    assert not fixed, (
+        f"these now bind correctly — remove them from _KNOWN_UNBOUND: {fixed}. "
+        "Close alpha-engine-config-I6897 when the set is empty."
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SF_TIMEOUT_LIVE_CHECK"),
+    reason="needs AWS credentials; set SF_TIMEOUT_LIVE_CHECK=1 to run",
+)
+def test_the_codified_function_timeouts_match_live() -> None:
+    """The map is a claim about the live account; this is what proves it.
+
+    `sf-pipeline-policy.md` §2.4 — verification reads the deployed artifact,
+    not the source claiming to produce it. Without this the ordering guard
+    would keep passing against timeouts that moved in another repo, which is
+    precisely how the Scanner's 300s ceiling stayed invisible from here.
+    """
+    import boto3
+
+    client = boto3.client("lambda")
+    drift: list[str] = []
+    for fn, codified in sorted(_FUNCTION_TIMEOUTS_SEC.items()):
+        live = client.get_function_configuration(FunctionName=fn)["Timeout"]
+        if live != codified:
+            drift.append(f"{fn}: codified {codified}s, live {live}s")
+    assert not drift, "\n  ".join(drift)

--- a/tests/test_sf_scanner_wiring.py
+++ b/tests/test_sf_scanner_wiring.py
@@ -241,6 +241,12 @@ class TestResultPaths:
 class TestTimeout:
     def test_timeout_is_bounded(self, states):
         # The handler's expected wallclock is ~minutes for the full
-        # ~903-ticker filter pass + small artifact write. 600s gives
-        # generous headroom while still tripping a hung run.
-        assert states["Scanner"]["TimeoutSeconds"] == 600
+        # ~903-ticker filter pass + universe board + membership + leaderboard.
+        # 600 -> 440 (alpha-engine-config-I6855). 600 could never bind: the
+        # function's own timeout was 300s, so both 2026-08-11 preopen
+        # invocations died at 300.00s with Sandbox.Timedout and the pipeline
+        # terminated DEGRADED. The function is now 450s (p95 x 1.5,
+        # crucible-research-PR601) and the SF budget sits below it, so an
+        # overrun surfaces as States.Timeout naming this state.
+        # Ordering guard: tests/test_sf_lambda_timeout_ordering.py.
+        assert states["Scanner"]["TimeoutSeconds"] == 440


### PR DESCRIPTION
## The defect class

A `lambda:invoke` task has **two** ceilings — the state's `TimeoutSeconds` and the function's own `Timeout` — and only the smaller one ever fires. Where the state's value is the larger, it describes nothing, and the real budget lives in another repo's deploy script, invisible to anyone reading the definition.

Measured 2026-08-11: `Scanner` declared `TimeoutSeconds: 600` while `alpha-engine-research-scanner` carried a **300s** function timeout. Both preopen invocations died at exactly 300.00s, the pipeline terminated DEGRADED, and that day's universe board, membership, leaderboard and trajectory were never written. The 600 had never been reachable.

`sf-pipeline-policy.md` §4 requires a declared timeout sized to observed p95 × 1.5. A declaration the service can never reach satisfies the letter and none of the point.

## The guard is one-sided, deliberately

| Relationship | Verdict |
|---|---|
| SF `<` function | **Legitimate.** The state's value binds. `alpha-engine-predictor-inference` serves nine states at budgets from 60s to 900s — a shared Lambda carrying per-call budgets below its ceiling is correct, and an overrun surfaces as `States.Timeout` naming the state. |
| SF `==` function | **Race.** Which ceiling fires is undefined, so the error an operator sees is not reproducible. |
| SF `>` function | **Defect.** The declaration is decorative; the function's ceiling silently governs. |

## Fixed here

`Scanner` **600 → 440**, in both `step_function.json` (inside `ResearchPredictorParallel`) and `step_function_daily.json`, against the function timeout raised **300 → 450** by `crucible-research-PR601`. The SF budget binds again, so a scanner overrun now names the state instead of surfacing as an opaque Lambda error.

Both definitions pass `aws stepfunctions validate-state-machine-definition`.

## Not fixed here — 21 stages, tabulated in `alpha-engine-config-I6897`

1 with no `TimeoutSeconds` at all, 4 where SF `>` function, 16 where SF `==` function.

`sf-pipeline-policy.md` §4: *"Timeouts are budgets, not accommodations. Raise only with a stated reason for the new baseline."* Choosing twenty numbers to make a test pass is that rule inverted — each needs its stage's observed p95 first, and most sit on the weekly pipeline, whose runtimes this arc did not measure.

They are pinned in `_KNOWN_UNBOUND` with **its own guard**: an entry naming a state that no longer exists fails, and so does an entry whose stage now binds correctly. The gap cannot widen while I6897 is open, and the exception cannot outlive the fix.

## Two things worth review

- **`_FUNCTION_TIMEOUTS_SEC` is codified, not read from AWS** — CI has no credentials and the functions deploy from four other repositories. That makes it a claim about the live account which can go stale, *exactly* the way the Scanner's 300s ceiling stayed invisible from here. `test_the_codified_function_timeouts_match_live` is what proves it has not; it skips without credentials, and wiring it into a credentialed scheduled job is deliverable 4 of I6897.
- **The state walker recurses into `Parallel` branches and `Map` iterators.** The weekly `Scanner` lives inside `ResearchPredictorParallel`, so a top-level-only scan would have silently exempted the very state this was written for.

## Validation

`1926 passed, 6 skipped` across the SF suite. Ten new tests. Two pre-existing assertions pinning `Scanner` at 600 (`test_sf_scanner_wiring.py`, `test_sf_daily_scanner_wiring.py`) updated to 440 with the reasoning inline.

**Rehearsal-path:** `tests/test_sf_lambda_timeout_ordering.py` — repo-only, no live run.

**Verified-when:** a scanner overrun surfaces as `States.Timeout` on the `Scanner` state rather than `Sandbox.Timedout`.

## Cross-repo

- `crucible-research-PR601` — raises the function to 450s. **Merge that first**: this PR lowers the SF budget to 440, which is below the current live 300s function timeout, so between the two merges the scanner has a 440s SF budget against a 300s function ceiling. That is the state it is in today, no worse — but the intended pairing is 450/440.
- `nousergon-data-PR1299`, `nousergon-data-PR1300` — the other two halves of the same 2026-08-11 alert. Independent of this one.

Relates to nousergon/alpha-engine-config#6855, nousergon/alpha-engine-config#6897

Rehearsal-path: tests/test_sf_lambda_timeout_ordering.py

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
