### PR TITLE
fix(alarms): both horizon-grading alarms were rejected by CloudWatch and have never existed (config-I7024)

### DIFF
--- a/infrastructure/setup_horizon_grading_alarms.sh
+++ b/infrastructure/setup_horizon_grading_alarms.sh
@@ -28,11 +28,34 @@
 # Cadence: universe_returns/predictor_outcomes are populated by the
 # data-weekly collector (Saturday SF, ~weekly cadence — see
 # collectors/universe_returns.py / collectors/signal_returns.py). One
-# datapoint per week. Period=604800 (7d) + EvaluationPeriods=3 +
-# DatapointsToAlarm=2 requires the lag to be sustained non-zero across at
-# least 2 of the last 3 weekly runs before paging — a single week's lag > 0
-# right after a new forward window closes (the expected transient) does not
-# alarm; only a lag that FAILS TO RESET across consecutive runs does.
+# datapoint per week.
+#
+# BOTH ALARMS BELOW WERE REJECTED BY CLOUDWATCH AND HAVE NEVER EXISTED.
+# Measured live 2026-08-12 (`describe-alarms`): neither name is present in the
+# account. The declaration was Period=604800 + EvaluationPeriods=3, and
+# CloudWatch enforces `EvaluationPeriods * Period <= 604800` for any alarm with
+# `period >= 3600` — 1,814,400 is a ValidationError, so `put-metric-alarm`
+# failed, `set -e` stopped the script, and every run of it since has died on
+# the first alarm. The horizon-grading gate this file exists to provide has
+# been unwatched the whole time, with nothing reporting that.
+#
+# Now: Period=86400 (1d) + EvaluationPeriods=7 + DatapointsToAlarm=1. Legal
+# (7 * 86400 == 604800), and it reads the same weekly datapoint: exactly one
+# daily bucket in any 7-day window carries data, so Maximum > 0 in that bucket
+# alarms. Daily granularity rather than one 604800s period is deliberate — a
+# single period exactly equal to the producer's interval sits on the boundary
+# and flaps immediately before each scheduled run.
+#
+# DELTA, STATED RATHER THAN SILENT: this fires on ONE weekly run with lag > 0.
+# The original intent was 2 of the last 3 runs, so that a single week's lag
+# right after a new forward window closes (the expected transient) would not
+# page. Three weekly periods is 21 days of alarm window and is NOT expressible
+# under the cap at any period >= 3600, so the suppression cannot live in the
+# alarm. It belongs in the producer: emit a consecutive-weeks-non-zero counter
+# from _emit_horizon_grading_lag_metric and alarm on that at threshold >= 2,
+# which has no window at all. Tracked as alpha-engine-config-I7044. Until it
+# lands, a detector that may page one week early beats two that do not exist.
+#
 # treat-missing-data=notBreaching: a week where the collector didn't run for
 # an unrelated reason (already covered by weekly_collector_manifest /
 # research_db_backup freshness checks in alpha-engine-config's
@@ -73,11 +96,11 @@ echo "==> alpha-engine-universe-returns-horizon-lag"
 aws cloudwatch put-metric-alarm \
   --region "$REGION" \
   --alarm-name "alpha-engine-universe-returns-horizon-lag" \
-  --alarm-description "Fires when universe_returns_horizon_grading_lag_trading_days (AlphaEngine/Data, HorizonDays=21 dimension) stays > 0 across 2 of the last 3 weekly data-weekly runs. Lag=0 on a healthy pipeline: every eval_date whose 21-trading-day forward window has closed gets return_21d/log_return_21d populated by the next run. Sustained lag means the collectors/universe_returns.py backfill (_get_existing_dates / _trading_days_to_process) has genuinely stalled — NOT that recent dates are still waiting on their forward window to close (that's the expected, non-alarming transient). config#2972." \
+  --alarm-description "Fires when universe_returns_horizon_grading_lag_trading_days (AlphaEngine/Data, HorizonDays=21 dimension) is > 0 on the most recent weekly data-weekly run (any of the last 7 daily periods). Lag=0 on a healthy pipeline: every eval_date whose 21-trading-day forward window has closed gets return_21d/log_return_21d populated by the next run. Sustained lag means the collectors/universe_returns.py backfill (_get_existing_dates / _trading_days_to_process) has genuinely stalled — NOT that recent dates are still waiting on their forward window to close (that's the expected, non-alarming transient). config#2972." \
   --comparison-operator "GreaterThanThreshold" \
-  --evaluation-periods 3 \
-  --datapoints-to-alarm 2 \
-  --period 604800 \
+  --evaluation-periods 7 \
+  --datapoints-to-alarm 1 \
+  --period 86400 \
   --statistic "Maximum" \
   --threshold 0 \
   --treat-missing-data "notBreaching" \
@@ -94,11 +117,11 @@ echo "==> alpha-engine-predictor-outcomes-grading-lag"
 aws cloudwatch put-metric-alarm \
   --region "$REGION" \
   --alarm-name "alpha-engine-predictor-outcomes-grading-lag" \
