### PR TITLE
[P1/mid] fix(sf): branch every *RetryGate on instance liveness before re-issuing (config#5688)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -814,8 +814,29 @@
     },
     "MorningEnrichRetryGate": {
       "Type": "Choice",
-      "Comment": "SOTA bounded auto-retry (config#1059): re-issue MorningEnrich ONCE on a polled non-Success SSM status before giving up (idempotent re-run on the same always-on instance). Absent counter => re-issue; counter=1 => give up to ExtractMorningEnrichError.",
+      "Comment": "SOTA bounded auto-retry (config#1059), liveness-branched (config#5688). The launcher is an EPHEMERAL per-execution spot since config#2248 (DispatchWeeklyFreshnessSpot replaced the always-on dashboard box as the $.ec2_instance_id source), so the dominant reason a poll goes non-Success is that the instance is GONE — and a re-issue of ssm:sendCommand to a terminated instance id can only raise Ssm.InvalidInstanceIdException, burning the retry ladder (5 attempts / ~4m20s measured on execution 158e7fe8-a6ca-4278-b097-c02ca4e34752) on a deterministic no-op. SUBSTRATE LOST (StatusDetails Undeliverable/Terminated) => fail fast to ExtractMorningEnrichSubstrateLostError WITHOUT consuming the re-issue counter, so a later genuine transient workload failure still gets its retry; recovery is the mechanical scripts/weekly_sf_rerun.py, which derives the skip-set from the failed execution. WORKLOAD FAILED on a live instance => the original single idempotent re-issue is correct and unchanged: absent counter => re-issue; counter=1 => give up to ExtractMorningEnrichError.",
       "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.morning_enrich_poll.StatusDetails",
+              "IsPresent": true
+            },
+            {
+              "Or": [
+                {
+                  "Variable": "$.morning_enrich_poll.StatusDetails",
+                  "StringEquals": "Undeliverable"
+                },
+                {
+                  "Variable": "$.morning_enrich_poll.StatusDetails",
+                  "StringEquals": "Terminated"
+                }
+              ]
+            }
+          ],
+          "Next": "ExtractMorningEnrichSubstrateLostError"
+        },
         {
           "And": [
             {
@@ -1004,8 +1025,29 @@
     },
     "DataPhase1RetryGate": {
       "Type": "Choice",
-      "Comment": "SOTA bounded auto-retry (config#1059): a polled non-Success SSM status on this idempotent batch step is retriable, not terminal. Re-issue DataPhase1 ONCE on the same always-on instance ($.ec2_instance_id) before giving up \u2014 re-running is safe (the data job overwrites the same run_date S3 keys). Absent counter => first failure => re-issue; counter present (=1) => second failure => give up to ExtractDataPhase1Error. Keeps the scheduled execution alive through a transient blip so it succeeds first-pass (moves unattended_first_pass_rate).",
+      "Comment": "SOTA bounded auto-retry (config#1059), liveness-branched (config#5688). A polled non-Success SSM status on this idempotent batch step is retriable, not terminal \u2014 but ONLY while the instance is alive. The launcher is an EPHEMERAL per-execution spot since config#2248, so re-issuing to $.ec2_instance_id after substrate loss can only raise Ssm.InvalidInstanceIdException. SUBSTRATE LOST (StatusDetails Undeliverable/Terminated) => fail fast to ExtractDataPhase1SubstrateLostError WITHOUT consuming the re-issue counter; recovery is the mechanical scripts/weekly_sf_rerun.py. WORKLOAD FAILED on a live instance => re-issue DataPhase1 ONCE ($.ec2_instance_id) before giving up \u2014 re-running is safe (the data job overwrites the same run_date S3 keys). Absent counter => first failure => re-issue; counter present (=1) => second failure => give up to ExtractDataPhase1Error. Keeps the scheduled execution alive through a transient blip so it succeeds first-pass (moves unattended_first_pass_rate).",
       "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.data_phase1_poll.StatusDetails",
+              "IsPresent": true
+            },
+            {
+              "Or": [
+                {
+                  "Variable": "$.data_phase1_poll.StatusDetails",
+                  "StringEquals": "Undeliverable"
+                },
+                {
+                  "Variable": "$.data_phase1_poll.StatusDetails",
+                  "StringEquals": "Terminated"
+                }
+              ]
+            }
+          ],
+          "Next": "ExtractDataPhase1SubstrateLostError"
+        },
         {
           "And": [
             {
@@ -1463,8 +1505,29 @@
             },
             "RAGIngestionRetryGate": {
               "Type": "Choice",
-              "Comment": "SOTA bounded auto-retry (config#1059): re-issue RAGIngestion ONCE on a polled non-Success SSM status before giving up (idempotent re-run on the same always-on instance). Absent counter => re-issue; counter=1 => give up to ExtractRAGIngestionError.",
+              "Comment": "SOTA bounded auto-retry (config#1059), liveness-branched (config#5688). The launcher is an EPHEMERAL per-execution spot since config#2248, so a re-issue to a terminated $.ec2_instance_id can only raise Ssm.InvalidInstanceIdException — this gate is where that was MEASURED (execution 158e7fe8-a6ca-4278-b097-c02ca4e34752, 2026-07-30: 5 consecutive TaskFailed over 4m20s after the reaper terminated the box 52s before the poll flipped to Undeliverable). SUBSTRATE LOST (StatusDetails Undeliverable/Terminated) => fail fast to ExtractRAGIngestionSubstrateLostError WITHOUT consuming the re-issue counter; recovery is the mechanical scripts/weekly_sf_rerun.py. WORKLOAD FAILED on a live instance => re-issue RAGIngestion ONCE before giving up: absent counter => re-issue; counter=1 => give up to ExtractRAGIngestionError.",
               "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.rag_ingestion_poll.StatusDetails",
+                      "IsPresent": true
+                    },
+                    {
+                      "Or": [
+                        {
+                          "Variable": "$.rag_ingestion_poll.StatusDetails",
+                          "StringEquals": "Undeliverable"
+                        },
+                        {
+                          "Variable": "$.rag_ingestion_poll.StatusDetails",
+                          "StringEquals": "Terminated"
+                        }
+                      ]
+                    }
+                  ],
+                  "Next": "ExtractRAGIngestionSubstrateLostError"
+                },
                 {
                   "And": [
                     {
@@ -1494,6 +1557,17 @@
               "Parameters": {
                 "phase": "RAGIngestion",
                 "source": "CheckRAGIngestionStatus.Default",
+                "poll.$": "$.rag_ingestion_poll"
+              },
+              "ResultPath": "$.error",
+              "Next": "PublishResearchFailureImmediate"
+            },
+            "ExtractRAGIngestionSubstrateLostError": {
+              "Type": "Pass",
+              "Comment": "config#5688: the SUBSTRATE-LOST sibling of ExtractRAGIngestionError. Same normalization, distinguishable phase — the launcher spot was gone (StatusDetails Undeliverable/Terminated) before the workload could report, so this is an infrastructure event, not a RAG failure. The distinct phase reaches the SNS body through the same NormalizeFailureContext chain, which is what makes substrate loss separable from workload failure in failure telemetry instead of both arriving as a bare \"RAGIngestion\" phase. Deliberately does NOT route through RAGIngestionReissue: re-issuing ssm:sendCommand to a terminated instance id is a guaranteed Ssm.InvalidInstanceIdException, and consuming $.rag_ingestion_attempts here would spend the one bounded retry that a genuine transient workload failure needs.",
+              "Parameters": {
+                "phase": "RAGIngestion/SubstrateLost",
+                "source": "RAGIngestionRetryGate.SubstrateLost",
                 "poll.$": "$.rag_ingestion_poll"
               },
               "ResultPath": "$.error",
@@ -1746,8 +1820,29 @@
             },
             "DataPhase2RetryGate": {
               "Type": "Choice",
-              "Comment": "One bounded re-issue, mirroring DataPhase1RetryGate. A second failure is a real failure and takes Branch A down rather than looping: alt data is a model input, and a silent skip would write 0.0 into seven feature-store columns for the whole universe.",
+              "Comment": "One bounded re-issue, mirroring DataPhase1RetryGate, liveness-branched (config#5688). A second failure is a real failure and takes Branch A down rather than looping: alt data is a model input, and a silent skip would write 0.0 into seven feature-store columns for the whole universe. SUBSTRATE LOST (StatusDetails Undeliverable/Terminated) => fail fast to ExtractDataPhase2SubstrateLostError WITHOUT consuming the re-issue counter — the launcher is an ephemeral spot (config#2248), so re-issuing to a terminated $.ec2_instance_id can only raise Ssm.InvalidInstanceIdException; recovery is the mechanical scripts/weekly_sf_rerun.py. This gate was NOT named in config#5688's three-gate scope; it carries the identical shape and premise, and fixing three of four would have left the class open (engagement-protocol §5).",
               "Choices": [
+                {
+                  "And": [
+                    {
+                      "Variable": "$.data_phase2_poll.StatusDetails",
+                      "IsPresent": true
+                    },
+                    {
+                      "Or": [
+                        {
+                          "Variable": "$.data_phase2_poll.StatusDetails",
+                          "StringEquals": "Undeliverable"
+                        },
+                        {
+                          "Variable": "$.data_phase2_poll.StatusDetails",
+                          "StringEquals": "Terminated"
+                        }
+                      ]
+                    }
+                  ],
+                  "Next": "ExtractDataPhase2SubstrateLostError"
+                },
                 {
                   "And": [
                     {
@@ -1771,6 +1866,17 @@
                 "phase": "DataPhase2",
                 "source": "DataPhase2RetryGate.exhausted",
                 "error": "DataPhase2 SSM command exhausted its retry budget (1 re-issue) without succeeding \u2014 the alternative data collector failed on both attempts."
+              },
+              "ResultPath": "$.error",
+              "Next": "PublishResearchFailureImmediate"
+            },
+            "ExtractDataPhase2SubstrateLostError": {
+              "Type": "Pass",
+              "Comment": "config#5688: the SUBSTRATE-LOST sibling of SetDataPhase2ExhaustedError. Same normalization, distinguishable phase \u2014 the launcher spot was gone (StatusDetails Undeliverable/Terminated) before the workload could report, so this is an infrastructure event, not a DataPhase2 failure, and it is emphatically NOT retry-budget exhaustion (the budget is untouched). Deliberately does NOT route through DataPhase2Reissue: re-issuing ssm:sendCommand to a terminated instance id is a guaranteed Ssm.InvalidInstanceIdException, and consuming $.data_phase2_attempts here would spend the one bounded retry a genuine transient workload failure needs.",
+              "Parameters": {
+                "phase": "DataPhase2/SubstrateLost",
+                "source": "DataPhase2RetryGate.SubstrateLost",
+                "poll.$": "$.data_phase2_poll"
               },
               "ResultPath": "$.error",
               "Next": "PublishResearchFailureImmediate"
@@ -5973,12 +6079,34 @@
       "ResultPath": "$.error",
       "Next": "NormalizeFailureContext"
     },
+    "ExtractMorningEnrichSubstrateLostError": {
+      "Type": "Pass",
+      "Comment": "config#5688: the SUBSTRATE-LOST sibling of ExtractMorningEnrichError. Same normalization, distinguishable phase \u2014 the launcher spot was gone (StatusDetails Undeliverable/Terminated) before the workload could report, so this is an infrastructure event, not a MorningEnrich failure. The distinct phase reaches the SNS body through the same NormalizeFailureContext chain, which is what makes substrate loss separable from workload failure in failure telemetry. Deliberately does NOT route through MorningEnrichReissue: re-issuing ssm:sendCommand to a terminated instance id is a guaranteed Ssm.InvalidInstanceIdException, and consuming $.morning_enrich_attempts here would spend the one bounded retry a genuine transient workload failure needs.",
+      "Parameters": {
+        "phase": "MorningEnrich/SubstrateLost",
+        "source": "MorningEnrichRetryGate.SubstrateLost",
+        "poll.$": "$.morning_enrich_poll"
+      },
+      "ResultPath": "$.error",
+      "Next": "NormalizeFailureContext"
+    },
     "ExtractDataPhase1Error": {
       "Type": "Pass",
       "Comment": "Normalize DataPhase1 SSM non-Success poll into $.error so HandleFailure's States.Format template has something to serialize (the soft-failure path from CheckDataPhase1Status.Default does not populate $.error \u2014 only Task Catch blocks do).",
       "Parameters": {
         "phase": "DataPhase1",
         "source": "CheckDataPhase1Status.Default",
+        "poll.$": "$.data_phase1_poll"
+      },
+      "ResultPath": "$.error",
+      "Next": "NormalizeFailureContext"
+    },
+    "ExtractDataPhase1SubstrateLostError": {
+      "Type": "Pass",
+      "Comment": "config#5688: the SUBSTRATE-LOST sibling of ExtractDataPhase1Error. Same normalization, distinguishable phase \u2014 the launcher spot was gone (StatusDetails Undeliverable/Terminated) before the workload could report, so this is an infrastructure event, not a DataPhase1 failure. The distinct phase reaches the SNS body through the same NormalizeFailureContext chain, which is what makes substrate loss separable from workload failure in failure telemetry. Deliberately does NOT route through DataPhase1Reissue: re-issuing ssm:sendCommand to a terminated instance id is a guaranteed Ssm.InvalidInstanceIdException, and consuming $.data_phase1_attempts here would spend the one bounded retry a genuine transient workload failure needs.",
+      "Parameters": {
+        "phase": "DataPhase1/SubstrateLost",
+        "source": "DataPhase1RetryGate.SubstrateLost",
         "poll.$": "$.data_phase1_poll"
       },
       "ResultPath": "$.error",

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -331,9 +331,13 @@ class TestBranchAContents:
         assert branch_a["MergeDataPhase2PollCount"]["ResultPath"] == "$.data_phase2_polls"
         # Exhaustion falls to the retry gate, never to the judge chain.
         assert branch_a["CheckDataPhase2Status"]["Default"] == "DataPhase2RetryGate"
-        assert branch_a["DataPhase2RetryGate"]["Choices"][0]["Next"] == (
-            "SetDataPhase2ExhaustedError"
-        )
+        # Position-independent: config#5688 inserted the substrate-loss branch
+        # ahead of the exhaustion arm (a dead instance must be caught before
+        # the re-issue decision), so what matters is that the exhaustion route
+        # is still REACHABLE from this gate, not that it is Choices[0].
+        assert "SetDataPhase2ExhaustedError" in [
+            c["Next"] for c in branch_a["DataPhase2RetryGate"]["Choices"]
+        ]
         assert branch_a["SetDataPhase2ExhaustedError"]["Next"] == (
             "PublishResearchFailureImmediate"
         )

--- a/tests/test_sf_retrygate_liveness_branch.py
+++ b/tests/test_sf_retrygate_liveness_branch.py
@@ -208,6 +208,77 @@ def test_substrate_lost_branch_does_not_consume_the_retry_counter(gate_name):
         )
 
 
+# ---------------------------------------------------------------------------
+# Drill — execute the gate logic, don't just inspect its shape
+#
+# weekly-sf-policy.md §7.2 route 1: the rehearsal for this change is a
+# CI-validatable path, not a live Saturday. Shape assertions alone would pass a
+# branch wired to the wrong target, so these feed real poll payloads through the
+# same ASL mini-evaluator test_sf_choice_guards uses (shared rather than
+# re-implemented) and assert where each one actually lands.
+# ---------------------------------------------------------------------------
+
+from tests.test_sf_choice_guards import _eval_rule  # noqa: E402  (shared drill evaluator)
+
+
+def _route(gate: dict, payload: dict) -> str:
+    for rule in gate.get("Choices", []):
+        if _eval_rule(rule, payload):
+            return rule["Next"]
+    return gate["Default"]
+
+
+def _poll_key(gate_name: str, scope: dict) -> str:
+    """The `$.<stage>_poll` key this gate's branch reads."""
+    gate = scope[gate_name]
+    for rule in gate.get("Choices", []):
+        for cond in _leaf_conditions(rule):
+            var = str(cond.get("Variable", ""))
+            if var.endswith("_poll.StatusDetails"):
+                return var.split(".")[1]
+    raise AssertionError(f"{gate_name} has no _poll.StatusDetails branch")
+
+
+@pytest.mark.parametrize("gate_name", _gate_ids())
+@pytest.mark.parametrize("status_details", sorted(_SUBSTRATE_LOST_DETAILS))
+def test_drill_dead_instance_never_reaches_a_reissue(gate_name, status_details):
+    """A poll reporting a gone instance must not route to the re-issue."""
+    _, gate, scope = next(g for g in _gate_scopes() if g[0] == gate_name)
+    key = _poll_key(gate_name, scope)
+
+    target = _route(gate, {key: {"Status": "Failed", "StatusDetails": status_details}})
+    assert target.endswith("SubstrateLostError"), (
+        f"{gate_name} routes a {status_details!r} poll to {target!r}; "
+        f"ssm:sendCommand to that instance id can only raise "
+        f"Ssm.InvalidInstanceIdException"
+    )
+
+
+@pytest.mark.parametrize("gate_name", _gate_ids())
+def test_drill_live_instance_workload_failure_still_gets_its_one_reissue(gate_name):
+    """The unchanged half: a real workload failure on a live box retries once."""
+    _, gate, scope = next(g for g in _gate_scopes() if g[0] == gate_name)
+    key = _poll_key(gate_name, scope)
+    poll = {"Status": "Failed", "StatusDetails": "Failed", "ResponseCode": 1}
+
+    first = _route(gate, {key: poll})
+    assert first.endswith("Reissue"), (
+        f"{gate_name} sends a first live-instance failure to {first!r} instead "
+        f"of re-issuing — the bounded retry this gate exists for is gone"
+    )
+
+    attempts_key = scope[first]["ResultPath"].lstrip("$.")
+    second = _route(gate, {key: poll, attempts_key: 1})
+    assert not second.endswith("Reissue"), (
+        f"{gate_name} re-issues a second time ({second!r}); the bound is one"
+    )
+    assert not second.endswith("SubstrateLostError"), (
+        f"{gate_name} attributes an exhausted live-instance failure to "
+        f"substrate loss ({second!r}) — that misreports a real workload failure "
+        f"as an infrastructure event"
+    )
+
+
 def test_stale_always_on_instance_premise_is_gone():
     """The comment that let the invalidated premise survive config#2248."""
     assert "always-on instance" not in _RAW, (

--- a/tests/test_sf_retrygate_liveness_branch.py
+++ b/tests/test_sf_retrygate_liveness_branch.py
@@ -1,0 +1,219 @@
+"""config#5688 — a bounded re-issue must never target a dead instance.
+
+The weekly pipeline's three `*RetryGate` Choice states re-issue
+`ssm:sendCommand` to `$.ec2_instance_id`. Their original rationale assumed an
+always-on launcher box. config#2248 replaced that box with a per-execution
+ephemeral spot (`DispatchWeeklyFreshnessSpot`), which makes *the instance is
+gone* the dominant reason a poll goes non-`Success` — precisely the case where
+re-issuing to the same instance id can only raise
+`Ssm.InvalidInstanceIdException`.
+
+Measured on execution ``158e7fe8-a6ca-4278-b097-c02ca4e34752`` (2026-07-30):
+after `WaitForRAGIngestion` returned ``Undeliverable``, the gate re-issued and
+burned **5 consecutive TaskFailed over 4m20s** on an outcome that was
+deterministic from the first attempt — the pipeline's one bounded retry spent
+as a guaranteed no-op.
+
+The fix is structural: branch on *why* the poll failed before deciding to
+re-issue. These tests keep it that way, and — because the stale
+``always-on instance`` comment is what let the premise survive config#2248 —
+also assert that text cannot come back.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+_DEFINITION = (
+    pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+)
+_RAW = _DEFINITION.read_text(encoding="utf-8")
+_DEF = json.loads(_RAW)
+
+# StatusDetails values SSM reports when the target instance is gone. A
+# re-issue in either state is a guaranteed no-op.
+_SUBSTRATE_LOST_DETAILS = {"Undeliverable", "Terminated"}
+
+
+def _iter_scopes(node):
+    """Yield every `States` map in the definition (top level + every branch)."""
+    if isinstance(node, dict):
+        states = node.get("States")
+        if isinstance(states, dict):
+            yield states
+        for value in node.values():
+            yield from _iter_scopes(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _iter_scopes(value)
+
+
+_SCOPES = list(_iter_scopes(_DEF))
+
+
+def _gate_scopes():
+    """(gate_name, scope) for every Choice state named `*RetryGate`."""
+    for scope in _SCOPES:
+        for name, state in scope.items():
+            if name.endswith("RetryGate") and state.get("Type") == "Choice":
+                yield name, state, scope
+
+
+def _leaf_conditions(rule):
+    """Flatten a Choice rule into its leaf comparison dicts."""
+    for key in ("And", "Or", "Not"):
+        if key in rule:
+            operands = rule[key]
+            if isinstance(operands, dict):
+                operands = [operands]
+            for operand in operands:
+                yield from _leaf_conditions(operand)
+            return
+    yield rule
+
+
+def _gate_ids():
+    return [name for name, _, _ in _gate_scopes()]
+
+
+def test_there_are_retry_gates_to_check():
+    """Guard against the tests silently passing on an empty set."""
+    assert _gate_ids(), (
+        "no *RetryGate Choice states found in the weekly definition — if the "
+        "bounded-re-issue pattern was retired, delete this test with the reason "
+        "rather than leaving it vacuously green"
+    )
+
+
+@pytest.mark.parametrize("gate_name", _gate_ids())
+def test_reissue_is_guarded_by_a_liveness_branch(gate_name):
+    """No `*Reissue` route may be reachable without a substrate-loss branch first.
+
+    The dead-instance branch must be evaluated BEFORE any rule that routes to
+    the re-issue, since ASL evaluates Choices in order.
+    """
+    _, gate, scope = next(g for g in _gate_scopes() if g[0] == gate_name)
+
+    rules = gate.get("Choices", [])
+    routes = [(i, r.get("Next", "")) for i, r in enumerate(rules)]
+    routes.append((len(rules), gate.get("Default", "")))
+    reissue_positions = [i for i, target in routes if target.endswith("Reissue")]
+    if not reissue_positions:
+        pytest.skip(f"{gate_name} no longer re-issues; nothing to guard")
+
+    liveness_positions = []
+    for i, rule in enumerate(rules):
+        values = {
+            c.get("StringEquals")
+            for c in _leaf_conditions(rule)
+            if str(c.get("Variable", "")).endswith("_poll.StatusDetails")
+        }
+        if values & _SUBSTRATE_LOST_DETAILS:
+            liveness_positions.append(i)
+
+    assert liveness_positions, (
+        f"{gate_name} routes to a re-issue without ever branching on "
+        f"$.<stage>_poll.StatusDetails. After config#2248 the launcher is an "
+        f"ephemeral spot, so re-issuing ssm:sendCommand to a terminated "
+        f"instance id can only raise Ssm.InvalidInstanceIdException — the "
+        f"pipeline's one bounded retry spent on a deterministic no-op "
+        f"(config#5688)."
+    )
+    assert min(liveness_positions) < min(reissue_positions), (
+        f"{gate_name} evaluates its re-issue rule before the substrate-loss "
+        f"branch; ASL takes the first matching Choice, so the dead-instance "
+        f"case would still re-issue"
+    )
+
+
+@pytest.mark.parametrize("gate_name", _gate_ids())
+def test_substrate_lost_branch_is_distinguishable_and_reaches_the_notifier(gate_name):
+    """The dead-instance path emits its own phase and joins the failure chain.
+
+    Substrate loss and workload failure arriving as the same `phase` is what
+    makes the two indistinguishable in failure telemetry. The target must also
+    hand off to the same downstream state its non-substrate sibling does, so
+    the alert body is produced by the identical chain.
+    """
+    _, gate, scope = next(g for g in _gate_scopes() if g[0] == gate_name)
+
+    def _is_substrate_rule(rule):
+        return bool(
+            {
+                c.get("StringEquals")
+                for c in _leaf_conditions(rule)
+                if str(c.get("Variable", "")).endswith("_poll.StatusDetails")
+            }
+            & _SUBSTRATE_LOST_DETAILS
+        )
+
+    targets = {r.get("Next") for r in gate.get("Choices", []) if _is_substrate_rule(r)}
+    if not targets:
+        pytest.skip(f"{gate_name} has no substrate-loss branch (covered by the guard test)")
+
+    # The sibling is the gate's OTHER terminal route (retry-budget exhaustion),
+    # found structurally rather than by name — the four gates do not share a
+    # naming convention (Extract*Error vs SetDataPhase2ExhaustedError).
+    siblings = [
+        scope[r["Next"]]
+        for r in gate.get("Choices", [])
+        if not _is_substrate_rule(r) and r.get("Next") in scope
+    ]
+    assert siblings, (
+        f"{gate_name} has no non-substrate error route to mirror; the substrate "
+        f"branch cannot be checked for chain parity"
+    )
+    sibling = siblings[0]
+
+    for target in targets:
+        state = scope.get(target)
+        assert state is not None, f"{gate_name} routes to {target}, absent from its scope"
+        phase = state.get("Parameters", {}).get("phase", "")
+        assert phase.endswith("/SubstrateLost"), (
+            f"{target} emits phase {phase!r}; substrate loss must be separable "
+            f"from workload failure in the SNS body (config#5688)"
+        )
+        assert state.get("ResultPath") == "$.error", (
+            f"{target} must write $.error — HandleFailure's "
+            f"States.JsonToString($.error) throws States.Runtime otherwise"
+        )
+        assert state.get("Next") == sibling.get("Next"), (
+            f"{target} hands off to {state.get('Next')!r} but {gate_name}'s "
+            f"non-substrate error route hands off to {sibling.get('Next')!r}; "
+            f"both must join the same failure-notification chain"
+        )
+
+
+@pytest.mark.parametrize("gate_name", _gate_ids())
+def test_substrate_lost_branch_does_not_consume_the_retry_counter(gate_name):
+    """A substrate event must not spend the retry a workload failure needs."""
+    _, gate, scope = next(g for g in _gate_scopes() if g[0] == gate_name)
+
+    for rule in gate.get("Choices", []):
+        leaves = list(_leaf_conditions(rule))
+        is_liveness = {
+            c.get("StringEquals")
+            for c in leaves
+            if str(c.get("Variable", "")).endswith("_poll.StatusDetails")
+        } & _SUBSTRATE_LOST_DETAILS
+        if not is_liveness:
+            continue
+        target = scope.get(rule.get("Next"), {})
+        assert not str(target.get("ResultPath", "")).endswith("_attempts"), (
+            f"{gate_name}'s substrate-loss branch writes an attempts counter; "
+            f"a later genuine transient workload failure then has no retry left"
+        )
+
+
+def test_stale_always_on_instance_premise_is_gone():
+    """The comment that let the invalidated premise survive config#2248."""
+    assert "always-on instance" not in _RAW, (
+        "a *RetryGate Comment still claims an always-on instance. There is no "
+        "always-on box in this pipeline since config#2248; that text is what "
+        "let the stale premise survive the change (doc-maintenance-policy: a "
+        "load-bearing comment contradicted by the live system is a same-turn "
+        "correction)."
+    )


### PR DESCRIPTION
## What

The weekly pipeline's bounded re-issue gates now branch on **why** a poll went non-`Success` before deciding to re-issue. Substrate loss fails fast with a distinguishable phase; a live-instance workload failure keeps its single idempotent retry, unchanged.

## Why

`*RetryGate` re-issued `ssm:sendCommand` to the same `$.ec2_instance_id` it had just failed against. That premise held while an always-on dashboard box was the launcher; **config#2248** replaced it with a per-execution ephemeral spot (`DispatchWeeklyFreshnessSpot`), making *the instance is gone* the dominant non-`Success` cause — the one case a re-issue cannot possibly help.

Measured on execution `158e7fe8-a6ca-4278-b097-c02ca4e34752` (2026-07-30), after `WaitForRAGIngestion` returned `Undeliverable`: **5 consecutive `TaskFailed` / `Ssm.InvalidInstanceIdException` over 4m20s**, then `PublishResearchFailureImmediate` → pipeline FAILED. The pipeline's one bounded retry, spent on an outcome deterministic from the first attempt.

The stale rationale was sitting in the definition the whole time — `"idempotent re-run on the same always-on instance"` — which is what let the premise survive config#2248 unexamined.

## Changes

`infrastructure/step_function.json`:

- Each `*RetryGate` gains a **first** Choice branch on `$.<stage>_poll.StatusDetails ∈ {Undeliverable, Terminated}` (`IsPresent`-guarded, per `test_sf_choice_guards`), routing to a new `Extract<Stage>SubstrateLostError` Pass.
- Each new Pass emits `phase: "<Stage>/SubstrateLost"` and `ResultPath: $.error`, handing off to **the same** downstream state its sibling error normalizer uses — `NormalizeFailureContext` at top scope, `PublishResearchFailureImmediate` inside Branch A — so substrate loss reaches the SNS body through the identical chain while staying separable in telemetry.
- The substrate branch **does not write `*_attempts`**, so a later genuine transient workload failure still has its retry.
- All four gate Comments rewritten; `"always-on instance"` no longer appears anywhere in the definition.

**Scope is four gates, not the three named in the issue.** `DataPhase2RetryGate` carries the identical shape and premise and was not in the issue's scope; fixing three of four would have left the class open (engagement-protocol §5). Its sibling is `SetDataPhase2ExhaustedError`, so the new test finds siblings structurally rather than by name.

`tests/test_sf_retrygate_liveness_branch.py` (new) — discovers `*RetryGate` states by walking every scope, so a fifth gate added later is covered on arrival. Asserts: a liveness branch exists and is evaluated *before* any re-issue route; the target emits a `/SubstrateLost` phase, writes `$.error`, and joins the sibling's chain; the branch never consumes the attempts counter; `"always-on instance"` stays gone.

`tests/test_sf_research_predictor_parallel_wiring.py` — pinned the exhaustion route as `Choices[0]`; relaxed to membership, since the substrate branch must precede it. Intent preserved (exhaustion still reaches `SetDataPhase2ExhaustedError`, never the judge chain).

## Verification

- New test verified as a real detector: **5 failures** against the pre-fix definition (all four gates + the stale-comment assertion), green after.
- Full suite: **4923 passed, 8 skipped** against pinned lib `v0.124.44`.
- `step_function.json` auto-deploys on merge via `deploy-infrastructure.yml` — no post-merge step.

## Rehearsal

`weekly-sf-policy.md` §7.2 route 1 — a CI-validatable path, not a live Saturday. The new test does not merely assert shape (which would pass a branch wired to the wrong target); it **executes** each gate's Choice logic through the ASL mini-evaluator `test_sf_choice_guards` already owns, shared rather than re-implemented:

- a poll reporting `Undeliverable`/`Terminated` never reaches a `*Reissue`, on all four gates;
- a live-instance workload failure still gets its one re-issue, and the second failure is attributed to **exhaustion** — not misreported as substrate loss.

Detector check against the pre-fix definition: **17 failed / 5 passed**; green after. Full suite **4935 passed, 8 skipped**.

Rehearsal-path: tests/test_sf_retrygate_liveness_branch.py

Closes nousergon/alpha-engine-config#5688

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
