### PR TITLE
[P2/high] feat(collectors): point-in-time membership is self-sourced; Wikipedia becomes the auditor (config-I6946)

### DIFF
--- a/collectors/constituents.py
+++ b/collectors/constituents.py
@@ -196,9 +196,39 @@ def collect(
         tickers, sector_etf_map, sub_industry_map
     )
 
+    # Explicit per-index rosters (alpha-engine-config-I6946). `tickers` is the
+    # SPY batch followed by the MDY batch, so the S&P 500 slice was recoverable
+    # only as `tickers[:sp500_count]` — an ORDERING contract that nothing
+    # declared and no test held. historical_constituents now diffs these
+    # snapshots to derive index membership changes, which makes a silent
+    # reordering here a burst of fabricated index churn there. Naming the two
+    # lists retires the dependency for every snapshot written from now on;
+    # `_sp500_roster` falls back to the prefix for the ones already on S3.
+    #
+    # The slice is only sound when the counts account for the whole list —
+    # `tickers` is deduped, so an overlap between the two funds would shorten
+    # it without moving either count. When they disagree the keys are OMITTED
+    # rather than written wrong: a reader that finds them absent falls back to
+    # the same guarded prefix, where a reader that finds them WRONG has no way
+    # to tell.
+    per_index: dict[str, list[str]] = {}
+    if sp500_count + sp400_count == len(tickers):
+        per_index = {
+            "sp500_tickers": tickers[:sp500_count],
+            "sp400_tickers": tickers[sp500_count:],
+        }
+    else:
+        logger.warning(
+            "constituents: sp500_count(%d) + sp400_count(%d) != len(tickers)(%d) "
+            "— omitting sp500_tickers/sp400_tickers rather than slicing on a "
+            "count that does not describe this list (config-I6946)",
+            sp500_count, sp400_count, len(tickers),
+        )
+
     result = {
         "date": run_date,
         "tickers": tickers,
+        **per_index,
         "sector_map": sector_map,
         "sector_etf_map": sector_etf_map,
         "sub_industry_map": sub_industry_map,

--- a/collectors/data/sp500_changes_frozen_pre_2026_04_04.json
+++ b/collectors/data/sp500_changes_frozen_pre_2026_04_04.json
@@ -1,0 +1,3804 @@
+{
+ "changes": [
+  {
+   "action": "removed",
+   "date": "1976-07-01",
+   "ticker": "AYE"
+  },
+  {
+   "action": "added",
+   "date": "1976-07-01",
+   "ticker": "BUD"
+  },
+  {
+   "action": "added",
+   "date": "1976-07-01",
+   "ticker": "DIS"
+  },
+  {
+   "action": "removed",
+   "date": "1976-07-01",
+   "ticker": "HNG"
+  },
+  {
+   "action": "removed",
+   "date": "1994-09-30",
+   "ticker": "MCK"
+  },
+  {
+   "action": "added",
+   "date": "1994-09-30",
+   "ticker": "NCC"
+  },
+  {
+   "action": "added",
+   "date": "1997-06-17",
+   "ticker": "CCR"
+  },
+  {
+   "action": "removed",
+   "date": "1997-06-17",
+   "ticker": "USL"
+  },
+  {
+   "action": "removed",
+   "date": "1998-12-11",
+   "ticker": "AN"
+  },
+  {
+   "action": "added",
+   "date": "1998-12-11",
+   "ticker": "CCL"
+  },
+  {
+   "action": "added",
+   "date": "1998-12-11",
+   "ticker": "CPWR"
+  },
+  {
+   "action": "added",
+   "date": "1998-12-11",
+   "ticker": "FSR"
+  },
+  {
+   "action": "removed",
+   "date": "1998-12-11",
+   "ticker": "GRN"
+  },
+  {
+   "action": "removed",
+   "date": "1998-12-11",
+   "ticker": "SUN"
+  },
+  {
+   "action": "added",
+   "date": "1999-04-12",
+   "ticker": "ACT"
+  },
+  {
+   "action": "removed",
+   "date": "1999-06-09",
+   "ticker": "HPH"
+  },
+  {
+   "action": "added",
+   "date": "1999-06-09",
+   "ticker": "WLP"
+  },
+  {
+   "action": "removed",
+   "date": "1999-12-08",
+   "ticker": "LDW"
+  },
+  {
+   "action": "added",
+   "date": "1999-12-08",
+   "ticker": "YHOO"
+  },
+  {
+   "action": "added",
+   "date": "2000-06-07",
+   "ticker": "SBUX"
+  },
+  {
+   "action": "removed",
+   "date": "2000-06-07",
+   "ticker": "SMS"
+  },
+  {
+   "action": "added",
+   "date": "2000-06-12",
+   "ticker": "CVG"
+  },
+  {
+   "action": "removed",
+   "date": "2000-06-12",
+   "ticker": "TMC"
+  },
+  {
+   "action": "added",
+   "date": "2000-07-27",
+   "ticker": "JDSU"
+  },
+  {
+   "action": "removed",
+   "date": "2000-07-27",
+   "ticker": "RAD"
+  },
+  {
+   "action": "added",
+   "date": "2000-12-05",
+   "ticker": "ABK"
+  },
+  {
+   "action": "added",
+   "date": "2000-12-05",
+   "ticker": "AYE"
+  },
+  {
+   "action": "removed",
+   "date": "2000-12-05",
+   "ticker": "BS"
+  },
+  {
+   "action": "removed",
+   "date": "2000-12-05",
+   "ticker": "CCK"
+  },
+  {
+   "action": "removed",
+   "date": "2000-12-05",
+   "ticker": "GRA"
+  },
+  {
+   "action": "added",
+   "date": "2000-12-05",
+   "ticker": "INTU"
+  },
+  {
+   "action": "removed",
+   "date": "2000-12-05",
+   "ticker": "OI"
+  },
+  {
+   "action": "added",
+   "date": "2000-12-05",
+   "ticker": "SBL"
+  },
+  {
+   "action": "added",
+   "date": "2003-09-25",
+   "ticker": "ESRX"
+  },
+  {
+   "action": "removed",
+   "date": "2003-09-25",
+   "ticker": "QTRN"
+  },
+  {
+   "action": "removed",
+   "date": "2005-07-01",
+   "ticker": "GLK"
+  },
+  {
+   "action": "added",
+   "date": "2005-07-01",
+   "ticker": "STZ"
+  },
+  {
+   "action": "added",
+   "date": "2005-11-18",
+   "ticker": "AMZN"
+  },
+  {
+   "action": "removed",
+   "date": "2005-11-18",
+   "ticker": "T"
+  },
+  {
+   "action": "removed",
+   "date": "2006-06-02",
+   "ticker": "ABS"
+  },
+  {
+   "action": "added",
+   "date": "2006-06-02",
+   "ticker": "JNPR"
+  },
+  {
+   "action": "added",
+   "date": "2007-01-10",
+   "ticker": "AVB"
+  },
+  {
+   "action": "removed",
+   "date": "2007-01-10",
+   "ticker": "SBL"
+  },
+  {
+   "action": "added",
+   "date": "2007-03-30",
+   "ticker": "KFT"
+  },
+  {
+   "action": "removed",
+   "date": "2007-03-30",
+   "ticker": "TSG"
+  },
+  {
+   "action": "removed",
+   "date": "2007-07-02",
+   "ticker": "ADCT"
+  },
+  {
+   "action": "added",
+   "date": "2007-07-02",
+   "ticker": "DFS"
+  },
+  {
+   "action": "removed",
+   "date": "2007-08-24",
+   "ticker": "KSE"
+  },
+  {
+   "action": "added",
+   "date": "2007-08-24",
+   "ticker": "LUK"
+  },
+  {
+   "action": "removed",
+   "date": "2007-09-26",
+   "ticker": "FDC"
+  },
+  {
+   "action": "added",
+   "date": "2007-09-26",
+   "ticker": "ICE"
+  },
+  {
+   "action": "removed",
+   "date": "2007-09-27",
+   "ticker": "MXIM"
+  },
+  {
+   "action": "added",
+   "date": "2007-09-27",
+   "ticker": "TSO"
+  },
+  {
+   "action": "removed",
+   "date": "2007-10-01",
+   "ticker": "NCR"
+  },
+  {
+   "action": "added",
+   "date": "2007-10-01",
+   "ticker": "TDC"
+  },
+  {
+   "action": "added",
+   "date": "2007-10-02",
+   "ticker": "EXPE"
+  },
+  {
+   "action": "removed",
+   "date": "2007-10-02",
+   "ticker": "SLR"
+  },
+  {
+   "action": "removed",
+   "date": "2007-10-26",
+   "ticker": "AV"
+  },
+  {
+   "action": "added",
+   "date": "2007-10-26",
+   "ticker": "JEC"
+  },
+  {
+   "action": "removed",
+   "date": "2007-12-13",
+   "ticker": "DJ"
+  },
+  {
+   "action": "added",
+   "date": "2007-12-13",
+   "ticker": "GME"
+  },
+  {
+   "action": "added",
+   "date": "2007-12-20",
+   "ticker": "RRC"
+  },
+  {
+   "action": "removed",
+   "date": "2007-12-20",
+   "ticker": "TRB"
+  },
+  {
+   "action": "removed",
+   "date": "2008-06-10",
+   "ticker": "ABK"
+  },
+  {
+   "action": "added",
+   "date": "2008-06-10",
+   "ticker": "LO"
+  },
+  {
+   "action": "removed",
+   "date": "2008-06-23",
+   "ticker": "BC"
+  },
+  {
+   "action": "added",
+   "date": "2008-06-23",
+   "ticker": "COG"
+  },
+  {
+   "action": "added",
+   "date": "2008-06-23",
+   "ticker": "MEE"
+  },
+  {
+   "action": "removed",
+   "date": "2008-06-23",
+   "ticker": "OMX"
+  },
+  {
+   "action": "added",
+   "date": "2008-07-01",
+   "ticker": "AKS"
+  },
+  {
+   "action": "removed",
+   "date": "2008-07-01",
+   "ticker": "CFC"
+  },
+  {
+   "action": "added",
+   "date": "2008-09-12",
+   "ticker": "CRM"
+  },
+  {
+   "action": "added",
+   "date": "2008-09-12",
+   "ticker": "FAST"
+  },
+  {
+   "action": "removed",
+   "date": "2008-09-12",
+   "ticker": "FNM"
+  },
+  {
+   "action": "removed",
+   "date": "2008-09-12",
+   "ticker": "FRE"
+  },
+  {
+   "action": "added",
+   "date": "2008-09-16",
+   "ticker": "HRS"
+  },
+  {
+   "action": "removed",
+   "date": "2008-09-16",
+   "ticker": "LEH"
+  },
+  {
+   "action": "added",
+   "date": "2008-12-31",
+   "ticker": "OI"
+  },
+  {
+   "action": "removed",
+   "date": "2008-12-31",
+   "ticker": "WB"
+  },
+  {
+   "action": "removed",
+   "date": "2009-03-03",
+   "ticker": "ACAS"
+  },
+  {
+   "action": "added",
+   "date": "2009-03-03",
+   "ticker": "HRL"
+  },
+  {
+   "action": "removed",
+   "date": "2009-03-03",
+   "ticker": "JNY"
+  },
+  {
+   "action": "added",
+   "date": "2009-03-03",
+   "ticker": "VTR"
+  },
+  {
+   "action": "removed",
+   "date": "2009-06-05",
+   "ticker": "COV"
+  },
+  {
+   "action": "added",
+   "date": "2009-06-05",
+   "ticker": "FTI"
+  },
+  {
+   "action": "removed",
+   "date": "2009-06-25",
+   "ticker": "TEL"
+  },
+  {
+   "action": "added",
+   "date": "2009-06-29",
+   "ticker": "PCS"
+  },
+  {
+   "action": "removed",
+   "date": "2009-08-19",
+   "ticker": "CTX"
+  },
+  {
+   "action": "added",
+   "date": "2009-08-19",
+   "ticker": "FMC"
+  },
+  {
+   "action": "added",
+   "date": "2009-09-28",
+   "ticker": "ARG"
+  },
+  {
+   "action": "removed",
+   "date": "2009-09-28",
+   "ticker": "CBE"
+  },
+  {
+   "action": "added",
+   "date": "2009-11-03",
+   "ticker": "PCLN"
+  },
+  {
+   "action": "removed",
+   "date": "2009-11-03",
+   "ticker": "SGP"
+  },
+  {
+   "action": "removed",
+   "date": "2009-12-18",
+   "ticker": "CIEN"
+  },
+  {
+   "action": "added",
+   "date": "2009-12-18",
+   "ticker": "CLF"
+  },
+  {
+   "action": "removed",
+   "date": "2009-12-18",
+   "ticker": "CVG"
+  },
+  {
+   "action": "removed",
+   "date": "2009-12-18",
+   "ticker": "DYN"
+  },
+  {
+   "action": "removed",
+   "date": "2009-12-18",
+   "ticker": "KBH"
+  },
+  {
+   "action": "removed",
+   "date": "2009-12-18",
+   "ticker": "MBI"
+  },
+  {
+   "action": "added",
+   "date": "2009-12-18",
+   "ticker": "MJN"
+  },
+  {
+   "action": "added",
+   "date": "2009-12-18",
+   "ticker": "ROST"
+  },
+  {
+   "action": "added",
+   "date": "2009-12-18",
+   "ticker": "SAI"
+  },
+  {
+   "action": "added",
+   "date": "2009-12-18",
+   "ticker": "V"
+  },
+  {
+   "action": "added",
+   "date": "2010-02-26",
+   "ticker": "HP"
+  },
+  {
+   "action": "removed",
+   "date": "2010-02-26",
+   "ticker": "RX"
+  },
+  {
+   "action": "removed",
+   "date": "2010-04-29",
+   "ticker": "BJS"
+  },
+  {
+   "action": "added",
+   "date": "2010-04-29",
+   "ticker": "CERN"
+  },
+  {
+   "action": "added",
+   "date": "2010-06-28",
+   "ticker": "KMX"
+  },
+  {
+   "action": "removed",
+   "date": "2010-06-28",
+   "ticker": "XTO"
+  },
+  {
+   "action": "added",
+   "date": "2010-06-30",
+   "ticker": "QEP"
+  },
+  {
+   "action": "removed",
+   "date": "2010-06-30",
+   "ticker": "STR"
+  },
+  {
+   "action": "added",
+   "date": "2010-07-14",
+   "ticker": "CB"
+  },
+  {
+   "action": "removed",
+   "date": "2010-07-14",
+   "ticker": "MIL"
+  },
+  {
+   "action": "removed",
+   "date": "2010-08-26",
+   "ticker": "SII"
+  },
+  {
+   "action": "added",
+   "date": "2010-08-26",
+   "ticker": "TYC"
+  },
+  {
+   "action": "added",
+   "date": "2010-11-17",
+   "ticker": "IR"
+  },
+  {
+   "action": "removed",
+   "date": "2010-11-17",
+   "ticker": "PTV"
+  },
+  {
+   "action": "added",
+   "date": "2010-12-17",
+   "ticker": "CVC"
+  },
+  {
+   "action": "removed",
+   "date": "2010-12-17",
+   "ticker": "EK"
+  },
+  {
+   "action": "added",
+   "date": "2010-12-17",
+   "ticker": "FFIV"
+  },
+  {
+   "action": "removed",
+   "date": "2010-12-17",
+   "ticker": "KG"
+  },
+  {
+   "action": "added",
+   "date": "2010-12-17",
+   "ticker": "NFLX"
+  },
+  {
+   "action": "added",
+   "date": "2010-12-17",
+   "ticker": "NFX"
+  },
+  {
+   "action": "removed",
+   "date": "2010-12-17",
+   "ticker": "NYT"
+  },
+  {
+   "action": "removed",
+   "date": "2010-12-17",
+   "ticker": "ODP"
+  },
+  {
+   "action": "removed",
+   "date": "2011-01-03",
+   "ticker": "MDP"
+  },
+  {
+   "action": "added",
+   "date": "2011-01-03",
+   "ticker": "MMI"
+  },
+  {
+   "action": "removed",
+   "date": "2011-02-25",
+   "ticker": "AYE"
+  },
+  {
+   "action": "added",
+   "date": "2011-02-25",
+   "ticker": "JOYG"
+  },
+  {
+   "action": "added",
+   "date": "2011-02-28",
+   "ticker": "COV"
+  },
+  {
+   "action": "removed",
+   "date": "2011-02-28",
+   "ticker": "MFE"
+  },
+  {
+   "action": "added",
+   "date": "2011-03-31",
+   "ticker": "EW"
+  },
+  {
+   "action": "removed",
+   "date": "2011-03-31",
+   "ticker": "Q"
+  },
+  {
+   "action": "added",
+   "date": "2011-04-01",
+   "ticker": "BLK"
+  },
+  {
+   "action": "removed",
+   "date": "2011-04-01",
+   "ticker": "GENZ"
+  },
+  {
+   "action": "added",
+   "date": "2011-04-27",
+   "ticker": "CMG"
+  },
+  {
+   "action": "removed",
+   "date": "2011-04-27",
+   "ticker": "NOVL"
+  },
+  {
+   "action": "added",
+   "date": "2011-06-01",
+   "ticker": "ANR"
+  },
+  {
+   "action": "removed",
+   "date": "2011-06-01",
+   "ticker": "MEE"
+  },
+  {
+   "action": "added",
+   "date": "2011-06-30",
+   "ticker": "MPC"
+  },
+  {
+   "action": "removed",
+   "date": "2011-06-30",
+   "ticker": "RSH"
+  },
+  {
+   "action": "added",
+   "date": "2011-07-05",
+   "ticker": "ACN"
+  },
+  {
+   "action": "removed",
+   "date": "2011-07-05",
+   "ticker": "MI"
+  },
+  {
+   "action": "added",
+   "date": "2011-09-23",
+   "ticker": "MOS"
+  },
+  {
+   "action": "removed",
+   "date": "2011-09-23",
+   "ticker": "NSM"
+  },
+  {
+   "action": "removed",
+   "date": "2011-10-14",
+   "ticker": "CEPH"
+  },
+  {
+   "action": "added",
+   "date": "2011-10-14",
+   "ticker": "TEL"
+  },
+  {
+   "action": "removed",
+   "date": "2011-10-31",
+   "ticker": "ITT"
+  },
+  {
+   "action": "added",
+   "date": "2011-10-31",
+   "ticker": "XYL"
+  },
+  {
+   "action": "added",
+   "date": "2011-11-18",
+   "ticker": "CBE"
+  },
+  {
+   "action": "removed",
+   "date": "2011-11-18",
+   "ticker": "JNS"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-12",
+   "ticker": "GAS"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-12",
+   "ticker": "GAS"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-16",
+   "ticker": "AKS"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-16",
+   "ticker": "BWA"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-16",
+   "ticker": "DLTR"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-16",
+   "ticker": "MWW"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-16",
+   "ticker": "PRGO"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-16",
+   "ticker": "WFR"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-20",
+   "ticker": "TLAB"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-20",
+   "ticker": "TRIP"
+  },
+  {
+   "action": "removed",
+   "date": "2011-12-31",
+   "ticker": "CPWR"
+  },
+  {
+   "action": "added",
+   "date": "2011-12-31",
+   "ticker": "WPX"
+  },
+  {
+   "action": "added",
+   "date": "2012-03-13",
+   "ticker": "CCI"
+  },
+  {
+   "action": "removed",
+   "date": "2012-03-13",
+   "ticker": "CEG"
+  },
+  {
+   "action": "added",
+   "date": "2012-04-03",
+   "ticker": "FOSL"
+  },
+  {
+   "action": "removed",
+   "date": "2012-04-03",
+   "ticker": "MHS"
+  },
+  {
+   "action": "added",
+   "date": "2012-04-23",
+   "ticker": "PSX"
+  },
+  {
+   "action": "removed",
+   "date": "2012-04-23",
+   "ticker": "SVU"
+  },
+  {
+   "action": "removed",
+   "date": "2012-05-17",
+   "ticker": "EP"
+  },
+  {
+   "action": "added",
+   "date": "2012-05-17",
+   "ticker": "KMI"
+  },
+  {
+   "action": "added",
+   "date": "2012-05-21",
+   "ticker": "ALXN"
+  },
+  {
+   "action": "removed",
+   "date": "2012-05-21",
+   "ticker": "MMI"
+  },
+  {
+   "action": "added",
+   "date": "2012-06-05",
+   "ticker": "LRCX"
+  },
+  {
+   "action": "removed",
+   "date": "2012-06-05",
+   "ticker": "NVLS"
+  },
+  {
+   "action": "added",
+   "date": "2012-06-29",
+   "ticker": "MNST"
+  },
+  {
+   "action": "removed",
+   "date": "2012-06-29",
+   "ticker": "SLE"
+  },
+  {
+   "action": "removed",
+   "date": "2012-07-02",
+   "ticker": "PGN"
+  },
+  {
+   "action": "added",
+   "date": "2012-07-02",
+   "ticker": "STX"
+  },
+  {
+   "action": "added",
+   "date": "2012-07-31",
+   "ticker": "ESV"
+  },
+  {
+   "action": "removed",
+   "date": "2012-07-31",
+   "ticker": "GR"
+  },
+  {
+   "action": "added",
+   "date": "2012-09-05",
+   "ticker": "LYB"
+  },
+  {
+   "action": "removed",
+   "date": "2012-09-05",
+   "ticker": "SHLD"
+  },
+  {
+   "action": "added",
+   "date": "2012-10-01",
+   "ticker": "ADT"
+  },
+  {
+   "action": "removed",
+   "date": "2012-10-01",
+   "ticker": "DV"
+  },
+  {
+   "action": "removed",
+   "date": "2012-10-01",
+   "ticker": "LXK"
+  },
+  {
+   "action": "added",
+   "date": "2012-10-01",
+   "ticker": "PNR"
+  },
+  {
+   "action": "removed",
+   "date": "2012-10-02",
+   "ticker": "ANR"
+  },
+  {
+   "action": "removed",
+   "date": "2012-10-02",
+   "ticker": "KFT"
+  },
+  {
+   "action": "added",
+   "date": "2012-10-02",
+   "ticker": "KRFT"
+  },
+  {
+   "action": "added",
+   "date": "2012-10-02",
+   "ticker": "MDLZ"
+  },
+  {
+   "action": "added",
+   "date": "2012-10-10",
+   "ticker": "PETM"
+  },
+  {
+   "action": "removed",
+   "date": "2012-10-10",
+   "ticker": "SUN"
+  },
+  {
+   "action": "removed",
+   "date": "2012-12-03",
+   "ticker": "CBE"
+  },
+  {
+   "action": "added",
+   "date": "2012-12-03",
+   "ticker": "DG"
+  },
+  {
+   "action": "added",
+   "date": "2012-12-11",
+   "ticker": "GRMN"
+  },
+  {
+   "action": "removed",
+   "date": "2012-12-11",
+   "ticker": "RRD"
+  },
+  {
+   "action": "added",
+   "date": "2012-12-21",
+   "ticker": "DLPH"
+  },
+  {
+   "action": "removed",
+   "date": "2012-12-21",
+   "ticker": "TIE"
+  },
+  {
+   "action": "added",
+   "date": "2013-01-02",
+   "ticker": "ABBV"
+  },
+  {
+   "action": "removed",
+   "date": "2013-01-02",
+   "ticker": "FII"
+  },
+  {
+   "action": "removed",
+   "date": "2013-02-15",
+   "ticker": "BIG"
+  },
+  {
+   "action": "added",
+   "date": "2013-02-15",
+   "ticker": "PVH"
+  },
+  {
+   "action": "removed",
+   "date": "2013-04-30",
+   "ticker": "PCS"
+  },
+  {
+   "action": "added",
+   "date": "2013-04-30",
+   "ticker": "REGN"
+  },
+  {
+   "action": "removed",
+   "date": "2013-05-08",
+   "ticker": "CVH"
+  },
+  {
+   "action": "added",
+   "date": "2013-05-08",
+   "ticker": "MAC"
+  },
+  {
+   "action": "removed",
+   "date": "2013-05-23",
+   "ticker": "DF"
+  },
+  {
+   "action": "added",
+   "date": "2013-05-23",
+   "ticker": "KSU"
+  },
+  {
+   "action": "added",
+   "date": "2013-06-06",
+   "ticker": "GM"
+  },
+  {
+   "action": "removed",
+   "date": "2013-06-06",
+   "ticker": "HNZ"
+  },
+  {
+   "action": "removed",
+   "date": "2013-06-21",
+   "ticker": "FHN"
+  },
+  {
+   "action": "added",
+   "date": "2013-06-21",
+   "ticker": "ZTS"
+  },
+  {
+   "action": "removed",
+   "date": "2013-07-01",
+   "ticker": "APOL"
+  },
+  {
+   "action": "added",
+   "date": "2013-07-01",
+   "ticker": "NWSA"
+  },
+  {
+   "action": "added",
+   "date": "2013-07-08",
+   "ticker": "NLSN"
+  },
+  {
+   "action": "removed",
+   "date": "2013-07-08",
+   "ticker": "S"
+  },
+  {
+   "action": "removed",
+   "date": "2013-09-10",
+   "ticker": "BMC"
+  },
+  {
+   "action": "added",
+   "date": "2013-09-10",
+   "ticker": "DAL"
+  },
+  {
+   "action": "removed",
+   "date": "2013-09-20",
+   "ticker": "AMD"
+  },
+  {
+   "action": "added",
+   "date": "2013-09-20",
+   "ticker": "AME"
+  },
+  {
+   "action": "removed",
+   "date": "2013-09-20",
+   "ticker": "SAI"
+  },
+  {
+   "action": "added",
+   "date": "2013-09-20",
+   "ticker": "VRTX"
+  },
+  {
+   "action": "removed",
+   "date": "2013-10-29",
+   "ticker": "DELL"
+  },
+  {
+   "action": "added",
+   "date": "2013-10-29",
+   "ticker": "RIG"
+  },
+  {
+   "action": "added",
+   "date": "2013-11-13",
+   "ticker": "KORS"
+  },
+  {
+   "action": "removed",
+   "date": "2013-11-13",
+   "ticker": "NYX"
+  },
+  {
+   "action": "added",
+   "date": "2013-12-02",
+   "ticker": "ALLE"
+  },
+  {
+   "action": "removed",
+   "date": "2013-12-02",
+   "ticker": "JCP"
+  },
+  {
+   "action": "added",
+   "date": "2013-12-10",
+   "ticker": "GGP"
+  },
+  {
+   "action": "removed",
+   "date": "2013-12-10",
+   "ticker": "MOLX"
+  },
+  {
+   "action": "added",
+   "date": "2013-12-23",
+   "ticker": "ADS"
+  },
+  {
+   "action": "removed",
+   "date": "2013-12-23",
+   "ticker": "ANF"
+  },
+  {
+   "action": "added",
+   "date": "2013-12-23",
+   "ticker": "FB"
+  },
+  {
+   "action": "removed",
+   "date": "2013-12-23",
+   "ticker": "JDSU"
+  },
+  {
+   "action": "added",
+   "date": "2013-12-23",
+   "ticker": "MHK"
+  },
+  {
+   "action": "removed",
+   "date": "2013-12-23",
+   "ticker": "TER"
+  },
+  {
+   "action": "removed",
+   "date": "2014-01-24",
+   "ticker": "LIFE"
+  },
+  {
+   "action": "added",
+   "date": "2014-01-24",
+   "ticker": "TSCO"
+  },
+  {
+   "action": "added",
+   "date": "2014-03-21",
+   "ticker": "GMCR"
+  },
+  {
+   "action": "removed",
+   "date": "2014-03-21",
+   "ticker": "WPX"
+  },
+  {
+   "action": "removed",
+   "date": "2014-04-02",
+   "ticker": "CLF"
+  },
+  {
+   "action": "added",
+   "date": "2014-04-02",
+   "ticker": "ESS"
+  },
+  {
+   "action": "added",
+   "date": "2014-04-03",
+   "ticker": "GOOGL"
+  },
+  {
+   "action": "removed",
+   "date": "2014-05-01",
+   "ticker": "BEAM"
+  },
+  {
+   "action": "added",
+   "date": "2014-05-01",
+   "ticker": "NAVI"
+  },
+  {
+   "action": "removed",
+   "date": "2014-05-01",
+   "ticker": "SLM"
+  },
+  {
+   "action": "added",
+   "date": "2014-05-01",
+   "ticker": "UA"
+  },
+  {
+   "action": "added",
+   "date": "2014-05-08",
+   "ticker": "AVGO"
+  },
+  {
+   "action": "removed",
+   "date": "2014-05-08",
+   "ticker": "LSI"
+  },
+  {
+   "action": "removed",
+   "date": "2014-06-20",
+   "ticker": "IGT"
+  },
+  {
+   "action": "added",
+   "date": "2014-06-20",
+   "ticker": "XEC"
+  },
+  {
+   "action": "added",
+   "date": "2014-07-01",
+   "ticker": "AMG"
+  },
+  {
+   "action": "removed",
+   "date": "2014-07-01",
+   "ticker": "FRX"
+  },
+  {
+   "action": "added",
+   "date": "2014-07-02",
+   "ticker": "MLM"
+  },
+  {
+   "action": "removed",
+   "date": "2014-07-02",
+   "ticker": "X"
+  },
+  {
+   "action": "added",
+   "date": "2014-08-06",
+   "ticker": "DISCK"
+  },
+  {
+   "action": "added",
+   "date": "2014-08-18",
+   "ticker": "MNK"
+  },
+  {
+   "action": "removed",
+   "date": "2014-08-18",
+   "ticker": "RDC"
+  },
+  {
+   "action": "removed",
+   "date": "2014-09-20",
+   "ticker": "BTU"
+  },
+  {
+   "action": "removed",
+   "date": "2014-09-20",
+   "ticker": "GHC"
+  },
+  {
+   "action": "added",
+   "date": "2014-09-20",
+   "ticker": "UHS"
+  },
+  {
+   "action": "added",
+   "date": "2014-09-20",
+   "ticker": "URI"
+  },
+  {
+   "action": "removed",
+   "date": "2014-11-05",
+   "ticker": "JBL"
+  },
+  {
+   "action": "added",
+   "date": "2014-11-05",
+   "ticker": "LVLT"
+  },
+  {
+   "action": "removed",
+   "date": "2014-12-05",
+   "ticker": "BMS"
+  },
+  {
+   "action": "added",
+   "date": "2014-12-05",
+   "ticker": "RCL"
+  },
+  {
+   "action": "removed",
+   "date": "2015-01-27",
+   "ticker": "COV"
+  },
+  {
+   "action": "added",
+   "date": "2015-01-27",
+   "ticker": "ENDP"
+  },
+  {
+   "action": "added",
+   "date": "2015-01-27",
+   "ticker": "HCA"
+  },
+  {
+   "action": "removed",
+   "date": "2015-01-27",
+   "ticker": "SWY"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-12",
+   "ticker": "PETM"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-12",
+   "ticker": "SWKS"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-18",
+   "ticker": "CFN"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-18",
+   "ticker": "HSIC"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-23",
+   "ticker": "AAL"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-23",
+   "ticker": "AGN"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-23",
+   "ticker": "AVP"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-23",
+   "ticker": "DNR"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-23",
+   "ticker": "EQIX"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-23",
+   "ticker": "HBI"
+  },
+  {
+   "action": "removed",
+   "date": "2015-03-23",
+   "ticker": "NBR"
+  },
+  {
+   "action": "added",
+   "date": "2015-03-23",
+   "ticker": "SLG"
+  },
+  {
+   "action": "added",
+   "date": "2015-04-07",
+   "ticker": "O"
+  },
+  {
+   "action": "removed",
+   "date": "2015-04-07",
+   "ticker": "WIN"
+  },
+  {
+   "action": "removed",
+   "date": "2015-06-11",
+   "ticker": "LO"
+  },
+  {
+   "action": "added",
+   "date": "2015-06-11",
+   "ticker": "QRVO"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-01",
+   "ticker": "BXLT"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-01",
+   "ticker": "JBHT"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-01",
+   "ticker": "QEP"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-01",
+   "ticker": "TEG"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-02",
+   "ticker": "ATI"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-02",
+   "ticker": "CPGX"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-06",
+   "ticker": "KHC"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-06",
+   "ticker": "KRFT"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-08",
+   "ticker": "AAP"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-08",
+   "ticker": "FDO"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-20",
+   "ticker": "NE"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-20",
+   "ticker": "PYPL"
+  },
+  {
+   "action": "removed",
+   "date": "2015-07-29",
+   "ticker": "DTV"
+  },
+  {
+   "action": "added",
+   "date": "2015-07-29",
+   "ticker": "SIG"
+  },
+  {
+   "action": "added",
+   "date": "2015-08-28",
+   "ticker": "ATVI"
+  },
+  {
+   "action": "removed",
+   "date": "2015-08-28",
+   "ticker": "PLL"
+  },
+  {
+   "action": "removed",
+   "date": "2015-09-02",
+   "ticker": "HSP"
+  },
+  {
+   "action": "added",
+   "date": "2015-09-02",
+   "ticker": "UAL"
+  },
+  {
+   "action": "added",
+   "date": "2015-09-18",
+   "ticker": "CMCSK"
+  },
+  {
+   "action": "added",
+   "date": "2015-09-18",
+   "ticker": "FOX"
+  },
+  {
+   "action": "added",
+   "date": "2015-09-18",
+   "ticker": "NWS"
+  },
+  {
+   "action": "removed",
+   "date": "2015-10-07",
+   "ticker": "JOY"
+  },
+  {
+   "action": "added",
+   "date": "2015-10-07",
+   "ticker": "VRSK"
+  },
+  {
+   "action": "removed",
+   "date": "2015-11-02",
+   "ticker": "HCBK"
+  },
+  {
+   "action": "added",
+   "date": "2015-11-02",
+   "ticker": "HPE"
+  },
+  {
+   "action": "removed",
+   "date": "2015-11-18",
+   "ticker": "GNW"
+  },
+  {
+   "action": "added",
+   "date": "2015-11-18",
+   "ticker": "SYF"
+  },
+  {
+   "action": "added",
+   "date": "2015-11-19",
+   "ticker": "ILMN"
+  },
+  {
+   "action": "removed",
+   "date": "2015-11-19",
+   "ticker": "SIAL"
+  },
+  {
+   "action": "removed",
+   "date": "2015-12-01",
+   "ticker": "CSC"
+  },
+  {
+   "action": "added",
+   "date": "2015-12-01",
+   "ticker": "CSRA"
+  },
+  {
+   "action": "removed",
+   "date": "2015-12-15",
+   "ticker": "CMCSK"
+  },
+  {
+   "action": "removed",
+   "date": "2015-12-29",
+   "ticker": "ALTR"
+  },
+  {
+   "action": "added",
+   "date": "2015-12-29",
+   "ticker": "CHD"
+  },
+  {
+   "action": "removed",
+   "date": "2016-01-05",
+   "ticker": "FOSL"
+  },
+  {
+   "action": "added",
+   "date": "2016-01-05",
+   "ticker": "WLTW"
+  },
+  {
+   "action": "removed",
+   "date": "2016-01-19",
+   "ticker": "ACE"
+  },
+  {
+   "action": "added",
+   "date": "2016-01-19",
+   "ticker": "EXR"
+  },
+  {
+   "action": "removed",
+   "date": "2016-02-01",
+   "ticker": "BRCM"
+  },
+  {
+   "action": "added",
+   "date": "2016-02-01",
+   "ticker": "CFG"
+  },
+  {
+   "action": "added",
+   "date": "2016-02-01",
+   "ticker": "FRT"
+  },
+  {
+   "action": "removed",
+   "date": "2016-02-01",
+   "ticker": "PCP"
+  },
+  {
+   "action": "added",
+   "date": "2016-02-22",
+   "ticker": "CXO"
+  },
+  {
+   "action": "removed",
+   "date": "2016-02-22",
+   "ticker": "PCL"
+  },
+  {
+   "action": "added",
+   "date": "2016-03-04",
+   "ticker": "AWK"
+  },
+  {
+   "action": "removed",
+   "date": "2016-03-04",
+   "ticker": "CNX"
+  },
+  {
+   "action": "removed",
+   "date": "2016-03-07",
+   "ticker": "GMCR"
+  },
+  {
+   "action": "added",
+   "date": "2016-03-07",
+   "ticker": "UDR"
+  },
+  {
+   "action": "added",
+   "date": "2016-03-30",
+   "ticker": "CNC"
+  },
+  {
+   "action": "removed",
+   "date": "2016-03-30",
+   "ticker": "ESV"
+  },
+  {
+   "action": "added",
+   "date": "2016-03-30",
+   "ticker": "HOLX"
+  },
+  {
+   "action": "removed",
+   "date": "2016-03-30",
+   "ticker": "POM"
+  },
+  {
+   "action": "removed",
+   "date": "2016-04-04",
+   "ticker": "CAM"
+  },
+  {
+   "action": "added",
+   "date": "2016-04-04",
+   "ticker": "FL"
+  },
+  {
+   "action": "added",
+   "date": "2016-04-08",
+   "ticker": "UA"
+  },
+  {
+   "action": "removed",
+   "date": "2016-04-18",
+   "ticker": "THC"
+  },
+  {
+   "action": "added",
+   "date": "2016-04-18",
+   "ticker": "ULTA"
+  },
+  {
+   "action": "removed",
+   "date": "2016-04-25",
+   "ticker": "GME"
+  },
+  {
+   "action": "added",
+   "date": "2016-04-25",
+   "ticker": "GPN"
+  },
+  {
+   "action": "removed",
+   "date": "2016-05-03",
+   "ticker": "ADT"
+  },
+  {
+   "action": "added",
+   "date": "2016-05-03",
+   "ticker": "AYI"
+  },
+  {
+   "action": "added",
+   "date": "2016-05-13",
+   "ticker": "ALK"
+  },
+  {
+   "action": "removed",
+   "date": "2016-05-13",
+   "ticker": "SNDK"
+  },
+  {
+   "action": "added",
+   "date": "2016-05-18",
+   "ticker": "DLR"
+  },
+  {
+   "action": "removed",
+   "date": "2016-05-18",
+   "ticker": "TWC"
+  },
+  {
+   "action": "removed",
+   "date": "2016-05-23",
+   "ticker": "ARG"
+  },
+  {
+   "action": "added",
+   "date": "2016-05-23",
+   "ticker": "LKQ"
+  },
+  {
+   "action": "added",
+   "date": "2016-05-31",
+   "ticker": "AJG"
+  },
+  {
+   "action": "removed",
+   "date": "2016-05-31",
+   "ticker": "CCE"
+  },
+  {
+   "action": "removed",
+   "date": "2016-06-03",
+   "ticker": "BXLT"
+  },
+  {
+   "action": "added",
+   "date": "2016-06-03",
+   "ticker": "TDG"
+  },
+  {
+   "action": "removed",
+   "date": "2016-06-22",
+   "ticker": "CVC"
+  },
+  {
+   "action": "added",
+   "date": "2016-06-22",
+   "ticker": "FBHS"
+  },
+  {
+   "action": "added",
+   "date": "2016-07-01",
+   "ticker": "ALB"
+  },
+  {
+   "action": "removed",
+   "date": "2016-07-01",
+   "ticker": "GAS"
+  },
+  {
+   "action": "added",
+   "date": "2016-07-01",
+   "ticker": "LNT"
+  },
+  {
+   "action": "removed",
+   "date": "2016-07-01",
+   "ticker": "TE"
+  },
+  {
+   "action": "removed",
+   "date": "2016-07-05",
+   "ticker": "CPGX"
+  },
+  {
+   "action": "added",
+   "date": "2016-07-05",
+   "ticker": "FTV"
+  },
+  {
+   "action": "added",
+   "date": "2016-09-06",
+   "ticker": "MTD"
+  },
+  {
+   "action": "removed",
+   "date": "2016-09-06",
+   "ticker": "TYC"
+  },
+  {
+   "action": "added",
+   "date": "2016-09-08",
+   "ticker": "CHTR"
+  },
+  {
+   "action": "removed",
+   "date": "2016-09-08",
+   "ticker": "EMC"
+  },
+  {
+   "action": "added",
+   "date": "2016-09-22",
+   "ticker": "COO"
+  },
+  {
+   "action": "removed",
+   "date": "2016-09-22",
+   "ticker": "HOT"
+  },
+  {
+   "action": "added",
+   "date": "2016-09-30",
+   "ticker": "COTY"
+  },
+  {
+   "action": "removed",
+   "date": "2016-09-30",
+   "ticker": "DO"
+  },
+  {
+   "action": "removed",
+   "date": "2016-11-01",
+   "ticker": "AA"
+  },
+  {
+   "action": "added",
+   "date": "2016-11-01",
+   "ticker": "ARNC"
+  },
+  {
+   "action": "added",
+   "date": "2016-12-02",
+   "ticker": "EVHC"
+  },
+  {
+   "action": "removed",
+   "date": "2016-12-02",
+   "ticker": "LM"
+  },
+  {
+   "action": "added",
+   "date": "2016-12-02",
+   "ticker": "MAA"
+  },
+  {
+   "action": "removed",
+   "date": "2016-12-02",
+   "ticker": "OI"
+  },
+  {
+   "action": "added",
+   "date": "2017-01-05",
+   "ticker": "IDXX"
+  },
+  {
+   "action": "removed",
+   "date": "2017-01-05",
+   "ticker": "STJ"
+  },
+  {
+   "action": "added",
+   "date": "2017-02-28",
+   "ticker": "INCY"
+  },
+  {
+   "action": "removed",
+   "date": "2017-02-28",
+   "ticker": "SE"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-01",
+   "ticker": "CBOE"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-01",
+   "ticker": "PBI"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-02",
+   "ticker": "ENDP"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-02",
+   "ticker": "REG"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-13",
+   "ticker": "DISH"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-13",
+   "ticker": "LLTC"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-16",
+   "ticker": "HAR"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-16",
+   "ticker": "SNPS"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-20",
+   "ticker": "AMD"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-20",
+   "ticker": "ARE"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-20",
+   "ticker": "FSLR"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-20",
+   "ticker": "FTR"
+  },
+  {
+   "action": "added",
+   "date": "2017-03-20",
+   "ticker": "RJF"
+  },
+  {
+   "action": "removed",
+   "date": "2017-03-20",
+   "ticker": "URBN"
+  },
+  {
+   "action": "added",
+   "date": "2017-04-04",
+   "ticker": "DXC"
+  },
+  {
+   "action": "removed",
+   "date": "2017-04-04",
+   "ticker": "SWN"
+  },
+  {
+   "action": "removed",
+   "date": "2017-04-05",
+   "ticker": "DNB"
+  },
+  {
+   "action": "added",
+   "date": "2017-04-05",
+   "ticker": "IT"
+  },
+  {
+   "action": "added",
+   "date": "2017-06-02",
+   "ticker": "INFO"
+  },
+  {
+   "action": "removed",
+   "date": "2017-06-02",
+   "ticker": "TGNA"
+  },
+  {
+   "action": "added",
+   "date": "2017-06-19",
+   "ticker": "ALGN"
+  },
+  {
+   "action": "added",
+   "date": "2017-06-19",
+   "ticker": "ANSS"
+  },
+  {
+   "action": "added",
+   "date": "2017-06-19",
+   "ticker": "HLT"
+  },
+  {
+   "action": "removed",
+   "date": "2017-06-19",
+   "ticker": "MJN"
+  },
+  {
+   "action": "removed",
+   "date": "2017-06-19",
+   "ticker": "R"
+  },
+  {
+   "action": "added",
+   "date": "2017-06-19",
+   "ticker": "RE"
+  },
+  {
+   "action": "removed",
+   "date": "2017-06-19",
+   "ticker": "TDC"
+  },
+  {
+   "action": "removed",
+   "date": "2017-06-19",
+   "ticker": "YHOO"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-07",
+   "ticker": "BHI"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-07",
+   "ticker": "BKR"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-26",
+   "ticker": "AOS"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-26",
+   "ticker": "BBBY"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-26",
+   "ticker": "DRE"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-26",
+   "ticker": "MGM"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-26",
+   "ticker": "MNK"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-26",
+   "ticker": "MUR"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-26",
+   "ticker": "PKG"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-26",
+   "ticker": "RAI"
+  },
+  {
+   "action": "removed",
+   "date": "2017-07-26",
+   "ticker": "RIG"
+  },
+  {
+   "action": "added",
+   "date": "2017-07-26",
+   "ticker": "RMD"
+  },
+  {
+   "action": "removed",
+   "date": "2017-08-08",
+   "ticker": "AN"
+  },
+  {
+   "action": "added",
+   "date": "2017-08-08",
+   "ticker": "BHF"
+  },
+  {
+   "action": "added",
+   "date": "2017-08-29",
+   "ticker": "Q"
+  },
+  {
+   "action": "removed",
+   "date": "2017-08-29",
+   "ticker": "WFM"
+  },
+  {
+   "action": "removed",
+   "date": "2017-09-01",
+   "ticker": "DD"
+  },
+  {
+   "action": "removed",
+   "date": "2017-09-01",
+   "ticker": "DOW"
+  },
+  {
+   "action": "added",
+   "date": "2017-09-01",
+   "ticker": "DWDP"
+  },
+  {
+   "action": "added",
+   "date": "2017-09-01",
+   "ticker": "SBAC"
+  },
+  {
+   "action": "added",
+   "date": "2017-09-18",
+   "ticker": "CDNS"
+  },
+  {
+   "action": "removed",
+   "date": "2017-09-18",
+   "ticker": "SPLS"
+  },
+  {
+   "action": "removed",
+   "date": "2017-10-13",
+   "ticker": "LVLT"
+  },
+  {
+   "action": "added",
+   "date": "2017-10-13",
+   "ticker": "NCLH"
+  },
+  {
+   "action": "added",
+   "date": "2017-11-15",
+   "ticker": "IQV"
+  },
+  {
+   "action": "removed",
+   "date": "2017-11-15",
+   "ticker": "Q"
+  },
+  {
+   "action": "removed",
+   "date": "2018-01-03",
+   "ticker": "BCR"
+  },
+  {
+   "action": "added",
+   "date": "2018-01-03",
+   "ticker": "HII"
+  },
+  {
+   "action": "added",
+   "date": "2018-03-07",
+   "ticker": "IPGP"
+  },
+  {
+   "action": "removed",
+   "date": "2018-03-07",
+   "ticker": "SNI"
+  },
+  {
+   "action": "removed",
+   "date": "2018-03-19",
+   "ticker": "CHK"
+  },
+  {
+   "action": "added",
+   "date": "2018-03-19",
+   "ticker": "NKTR"
+  },
+  {
+   "action": "removed",
+   "date": "2018-03-19",
+   "ticker": "PDCO"
+  },
+  {
+   "action": "removed",
+   "date": "2018-03-19",
+   "ticker": "SIG"
+  },
+  {
+   "action": "added",
+   "date": "2018-03-19",
+   "ticker": "SIVB"
+  },
+  {
+   "action": "added",
+   "date": "2018-03-19",
+   "ticker": "TTWO"
+  },
+  {
+   "action": "removed",
+   "date": "2018-04-04",
+   "ticker": "CSRA"
+  },
+  {
+   "action": "added",
+   "date": "2018-04-04",
+   "ticker": "MSCI"
+  },
+  {
+   "action": "added",
+   "date": "2018-05-31",
+   "ticker": "ABMD"
+  },
+  {
+   "action": "removed",
+   "date": "2018-05-31",
+   "ticker": "WYN"
+  },
+  {
+   "action": "added",
+   "date": "2018-06-05",
+   "ticker": "EVRG"
+  },
+  {
+   "action": "removed",
+   "date": "2018-06-05",
+   "ticker": "NAVI"
+  },
+  {
+   "action": "removed",
+   "date": "2018-06-07",
+   "ticker": "MON"
+  },
+  {
+   "action": "added",
+   "date": "2018-06-07",
+   "ticker": "TWTR"
+  },
+  {
+   "action": "removed",
+   "date": "2018-06-18",
+   "ticker": "AYI"
+  },
+  {
+   "action": "added",
+   "date": "2018-06-18",
+   "ticker": "BR"
+  },
+  {
+   "action": "added",
+   "date": "2018-06-18",
+   "ticker": "HFC"
+  },
+  {
+   "action": "removed",
+   "date": "2018-06-18",
+   "ticker": "RRC"
+  },
+  {
+   "action": "added",
+   "date": "2018-06-20",
+   "ticker": "FLT"
+  },
+  {
+   "action": "removed",
+   "date": "2018-06-20",
+   "ticker": "TWX"
+  },
+  {
+   "action": "added",
+   "date": "2018-07-02",
+   "ticker": "CPRT"
+  },
+  {
+   "action": "removed",
+   "date": "2018-07-02",
+   "ticker": "DPS"
+  },
+  {
+   "action": "added",
+   "date": "2018-08-28",
+   "ticker": "ANET"
+  },
+  {
+   "action": "removed",
+   "date": "2018-08-28",
+   "ticker": "GGP"
+  },
+  {
+   "action": "added",
+   "date": "2018-09-14",
+   "ticker": "WCG"
+  },
+  {
+   "action": "removed",
+   "date": "2018-09-14",
+   "ticker": "XL"
+  },
+  {
+   "action": "removed",
+   "date": "2018-10-01",
+   "ticker": "ANDV"
+  },
+  {
+   "action": "added",
+   "date": "2018-10-01",
+   "ticker": "ROL"
+  },
+  {
+   "action": "removed",
+   "date": "2018-10-11",
+   "ticker": "EVHC"
+  },
+  {
+   "action": "added",
+   "date": "2018-10-11",
+   "ticker": "FTNT"
+  },
+  {
+   "action": "removed",
+   "date": "2018-11-06",
+   "ticker": "CA"
+  },
+  {
+   "action": "added",
+   "date": "2018-11-06",
+   "ticker": "KEYS"
+  },
+  {
+   "action": "removed",
+   "date": "2018-11-13",
+   "ticker": "EQT"
+  },
+  {
+   "action": "added",
+   "date": "2018-11-13",
+   "ticker": "JKHY"
+  },
+  {
+   "action": "removed",
+   "date": "2018-12-03",
+   "ticker": "AET"
+  },
+  {
+   "action": "removed",
+   "date": "2018-12-03",
+   "ticker": "COL"
+  },
+  {
+   "action": "added",
+   "date": "2018-12-03",
+   "ticker": "FANG"
+  },
+  {
+   "action": "added",
+   "date": "2018-12-03",
+   "ticker": "LW"
+  },
+  {
+   "action": "added",
+   "date": "2018-12-03",
+   "ticker": "MXIM"
+  },
+  {
+   "action": "removed",
+   "date": "2018-12-03",
+   "ticker": "SRCL"
+  },
+  {
+   "action": "added",
+   "date": "2018-12-24",
+   "ticker": "CE"
+  },
+  {
+   "action": "removed",
+   "date": "2018-12-24",
+   "ticker": "ESRX"
+  },
+  {
+   "action": "added",
+   "date": "2019-01-02",
+   "ticker": "FRC"
+  },
+  {
+   "action": "removed",
+   "date": "2019-01-02",
+   "ticker": "SCG"
+  },
+  {
+   "action": "removed",
+   "date": "2019-01-18",
+   "ticker": "PCG"
+  },
+  {
+   "action": "added",
+   "date": "2019-01-18",
+   "ticker": "TFX"
+  },
+  {
+   "action": "added",
+   "date": "2019-02-15",
+   "ticker": "ATO"
+  },
+  {
+   "action": "removed",
+   "date": "2019-02-15",
+   "ticker": "NFX"
+  },
+  {
+   "action": "removed",
+   "date": "2019-02-27",
+   "ticker": "GT"
+  },
+  {
+   "action": "added",
+   "date": "2019-02-27",
+   "ticker": "WAB"
+  },
+  {
+   "action": "added",
+   "date": "2019-03-19",
+   "ticker": "FOX"
+  },
+  {
+   "action": "removed",
+   "date": "2019-03-19",
+   "ticker": "FOX"
+  },
+  {
+   "action": "added",
+   "date": "2019-03-19",
+   "ticker": "FOXA"
+  },
+  {
+   "action": "removed",
+   "date": "2019-03-19",
+   "ticker": "FOXA"
+  },
+  {
+   "action": "removed",
+   "date": "2019-04-02",
+   "ticker": "BHF"
+  },
+  {
+   "action": "added",
+   "date": "2019-04-02",
+   "ticker": "DOW"
+  },
+  {
+   "action": "added",
+   "date": "2019-06-03",
+   "ticker": "CTVA"
+  },
+  {
+   "action": "added",
+   "date": "2019-06-03",
+   "ticker": "DD"
+  },
+  {
+   "action": "removed",
+   "date": "2019-06-03",
+   "ticker": "DWDP"
+  },
+  {
+   "action": "removed",
+   "date": "2019-06-03",
+   "ticker": "FLR"
+  },
+  {
+   "action": "added",
+   "date": "2019-06-07",
+   "ticker": "BMS"
+  },
+  {
+   "action": "removed",
+   "date": "2019-06-07",
+   "ticker": "MAT"
+  },
+  {
+   "action": "added",
+   "date": "2019-06-11",
+   "ticker": "AMCR"
+  },
+  {
+   "action": "removed",
+   "date": "2019-06-11",
+   "ticker": "BMS"
+  },
+  {
+   "action": "removed",
+   "date": "2019-07-01",
+   "ticker": "LLL"
+  },
+  {
+   "action": "added",
+   "date": "2019-07-01",
+   "ticker": "MKTX"
+  },
+  {
+   "action": "removed",
+   "date": "2019-07-15",
+   "ticker": "RHT"
+  },
+  {
+   "action": "added",
+   "date": "2019-07-15",
+   "ticker": "TMUS"
+  },
+  {
+   "action": "removed",
+   "date": "2019-08-09",
+   "ticker": "APC"
+  },
+  {
+   "action": "removed",
+   "date": "2019-08-09",
+   "ticker": "FL"
+  },
+  {
+   "action": "added",
+   "date": "2019-08-09",
+   "ticker": "IEX"
+  },
+  {
+   "action": "added",
+   "date": "2019-08-09",
+   "ticker": "LDOS"
+  },
+  {
+   "action": "added",
+   "date": "2019-09-23",
+   "ticker": "CDW"
+  },
+  {
+   "action": "removed",
+   "date": "2019-09-23",
+   "ticker": "TSS"
+  },
+  {
+   "action": "removed",
+   "date": "2019-09-26",
+   "ticker": "JEF"
+  },
+  {
+   "action": "added",
+   "date": "2019-09-26",
+   "ticker": "NVR"
+  },
+  {
+   "action": "added",
+   "date": "2019-10-03",
+   "ticker": "LVS"
+  },
+  {
+   "action": "removed",
+   "date": "2019-10-03",
+   "ticker": "NKTR"
+  },
+  {
+   "action": "removed",
+   "date": "2019-11-21",
+   "ticker": "CELG"
+  },
+  {
+   "action": "added",
+   "date": "2019-11-21",
+   "ticker": "NOW"
+  },
+  {
+   "action": "removed",
+   "date": "2019-12-05",
+   "ticker": "VIAB"
+  },
+  {
+   "action": "added",
+   "date": "2019-12-05",
+   "ticker": "WRB"
+  },
+  {
+   "action": "added",
+   "date": "2019-12-09",
+   "ticker": "ODFL"
+  },
+  {
+   "action": "removed",
+   "date": "2019-12-09",
+   "ticker": "STI"
+  },
+  {
+   "action": "removed",
+   "date": "2019-12-23",
+   "ticker": "AMG"
+  },
+  {
+   "action": "added",
+   "date": "2019-12-23",
+   "ticker": "LYV"
+  },
+  {
+   "action": "removed",
+   "date": "2019-12-23",
+   "ticker": "MAC"
+  },
+  {
+   "action": "added",
+   "date": "2019-12-23",
+   "ticker": "STE"
+  },
+  {
+   "action": "removed",
+   "date": "2019-12-23",
+   "ticker": "TRIP"
+  },
+  {
+   "action": "added",
+   "date": "2019-12-23",
+   "ticker": "ZBRA"
+  },
+  {
+   "action": "added",
+   "date": "2020-01-28",
+   "ticker": "PAYC"
+  },
+  {
+   "action": "removed",
+   "date": "2020-01-28",
+   "ticker": "WCG"
+  },
+  {
+   "action": "added",
+   "date": "2020-03-02",
+   "ticker": "IR"
+  },
+  {
+   "action": "removed",
+   "date": "2020-03-02",
+   "ticker": "XEC"
+  },
+  {
+   "action": "removed",
+   "date": "2020-04-01",
+   "ticker": "ARNC"
+  },
+  {
+   "action": "added",
+   "date": "2020-04-01",
+   "ticker": "HWM"
+  },
+  {
+   "action": "added",
+   "date": "2020-04-03",
+   "ticker": "CARR"
+  },
+  {
+   "action": "added",
+   "date": "2020-04-03",
+   "ticker": "OTIS"
+  },
+  {
+   "action": "removed",
+   "date": "2020-04-06",
+   "ticker": "M"
+  },
+  {
+   "action": "removed",
+   "date": "2020-04-06",
+   "ticker": "RTN"
+  },
+  {
+   "action": "removed",
+   "date": "2020-05-12",
+   "ticker": "AGN"
+  },
+  {
+   "action": "removed",
+   "date": "2020-05-12",
+   "ticker": "CPRI"
+  },
+  {
+   "action": "added",
+   "date": "2020-05-12",
+   "ticker": "DPZ"
+  },
+  {
+   "action": "added",
+   "date": "2020-05-12",
+   "ticker": "DXCM"
+  },
+  {
+   "action": "removed",
+   "date": "2020-05-22",
+   "ticker": "HP"
+  },
+  {
+   "action": "added",
+   "date": "2020-05-22",
+   "ticker": "WST"
+  },
+  {
+   "action": "removed",
+   "date": "2020-06-22",
+   "ticker": "ADS"
+  },
+  {
+   "action": "added",
+   "date": "2020-06-22",
+   "ticker": "BIO"
+  },
+  {
+   "action": "removed",
+   "date": "2020-06-22",
+   "ticker": "HOG"
+  },
+  {
+   "action": "removed",
+   "date": "2020-06-22",
+   "ticker": "JWN"
+  },
+  {
+   "action": "added",
+   "date": "2020-06-22",
+   "ticker": "TDY"
+  },
+  {
+   "action": "added",
+   "date": "2020-06-22",
+   "ticker": "TYL"
+  },
+  {
+   "action": "removed",
+   "date": "2020-09-21",
+   "ticker": "COTY"
+  },
+  {
+   "action": "added",
+   "date": "2020-09-21",
+   "ticker": "CTLT"
+  },
+  {
+   "action": "added",
+   "date": "2020-09-21",
+   "ticker": "ETSY"
+  },
+  {
+   "action": "removed",
+   "date": "2020-09-21",
+   "ticker": "HRB"
+  },
+  {
+   "action": "removed",
+   "date": "2020-09-21",
+   "ticker": "KSS"
+  },
+  {
+   "action": "added",
+   "date": "2020-09-21",
+   "ticker": "TER"
+  },
+  {
+   "action": "removed",
+   "date": "2020-10-07",
+   "ticker": "ETFC"
+  },
+  {
+   "action": "added",
+   "date": "2020-10-07",
+   "ticker": "POOL"
+  },
+  {
+   "action": "added",
+   "date": "2020-10-09",
+   "ticker": "VNT"
+  },
+  {
+   "action": "removed",
+   "date": "2020-10-12",
+   "ticker": "NBL"
+  },
+  {
+   "action": "removed",
+   "date": "2020-12-21",
+   "ticker": "AIV"
+  },
+  {
+   "action": "added",
+   "date": "2020-12-21",
+   "ticker": "TSLA"
+  },
+  {
+   "action": "added",
+   "date": "2021-01-07",
+   "ticker": "ENPH"
+  },
+  {
+   "action": "removed",
+   "date": "2021-01-07",
+   "ticker": "TIF"
+  },
+  {
+   "action": "removed",
+   "date": "2021-01-21",
+   "ticker": "CXO"
+  },
+  {
+   "action": "added",
+   "date": "2021-01-21",
+   "ticker": "TRMB"
+  },
+  {
+   "action": "removed",
+   "date": "2021-02-12",
+   "ticker": "FTI"
+  },
+  {
+   "action": "added",
+   "date": "2021-02-12",
+   "ticker": "MPWR"
+  },
+  {
+   "action": "added",
+   "date": "2021-03-22",
+   "ticker": "CZR"
+  },
+  {
+   "action": "removed",
+   "date": "2021-03-22",
+   "ticker": "FLS"
+  },
+  {
+   "action": "added",
+   "date": "2021-03-22",
+   "ticker": "GNRC"
+  },
+  {
+   "action": "added",
+   "date": "2021-03-22",
+   "ticker": "NXPI"
+  },
+  {
+   "action": "added",
+   "date": "2021-03-22",
+   "ticker": "PENN"
+  },
+  {
+   "action": "removed",
+   "date": "2021-03-22",
+   "ticker": "SLG"
+  },
+  {
+   "action": "removed",
+   "date": "2021-03-22",
+   "ticker": "VNT"
+  },
+  {
+   "action": "removed",
+   "date": "2021-03-22",
+   "ticker": "XRX"
+  },
+  {
+   "action": "added",
+   "date": "2021-04-20",
+   "ticker": "PTC"
+  },
+  {
+   "action": "removed",
+   "date": "2021-04-20",
+   "ticker": "VAR"
+  },
+  {
+   "action": "added",
+   "date": "2021-05-14",
+   "ticker": "CRL"
+  },
+  {
+   "action": "removed",
+   "date": "2021-05-14",
+   "ticker": "FLIR"
+  },
+  {
+   "action": "added",
+   "date": "2021-06-03",
+   "ticker": "OGN"
+  },
+  {
+   "action": "removed",
+   "date": "2021-06-04",
+   "ticker": "HFC"
+  },
+  {
+   "action": "removed",
+   "date": "2021-07-21",
+   "ticker": "ALXN"
+  },
+  {
+   "action": "added",
+   "date": "2021-07-21",
+   "ticker": "MRNA"
+  },
+  {
+   "action": "removed",
+   "date": "2021-08-30",
+   "ticker": "MXIM"
+  },
+  {
+   "action": "added",
+   "date": "2021-08-30",
+   "ticker": "TECH"
+  },
+  {
+   "action": "added",
+   "date": "2021-09-20",
+   "ticker": "BRO"
+  },
+  {
+   "action": "added",
+   "date": "2021-09-20",
+   "ticker": "CDAY"
+  },
+  {
+   "action": "added",
+   "date": "2021-09-20",
+   "ticker": "MTCH"
+  },
+  {
+   "action": "removed",
+   "date": "2021-09-20",
+   "ticker": "NOV"
+  },
+  {
+   "action": "removed",
+   "date": "2021-09-20",
+   "ticker": "PRGO"
+  },
+  {
+   "action": "removed",
+   "date": "2021-09-20",
+   "ticker": "UNM"
+  },
+  {
+   "action": "added",
+   "date": "2021-12-14",
+   "ticker": "EPAM"
+  },
+  {
+   "action": "removed",
+   "date": "2021-12-14",
+   "ticker": "KSU"
+  },
+  {
+   "action": "added",
+   "date": "2021-12-20",
+   "ticker": "FDS"
+  },
+  {
+   "action": "removed",
+   "date": "2021-12-20",
+   "ticker": "HBI"
+  },
+  {
+   "action": "removed",
+   "date": "2021-12-20",
+   "ticker": "LEG"
+  },
+  {
+   "action": "added",
+   "date": "2021-12-20",
+   "ticker": "SBNY"
+  },
+  {
+   "action": "added",
+   "date": "2021-12-20",
+   "ticker": "SEDG"
+  },
+  {
+   "action": "removed",
+   "date": "2021-12-20",
+   "ticker": "WU"
+  },
+  {
+   "action": "removed",
+   "date": "2022-01-10",
+   "ticker": "WLTW"
+  },
+  {
+   "action": "added",
+   "date": "2022-01-10",
+   "ticker": "WTW"
+  },
+  {
+   "action": "added",
+   "date": "2022-02-02",
+   "ticker": "CEG"
+  },
+  {
+   "action": "removed",
+   "date": "2022-02-03",
+   "ticker": "GPS"
+  },
+  {
+   "action": "added",
+   "date": "2022-02-15",
+   "ticker": "NDSN"
+  },
+  {
+   "action": "removed",
+   "date": "2022-02-15",
+   "ticker": "XLNX"
+  },
+  {
+   "action": "removed",
+   "date": "2022-03-02",
+   "ticker": "INFO"
+  },
+  {
+   "action": "added",
+   "date": "2022-03-02",
+   "ticker": "MOH"
+  },
+  {
+   "action": "added",
+   "date": "2022-04-04",
+   "ticker": "CPT"
+  },
+  {
+   "action": "removed",
+   "date": "2022-04-04",
+   "ticker": "PBCT"
+  },
+  {
+   "action": "removed",
+   "date": "2022-04-11",
+   "ticker": "DISCA"
+  },
+  {
+   "action": "removed",
+   "date": "2022-04-11",
+   "ticker": "DISCK"
+  },
+  {
+   "action": "added",
+   "date": "2022-04-11",
+   "ticker": "WBD"
+  },
+  {
+   "action": "removed",
+   "date": "2022-06-08",
+   "ticker": "CERN"
+  },
+  {
+   "action": "added",
+   "date": "2022-06-08",
+   "ticker": "VICI"
+  },
+  {
+   "action": "removed",
+   "date": "2022-06-21",
+   "ticker": "IPGP"
+  },
+  {
+   "action": "added",
+   "date": "2022-06-21",
+   "ticker": "KDP"
+  },
+  {
+   "action": "added",
+   "date": "2022-06-21",
+   "ticker": "ON"
+  },
+  {
+   "action": "removed",
+   "date": "2022-06-21",
+   "ticker": "UA"
+  },
+  {
+   "action": "removed",
+   "date": "2022-06-21",
+   "ticker": "UAA"
+  },
+  {
+   "action": "added",
+   "date": "2022-09-19",
+   "ticker": "CSGP"
+  },
+  {
+   "action": "added",
+   "date": "2022-09-19",
+   "ticker": "INVH"
+  },
+  {
+   "action": "removed",
+   "date": "2022-09-19",
+   "ticker": "PENN"
+  },
+  {
+   "action": "removed",
+   "date": "2022-09-19",
+   "ticker": "PVH"
+  },
+  {
+   "action": "removed",
+   "date": "2022-10-03",
+   "ticker": "CTXS"
+  },
+  {
+   "action": "removed",
+   "date": "2022-10-03",
+   "ticker": "DRE"
+  },
+  {
+   "action": "added",
+   "date": "2022-10-03",
+   "ticker": "EQT"
+  },
+  {
+   "action": "added",
+   "date": "2022-10-03",
+   "ticker": "PCG"
+  },
+  {
+   "action": "removed",
+   "date": "2022-10-12",
+   "ticker": "NLSN"
+  },
+  {
+   "action": "added",
+   "date": "2022-10-12",
+   "ticker": "TRGP"
+  },
+  {
+   "action": "added",
+   "date": "2022-11-01",
+   "ticker": "ACGL"
+  },
+  {
+   "action": "removed",
+   "date": "2022-11-01",
+   "ticker": "TWTR"
+  },
+  {
+   "action": "added",
+   "date": "2022-12-15",
+   "ticker": "MBC"
+  },
+  {
+   "action": "removed",
+   "date": "2022-12-19",
+   "ticker": "FBHS"
+  },
+  {
+   "action": "added",
+   "date": "2022-12-19",
+   "ticker": "FSLR"
+  },
+  {
+   "action": "removed",
+   "date": "2022-12-19",
+   "ticker": "MBC"
+  },
+  {
+   "action": "removed",
+   "date": "2022-12-22",
+   "ticker": "ABMD"
+  },
+  {
+   "action": "added",
+   "date": "2022-12-22",
+   "ticker": "STLD"
+  },
+  {
+   "action": "added",
+   "date": "2023-01-04",
+   "ticker": "GEHC"
+  },
+  {
+   "action": "removed",
+   "date": "2023-01-05",
+   "ticker": "VNO"
+  },
+  {
+   "action": "added",
+   "date": "2023-03-15",
+   "ticker": "BG"
+  },
+  {
+   "action": "added",
+   "date": "2023-03-15",
+   "ticker": "PODD"
+  },
+  {
+   "action": "removed",
+   "date": "2023-03-15",
+   "ticker": "SBNY"
+  },
+  {
+   "action": "removed",
+   "date": "2023-03-15",
+   "ticker": "SIVB"
+  },
+  {
+   "action": "added",
+   "date": "2023-03-20",
+   "ticker": "FICO"
+  },
+  {
+   "action": "removed",
+   "date": "2023-03-20",
+   "ticker": "LUMN"
+  },
+  {
+   "action": "added",
+   "date": "2023-05-04",
+   "ticker": "AXON"
+  },
+  {
+   "action": "removed",
+   "date": "2023-05-04",
+   "ticker": "FRC"
+  },
+  {
+   "action": "removed",
+   "date": "2023-06-20",
+   "ticker": "DISH"
+  },
+  {
+   "action": "added",
+   "date": "2023-06-20",
+   "ticker": "PANW"
+  },
+  {
+   "action": "added",
+   "date": "2023-07-10",
+   "ticker": "EG"
+  },
+  {
+   "action": "removed",
+   "date": "2023-07-10",
+   "ticker": "RE"
+  },
+  {
+   "action": "removed",
+   "date": "2023-08-25",
+   "ticker": "AAP"
+  },
+  {
+   "action": "added",
+   "date": "2023-08-25",
+   "ticker": "KVUE"
+  },
+  {
+   "action": "added",
+   "date": "2023-09-18",
+   "ticker": "ABNB"
+  },
+  {
+   "action": "added",
+   "date": "2023-09-18",
+   "ticker": "BX"
+  },
+  {
+   "action": "removed",
+   "date": "2023-09-18",
+   "ticker": "LNC"
+  },
+  {
+   "action": "removed",
+   "date": "2023-09-18",
+   "ticker": "NWL"
+  },
+  {
+   "action": "added",
+   "date": "2023-10-02",
+   "ticker": "VLTO"
+  },
+  {
+   "action": "removed",
+   "date": "2023-10-03",
+   "ticker": "DXC"
+  },
+  {
+   "action": "removed",
+   "date": "2023-10-18",
+   "ticker": "ATVI"
+  },
+  {
+   "action": "added",
+   "date": "2023-10-18",
+   "ticker": "HUBB"
+  },
+  {
+   "action": "added",
+   "date": "2023-10-18",
+   "ticker": "LULU"
+  },
+  {
+   "action": "removed",
+   "date": "2023-10-18",
+   "ticker": "OGN"
+  },
+  {
+   "action": "removed",
+   "date": "2023-12-18",
+   "ticker": "ALK"
+  },
+  {
+   "action": "added",
+   "date": "2023-12-18",
+   "ticker": "BLDR"
+  },
+  {
+   "action": "added",
+   "date": "2023-12-18",
+   "ticker": "JBL"
+  },
+  {
+   "action": "removed",
+   "date": "2023-12-18",
+   "ticker": "SEDG"
+  },
+  {
+   "action": "removed",
+   "date": "2023-12-18",
+   "ticker": "SEE"
+  },
+  {
+   "action": "added",
+   "date": "2023-12-18",
+   "ticker": "UBER"
+  },
+  {
+   "action": "removed",
+   "date": "2024-02-01",
+   "ticker": "CDAY"
+  },
+  {
+   "action": "added",
+   "date": "2024-02-01",
+   "ticker": "DAY"
+  },
+  {
+   "action": "added",
+   "date": "2024-03-18",
+   "ticker": "DECK"
+  },
+  {
+   "action": "added",
+   "date": "2024-03-18",
+   "ticker": "SMCI"
+  },
+  {
+   "action": "removed",
+   "date": "2024-03-18",
+   "ticker": "WHR"
+  },
+  {
+   "action": "removed",
+   "date": "2024-03-18",
+   "ticker": "ZION"
+  },
+  {
+   "action": "added",
+   "date": "2024-03-25",
+   "ticker": "CPAY"
+  },
+  {
+   "action": "removed",
+   "date": "2024-03-25",
+   "ticker": "FLT"
+  },
+  {
+   "action": "added",
+   "date": "2024-04-01",
+   "ticker": "SOLV"
+  },
+  {
+   "action": "added",
+   "date": "2024-04-02",
+   "ticker": "GEV"
+  },
+  {
+   "action": "removed",
+   "date": "2024-04-03",
+   "ticker": "VFC"
+  },
+  {
+   "action": "removed",
+   "date": "2024-04-03",
+   "ticker": "XRAY"
+  },
+  {
+   "action": "removed",
+   "date": "2024-05-08",
+   "ticker": "PXD"
+  },
+  {
+   "action": "added",
+   "date": "2024-05-08",
+   "ticker": "VST"
+  },
+  {
+   "action": "removed",
+   "date": "2024-06-24",
+   "ticker": "CMA"
+  },
+  {
+   "action": "added",
+   "date": "2024-06-24",
+   "ticker": "CRWD"
+  },
+  {
+   "action": "added",
+   "date": "2024-06-24",
+   "ticker": "GDDY"
+  },
+  {
+   "action": "removed",
+   "date": "2024-06-24",
+   "ticker": "ILMN"
+  },
+  {
+   "action": "added",
+   "date": "2024-06-24",
+   "ticker": "KKR"
+  },
+  {
+   "action": "removed",
+   "date": "2024-06-24",
+   "ticker": "RHI"
+  },
+  {
+   "action": "removed",
+   "date": "2024-09-23",
+   "ticker": "AAL"
+  },
+  {
+   "action": "removed",
+   "date": "2024-09-23",
+   "ticker": "BIO"
+  },
+  {
+   "action": "added",
+   "date": "2024-09-23",
+   "ticker": "DELL"
+  },
+  {
+   "action": "added",
+   "date": "2024-09-23",
+   "ticker": "ERIE"
+  },
+  {
+   "action": "removed",
+   "date": "2024-09-23",
+   "ticker": "ETSY"
+  },
+  {
+   "action": "added",
+   "date": "2024-09-23",
+   "ticker": "PLTR"
+  },
+  {
+   "action": "added",
+   "date": "2024-09-30",
+   "ticker": "AMTM"
+  },
+  {
+   "action": "removed",
+   "date": "2024-10-01",
+   "ticker": "BBWI"
+  },
+  {
+   "action": "removed",
+   "date": "2024-11-26",
+   "ticker": "MRO"
+  },
+  {
+   "action": "added",
+   "date": "2024-11-26",
+   "ticker": "TPL"
+  },
+  {
+   "action": "removed",
+   "date": "2024-12-23",
+   "ticker": "AMTM"
+  },
+  {
+   "action": "added",
+   "date": "2024-12-23",
+   "ticker": "APO"
+  },
+  {
+   "action": "removed",
+   "date": "2024-12-23",
+   "ticker": "CTLT"
+  },
+  {
+   "action": "added",
+   "date": "2024-12-23",
+   "ticker": "LII"
+  },
+  {
+   "action": "removed",
+   "date": "2024-12-23",
+   "ticker": "QRVO"
+  },
+  {
+   "action": "added",
+   "date": "2024-12-23",
+   "ticker": "WDAY"
+  },
+  {
+   "action": "removed",
+   "date": "2025-03-24",
+   "ticker": "BWA"
+  },
+  {
+   "action": "removed",
+   "date": "2025-03-24",
+   "ticker": "CE"
+  },
+  {
+   "action": "added",
+   "date": "2025-03-24",
+   "ticker": "DASH"
+  },
+  {
+   "action": "added",
+   "date": "2025-03-24",
+   "ticker": "EXE"
+  },
+  {
+   "action": "removed",
+   "date": "2025-03-24",
+   "ticker": "FMC"
+  },
+  {
+   "action": "removed",
+   "date": "2025-03-24",
+   "ticker": "TFX"
+  },
+  {
+   "action": "added",
+   "date": "2025-03-24",
+   "ticker": "TKO"
+  },
+  {
+   "action": "added",
+   "date": "2025-03-24",
+   "ticker": "WSM"
+  },
+  {
+   "action": "added",
+   "date": "2025-05-19",
+   "ticker": "COIN"
+  },
+  {
+   "action": "removed",
+   "date": "2025-05-19",
+   "ticker": "DFS"
+  },
+  {
+   "action": "added",
+   "date": "2025-07-09",
+   "ticker": "DDOG"
+  },
+  {
+   "action": "removed",
+   "date": "2025-07-09",
+   "ticker": "JNPR"
+  },
+  {
+   "action": "removed",
+   "date": "2025-07-18",
+   "ticker": "ANSS"
+  },
+  {
+   "action": "added",
+   "date": "2025-07-18",
+   "ticker": "TTD"
+  },
+  {
+   "action": "removed",
+   "date": "2025-07-23",
+   "ticker": "HES"
+  },
+  {
+   "action": "added",
+   "date": "2025-07-23",
+   "ticker": "XYZ"
+  },
+  {
+   "action": "added",
+   "date": "2025-08-28",
+   "ticker": "IBKR"
+  },
+  {
+   "action": "removed",
+   "date": "2025-08-28",
+   "ticker": "WBA"
+  },
+  {
+   "action": "added",
+   "date": "2025-09-22",
+   "ticker": "APP"
+  },
+  {
+   "action": "removed",
+   "date": "2025-09-22",
+   "ticker": "CZR"
+  },
+  {
+   "action": "added",
+   "date": "2025-09-22",
+   "ticker": "EME"
+  },
+  {
+   "action": "removed",
+   "date": "2025-09-22",
+   "ticker": "ENPH"
+  },
+  {
+   "action": "added",
+   "date": "2025-09-22",
+   "ticker": "HOOD"
+  },
+  {
+   "action": "removed",
+   "date": "2025-09-22",
+   "ticker": "MKTX"
+  },
+  {
+   "action": "added",
+   "date": "2025-10-30",
+   "ticker": "SOLS"
+  },
+  {
+   "action": "removed",
+   "date": "2025-10-31",
+   "ticker": "KMX"
+  },
+  {
+   "action": "added",
+   "date": "2025-11-03",
+   "ticker": "Q"
+  },
+  {
+   "action": "removed",
+   "date": "2025-11-04",
+   "ticker": "EMN"
+  },
+  {
+   "action": "removed",
+   "date": "2025-11-28",
+   "ticker": "IPG"
+  },
+  {
+   "action": "added",
+   "date": "2025-11-28",
+   "ticker": "SNDK"
+  },
+  {
+   "action": "added",
+   "date": "2025-12-11",
+   "ticker": "ARES"
+  },
+  {
+   "action": "removed",
+   "date": "2025-12-11",
+   "ticker": "K"
+  },
+  {
+   "action": "added",
+   "date": "2025-12-22",
+   "ticker": "CRH"
+  },
+  {
+   "action": "added",
+   "date": "2025-12-22",
+   "ticker": "CVNA"
+  },
+  {
+   "action": "added",
+   "date": "2025-12-22",
+   "ticker": "FIX"
+  },
+  {
+   "action": "removed",
+   "date": "2025-12-22",
+   "ticker": "LKQ"
+  },
+  {
+   "action": "removed",
+   "date": "2025-12-22",
+   "ticker": "MHK"
+  },
+  {
+   "action": "removed",
+   "date": "2025-12-22",
+   "ticker": "SOLS"
+  },
+  {
+   "action": "added",
+   "date": "2026-02-09",
+   "ticker": "CIEN"
+  },
+  {
+   "action": "removed",
+   "date": "2026-02-09",
+   "ticker": "DAY"
+  },
+  {
+   "action": "added",
+   "date": "2026-03-23",
+   "ticker": "COHR"
+  },
+  {
+   "action": "added",
+   "date": "2026-03-23",
+   "ticker": "LITE"
+  },
+  {
+   "action": "removed",
+   "date": "2026-03-23",
+   "ticker": "LW"
+  },
+  {
+   "action": "removed",
+   "date": "2026-03-23",
+   "ticker": "MOH"
+  },
+  {
+   "action": "removed",
+   "date": "2026-03-23",
+   "ticker": "MTCH"
+  },
+  {
+   "action": "removed",
+   "date": "2026-03-23",
+   "ticker": "PAYC"
+  },
+  {
+   "action": "added",
+   "date": "2026-03-23",
+   "ticker": "SATS"
+  },
+  {
+   "action": "added",
+   "date": "2026-03-23",
+   "ticker": "VRT"
+  }
+ ],
+ "content_sha256": "bd7d1e8518966db35c179505f9955fe0ae89ccd6292ba424789666a796a3f911",
+ "covers": {
+  "from": "1976-07-01",
+  "to_exclusive": "2026-04-04"
+ },
+ "frozen_at": "2026-08-12",
+ "index": "S&P 500",
+ "n_changes": 758,
+ "schema_version": 1,
+ "source": "https://en.wikipedia.org/wiki/Historical_components_of_the_S%26P_500"
+}

--- a/collectors/data/sp500_known_retickers.json
+++ b/collectors/data/sp500_known_retickers.json
@@ -1,0 +1,18 @@
+{
+ "_comment": "Ticker changes that a holdings diff sees as a same-date remove+add but that are NOT index-membership events. Consulted before Polygon, which does not report these as ticker_change (verified 2026-08-12: get_ticker_events('BK') returns []). Each entry needs the effective date and one line of evidence; the reference changes table NOT listing it is corroboration, not proof. alpha-engine-config-I6946.",
+ "schema_version": 1,
+ "retickers": [
+  {
+   "old": "BK",
+   "new": "BNY",
+   "effective": "2026-05-22",
+   "evidence": "BNY Mellon corporate rebrand to 'BNY'; identity preserved, no index change. Absent from the reference changes table, which lists every real S&P 500 add/remove."
+  },
+  {
+   "old": "SATS",
+   "new": "ECHO",
+   "effective": "2026-06-25",
+   "evidence": "EchoStar symbol change; identity preserved, no index change. Absent from the reference changes table."
+  }
+ ]
+}

--- a/collectors/historical_constituents.py
+++ b/collectors/historical_constituents.py
@@ -8,21 +8,45 @@ silently exclude every name that was delisted, acquired, or index-dropped —
 an upward (survivor) bias on backtest credibility (~1-4%/yr overstatement
 class).
 
-This module reconstructs as-of-date membership by **replaying the Wikipedia
-"Selected changes to the list" table backward from today's roster**: starting
-from the current constituents, each change (ticker *added* on date D, ticker
+This module reconstructs as-of-date membership by **replaying index changes
+backward from today's roster**: each change (ticker *added* on date D, ticker
 *removed* on date D) is undone walking from newest to oldest, so the membership
 set immediately *before* date D is recovered. The output is a
 ``{date: [tickers]}`` map the backtester reads to define the point-in-time
 universe for each backtest date.
 
-Two layers, deliberately separated so the risky parsing is unit-tested with no
+WHERE THOSE CHANGES COME FROM (alpha-engine-config-I6946). Originally, all of
+them were scraped from Wikipedia's "Selected changes to the list" table on
+every run. On 2026-08-11 an editor moved that table to a different article and
+the weekly pipeline failed three hours later — a load-bearing backtest input
+taken down by a formatting edit. Two producers replaced it, split at
+``SNAPSHOT_CUTOVER``:
+
+  * **Before the cutover** — ``collectors/data/sp500_changes_frozen_*.json``,
+    a committed, content-hashed reconstruction. 1976-2026 index changes are
+    settled; re-deriving them weekly from an editable page re-ran the risk to
+    re-learn facts that had not moved.
+  * **On and after** — a diff of our own dated roster snapshots at
+    ``market_data/weekly/{date}/constituents.json``, themselves sourced from
+    SSGA's SPY holdings (config#2812). Membership is OBSERVED, not replayed.
+
+Wikipedia is still fetched, but only to ATTEST the post-cutover window — never
+to produce it. A page that moves, 404s or is vandalised now costs an
+attestation and a WARNING, not the pipeline. Disagreement between the two
+derivations is itself the signal worth having: it means a bad upstream edit or
+a gap in our own collection.
+
+Layers, deliberately separated so the risky parsing is unit-tested with no
 network:
   * ``parse_changes_table(df)`` — Wikipedia changes DataFrame -> list of
-    structured ``ConstituentChange`` events (pure).
+    structured ``ConstituentChange`` events (pure). Attestation only.
+  * ``changes_from_snapshots(snapshots)`` -> the same list type, from observed
+    dated rosters (pure).
+  * ``load_frozen_changes()`` — the hash-verified pre-cutover history.
   * ``build_pit_membership(current_tickers, changes)`` -> ``{date: [tickers]}``
     point-in-time map (pure).
-  * ``collect(...)`` — fetch + build + write to S3 (the I/O shell).
+  * ``divergences(observed, reference, since=...)`` — the attestation (pure).
+  * ``collect(...)`` — read + build + write to S3 (the I/O shell).
 
 S&P 500 only (the changes table on the S&P 400 page is sparser); the memo
 flags S&P 400 mid-cap as a follow-on. Delisted-ticker *prices* are memo
@@ -31,18 +55,43 @@ Phase 2 — out of scope here; this ships the membership list.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import StringIO
+from pathlib import Path
 
 import boto3
 import pandas as pd
 import requests
 
 logger = logging.getLogger(__name__)
+
+#: First date with a dated roster snapshot at
+#: ``market_data/weekly/{date}/constituents.json``. On and after this date
+#: membership is DIRECTLY OBSERVED and no wiki is consulted to produce it;
+#: before it, history comes from the frozen artifact below.
+SNAPSHOT_CUTOVER = "2026-04-04"
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+#: Index changes from 1976 to the cutover are settled history — they do not
+#: change, so re-deriving them from an editable wiki on every weekly run buys
+#: nothing and costs an outage when the page moves (alpha-engine-config-I6944,
+#: 2026-08-11). Reconstructed once, hashed, and committed.
+_FROZEN_CHANGES_PATH = (
+    Path(__file__).resolve().parent / "data" / "sp500_changes_frozen_pre_2026_04_04.json"
+)
+
+#: Ticker changes a holdings diff cannot tell apart from index churn, and
+#: which Polygon does not report as ``ticker_change``. Same reasoning as the
+#: frozen history: a settled fact, written down once.
+_KNOWN_RETICKERS_PATH = (
+    Path(__file__).resolve().parent / "data" / "sp500_known_retickers.json"
+)
 
 # The changes table is not pinned to one page: on 2026-08-11 a Wikipedia editor
 # split it out of "List of S&P 500 companies" into its own article
@@ -180,6 +229,137 @@ def parse_changes_table(df: pd.DataFrame) -> list[ConstituentChange]:
     return changes
 
 
+def load_frozen_changes(path: Path = _FROZEN_CHANGES_PATH) -> list[ConstituentChange]:
+    """Pre-cutover index changes from the committed, content-hashed artifact.
+
+    The hash is verified, and a mismatch RAISES. This artifact defines the
+    universe every 10y backtest runs against; silently accepting an altered
+    copy would change what the whole system believes about the past without
+    anything failing. Regenerating it legitimately means regenerating the
+    hash in the same commit, where a reviewer sees both.
+    """
+    body = json.loads(path.read_text())
+    payload = json.dumps(body["changes"], sort_keys=True, separators=(",", ":")).encode()
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != body["content_sha256"]:
+        raise RuntimeError(
+            f"{path.name} content hash mismatch: recorded "
+            f"{body['content_sha256'][:16]}…, computed {actual[:16]}… — the "
+            "frozen index history has been altered without its hash being "
+            "regenerated. Refusing to build a backtest universe from it."
+        )
+    return [
+        ConstituentChange(c["date"], c["ticker"], c["action"]) for c in body["changes"]
+    ]
+
+
+def same_date_swaps(snapshots: dict[str, list[str]]) -> dict[str, list[str]]:
+    """``{date: [tickers that left on that date]}`` where something also joined.
+
+    A ticker RENAME shows up in a holdings diff exactly like an index change:
+    the old symbol disappears and the new one appears on the same date. Both
+    the 2026-05-22 ``BK`` -> ``BNY`` and the 2026-06-25 ``SATS`` -> ``ECHO``
+    reticker did, and treating them as membership events would tell the
+    backtester that a company left the index and a different one joined —
+    a fabricated churn event in the exact dataset built to make the universe
+    honest. This narrows the set worth asking Polygon about; it does not
+    decide anything.
+    """
+    out: dict[str, list[str]] = {}
+    dates = sorted(snapshots)
+    for prev_date, date in zip(dates, dates[1:]):
+        before, after = set(snapshots[prev_date]), set(snapshots[date])
+        left, joined = sorted(before - after), sorted(after - before)
+        if left and joined:
+            out[date] = left
+    return out
+
+
+def changes_from_snapshots(
+    snapshots: dict[str, list[str]],
+    renames: dict[str, str] | None = None,
+) -> tuple[list[ConstituentChange], list[str]]:
+    """Dated rosters -> membership changes, by diffing consecutive snapshots.
+
+    ``snapshots`` maps ``YYYY-MM-DD`` to that date's S&P 500 roster. A ticker
+    present on date D+1 and absent on the preceding snapshot D is ADDED on
+    D+1; present on D and absent on D+1 is REMOVED on D+1. Pure — the caller
+    does the S3 reads.
+
+    This is the whole point of the collector'"'"'s rewrite: after the cutover,
+    membership is something we OBSERVED rather than something we replayed
+    from a third party'"'"'s prose. The earliest snapshot yields no changes —
+    it is the baseline the rest are diffed against, not an event.
+
+    The change is dated to the LATER snapshot because that is the first date
+    we can attest to it. A weekly cadence therefore dates a change up to a
+    week late; that is a known and bounded imprecision, and it is the honest
+    one — claiming the exact effective date would assert something the
+    snapshots do not contain.
+
+    ``renames`` maps an old ticker to its new one (the caller resolves these
+    via :func:`corporate_actions.detect_renames`); a matching same-date
+    disappear/appear pair is dropped, because the company never left the
+    index. Returns ``(changes, unresolved)`` where ``unresolved`` names the
+    same-date swaps no rename explains — those changes ARE emitted, since a
+    swap is far more often real index churn than a rename, but they are
+    reported so a run cannot quietly decide either way. See
+    :func:`same_date_swaps`.
+    """
+    renames = renames or {}
+    changes: list[ConstituentChange] = []
+    unresolved: list[str] = []
+    dates = sorted(snapshots)
+    for prev_date, date in zip(dates, dates[1:]):
+        before = set(snapshots[prev_date])
+        after = set(snapshots[date])
+        left, joined = before - after, after - before
+        renamed_away = {t for t in left if renames.get(t) in joined}
+        renamed_into = {renames[t] for t in renamed_away}
+        for ticker in sorted(joined - renamed_into):
+            changes.append(ConstituentChange(date, ticker, ADDED))
+        for ticker in sorted(left - renamed_away):
+            changes.append(ConstituentChange(date, ticker, REMOVED))
+        still_left, still_joined = left - renamed_away, joined - renamed_into
+        if still_left and still_joined:
+            unresolved.append(
+                f"{date}: out={sorted(still_left)} in={sorted(still_joined)}"
+            )
+    changes.sort(key=lambda c: (c.date, c.ticker, c.action))
+    return changes, unresolved
+
+
+def divergences(
+    observed: list[ConstituentChange],
+    reference: list[ConstituentChange],
+    *,
+    since: str,
+) -> list[str]:
+    """Human-readable disagreements between two derivations, on/after ``since``.
+
+    The frozen artifact is only as good as the wiki was on the day it was
+    frozen, and nothing about a committed file makes it true. Comparing the
+    observed post-cutover changes against the same window of the live wiki
+    every run is what turns "we froze it and hope" into a claim under test:
+    a disagreement means either a bad wiki edit or a gap in our own
+    collection, and both are worth knowing about.
+
+    Dates are NOT compared — the snapshot derivation dates a change to the
+    first snapshot that shows it, which is up to a cadence-interval later
+    than the wiki'"'"'s effective date. Comparing them would report a
+    disagreement on every single change. Membership of the (ticker, action)
+    set is the claim being tested.
+    """
+    obs = {(c.ticker, c.action) for c in observed if c.date >= since}
+    ref = {(c.ticker, c.action) for c in reference if c.date >= since}
+    out = []
+    for ticker, action in sorted(obs - ref):
+        out.append(f"observed {action} {ticker} not in reference")
+    for ticker, action in sorted(ref - obs):
+        out.append(f"reference {action} {ticker} not observed")
+    return out
+
+
 def build_pit_membership(
     current_tickers: list[str],
     changes: list[ConstituentChange],
@@ -244,6 +424,131 @@ def _fetch_changes_table(
     )
 
 
+def _sp500_roster(snapshot: dict) -> list[str] | None:
+    """The S&P 500 slice of one dated ``constituents.json``, or None.
+
+    ``constituents.collect`` writes a single combined ``tickers`` list —
+    the SPY holdings followed by the MDY holdings, deduped preserving order
+    — plus ``sp500_count`` / ``sp400_count``. Explicit per-index lists were
+    added later, so newer snapshots carry ``sp500_tickers`` and are read
+    directly; the 84 already on S3 are not, and for those the prefix is the
+    only way in.
+
+    That prefix is only sound when nothing was lost to the dedupe, so the
+    counts must account for the whole list. When they do not, this returns
+    None rather than slicing anyway: a roster silently short by the overlap
+    would surface as a burst of fabricated ADDED/REMOVED events on that
+    date, which is worse than a gap because it looks like real index churn.
+    """
+    explicit = snapshot.get("sp500_tickers")
+    if explicit:
+        return list(explicit)
+    tickers = snapshot.get("tickers") or []
+    n500 = snapshot.get("sp500_count") or 0
+    n400 = snapshot.get("sp400_count") or 0
+    if not tickers or not n500 or n500 + n400 != len(tickers):
+        return None
+    return list(tickers[:n500])
+
+
+def load_roster_snapshots(
+    bucket: str,
+    s3=None,
+    prefix: str = "market_data/weekly/",
+) -> dict[str, list[str]]:
+    """Read every dated ``constituents.json`` under ``prefix`` from S3.
+
+    Returns ``{YYYY-MM-DD: sp500_roster}``. Snapshots whose S&P 500 slice
+    cannot be established are logged and skipped — see :func:`_sp500_roster`.
+    """
+    s3 = s3 or boto3.client("s3")
+    snapshots: dict[str, list[str]] = {}
+    unusable: list[str] = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith("/constituents.json"):
+                continue
+            date = key[len(prefix):].split("/", 1)[0]
+            if not _ISO_DATE_RE.match(date):
+                continue
+            body = json.loads(
+                s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            )
+            roster = _sp500_roster(body)
+            if roster is None:
+                unusable.append(date)
+                continue
+            snapshots[date] = roster
+    if unusable:
+        logger.warning(
+            "historical_constituents: %d roster snapshot(s) skipped — no "
+            "usable S&P 500 slice (sp500_count + sp400_count != len(tickers)): %s",
+            len(unusable), sorted(unusable)[:20],
+        )
+    return snapshots
+
+
+def resolve_renames(swaps: dict[str, list[str]]) -> dict[str, str]:
+    """Ask Polygon which of the disappearing tickers were retickers.
+
+    Reuses ``corporate_actions.detect_renames`` — the same detection the
+    prune path runs, so a reticker is classified once in this repo rather
+    than twice with two answers. Imported lazily: this module's pure layer
+    is unit-tested without the polygon client or its config.
+
+    A detection failure returns no rename for that candidate, which lands
+    the pair in ``unresolved`` and emits it as index churn with a WARNING.
+    That is the opposite of the prune path's history-safety default, and
+    deliberately so: prune DELETES history on a wrong answer, where this
+    only mis-dates one membership event that the attestation then flags.
+    """
+    if not swaps:
+        return {}
+    candidates = sorted({t for tickers in swaps.values() for t in tickers})
+
+    # Committed retickers first. Polygon does NOT report these as
+    # ticker_change — verified 2026-08-12, `get_ticker_events("BK")` returns
+    # `[]` for the BNY Mellon rebrand — so detection alone would emit them as
+    # index churn. A reticker is settled history exactly like a pre-cutover
+    # index change, so it gets the same treatment: written down once, reviewed
+    # in a diff, and not re-derived weekly from a source that does not have it.
+    known = json.loads(_KNOWN_RETICKERS_PATH.read_text())
+    renames = {
+        r["old"]: r["new"]
+        for r in known["retickers"]
+        if r["old"] in candidates
+    }
+    candidates = [t for t in candidates if t not in renames]
+    if not candidates:
+        return renames
+
+    try:
+        from builders.prune_delisted_tickers import _build_rename_client
+
+        import corporate_actions as ca
+
+        client = _build_rename_client()
+        if client is None:
+            raise RuntimeError("no polygon client for rename detection")
+        detection = ca.detect_renames(candidates, client=client)
+    except Exception as exc:  # noqa: BLE001 — recorded, and callers warn
+        logger.warning(
+            "historical_constituents: rename detection unavailable (%s) — %d "
+            "same-date swap(s) will be emitted as index changes unclassified",
+            exc, len(candidates),
+        )
+        return renames
+    renames.update({a.ticker: a.new_ticker for a in detection.renames})
+    if renames:
+        logger.info(
+            "historical_constituents: %d reticker(s) resolved and excluded "
+            "from membership changes: %s", len(renames), renames,
+        )
+    return renames
+
+
 def collect(
     bucket: str,
     current_tickers: list[str],
@@ -256,27 +561,95 @@ def collect(
     ``constituents.collect``); this avoids a second live fetch of the live
     roster and keeps the two collectors' rosters consistent. Writes
     ``{s3_prefix}historical_constituents.json`` per the memo's recommended
-    path."""
-    changes_table, source_url = _fetch_changes_table()
-    changes = parse_changes_table(changes_table)
+    path.
+
+    Two producers, joined at ``SNAPSHOT_CUTOVER``: the committed frozen
+    artifact for settled pre-cutover history, and a diff of our own dated
+    roster snapshots for everything after. Wikipedia is fetched only to
+    ATTEST the post-cutover window and never to produce it, so a page that
+    moves or 404s costs an attestation, not the pipeline
+    (alpha-engine-config-I6946).
+    """
+    frozen = load_frozen_changes()
+    snapshots = load_roster_snapshots(bucket)
+    renames = resolve_renames(same_date_swaps(snapshots))
+    observed, unresolved = changes_from_snapshots(snapshots, renames)
+    changes = sorted(
+        frozen + observed, key=lambda c: (c.date, c.ticker, c.action)
+    )
     pit = build_pit_membership(current_tickers, changes)
 
+    # Attestation. Non-fatal by deliberate carve-out from fail-loud:
+    # (a) the failure swallowed is an unreachable or restructured wiki page,
+    # which says nothing about the membership map already built from two
+    # sources that do not involve it; (b) it is recorded as a WARNING on this
+    # phase's log and as `attestation` in the written artifact, so a run that
+    # could not attest is distinguishable from one that attested cleanly —
+    # `divergences` null is not the same value as `[]`.
+    attestation: dict = {"status": "skipped", "divergences": None}
+    try:
+        reference = parse_changes_table(_fetch_changes_table()[0])
+    except Exception as exc:  # noqa: BLE001 — recorded above and below
+        attestation["status"] = "unavailable"
+        attestation["error"] = f"{type(exc).__name__}: {exc}"
+        logger.warning(
+            "historical_constituents: post-cutover attestation UNAVAILABLE "
+            "(%s) — membership was still built from the frozen artifact + %d "
+            "observed snapshots; nothing cross-checked it this run",
+            exc, len(snapshots),
+        )
+    else:
+        found = divergences(observed, reference, since=SNAPSHOT_CUTOVER)
+        attestation = {
+            "status": "diverged" if found else "agreed",
+            "divergences": found,
+            "since": SNAPSHOT_CUTOVER,
+        }
+        if found:
+            # An unresolved same-date swap is NOT reported on its own: a real
+            # index change is a swap most weeks (one name in, one out), so
+            # warning on every one of them would fire on healthy runs and be
+            # tuned out long before the week it meant something. It becomes
+            # interesting only where it ALSO diverges from the reference —
+            # which is exactly how the BK->BNY and SATS->ECHO retickers were
+            # caught on this collector's first observed run.
+            logger.warning(
+                "historical_constituents: observed membership DISAGREES with "
+                "the reference on %d change(s) since %s — a bad upstream edit, "
+                "a gap in our snapshots, or a reticker missing from %s: %s "
+                "(unresolved same-date swaps this run: %s)",
+                len(found), SNAPSHOT_CUTOVER, _KNOWN_RETICKERS_PATH.name,
+                found[:20], unresolved[:20],
+            )
+
     result = {
-        "schema_version": 1,
-        "source": source_url,
+        "schema_version": 2,
+        "source": {
+            "frozen": _FROZEN_CHANGES_PATH.name,
+            "observed": f"s3://{bucket}/market_data/weekly/*/constituents.json",
+            "cutover": SNAPSHOT_CUTOVER,
+        },
         "index": "S&P 500",
         "current_count": len(current_tickers),
         "n_changes": len(changes),
+        "n_changes_frozen": len(frozen),
+        "n_changes_observed": len(observed),
+        "n_roster_snapshots": len(snapshots),
+        "renames_excluded": renames,
+        "unresolved_swaps": unresolved,
         "n_snapshots": len(pit),
+        "attestation": attestation,
         "membership": pit,  # {date: [tickers as-of just before that date]}
         "built_at": datetime.now(timezone.utc).isoformat(),
     }
 
     if dry_run:
         logger.info(
-            "[dry-run] historical_constituents: %d changes -> %d PIT snapshots "
-            "(current roster %d)",
-            len(changes), len(pit), len(current_tickers),
+            "[dry-run] historical_constituents: %d changes (%d frozen + %d "
+            "observed from %d roster snapshots) -> %d PIT snapshots "
+            "(current roster %d); attestation=%s",
+            len(changes), len(frozen), len(observed), len(snapshots),
+            len(pit), len(current_tickers), attestation["status"],
         )
         return {"status": "ok_dry_run", "n_changes": len(changes), "n_snapshots": len(pit)}
 

--- a/tests/test_historical_constituents.py
+++ b/tests/test_historical_constituents.py
@@ -205,3 +205,141 @@ def test_fetch_raises_naming_every_candidate_when_all_fail(monkeypatch):
 def test_the_dedicated_article_is_tried_before_the_roster_page():
     assert hc._SP500_CHANGES_URLS[0].endswith("Historical_components_of_the_S%26P_500")
     assert "List_of_S%26P_500_companies" in hc._SP500_CHANGES_URLS[1]
+
+
+# ── Self-sourced membership (config-I6946) ─────────────────────────────────
+#
+# Wikipedia went from the PRODUCER of index changes to their auditor. The
+# frozen artifact covers settled pre-cutover history; everything after comes
+# from diffing our own dated roster snapshots.
+
+
+def _snaps() -> dict[str, list[str]]:
+    return {
+        "2026-04-04": ["AAA", "BBB", "CCC"],
+        "2026-04-11": ["AAA", "BBB", "DDD"],   # CCC out, DDD in
+        "2026-04-18": ["AAA", "BBB", "DDD", "EEE"],  # EEE in, nothing out
+    }
+
+
+def test_snapshot_diff_emits_the_observed_adds_and_removes():
+    changes, _ = hc.changes_from_snapshots(_snaps())
+    assert set((c.ticker, c.action) for c in changes) == {
+        ("CCC", REMOVED), ("DDD", ADDED), ("EEE", ADDED),
+    }
+
+
+def test_the_earliest_snapshot_is_a_baseline_not_an_event():
+    changes, _ = hc.changes_from_snapshots(_snaps())
+    # AAA/BBB/CCC exist on the first snapshot; none of them may be reported
+    # as ADDED, or every backtest would think the index was created that day.
+    assert not [c for c in changes if c.date == "2026-04-04"]
+
+
+def test_a_change_is_dated_to_the_snapshot_that_observed_it():
+    changes, _ = hc.changes_from_snapshots(_snaps())
+    assert {c.date for c in changes} == {"2026-04-11", "2026-04-18"}
+
+
+def test_a_known_reticker_is_not_a_membership_change():
+    """The failure this pins: BK -> BNY and SATS -> ECHO showed up in the
+    holdings diff as a company leaving the index and a different one joining.
+    Both are corporate rebrands. Polygon reports neither as a ticker_change
+    (verified live 2026-08-12), so nothing downstream would have caught it."""
+    snaps = {
+        "2026-05-15": ["AAA", "BK"],
+        "2026-05-22": ["AAA", "BNY"],
+    }
+    changes, unresolved = hc.changes_from_snapshots(snaps, {"BK": "BNY"})
+    assert changes == []
+    assert unresolved == []
+
+
+def test_an_unexplained_swap_is_still_emitted_and_reported():
+    # A real index change is a swap most weeks. Suppressing it would be
+    # strictly worse than mis-dating a rename, so it is emitted — and named.
+    snaps = {"2026-05-15": ["AAA", "OLD"], "2026-05-22": ["AAA", "NEW"]}
+    changes, unresolved = hc.changes_from_snapshots(snaps)
+    assert set((c.ticker, c.action) for c in changes) == {
+        ("OLD", REMOVED), ("NEW", ADDED),
+    }
+    assert len(unresolved) == 1 and "OLD" in unresolved[0] and "NEW" in unresolved[0]
+
+
+def test_same_date_swaps_only_flags_dates_with_both_directions():
+    swaps = hc.same_date_swaps(_snaps())
+    assert "2026-04-11" in swaps          # CCC out / DDD in
+    assert "2026-04-18" not in swaps      # EEE in, nothing out — not a swap
+
+
+# ── The frozen pre-cutover history ─────────────────────────────────────────
+
+
+def test_frozen_history_loads_and_its_hash_verifies():
+    changes = hc.load_frozen_changes()
+    assert len(changes) > 700
+    assert all(c.date < hc.SNAPSHOT_CUTOVER for c in changes), (
+        "the frozen artifact must not overlap the observed window, or every "
+        "post-cutover change would be counted twice"
+    )
+
+
+def test_a_tampered_frozen_history_raises_rather_than_building_a_universe(tmp_path):
+    import json as _json
+    body = _json.loads(hc._FROZEN_CHANGES_PATH.read_text())
+    body["changes"].append({"date": "1999-01-01", "ticker": "FAKE", "action": ADDED})
+    path = tmp_path / "frozen.json"
+    path.write_text(_json.dumps(body))
+    with pytest.raises(RuntimeError, match="content hash mismatch"):
+        hc.load_frozen_changes(path)
+
+
+# ── The attestation ────────────────────────────────────────────────────────
+
+
+def test_divergences_ignores_dates_and_compares_membership():
+    # The snapshot derivation dates a change to the snapshot that observed
+    # it, which is later than the effective date. Comparing dates would
+    # report a disagreement on every change and mean nothing.
+    observed = [ConstituentChange("2026-05-22", "AAA", ADDED)]
+    reference = [ConstituentChange("2026-05-19", "AAA", ADDED)]
+    assert hc.divergences(observed, reference, since=hc.SNAPSHOT_CUTOVER) == []
+
+
+def test_divergences_reports_both_directions():
+    observed = [ConstituentChange("2026-05-22", "AAA", ADDED)]
+    reference = [ConstituentChange("2026-05-22", "BBB", ADDED)]
+    found = hc.divergences(observed, reference, since=hc.SNAPSHOT_CUTOVER)
+    assert any("AAA" in f and "observed" in f for f in found)
+    assert any("BBB" in f and "reference" in f for f in found)
+
+
+def test_divergences_ignores_everything_before_the_cutover():
+    # Pre-cutover changes come from the frozen artifact, which was built FROM
+    # the reference — comparing them would assert nothing and hide the window
+    # that matters.
+    observed = []
+    reference = [ConstituentChange("2020-01-01", "OLD", ADDED)]
+    assert hc.divergences(observed, reference, since=hc.SNAPSHOT_CUTOVER) == []
+
+
+# ── The S&P 500 slice of a roster snapshot ─────────────────────────────────
+
+
+def test_explicit_per_index_list_is_preferred_over_the_prefix():
+    snap = {"tickers": ["A", "B", "C"], "sp500_count": 1, "sp400_count": 2,
+            "sp500_tickers": ["A", "B"]}
+    assert hc._sp500_roster(snap) == ["A", "B"]
+
+
+def test_the_prefix_is_used_when_the_counts_account_for_the_whole_list():
+    snap = {"tickers": ["A", "B", "C"], "sp500_count": 2, "sp400_count": 1}
+    assert hc._sp500_roster(snap) == ["A", "B"]
+
+
+def test_a_snapshot_whose_counts_do_not_add_up_is_refused():
+    """Slicing anyway would drop names off the roster, which the diff would
+    then emit as a burst of index removals that never happened — worse than
+    a gap, because it looks like real churn."""
+    snap = {"tickers": ["A", "B", "C"], "sp500_count": 2, "sp400_count": 5}
+    assert hc._sp500_roster(snap) is None


### PR DESCRIPTION
Answers Brian, 2026-08-11: *"I thought we weren't going to use wikipedia anymore, is there no better source"*.

`nousergon-data#898` (config#2812, 2026-07-17) moved **current** membership to SSGA's SPY/MDY holdings. `historical_constituents` is a later, separate collector and was never part of that migration — so a load-bearing backtest input was still scraped from an editable page. On 2026-08-11 an editor moved that page and DataPhase1 died three hours later (#1309, config-I6944).

## Two producers, split at `SNAPSHOT_CUTOVER = 2026-04-04`

| Window | Source |
|---|---|
| 1976-07-01 → 2026-03-23 | `collectors/data/sp500_changes_frozen_pre_2026_04_04.json` — 758 changes, committed and content-hashed |
| 2026-04-04 → now | diff of `market_data/weekly/{date}/constituents.json` — 82 usable of the 84 on S3, SSGA-sourced |

Index changes from 1976 do not change; re-deriving them weekly re-ran the exposure to re-learn settled facts. A frozen-artifact hash mismatch **raises** — this file defines the universe every 10y backtest runs against.

Wikipedia is still fetched, but only to **attest** the post-cutover window, and non-fatally. A page that moves or 404s now costs an attestation and a WARNING, not the pipeline.

## The attestation caught a real defect on its first run

The raw diff gave **18** post-cutover changes against the reference's **14**. The four extra were `BK`/`BNY` and `SATS`/`ECHO` — corporate **retickers**, which a holdings diff cannot distinguish from index churn. Polygon reports neither as a `ticker_change` (verified live: `get_ticker_events("BK")` returns `[]`), so the existing rename detection would not have caught them either.

Two fabricated churn events would have entered the exact dataset built to make the universe honest. Known retickers are now a committed record read before Polygon, on the same reasoning as the frozen history. With them excluded:

```
observed: 14   unresolved swaps: 6 (all genuine index changes)
DIVERGENCES: []
total changes: 772   pit snapshots: 305
```

772 is exactly what the Wikipedia-only version produced. The two independent derivations now agree completely.

## Also in this PR

`constituents.json` writes explicit `sp500_tickers` / `sp400_tickers`. The S&P 500 roster was recoverable only as `tickers[:sp500_count]` — an ordering contract nothing declared and no test held — and this collector's diff turns a silent reordering there into fabricated index churn here. Both the writer and the reader's fallback **refuse** the slice when the counts do not account for the whole list, rather than slicing anyway; two April snapshots are skipped on exactly that guard.

## Known behaviour change

PIT snapshots 307 → 305. A change is dated to the snapshot that observed it, up to a cadence-interval after its effective date, which collapses two pairs onto shared dates. Documented and deliberate — claiming the exact effective date would assert something the snapshots do not contain.

## Test plan

Run before opening.

- `tests/test_historical_constituents.py`: **26 passed** (14 new — snapshot diff, baseline-is-not-an-event, reticker exclusion, unexplained-swap reporting, hash tamper, attestation date-insensitivity, roster-slice guard).
- Full suite against the pinned lib (`PYTHONPATH` at a `v0.124.48` worktree — the shared `.venv` is stale): **5015 passed, 4 failed**. The same 4 fail on clean `origin/main` in this checkout: `test_no_local_iam_tree_references`, `test_no_secret_environ_reads`, `test_severity_taxonomy_chokepoint`, `test_telegram_raw_send_message_burndown_guard`. None are touched by this change.
- Live end-to-end against real S3 + Polygon + Wikipedia, output quoted above.

**`main` is independently red** — CI run `31550072599` fails on `tests/test_ingest_form4.py`, unrelated to this PR and predating it. Filed separately.

No post-merge step. The next `data-weekly` run picks this up on its `git pull`.

Closes #6946

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)