### PR TITLE
[P1/low] fix(tests): form4 discovery fixtures pinned a date into a rolling window (config-I6953)

### DIFF
--- a/tests/test_ingest_form4.py
+++ b/tests/test_ingest_form4.py
@@ -15,7 +15,7 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from io import BytesIO
 from unittest.mock import MagicMock
 
@@ -404,6 +404,18 @@ class TestS3ParquetWriter:
 
 
 class TestIngestForTickers:
+    # ``_search_form4_filings`` drops any filing older than
+    # ``date.today() - lookback_days``. A PINNED filed_date in a
+    # discovery fixture therefore has an expiry: it silently ages out of
+    # the window and every orchestrator test starts asserting against 0
+    # discoveries, with no code change to blame. That is exactly what
+    # happened on 2026-08-12 UTC, when the pinned 2026-05-13 fixtures
+    # passed day 90 of the default 90-day lookback and turned main red
+    # (config-I6953). Discovery fixture dates are always computed
+    # relative to today so the window they sit in is the one under test.
+    _FILED_IN_WINDOW = date.today() - timedelta(days=7)
+    _FILED_IN_WINDOW_OLDER = date.today() - timedelta(days=30)
+
     def _make_http_mock(self, *, form4_list, xml_by_url):
         """Build a MagicMock http object that responds to:
           - GET /files/company_tickers.json → returns ticker→CIK map
@@ -464,7 +476,7 @@ class TestIngestForTickers:
             {
                 "form_type": "4",
                 "accession_number": "0000320193-26-000001",
-                "filed_date": date(2026, 5, 13),
+                "filed_date": self._FILED_IN_WINDOW,
                 "primary": "form4.xml",
             },
         ]
@@ -501,13 +513,13 @@ class TestIngestForTickers:
             {
                 "form_type": "10-K",  # not form 4
                 "accession_number": "0000320193-26-100001",
-                "filed_date": date(2026, 5, 1),
+                "filed_date": self._FILED_IN_WINDOW_OLDER,
                 "primary": "10k.htm",
             },
             {
                 "form_type": "4",
                 "accession_number": "0000320193-26-100002",
-                "filed_date": date(2026, 5, 13),
+                "filed_date": self._FILED_IN_WINDOW,
                 "primary": "form4.xml",
             },
         ]
@@ -533,7 +545,7 @@ class TestIngestForTickers:
         form4_list = [{
             "form_type": "4",
             "accession_number": "abc",
-            "filed_date": date(2026, 5, 13),
+            "filed_date": self._FILED_IN_WINDOW,
             "primary": "form4.xml",
         }]
         http = self._make_http_mock(
@@ -561,13 +573,13 @@ class TestIngestForTickers:
             {
                 "form_type": "4",
                 "accession_number": "a",
-                "filed_date": date(2026, 5, 13),
+                "filed_date": self._FILED_IN_WINDOW,
                 "primary": "form4.xml",
             },
             {
                 "form_type": "4",
                 "accession_number": "b",
-                "filed_date": date(2026, 5, 13),
+                "filed_date": self._FILED_IN_WINDOW,
                 "primary": "missing.xml",  # 404
             },
         ]
@@ -585,6 +597,44 @@ class TestIngestForTickers:
         # Successful filing still got parsed + written
         assert stats["n_transactions_parsed"] == 1
         assert stats["n_parquet_writes"] == 1
+
+    def test_filings_older_than_the_lookback_are_dropped(self, monkeypatch):
+        """The lookback window is asserted directly, relative to today.
+
+        Every other orchestrator test above sits comfortably INSIDE the
+        window, so none of them would notice if the cutoff stopped
+        filtering. This one pins both sides of the boundary to
+        ``date.today()`` so it tests the window rather than a calendar
+        date (config-I6953).
+        """
+        from rag.pipelines import ingest_form4
+        monkeypatch.setattr(ingest_form4, "_CIK_CACHE", {})
+        monkeypatch.setattr(ingest_form4, "_INTER_REQUEST_SLEEP_SECONDS", 0)
+
+        lookback_days = 30
+        form4_list = [
+            {
+                "form_type": "4",
+                "accession_number": "in-window",
+                "filed_date": date.today() - timedelta(days=lookback_days - 1),
+                "primary": "form4.xml",
+            },
+            {
+                "form_type": "4",
+                "accession_number": "too-old",
+                "filed_date": date.today() - timedelta(days=lookback_days + 1),
+                "primary": "form4.xml",
+            },
+        ]
+        http = self._make_http_mock(
+            form4_list=form4_list,
+            xml_by_url={"form4.xml": _FORM4_SINGLE_SALE},
+        )
+        stats = ingest_for_tickers(
+            ["AAPL"], lookback_days=lookback_days,
+            s3_client=_InMemoryS3(), http=http,
+        )
+        assert stats["n_filings_discovered"] == 1
 
 
 # ── Schema version ────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

`main` went red at [run 31550072599](https://github.com/nousergon/nousergon-data/actions/runs/31550072599) on `3196f4d` with four `TestIngestForTickers` failures, all `n_filings_discovered == 0` and `n_failures == 0`. The cause is the wall clock, not any diff.

`rag/pipelines/ingest_form4.py:366` drops any filing older than the lookback window:

```python
cutoff = date.today() - timedelta(days=lookback_days)
...
if filed < cutoff:
    continue
```

The four orchestrator tests pinned their discovery fixtures at `date(2026, 5, 13)` with the default `lookback_days=90`. 2026-05-13 + 90 days = 2026-08-11. On 2026-08-11 the filing sits exactly on the cutoff and is kept; on **2026-08-12 UTC** it falls outside and discovery correctly returns nothing. The tests had an expiry date and reached it.

Deterministic reproduction on `main`, which is also why it never reproduced on a Pacific-time laptop:

```
TZ=UTC pytest tests/test_ingest_form4.py -q                    # 4 failed
TZ=America/Los_Angeles pytest tests/test_ingest_form4.py -q    # 16 passed (before 2026-08-12 PT)
```

## Ruled out

- **#1309** (historical-constituents URL failover) — touches only `collectors/historical_constituents.py`; no path to `ingest_form4`.
- **Test-ordering / fixture-composition sensitivity** — the hypothesis behind the closed #1310. The four tests fail in isolation, with no other test in the process.
- **CIK cache leakage** — the http mock IS consulted, the CIK resolves, the submissions payload comes back. The filings are dropped downstream, by the date cutoff.

## Fix

- Discovery fixture dates are computed relative to `date.today()` (`_FILED_IN_WINDOW`, `_FILED_IN_WINDOW_OLDER`) instead of pinned, so the window under test is the one they sit in.
- New `test_filings_older_than_the_lookback_are_dropped` asserts both sides of the boundary relative to today. Mutation-checked: replacing `if filed < cutoff` with `if False` fails it.
- Secondary: `test_non_form4_filings_skipped_in_discovery`'s 10-K fixture was ALSO out of window, so the test could have passed with the form-type filter broken. Both entries are now in-window and the assertion tests form-type filtering.

No production code changed.

## Class

`ingest_8k_filings.py:100` and `ingest_sec_filings.py:100` carry the identical cutoff, but their tests cover only CIK lookup — no pinned discovery fixtures, so no second live instance. The general class (a test whose correctness expires on a calendar date) is not caught by any current gate; a clock-advanced CI run is the detector, filed as nousergon/alpha-engine-config#6954.

## Verification

- `tests/test_ingest_form4.py`: 17 passed under both `TZ=UTC` (2026-08-12) and local Pacific (2026-08-11).
- Full suite in the worktree under `TZ=UTC`: 4941 passed, 3 failed — the 3 are `test_pipeline_status_registry_source_check`, caused by the shared local `.venv` carrying `nousergon-lib` 0.124.43 against a `requirements.txt` pin of v0.124.48. They pass in CI on `main` and are untouched by this change.

Closes nousergon/alpha-engine-config#6953

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