-  --alarm-description "Fires when predictor_outcomes_grading_lag_trading_days (AlphaEngine/Data, HorizonDays=21 dimension) stays > 0 across 2 of the last 3 weekly data-weekly runs. Lag=0 on a healthy pipeline: every prediction_date whose forward_days window has closed gets horizon_days/correct/actual_log_alpha populated by collectors/signal_returns.py::_backfill_predictor_returns on the next run. Sustained lag means the universe_returns JOIN this backfill depends on has stopped finding matches for closed-window predictions — NOT that recent predictions are still waiting on grading (that's the expected, non-alarming transient). config#2972." \
+  --alarm-description "Fires when predictor_outcomes_grading_lag_trading_days (AlphaEngine/Data, HorizonDays=21 dimension) is > 0 on the most recent weekly data-weekly run (any of the last 7 daily periods). Lag=0 on a healthy pipeline: every prediction_date whose forward_days window has closed gets horizon_days/correct/actual_log_alpha populated by collectors/signal_returns.py::_backfill_predictor_returns on the next run. Sustained lag means the universe_returns JOIN this backfill depends on has stopped finding matches for closed-window predictions — NOT that recent predictions are still waiting on grading (that's the expected, non-alarming transient). config#2972." \
   --comparison-operator "GreaterThanThreshold" \
-  --evaluation-periods 3 \
-  --datapoints-to-alarm 2 \
-  --period 604800 \
+  --evaluation-periods 7 \
+  --datapoints-to-alarm 1 \
+  --period 86400 \
   --statistic "Maximum" \
   --threshold 0 \
   --treat-missing-data "notBreaching" \
@@ -116,4 +139,4 @@ echo "  aws cloudwatch describe-alarms --region $REGION \\"
 echo "    --alarm-names alpha-engine-universe-returns-horizon-lag alpha-engine-predictor-outcomes-grading-lag \\"
 echo "    --query 'MetricAlarms[].[AlarmName,StateValue]' --output table"
 echo ""
-echo "First firing eligibility: both alarms remain INSUFFICIENT_DATA until 2 of the last 3 weekly data-weekly runs have emitted the metric (~2-3 weeks after this script + the signal_returns.py change deploy). treat-missing-data=notBreaching means a skipped run doesn't independently page — the existing weekly_collector_manifest / research_db_backup freshness checks (alpha-engine-config ARTIFACT_REGISTRY.yaml) already cover run-absence."
+echo "First firing eligibility: both alarms remain INSUFFICIENT_DATA until one weekly data-weekly run has emitted the metric (~1 week). treat-missing-data=notBreaching means a skipped run doesn't independently page — the existing weekly_collector_manifest / research_db_backup freshness checks (alpha-engine-config ARTIFACT_REGISTRY.yaml) already cover run-absence. The 2-of-3-weeks suppression these alarms were meant to carry is not expressible under CloudWatch's window cap and moves to the producer: alpha-engine-config-I7044."

--- a/tests/test_alarm_windows_within_cloudwatch_cap.py
+++ b/tests/test_alarm_windows_within_cloudwatch_cap.py
@@ -1,0 +1,71 @@
+"""No `put-metric-alarm` in this repo may declare a window CloudWatch rejects.
+
+WHY
+---
+CloudWatch enforces `EvaluationPeriods * Period <= 604800` for any alarm with
+`period >= 3600`. A declaration that violates it is not a degraded alarm — the
+API call fails with a ValidationError, so **the alarm does not exist**, and
+under `set -euo pipefail` every alarm declared after it in the same script is
+never applied either.
+
+Nothing reports that. The component reads as monitored because a file in the
+repo says it is.
+
+Measured 2026-08-12: `setup_horizon_grading_alarms.sh` declared both of its
+alarms at `Period=604800, EvaluationPeriods=3` (1,814,400). Neither alarm
+existed in the account, and the script had been failing on its first call for
+as long as the declaration had been there. The same cap took out four of six
+alarms on the router degraded-mode drill in nous-ergon-ops the same day,
+including that component's absence detector.
+
+This is a source-text assertion because the alarms are created by shell scripts
+run against a live account; what it pins is that the declaration is applicable
+at all.
+"""
+
+import re
+from pathlib import Path
+
+INFRA = Path(__file__).resolve().parents[1] / "infrastructure"
+
+MAX_WINDOW_SECONDS = 604800
+CAP_APPLIES_AT_PERIOD = 3600
+
+_CALL = re.compile(r"put-metric-alarm(.*?)(?=put-metric-alarm|\Z)", re.S)
+_PERIOD = re.compile(r"--period[= ]+\"?(\d+)")
+_EVAL = re.compile(r"--evaluation-periods[= ]+\"?(\d+)")
+_NAME = re.compile(r"--alarm-name[= ]+\"?([^\"\s\\]+)")
+
+
+def _declarations():
+    for path in sorted(INFRA.rglob("*.sh")):
+        text = path.read_text(errors="ignore")
+        if "put-metric-alarm" not in text:
+            continue
+        for chunk in _CALL.findall(text):
+            period, evals = _PERIOD.search(chunk), _EVAL.search(chunk)
+            if not period or not evals:
+                continue
+            name = _NAME.search(chunk)
+            yield (path.name, name.group(1) if name else "<unnamed>",
+                   int(period.group(1)), int(evals.group(1)))
+
+
+def test_every_alarm_declares_a_window_cloudwatch_will_accept():
+    declarations = list(_declarations())
+    assert declarations, (
+        "No put-metric-alarm declaration found under infrastructure/. This "
+        "assertion is here so the test cannot pass vacuously if the alarm "
+        "scripts move or change shape."
+    )
+    for script, name, period, evals in declarations:
+        if period < CAP_APPLIES_AT_PERIOD:
+            continue
+        assert period * evals <= MAX_WINDOW_SECONDS, (
+            f"{script}: alarm {name} declares period={period} x "
+            f"evaluation-periods={evals} = {period * evals}s, over the "
+            f"{MAX_WINDOW_SECONDS}s cap that applies at period >= "
+            f"{CAP_APPLIES_AT_PERIOD}. put-metric-alarm will reject this, so "
+            f"the alarm will not exist and every alarm after it in "
+            f"{script} will never be applied."
+        )


