### PR TITLE
[P1/low] fix(sf): the weekday fail-opens page when they fire, not an hour later (config-I6903)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -76,4 +76,4 @@ boto3>=1.34.0
 # post-merge tag against `git -C nousergon-lib tag --sort=-v:refname | head -1`
 # and correct this line if it drifted from .36, then bump this in lockstep
 # with the root pin.
-nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor,github_app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 krepis>=0.14.0

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1057,6 +1057,28 @@
         "stage_error.$": "$.daemon_error"
       },
       "ResultPath": "$.degraded_summary",
+      "Next": "PublishDaemonFailureImmediate"
+    },
+    "PublishDaemonFailureImmediate": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I6903: best-effort SNS alert that the daemon restart failed. sf-pipeline-policy.md \u00a75 names this fail-open explicitly \u2014 'the daemon systemd restart must not abort the trading chain (the boot trigger is the daemon's backup); both set the degraded flag \u00a72.3 requires AND page immediately' \u2014 and the second half was never built. Without it the only signal is the terminal, which on a run that degrades early is up to an hour later. That the boot trigger is a backup is the reason this fails OPEN; it is not a reason to stay quiet, because a backup that also failed is exactly what an operator needs to hear about before the open. Catch mirrors the sibling publishes: an SNS failure must not hard-fail a pipeline that deliberately continued.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Daemon Restart \u2014 FAILED (fail-open, systemd boot trigger is the backup)",
+        "Message.$": "States.Format('The RunDaemon systemd restart failed; the pipeline continued on the assumption that the boot trigger starts the daemon instead. VERIFY the daemon is running before the open \u2014 if the boot trigger also missed, the book is unmanaged. Detail: {}', States.JsonToString($.daemon_error))"
+      },
+      "ResultPath": "$.daemon_failure_notify",
+      "TimeoutSeconds": 60,
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": null,
+          "Next": "CheckDegradedOutcome"
+        }
+      ],
       "Next": "CheckDegradedOutcome"
     },
     "CheckDegradedOutcome": {
@@ -1230,6 +1252,28 @@
         "stage_error.$": "$.scanner_error"
       },
       "ResultPath": "$.degraded_summary",
