### PR TITLE
[P2/low] test(form4): guard the class, not just the variable — one literal survived (config-I6951)

### DIFF
--- a/tests/test_ingest_form4.py
+++ b/tests/test_ingest_form4.py
@@ -511,7 +511,7 @@ class TestIngestForTickers:
             {
                 "form_type": "10-K",  # not form 4
                 "accession_number": "0000320193-26-100001",
-                "filed_date": date(2026, 5, 1),
+                "filed_date": _FILED,
                 "primary": "10k.htm",
             },
             {
@@ -625,4 +625,35 @@ def test_discovery_fixtures_stay_inside_the_lookback_window():
     assert 0 < age < _DISCOVERY_LOOKBACK_DAYS, (
         f"_FILED is {age}d old, outside the {_DISCOVERY_LOOKBACK_DAYS}d window "
         f"these tests pass to ingest_for_tickers"
+    )
+
+
+def test_no_orchestrator_fixture_is_dated_by_a_literal():
+    """Guard the CLASS, not just `_FILED` (alpha-engine-config-I6951).
+
+    `test_filed_fixture_stays_inside_the_lookback_window` keeps `_FILED`
+    fresh, which is necessary and not sufficient: it can only vouch for the
+    variable, so a fixture written as a literal is invisible to it. One was.
+    The `10-K` entry in `test_non_form4_filings_skipped_in_discovery` kept
+    `date(2026, 5, 1)` through the config#6923 fix and is, as of 2026-08-12,
+    already ~103 days old against the 90-day window.
+
+    Nothing failed, which is the point. That filing is supposed to be skipped
+    for its FORM TYPE; aged out, it gets skipped for its AGE instead, and the
+    test goes on passing while no longer exercising the form-type filter it
+    is named for. A green test that has quietly stopped asserting its subject
+    is worse than a red one.
+    """
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).read_text()
+    body = src[src.index("class TestIngestForTickers:"):]
+    end = re.search(r"\n(?:def |class )", body)   # stop at the next top-level
+    if end:
+        body = body[: end.start()]
+    literals = re.findall(r"filed_date[\"']?\s*[:=]\s*date\(\d{4},\s*\d+,\s*\d+\)", body)
+    assert not literals, (
+        "orchestrator fixtures run through the lookback filter, so they must "
+        f"be anchored to `_FILED`, not written as a calendar date: {literals}"
     )


### PR DESCRIPTION
Narrowed. `nousergon-data#1310` (config#6923) landed the same root cause and fix for the four failing tests while this was in CI — independently reached, same diagnosis. **main is already green.** This is only the part that fix does not cover.

## What survived

#1310 anchored the failing fixtures to `_FILED = date.today() - timedelta(days=30)` and added `test_filed_fixture_stays_inside_the_lookback_window`. That guard can only vouch for the **variable**. A fixture written as a **literal** is invisible to it — and one is:

```python
# test_non_form4_filings_skipped_in_discovery
{
    "form_type": "10-K",              # not form 4
    "filed_date": date(2026, 5, 1),   # ~103 days old vs the 90-day window
    ...
}
```

## Why a passing test is the worse half

Nothing failed here, and that is the finding. That filing is supposed to be skipped **for its form type**. Aged out of the lookback window, it now gets skipped **for its age** instead — so the test keeps passing while no longer exercising the form-type filter it is named for.

The four loud `assert 0 == 1` failures were the visible half of this expiry. This is the half that goes quiet, and it would have outlived the fix that was prompted by the noisy half.

## Change

- Anchors that fixture to `_FILED`.
- Adds a class-level guard: no `filed_date=date(YYYY, M, D)` literal inside `TestIngestForTickers`, since every fixture in that class runs through the lookback filter. Guards the class rather than the one variable, so the next literal fails at review instead of going quiet.

Parser tests outside the class keep their literals — those assert a transaction date parsed out of fixed XML, which is about the XML, not the window.

## Test plan

Run before opening.

- `TZ=UTC pytest tests/test_ingest_form4.py -q` → **18 passed**.
- `TZ=UTC pytest tests/ -q` against the current `v0.124.49` pin → **5021 passed, 9 skipped, 1 xfailed, 0 failed**.

UTC is the condition that produced the original failure — a Pacific laptop was still on the previous day, which is why it presented as a CI-only flake.

Also recorded in alpha-engine-config#6951: four guard tests (`test_no_local_iam_tree_references`, `test_no_secret_environ_reads`, `test_severity_taxonomy_chokepoint`, `test_telegram_raw_send_message_burndown_guard`) fail in the **shared checkout** and pass in a clean worktree — they scan the repo tree and trip on the `.claude/worktrees/agent-*` copies of other repos inside it. A local artifact, not a main-branch defect.

Closes #6951

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)