### PR DESCRIPTION
## What this fixes

`infrastructure/setup_horizon_grading_alarms.sh` declared both of its alarms with `Period=604800, EvaluationPeriods=3`. CloudWatch enforces `EvaluationPeriods * Period <= 604800` for any alarm with `period >= 3600`, so 1,814,400 raises `ValidationError`, `put-metric-alarm` fails, and `set -euo pipefail` stops the script on the **first** call.

**Verified live 2026-08-12** — `describe-alarms` returned neither `alpha-engine-universe-returns-horizon-lag` nor `alpha-engine-predictor-outcomes-grading-lag`. The horizon-grading gate this file exists to provide has been unwatched for as long as the declaration has been there, and nothing reported it: the repo says the component is monitored.

This is deliverable 4 of `alpha-engine-config-I7024`, found by sweeping the fleet after the same cap took out four of six alarms on the router degraded-mode drill (nous-ergon-ops-PR600). **Sweep result: 380 `put-metric-alarm` declarations across 19 repos, 5 over the cap — the drill's 3, now fixed on `main`, and these 2.** No other component is affected.

## The fix

`Period=86400, EvaluationPeriods=7, DatapointsToAlarm=1`. Legal (`7 x 86400 == 604800`), and it reads the same weekly datapoint: exactly one daily bucket in any 7-day window carries data, so `Maximum > 0` in that bucket alarms.

Daily granularity rather than one 604800s period is deliberate — a single period exactly equal to the producer's interval sits on the boundary and flaps immediately before each scheduled run.

### Stated delta

This fires on **one** weekly run with lag > 0. The intent was 2 of the last 3, so a single week's lag right after a forward window closes would not page. Three weekly periods is a 21-day alarm window, not expressible under the cap at any `period >= 3600`, so the suppression cannot live in the alarm — it moves to the producer as a consecutive-weeks-non-zero counter, tracked as **alpha-engine-config-I7044**. Until that lands, a detector that may page one week early beats two that do not exist.

## Applied before this PR, not after the merge

There is no deploy-on-merge for this script — it is operator-run, which is exactly how the rejection stayed invisible. Ran it in-session with `AWS_PROFILE=ne-admin` (pull-request-policy §4.2 form 2), so this commit codifies state that already exists:

```
alpha-engine-predictor-outcomes-grading-lag  period=86400  eval=7  dta=1  INSUFFICIENT_DATA
alpha-engine-universe-returns-horizon-lag    period=86400  eval=7  dta=1  INSUFFICIENT_DATA
```

`INSUFFICIENT_DATA` is correct here: the first weekly datapoint has not landed yet, and `treat-missing-data=notBreaching` keeps run-absence with the `weekly_collector_manifest` freshness row that already owns it.

## Surviving the class

`tests/test_alarm_windows_within_cloudwatch_cap.py` — no `put-metric-alarm` under `infrastructure/` may declare a window CloudWatch will reject. **Shown failing against the pre-fix declaration** (restored it, ran the test, got the failure, restored the fix), and it carries a non-vacuity assertion so it cannot silently stop checking if the scripts move.

## Testing

- `pytest tests/test_alarm_windows_within_cloudwatch_cap.py` — 1 passed; 1 failed against the pre-fix text.
- The full suite has 19 collection errors and ~177 failures on this laptop from missing `bs4`, `tenacity`, `yfinance` and a `nousergon_lib.shell_guards` that is absent from the installed pin — environment, not code. Neither changed file is importable Python, and the new test collects and passes standalone. CI has the real dependency set.

Closes #7024

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)