### PR TITLE
[P1/low] fix(collectors): the S&P 500 changes table is a candidate list, not one pinned URL (config-I6944)

### DIFF
--- a/collectors/historical_constituents.py
+++ b/collectors/historical_constituents.py
@@ -44,7 +44,16 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-_SP500_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+# The changes table is not pinned to one page: on 2026-08-11 a Wikipedia editor
+# split it out of "List of S&P 500 companies" into its own article
+# ("move to [[Historical components of the S&P 500]], format"), which failed
+# this collector 3h later. Both candidates are tried in order and the first
+# carrying a date+added+removed table wins, so a future move back — or to a
+# third title added here — degrades to a slower fetch rather than a hard stop.
+_SP500_CHANGES_URLS = (
+    "https://en.wikipedia.org/wiki/Historical_components_of_the_S%26P_500",
+    "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies",
+)
 _HEADERS = {"User-Agent": "alpha-engine-data/1.0 (historical-constituents)"}
 
 ADDED = "added"
@@ -204,11 +213,35 @@ def build_pit_membership(
     return pit
 
 
-def _fetch_changes_table() -> pd.DataFrame:
-    resp = requests.get(_SP500_URL, headers=_HEADERS, timeout=15)
-    resp.raise_for_status()
-    tables = pd.read_html(StringIO(resp.text))
-    return select_changes_table(tables)
+def _fetch_changes_table(
+    urls: tuple[str, ...] = _SP500_CHANGES_URLS,
+) -> tuple[pd.DataFrame, str]:
+    """Return the changes table and the URL it actually came from.
+
+    Tries each candidate in order; a fetch error or a page with no matching
+    table falls through to the next. Raises only when every candidate fails,
+    naming what was tried and why each one did not serve."""
+    failures = []
+    for url in urls:
+        try:
+            resp = requests.get(url, headers=_HEADERS, timeout=15)
+            resp.raise_for_status()
+            df = select_changes_table(pd.read_html(StringIO(resp.text)))
+        except Exception as exc:  # noqa: BLE001 — recorded and re-raised below
+            failures.append(f"{url}: {type(exc).__name__}: {exc}")
+            continue
+        if failures:
+            logger.warning(
+                "historical_constituents: changes table served by fallback %s "
+                "(earlier candidates failed: %s)", url, "; ".join(failures),
+            )
+        return df, url
+    raise RuntimeError(
+        "No S&P 500 'Selected changes to the list' table found on any known "
+        "Wikipedia page (need columns matching date + added + removed). "
+        "Wikipedia layout drift — add the new article to _SP500_CHANGES_URLS. "
+        "Tried: " + " | ".join(failures)
+    )
 
 
 def collect(
@@ -224,12 +257,13 @@ def collect(
     roster and keeps the two collectors' rosters consistent. Writes
     ``{s3_prefix}historical_constituents.json`` per the memo's recommended
     path."""
-    changes = parse_changes_table(_fetch_changes_table())
+    changes_table, source_url = _fetch_changes_table()
+    changes = parse_changes_table(changes_table)
     pit = build_pit_membership(current_tickers, changes)
 
     result = {
         "schema_version": 1,
-        "source": _SP500_URL,
+        "source": source_url,
         "index": "S&P 500",
         "current_count": len(current_tickers),
         "n_changes": len(changes),

--- a/tests/test_historical_constituents.py
+++ b/tests/test_historical_constituents.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+import collectors.historical_constituents as hc
 from collectors.historical_constituents import (
     ADDED,
     REMOVED,
@@ -125,3 +126,82 @@ def test_delisted_ticker_reappears_in_historical_universe():
     changes = [ConstituentChange("2024-06-01", "DELISTED", REMOVED)]
     pit = build_pit_membership(current, changes)
     assert "DELISTED" in pit["2024-06-01"]
+
+
+# ── Source failover (config-I6944) ─────────────────────────────────────────
+#
+# The changes table moved off "List of S&P 500 companies" into its own
+# article on 2026-08-11 and hard-failed DataPhase1 of the weekly SF three
+# hours later. These pin the failover: a candidate that 404s, or that serves
+# a page with no changes table, must fall through to the next one.
+
+
+class _FakeResponse:
+    def __init__(self, text: str, ok: bool = True):
+        self.text = text
+        self._ok = ok
+
+    def raise_for_status(self):
+        if not self._ok:
+            raise RuntimeError("HTTP 404")
+
+
+def _install_fake_fetch(monkeypatch, pages: dict[str, object]):
+    """Map url -> _FakeResponse; read_html returns the tables keyed by text."""
+    tables_by_text: dict[str, list[pd.DataFrame]] = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        entry = pages[url]
+        if isinstance(entry, _FakeResponse):
+            return entry
+        text = f"page:{url}"
+        tables_by_text[text] = entry
+        return _FakeResponse(text)
+
+    monkeypatch.setattr(hc.requests, "get", fake_get)
+    monkeypatch.setattr(hc.pd, "read_html", lambda buf: tables_by_text[buf.getvalue()])
+
+
+def test_fetch_falls_through_to_the_next_url_when_a_page_lacks_the_table(monkeypatch):
+    roster_only = [pd.DataFrame({"Symbol": ["AAPL"], "GICS Sector": ["Tech"]})]
+    _install_fake_fetch(
+        monkeypatch,
+        {"https://a.example/moved": roster_only, "https://b.example/old": [_changes_df()]},
+    )
+    df, url = hc._fetch_changes_table(
+        ("https://a.example/moved", "https://b.example/old")
+    )
+    assert url == "https://b.example/old"
+    assert any("added" in str(c).lower() for c in df.columns)
+
+
+def test_fetch_falls_through_when_a_page_errors(monkeypatch):
+    _install_fake_fetch(
+        monkeypatch,
+        {
+            "https://a.example/gone": _FakeResponse("", ok=False),
+            "https://b.example/old": [_changes_df()],
+        },
+    )
+    _, url = hc._fetch_changes_table(
+        ("https://a.example/gone", "https://b.example/old")
+    )
+    assert url == "https://b.example/old"
+
+
+def test_fetch_raises_naming_every_candidate_when_all_fail(monkeypatch):
+    roster_only = [pd.DataFrame({"Symbol": ["AAPL"]})]
+    _install_fake_fetch(
+        monkeypatch,
+        {"https://a.example/one": roster_only, "https://b.example/two": roster_only},
+    )
+    with pytest.raises(RuntimeError) as exc:
+        hc._fetch_changes_table(("https://a.example/one", "https://b.example/two"))
+    # A failure that names only the last URL tried sends the reader to the
+    # wrong page; both candidates must appear.
+    assert "a.example/one" in str(exc.value) and "b.example/two" in str(exc.value)
+
+
+def test_the_dedicated_article_is_tried_before_the_roster_page():
+    assert hc._SP500_CHANGES_URLS[0].endswith("Historical_components_of_the_S%26P_500")
+    assert "List_of_S%26P_500_companies" in hc._SP500_CHANGES_URLS[1]


### PR DESCRIPTION
Restores the Weekly Freshness SF, which failed 2026-08-11 in `DataPhase1` after 1h48m (execution `ed3c8b3d-4996-4446-8e30-653b486f4e3b`).

## Root cause — external, not a regression

Wikipedia revision `2026-08-11T19:09:37Z` by `Pats322`, comment **"move to [[Historical components of the S&P 500]], format"**, split the "Selected changes to the list" table out of `List_of_S%26P_500_companies` into its own article. Page size 220251 -> 86907 bytes. The SF ran ~3h later against the pinned roster URL and `select_changes_table` correctly raised. Collector code unchanged since #490. Last success 2026-08-07 (772 changes, 307 snapshots).

## Change

`_SP500_CHANGES_URLS` is an ordered candidate tuple — dedicated article first, roster page second. `_fetch_changes_table()` tries each; a fetch error or a page with no date+added+removed table falls through. It raises only when all fail, naming every candidate and its failure instead of implying one page. The URL that served is recorded in `result["source"]`.

## Verification

- Live end-to-end against real Wikipedia: **772 changes / 307 snapshots** — identical to the 2026-08-07 successful run.
- `tests/test_historical_constituents.py`: 4 new tests — fall-through on a table-less page, fall-through on an HTTP error, the raise names every candidate, and the dedicated article is ordered first. 12 passed.
- Full suite: **5008 passed, 9 skipped, 1 xfailed** (run with `PYTHONPATH` at a `v0.124.47` nousergon-lib worktree — the shared `.venv` is stale on `nousergon_lib.shell_guards`, unrelated to this change).

## Out of scope, filed

- **alpha-engine-config#6946** — a fallback URL buys time; it does not remove a user-editable wiki as the sole source of a load-bearing backtest input. Self-source membership forward from our own `constituents.json` snapshots, freeze the pre-collection bootstrap, attest the seam.
- **alpha-engine-config#6945** — the actual cause never reached the alert. A 617-ticker split-jump audit dump consumed the 24KB stderr cap, so the SF `cause` field showed a git fetch banner instead.

No post-merge step. The next `data-weekly` run picks this up on its `git pull`.

Closes #6944

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