+      "Next": "PublishScannerFailureImmediate"
+    },
+    "PublishScannerFailureImmediate": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I6903: best-effort SNS alert that the Scanner failed \u2014 surfaces the miss at the MOMENT it happens, WITHOUT blocking the trading chain. The Scanner fail-open was the only one of the five degraded paths in this definition with no Publish state, so on 2026-08-11 there were 37 minutes of silence between the second Scanner timeout (05:32 PT) and the terminal (06:09 PT) \u2014 inside the window where an operator could still have rerun it before the 06:30 open. sf-pipeline-policy.md \u00a75 requires weekday fail-opens to set the degraded flag AND page immediately; this is the missing half. Mirrors PublishDataSpotFailureImmediate exactly, including the Catch: an SNS failure must not hard-fail a pipeline that deliberately continued.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Scanner \u2014 FAILED (fail-open, pipeline continues)",
+        "Message.$": "States.Format('Weekday Scanner failed but the pipeline continued to predictor inference and daemon start (fail-open, config#6722). Today candidates may be stale and the universe board, membership and leaderboard were not written \u2014 the optimizer runs without per-name ADV (config-I6902). Detail: {}', States.JsonToString($.scanner_error))"
+      },
+      "ResultPath": "$.scanner_failure_notify",
+      "TimeoutSeconds": 60,
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "ResultPath": null,
+          "Next": "CheckSkipPredictorInference"
+        }
+      ],
       "Next": "CheckSkipPredictorInference"
     },
     "CheckSkipPredictorInference": {

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[rag,flow_doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,12 +61,7 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-# v0.124.47 -> v0.124.47 (config-I3112, nousergon-lib-PR303): the weekly SF's
-# single Evaluator state became EvaluatorDiagnostics -> EvaluatorOptimize, and
-# test_pipeline_status_registry_source_check.py reads the LIB registry — the
-# SF JSON in this PR is red until the pin carries both halves. Lockstep by
-# construction: registry entry first, pin second, same PR as the SF change.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.47
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.48
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_degraded_paths_page_immediately.py
+++ b/tests/test_degraded_paths_page_immediately.py
@@ -1,0 +1,220 @@
+"""A fail-open that pages only at the terminal is silent when it matters.
+
+`sf-pipeline-policy.md` §5 permits the weekday fail-opens on exactly one
+condition: they *"set the degraded flag §2.3 requires **and page
+immediately**"*. The second half was built for some paths and not others, and
+nothing checked.
+
+Measured 2026-08-11. The Scanner Lambda timed out twice at 300s and the
+pipeline fail-opened past it. Its path was:
+
+    Scanner --Catch--> SetScannerDegradedFlag --> CheckSkipPredictorInference
+
+No SNS publish anywhere on it. The only signal was the terminal, **37 minutes
+later** — inside the window where an operator could still have rerun the
+Scanner before the 06:30 open. The sibling data-spot and deploy-drift
+fail-opens in the same definition both had a publish; the Scanner one, added
+later by `#6722`, did not, and `§5` does not name it at all.
+
+The audit this test encodes found a second instance immediately:
+`SetDaemonDegradedFlag`, which §5 *does* name explicitly, also went straight
+to the terminal.
+
+## Why membership is keyed on the RESOURCE, not the state name
+
+Writing this audit by hand, a `name.startswith("Publish")` heuristic reported
+the EOD weekly-exercise path as silent. It is not — `WeeklyExerciseLaunchFailed`
+is an `sns:publish`; it simply is not named `Publish*`. A guard that reads
+names produces false findings on correct code and, worse, would pass a state
+called `PublishFoo` that publishes nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+
+_WEEKDAY_DEFS = ("step_function_daily.json", "step_function_eod.json")
+
+_SNS_PUBLISH = "arn:aws:states:::sns:publish"
+
+#: How many `Next` hops a degraded setter may take before it must have
+#: reached a publish. Generous: the paths in practice are 1-2 hops, and a
+#: longer walk would start crediting a notification that fires for an
+#: unrelated reason further down the pipeline.
+_MAX_HOPS = 4
+
+# Degraded setters that legitimately do NOT page at the moment they fire.
+# Exhaustive and exempt-by-reason, not by omission — an entry here is a claim
+# somebody has to defend, and a new setter is silent-by-default only until
+# this test fails on it.
+_NO_IMMEDIATE_PAGE: dict[tuple[str, str], str] = {
+    (
+        "step_function_daily.json",
+        "SetMutexAcquireDegradedFlag",
+    ): (
+        "Best-effort architectural insurance, not a producer. A DynamoDB / IAM "
+        "blip on mutex acquisition does not change what the run produces, and "
+        "the terminal reports it. Paging here would train the operator to "
+        "ignore the channel that the Scanner and daemon pages use."
+    ),
+    (
+        "step_function_eod.json",
+        "SetMutexAcquireDegradedFlag",
+    ): "Same as the daily mutex path.",
+    (
+        "step_function_eod.json",
+        "SetDegradedFlag",
+    ): (
+        "EODReconcile skipped on a data gap routes into the heal loop "
+        "(CheckHealLoopEligible), which notifies on its own outcome. Paging "
+        "before the heal has run would page on a condition the pipeline is "
+        "actively repairing."
+    ),
+}
+
+
+def _states(definition: str) -> dict:
+    return json.loads((_INFRA / definition).read_text(encoding="utf-8"))["States"]
+
+
+def _degraded_setters(states: dict) -> dict[str, dict]:
+    return {
+        name: body["Parameters"]
+        for name, body in states.items()
+        if isinstance(body.get("Parameters"), dict)
+        and body["Parameters"].get("degraded") is True
+    }
+
+
+def _publishes(states: dict, name: str) -> bool:
+    return states.get(name, {}).get("Resource") == _SNS_PUBLISH
+
+
+def _reaches_a_publish(states: dict, start: str) -> str | None:
+    """Walk ``Next`` from ``start``, returning the publishing state or None."""
+    cur = states.get(start, {}).get("Next")
+    for _ in range(_MAX_HOPS):
+        if not cur:
+            return None
+        if _publishes(states, cur):
+            return cur
+        cur = states.get(cur, {}).get("Next")
+    return None
+
+
+@pytest.mark.parametrize("definition", _WEEKDAY_DEFS)
+def test_every_degraded_path_pages_immediately_or_is_exempt_with_a_reason(
+    definition: str,
+) -> None:
+    """§5's second half, enforced.
+
+    A new fail-open path is silent until somebody notices — which on
+    2026-08-11 took 37 minutes and a direct question. This is what notices.
+    """
+    states = _states(definition)
+    setters = _degraded_setters(states)
+    assert setters, f"{definition} has no degraded setters — nothing exercised"
+
+    silent = []
+    for name in setters:
+        if (definition, name) in _NO_IMMEDIATE_PAGE:
+            continue
+        if _reaches_a_publish(states, name) is None:
+            silent.append(name)
+
+    assert not silent, (
+        f"{definition}: {silent} set degraded: true and reach no sns:publish "
+        f"within {_MAX_HOPS} hops. sf-pipeline-policy.md §5 permits a weekday "
+        "fail-open only if it sets the flag AND pages immediately. Either add "
+        "the publish, or add an entry to _NO_IMMEDIATE_PAGE stating why this "
+        "path is different."
+    )
+
+
+@pytest.mark.parametrize("definition", _WEEKDAY_DEFS)
+def test_the_paging_check_reads_the_resource_not_the_state_name(
+    definition: str,
+) -> None:
+    """Guards the guard.
+
+    `WeeklyExerciseLaunchFailed` publishes and is not named `Publish*`; a
+    name-based check calls it silent. The inverse is worse — a state named
+    `PublishX` that publishes nothing would pass. Assert that at least one
+    publishing state in the fleet's definitions is NOT named `Publish*`, so a
+    future simplification back to a name check fails here.
+    """
+    states = _states(definition)
+    publishers = [n for n in states if _publishes(states, n)]
+    if not publishers:
+        pytest.skip(f"{definition} has no sns:publish states")
+    # Membership is decided by Resource, which is the point: every state this
+    # helper admits publishes, whatever it is called.
+    for name in publishers:
+        assert states[name]["Resource"] == _SNS_PUBLISH
+    # And a name check would be strictly weaker — some publishers are not
+    # named Publish*, asserted concretely in the weekly-exercise test below.
+
+
+def test_the_weekly_exercise_path_is_recognised_as_paging() -> None:
+    """The concrete false finding this design avoids.
+
+    `WeeklyExerciseLaunchFailed` is an sns:publish reached from
+    `SetWeeklyExerciseDegradedFlag`. A name-prefix check reports it silent,
+    which sends somebody to add a duplicate publish beside a working one.
+    """
+    states = _states("step_function_eod.json")
+    reached = _reaches_a_publish(states, "SetWeeklyExerciseDegradedFlag")
+    assert reached == "WeeklyExerciseLaunchFailed"
+    assert not reached.startswith("Publish")
+
+
+@pytest.mark.parametrize("definition", _WEEKDAY_DEFS)
+def test_no_exemption_names_a_setter_that_no_longer_exists(definition: str) -> None:
+    """An exemption outliving its path silently excuses the next one to take
+    that name."""
+    states = _states(definition)
+    setters = set(_degraded_setters(states))
+    stale = sorted(
+        name for (d, name) in _NO_IMMEDIATE_PAGE if d == definition and name not in setters
+    )
+    assert not stale, f"{definition}: _NO_IMMEDIATE_PAGE names absent setters: {stale}"
+
+
+@pytest.mark.parametrize("definition", _WEEKDAY_DEFS)
+def test_no_exemption_covers_a_path_that_now_pages(definition: str) -> None:
+    """An exemption is a claim, and a claim that has become false is worse
+    than no claim — it asserts a path is deliberately silent when it is not."""
+    states = _states(definition)
+    wrong = sorted(
+        name
+        for (d, name) in _NO_IMMEDIATE_PAGE
+        if d == definition and _reaches_a_publish(states, name) is not None
+    )
+    assert not wrong, (
+        f"{definition}: {wrong} now page — remove them from _NO_IMMEDIATE_PAGE"
+    )
+
+
+@pytest.mark.parametrize("definition", _WEEKDAY_DEFS)
+def test_every_immediate_page_survives_its_own_sns_failure(definition: str) -> None:
+    """A best-effort notification must not hard-fail a run that deliberately
+    continued. Every publish on a degraded path carries a Catch back onto the
+    continue path — otherwise an SNS outage converts a degraded run into a
+    failed one, which is the opposite of fail-open."""
+    states = _states(definition)
+    for setter in _degraded_setters(states):
+        reached = _reaches_a_publish(states, setter)
+        if reached is None:
+            continue
+        body = states[reached]
+        catches = body.get("Catch") or []
+        assert catches, f"{definition}::{reached} has no Catch — an SNS failure would abort the run"
+        assert any(
+            "States.ALL" in (c.get("ErrorEquals") or []) for c in catches
+        ), f"{definition}::{reached} does not Catch States.ALL"

--- a/tests/test_sf_completion_marker_wiring_daily.py
+++ b/tests/test_sf_completion_marker_wiring_daily.py
@@ -69,7 +69,18 @@ def test_run_daemon_catch_degraded_flag_shape(daily_states):
     assert st["Type"] == "Pass"
     assert st["Parameters"]["degraded"] is True
     assert st["ResultPath"] == "$.degraded_summary"
-    assert st["Next"] == "CheckDegradedOutcome"
+    # config-I6903: PublishDaemonFailureImmediate now sits between the flag and
+    # the terminal, so the invariant is that the path CONVERGES on
+    # CheckDegradedOutcome, not that it hops there directly. Asserting the
+    # immediate Next forbids ever adding a notification to a fail-open path —
+    # which is the defect I6903 fixed. sf-pipeline-policy.md §5 names this
+    # specific fail-open as one that must page immediately.
+    assert st["Next"] == "PublishDaemonFailureImmediate"
+    publish = daily_states["PublishDaemonFailureImmediate"]
+    assert publish["Next"] == "CheckDegradedOutcome"
+    assert publish["Catch"][0]["Next"] == "CheckDegradedOutcome", (
+        "an SNS failure must not divert a run that deliberately continued"
+    )
 
 
 def test_skip_run_daemon_edge_converges_on_degraded_check(daily_states):

--- a/tests/test_sf_daily_scanner_wiring.py
+++ b/tests/test_sf_daily_scanner_wiring.py
@@ -133,7 +133,16 @@ class TestEdges:
             and "States.ALL" in c["ErrorEquals"]
             for c in catches
         )
-        assert states["SetScannerDegradedFlag"]["Next"] == "CheckSkipPredictorInference"
+        # config-I6903: PublishScannerFailureImmediate now sits between the
+        # flag and the gate. The edge that matters is CONVERGENCE — both the
+        # success and the fail-open path reach CheckSkipPredictorInference —
+        # and it survives inserting the notification the fail-open was missing.
+        assert states["SetScannerDegradedFlag"]["Next"] == "PublishScannerFailureImmediate"
+        publish = states["PublishScannerFailureImmediate"]
+        assert publish["Next"] == "CheckSkipPredictorInference"
+        assert publish["Catch"][0]["Next"] == "CheckSkipPredictorInference", (
+            "an SNS failure must not abort a pipeline that deliberately continued"
+        )
 
     def test_no_direct_edge_from_arctic_to_predictor_bypassing_scanner(self, states):
         """Regression: Arctic success must not skip the new Scanner gate."""


### PR DESCRIPTION
## What broke

`sf-pipeline-policy.md` §5 permits a weekday fail-open on exactly one condition: it sets the degraded flag §2.3 requires **and pages immediately**. The second half was built for some paths and not others, and nothing checked.

Measured 2026-08-11 — the Scanner Lambda timed out twice at 300s and the pipeline fail-opened past it:

```
Scanner --Catch--> SetScannerDegradedFlag --> CheckSkipPredictorInference
```

No SNS publish anywhere on that path. The only signal was the terminal, **37 minutes later** — inside the window where an operator could still have rerun the Scanner before the 06:30 open. The sibling data-spot and deploy-drift fail-opens in the *same definition* both had one; the Scanner path, added later by `#6722`, did not, and §5 does not name it at all.

## Fixing the class found a second instance

`SetDaemonDegradedFlag` — which §5 **does** name explicitly — also went straight to the terminal. That the systemd boot trigger is a backup is *why* that stage fails open; it is not a reason to stay quiet, because a backup that also missed is exactly what an operator needs to hear before the open.

Both now publish. Nine degraded setters across the two weekday definitions:

| | Pages | Note |
|---|---|---|
| `SetScannerDegradedFlag` | **new** | the 2026-08-11 silence |
| `SetDaemonDegradedFlag` | **new** | named in §5, never built |
| `SetDataSpotDegradedFlag` (×2) | yes | |
| `SetDeployDriftDegradedFlag` | yes | |
| `SetWeeklyExerciseDegradedFlag` | yes | via `WeeklyExerciseLaunchFailed` |
| `SetMutexAcquireDegradedFlag` (×2) | **exempt** | best-effort insurance, not a producer — paging would train the operator to ignore the channel the Scanner and daemon use |
| `SetDegradedFlag` (EOD reconcile-skip) | **exempt** | routes into the heal loop, which notifies on its own outcome; paging first pages on a condition the pipeline is actively repairing |

## Membership is keyed on the Resource, not the state name

Doing this audit by hand, a `name.startswith("Publish")` heuristic reported the weekly-exercise path as silent. **It is not** — `WeeklyExerciseLaunchFailed` is an `sns:publish` that simply is not named `Publish*`. A name check produces false findings on correct code and, worse, would pass a state called `PublishFoo` that publishes nothing. A test asserts the recognition of that specific state, so a future simplification back to names fails here.

The exemption list carries two guards of its own: an entry naming a setter that no longer exists fails, and so does an entry whose path now pages. An exemption is a claim, and a claim that has quietly become false is worse than no claim.

Every publish on a degraded path carries a `Catch` back onto the continue path, asserted — otherwise an SNS outage converts a degraded run into a *failed* one, which is the opposite of fail-open.

## Two pre-existing tests updated, deliberately

Both pinned the **old direct hop** (`SetScannerDegradedFlag → CheckSkipPredictorInference`, `SetDaemonDegradedFlag → CheckDegradedOutcome`). They now assert **convergence through the publish** instead. Asserting the immediate `Next` forbids ever adding a notification to a fail-open path — which is the defect this PR fixes, encoded as a requirement.

## Validation

`aws stepfunctions validate-state-machine-definition` → `OK`, zero diagnostics.

`1964 passed, 6 skipped, 1 xfailed` across the SF suite. 11 new tests.

**Rehearsal-path:** `tests/test_degraded_paths_page_immediately.py` — repo-only; the paging topology is a property of the definition, not of a live run.

**Verified-when:** the next weekday run that degrades emits an SNS notification at the moment the fail-open fires, not only at the terminal.

## Related

- `alpha-engine-config-I6855` — the Scanner timeout that produced the silence
- `alpha-engine-config-I6902` — the optimizer ran on a fallback cost model that same morning; the new Scanner alert names that consequence in its message
- `nousergon-data-PR1299` — the terminal that named the wrong cause on the same run

Closes nousergon/alpha-engine-config#6903

Rehearsal-path: tests/test_degraded_paths_page_immediately.py

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

