### PR TITLE
[P1/mid] fix(sf): migrate weekly-SF health checks off broken log-ship trap + I7048 sweep fixes

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1404,7 +1404,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Next": "PublishResearchFailureImmediate",
+                  "Next": "NormalizeBranchAFailureContext",
                   "ResultPath": "$.error"
                 }
               ],
@@ -1444,7 +1444,7 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Next": "PublishResearchFailureImmediate",
+                  "Next": "NormalizeBranchAFailureContext",
                   "ResultPath": "$.error"
                 }
               ],
@@ -1560,7 +1560,7 @@
                 "poll.$": "$.rag_ingestion_poll"
               },
               "ResultPath": "$.error",
-              "Next": "PublishResearchFailureImmediate"
+              "Next": "NormalizeBranchAFailureContext"
             },
             "ExtractRAGIngestionSubstrateLostError": {
               "Type": "Pass",
@@ -1571,7 +1571,7 @@
                 "poll.$": "$.rag_ingestion_poll"
               },
               "ResultPath": "$.error",
-              "Next": "PublishResearchFailureImmediate"
+              "Next": "NormalizeBranchAFailureContext"
             },
             "CheckSkipRegimeRetrospectiveEval": {
               "Type": "Choice",
@@ -1868,7 +1868,7 @@
                 "error": "DataPhase2 SSM command exhausted its retry budget (1 re-issue) without succeeding \u2014 the alternative data collector failed on both attempts."
               },
               "ResultPath": "$.error",
-              "Next": "PublishResearchFailureImmediate"
+              "Next": "NormalizeBranchAFailureContext"
             },
             "ExtractDataPhase2SubstrateLostError": {
               "Type": "Pass",
@@ -1879,7 +1879,7 @@
                 "poll.$": "$.data_phase2_poll"
               },
               "ResultPath": "$.error",
-              "Next": "PublishResearchFailureImmediate"
+              "Next": "NormalizeBranchAFailureContext"
             },
             "DataPhase2Reissue": {
               "Type": "Pass",
@@ -2497,6 +2497,15 @@
                 "error.$": "$.error"
               },
               "ResultPath": "$.error",
+              "Next": "NormalizeBranchAFailureContext"
+            },
+            "NormalizeBranchAFailureContext": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I7048 Defect B hardening (2026-08-12): defensive $.error normalizer inserted ahead of PublishResearchFailureImmediate. Every current predecessor (ExtractRAGIngestionError, ExtractRAGIngestionSubstrateLostError, SetDataPhase2ExhaustedError, ExtractDataPhase2SubstrateLostError, ExtractSignalsEnvelopeError, plus RAGIngestion's and WaitForRAGIngestion's own Catch edges) was repointed here from PublishResearchFailureImmediate \u2014 each verified live to already set $.error via ResultPath, so this never overrides real data today. Exists because the 2026-08-01 scheduled run (execution 29056da2-812e-b4a2-28fb-e62eaaf8e917_3188dff4-...) crashed inside PublishResearchFailureImmediate: its States.Format dereferenced $.error, found it absent on the inbound path, and the resulting States.Runtime REPLACED the real branch-A error this state exists to report \u2014 the failure-mode class recorded 2026-08-11 as 'the error handler that destroys its own error'. States.JsonMerge(placeholder, $, false): $ (the second arg) wins on any key it already has, so a real $.error is never touched; only an ABSENT $.error falls back to the placeholder message. Kept PublishResearchFailureImmediate's Task name unchanged (rather than renaming it out) so nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE needs no companion nousergon-lib PR for this hardening.",
+              "Parameters": {
+                "merged.$": "States.JsonMerge(States.StringToJson('{\"error\":{\"message\":\"no error captured on this branch-A failure path (defensive default \u2014 alpha-engine-config-I7048)\"}}'), $, false)"
+              },
+              "OutputPath": "$.merged",
               "Next": "PublishResearchFailureImmediate"
             },
             "PublishResearchFailureImmediate": {
@@ -2842,6 +2851,15 @@
                 "poll.$": "$.predictor_poll"
               },
               "ResultPath": "$.error",
+              "Next": "NormalizeBranchBFailureContext"
+            },
+            "NormalizeBranchBFailureContext": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I7048 Defect B hardening (2026-08-12): same defensive $.error normalizer as NormalizeBranchAFailureContext, applied to this identical-shape Branch B sibling ahead of PublishPredictorFailureImmediate (both dereference $.error via States.JsonToString; 'same shape, different pipeline' per I7048). Both current predecessors (ExtractPredictorError, ExtractPredictorTrainingSubstrateLostError) were repointed here from PublishPredictorFailureImmediate \u2014 each verified live to set $.error via ResultPath, so this never overrides real data today \u2014 it guards against a FUTURE predecessor being wired in without setting $.error, which is exactly how the sibling PublishResearchFailureImmediate crashed on the 2026-08-01 run. States.JsonMerge(placeholder, $, false): $ (second arg) wins on any key it already has. Kept PublishPredictorFailureImmediate's Task name unchanged so nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE needs no companion nousergon-lib PR for this hardening.",
+              "Parameters": {
+                "merged.$": "States.JsonMerge(States.StringToJson('{\"error\":{\"message\":\"no error captured on this branch-B failure path (defensive default \u2014 alpha-engine-config-I7048)\"}}'), $, false)"
+              },
+              "OutputPath": "$.merged",
               "Next": "PublishPredictorFailureImmediate"
             },
             "PublishPredictorFailureImmediate": {
@@ -3548,7 +3566,7 @@
                 "poll.$": "$.predictor_poll"
               },
               "ResultPath": "$.error",
-              "Next": "PublishPredictorFailureImmediate"
+              "Next": "NormalizeBranchBFailureContext"
             },
             "ModelZooResolveLivenessGate": {
               "Type": "Choice",
@@ -3580,13 +3598,13 @@
             },
             "ExtractModelZooResolveSubstrateLostError": {
               "Type": "Pass",
-              "Comment": "config#6938: the SUBSTRATE-LOST sibling of ExtractModelZooResolveError. Same normalization, distinguishable phase, same downstream hand-off \u2014 so an operator can tell a reclaimed box from a ModelZooResolve failure without opening the execution history.",
+              "Comment": "config#6938: the SUBSTRATE-LOST sibling of ExtractModelZooResolveError. Same normalization, distinguishable phase, same downstream hand-off \u2014 so an operator can tell a reclaimed box from a ModelZooResolve failure without opening the execution history. alpha-engine-config-I7048 (2026-08-12): ResultPath corrected from $.error to $.model_zoo_error \u2014 ExtractModelZooResolveError's own Comment already documents this exact class (config#2160: a direct Choice->Task jump on this edge died with States.Runtime, 'could not be found', masking the real failure) and this SubstrateLost sibling reintroduced it: PublishModelZooFailureImmediate's Message dereferences $.model_zoo_error, not $.error, so a SubstrateLost-during-resolve failure hit the identical States.Runtime crash the config#2160 fix exists to prevent. Never exercised by a healthy run \u2014 caught by static sweep, not by observed failure.",
               "Parameters": {
                 "phase": "ModelZooResolve/SubstrateLost",
                 "source": "ModelZooResolveLivenessGate.SubstrateLost",
                 "poll.$": "$.resolve_zoo_poll"
               },
-              "ResultPath": "$.error",
+              "ResultPath": "$.model_zoo_error",
               "Next": "PublishModelZooFailureImmediate"
             },
             "ModelZooSelectLivenessGate": {
@@ -3619,13 +3637,13 @@
             },
             "ExtractModelZooSelectSubstrateLostError": {
               "Type": "Pass",
-              "Comment": "config#6938: the SUBSTRATE-LOST sibling of ExtractModelZooSelectError. Same normalization, distinguishable phase, same downstream hand-off \u2014 so an operator can tell a reclaimed box from a ModelZooSelect failure without opening the execution history.",
+              "Comment": "config#6938: the SUBSTRATE-LOST sibling of ExtractModelZooSelectError. Same normalization, distinguishable phase, same downstream hand-off \u2014 so an operator can tell a reclaimed box from a ModelZooSelect failure without opening the execution history. alpha-engine-config-I7048 (2026-08-12): ResultPath corrected from $.error to $.model_zoo_error \u2014 same class + fix as ExtractModelZooResolveSubstrateLostError; PublishModelZooFailureImmediate's Message dereferences $.model_zoo_error, not $.error, so a SubstrateLost-during-select failure hit the exact States.Runtime crash the config#2160 fix (see ExtractModelZooSelectError's Comment) exists to prevent. Never exercised by a healthy run \u2014 caught by static sweep, not by observed failure.",
               "Parameters": {
                 "phase": "ModelZooSelect/SubstrateLost",
                 "source": "ModelZooSelectLivenessGate.SubstrateLost",
                 "poll.$": "$.model_zoo_poll"
               },
-              "ResultPath": "$.error",
+              "ResultPath": "$.model_zoo_error",
               "Next": "PublishModelZooFailureImmediate"
             }
           }
@@ -5586,20 +5604,13 @@
     },
     "SaturdayHealthCheck": {
       "Type": "Task",
-      "Comment": "Check data freshness after full pipeline \u2014 non-blocking (a failure degrades the completion email, it does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 timeout convention (both health-observe states): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded \u2014 it is a runaway bound, no longer a silent kill-and-skip); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout \u2014 time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call, which returns in <1s \u2014 pinned to inner+30 so the relation stays coherent if this ever flips to a .sync integration). Budget: executionTimeout raised 60\u2192300 (config#2276): observed successful health_checker.py runs complete in ~2.7-2.8s (n=2 Success in the 30-day SSM history sampled 2026-07-11 \u2014 most runs FAILED sub-second on git-pull collisions, see CheckSaturdayHealthCheckStatus), so 300s is ~100x observed with headroom for S3-latency-bound freshness scans; under the poll loop a generous budget costs nothing on the happy path.",
+      "Comment": "Check data freshness after full pipeline \u2014 non-blocking (a failure degrades the completion email, it does not halt). Runs from alpha-engine-dashboard post-2026-04-16 health_checker migration. config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 it is best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 timeout convention (both health-observe states): inner executionTimeout = script runtime budget (agent-enforced; its expiry surfaces as a terminal non-Success status the poll Choice turns into health_check_degraded \u2014 it is a runaway bound, no longer a silent kill-and-skip); SSM Parameters.TimeoutSeconds = 60 uniform (DELIVERY timeout \u2014 time for the agent to PICK UP the command, not to run it); outer Task TimeoutSeconds = executionTimeout + 30 (bounds only the async SendCommand API call, which returns in <1s \u2014 pinned to inner+30 so the relation stays coherent if this ever flips to a .sync integration). Budget: executionTimeout raised 60\u2192300 (config#2276): observed successful health_checker.py runs complete in ~2.7-2.8s (n=2 Success in the 30-day SSM history sampled 2026-07-11 \u2014 most runs FAILED sub-second on git-pull collisions, see CheckSaturdayHealthCheckStatus), so 300s is ~100x observed with headroom for S3-latency-bound freshness scans; under the poll loop a generous budget costs nothing on the happy path. alpha-engine-config-I7047 (2026-08-12): migrated off the inline `trap 'aws s3 cp ... EXIT'` log-ship wrapper to krepis.ssm_log_capture (mirrors the 17 other Saturday SF stages) \u2014 the trap collapsed under ASL's States.Array escape semantics on EVERY run using it (`trap: s3: invalid signal specification`, rc=127), which is why the 2026-08-08 scheduled run finished DEGRADED despite every real work stage succeeding with ResponseCode 0. Deliberately does NOT thread $.preflight_args: config#902's shell-run comment states this pair has no skip gate by design and runs for-real (not dry) even under shell_run \u2014 threading preflight_args would pass --preflight-only into a health_checker.py invocation that has no such flag.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main",
-            "cd /home/ec2-user/alpha-engine-dashboard",
-            "source .venv/bin/activate",
-            "trap 'aws s3 cp /var/log/health-check.log \"s3://alpha-engine-research/_ssm_logs/health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python health_checker.py --alert 2>&1 | tee /var/log/health-check.log"
-          ],
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
           "executionTimeout": [
             "300"
           ]
@@ -5721,13 +5732,13 @@
     },
     "WeeklySubstrateHealthCheck": {
       "Type": "Task",
-      "Comment": "Phase 2 \u2192 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) \u2014 agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (a failure degrades the completion email, it does not halt) \u2014 same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 \u2014 DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 \u2014 NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync \u2014 infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. Timeout convention + budget: see SaturdayHealthCheck's Comment \u2014 inner 240 (observed Success ~19-20s incl. the since-removed pip; ~12x headroom as a runaway bound), delivery 60, outer = inner + 30. The previous 240/180/240 set conflated the delivery timeout with an execution ceiling (inversion flagged by config#2276).",
+      "Comment": "Phase 2 \u2192 3 transparency-substrate health check. Validates every row of the transparency inventory (alpha-engine-lib transparency_inventory.yaml) \u2014 agent decisions, predictor decisions, trade lineage, risk events, P&L attribution, config changes, data quality, agent quality, pipeline execution. Per-row CloudWatch metrics emit to AlphaEngine/Substrate so individual rows have their own alarms. Non-blocking (a failure degrades the completion email, it does not halt) \u2014 same pattern as SaturdayHealthCheck. The Sat SF passes --cadence weekly which sweeps weekly + daily rows; the weekday EOD SF runs --cadence daily on the daily-only subset (PR #178 \u2014 DailySubstrateHealthCheck state). config#2279: deliberately carries NO Retry ladder (declared class: health-observe) \u2014 best-effort observability at the tail of an already-green run; its States.ALL Catch fail-softs into the DEGRADED completion path, so a retry ladder would only delay completion, never protect spend. config#2276 \u2014 NO runtime pip: the former in-pipeline `pip install --quiet --upgrade -r requirements.txt` (a live PyPI/network dependency inside an observability stage, with --upgrade able to float unpinned transitive deps past tested versions) was removed; the stage relies on the dashboard box's deploy-time venv sync \u2014 infrastructure/deploy-on-merge.sh in crucible-dashboard runs `.venv/bin/pip install -r requirements.txt` on every merge that diffs requirements.txt, and nousergon-lib is TAG-pinned there (@vX.Y.Z), so a lib bump always changes requirements.txt and always refreshes the same /home/ec2-user/alpha-engine-dashboard/.venv this command activates. Timeout convention + budget: see SaturdayHealthCheck's Comment \u2014 inner 240 (observed Success ~19-20s incl. the since-removed pip; ~12x headroom as a runaway bound), delivery 60, outer = inner + 30. The previous 240/180/240 set conflated the delivery timeout with an execution ceiling (inversion flagged by config#2276). alpha-engine-config-I7047 (2026-08-12): the three commands are now a single crucible-dashboard infrastructure/substrate_health_check.sh script, invoked through krepis.ssm_log_capture instead of the inline `trap 'aws s3 cp ... EXIT'` wrapper \u2014 that trap's inner single-quote had to be `\\'`-escaped inside this state's States.Array, and ASL does NOT unescape `\\'` to `'` (it passes the backslash through literally), so bash word-split the trap's own command line into signal names (`trap: s3: invalid signal specification`, rc=127) on EVERY run \u2014 the 2026-08-08 scheduled run finished DEGRADED for exactly this reason despite every real work stage succeeding with ResponseCode 0. Mirrors the 17 other Saturday SF stages already on krepis.ssm_log_capture. Deliberately does NOT thread $.preflight_args \u2014 see SaturdayHealthCheck's Comment; this pair has no skip gate by design and runs for-real even under shell_run, and substrate_health_check.sh has no --preflight-only flag to receive it.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','source .venv/bin/activate','trap \\'aws s3 cp /var/log/substrate-health-check.log \"s3://alpha-engine-research/_ssm_logs/substrate-health-check/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true\\' EXIT','python -m nousergon_lib.transparency --cadence weekly --alert 2>&1 | tee /var/log/substrate-health-check.log','echo \\'--- constituents drift check ---\\' | tee -a /var/log/substrate-health-check.log','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.constituents_drift_check 2>&1 | tee -a /var/log/substrate-health-check.log','echo \\'--- phase marker sweep ---\\' | tee -a /var/log/substrate-health-check.log',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'cd /home/ec2-user/alpha-engine-data && /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m validators.phase_marker_sweep --run-date \"$RUN_DATE\" --alert 2>&1 | tee -a /var/log/substrate-health-check.log')",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {}',$$.Execution.Name,$.run_date))",
           "executionTimeout": [
             "240"
           ]

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -835,25 +835,13 @@
     },
     "RunMorningPlanner": {
       "Type": "Task",
-      "Comment": "Run morning order-book planner via SSM",
+      "Comment": "Run morning order-book planner via SSM. alpha-engine-config-I7047 sweep (2026-08-12): migrated off the inline `trap 'aws s3 cp ... EXIT'` log-ship wrapper to krepis.ssm_log_capture — found by the I7047 guard test, which asserts zero occurrences of the anti-pattern in ANY nousergon-data SF definition, not just the two Saturday health-observe stages the issue named. Unlike WeeklySubstrateHealthCheck's instance, this one was a plain `commands` JSON array (not `commands.$`/States.Array), so it was not exhibiting the ASL `\\'`-escape-collapse bug specifically — but it is the same anti-pattern this fleet is retiring in favor of krepis (17+ sibling stages), so it is migrated for consistency rather than left as a second, differently-shaped copy. Behavior-preserving: `source .venv/bin/activate` is kept (subprocess inherits the activated PATH so a bare `python` invocation still resolves to this venv's interpreter) — only the krepis wrapper binary itself is called by absolute path, per fleet convention.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.trading_instance_id",
         "Parameters": {
-          "commands": [
-            "set -eo pipefail",
-            "export FLOW_DOCTOR_ENABLED=1",
-            "export ALPHA_ENGINE_DEPLOYED=1",
-            "export AWS_REGION=us-east-1",
-            "export AWS_DEFAULT_REGION=us-east-1",
-            "cd /home/ec2-user/alpha-engine",
-            "source .venv/bin/activate",
-            "export EXPECTED_EXECUTOR_SHA=\"$(cat /home/ec2-user/.frozen_executor_sha 2>/dev/null || true)\"",
-            "/home/ec2-user/alpha-engine/infrastructure/wait-for-ibgateway.sh",
-            "trap 'aws s3 cp /var/log/executor.log \"s3://alpha-engine-research/_ssm_logs/executor/$(date -u +%Y-%m-%d)/$(hostname)-$(date -u +%H%M%SZ).log\" --only-show-errors || true' EXIT",
-            "python executor/main.py 2>&1 | tee -a /var/log/executor.log"
-          ],
+          "commands.$": "States.Array('set -eo pipefail','export FLOW_DOCTOR_ENABLED=1','export ALPHA_ENGINE_DEPLOYED=1','export AWS_REGION=us-east-1','export AWS_DEFAULT_REGION=us-east-1','cd /home/ec2-user/alpha-engine','source .venv/bin/activate','export EXPECTED_EXECUTOR_SHA=\"$(cat /home/ec2-user/.frozen_executor_sha 2>/dev/null || true)\"','/home/ec2-user/alpha-engine/infrastructure/wait-for-ibgateway.sh',States.Format('/home/ec2-user/alpha-engine/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug executor --log /var/log/executor.log -- python executor/main.py',$$.Execution.Name))",
           "executionTimeout": [
             "600"
           ]

--- a/tests/test_no_inline_log_ship_trap_anywhere.py
+++ b/tests/test_no_inline_log_ship_trap_anywhere.py
@@ -1,0 +1,101 @@
+"""alpha-engine-config-I7047 deliverable 3: assert the ABSENCE of the inline
+`trap 'aws s3 cp ... EXIT'` log-ship anti-pattern across every state of every
+scheduled SF definition in this repo — not the presence of the krepis
+wrapper on the two health-observe stages the issue named.
+
+Why absence, not presence: enumerating the states that already got fixed is
+blind to the one that is still missing. Measured 2026-08-08: the scheduled
+Saturday weekly run succeeded on every real work stage and still reported
+DEGRADED, solely because SaturdayHealthCheck and WeeklySubstrateHealthCheck
+carried this pattern — `WeeklySubstrateHealthCheck`'s copy additionally
+collapsed under ASL's `commands.$`/States.Array `\\'`-escape semantics
+(`trap: s3: invalid signal specification`, rc=127; ASL does not unescape
+`\\'` to `'`, it passes the backslash through literally and bash word-splits
+the trap's own command line into bogus signal names).
+
+The sweep this test backs found a THIRD, differently-shaped instance:
+`RunMorningPlanner` in step_function_daily.json carried the same textual
+pattern inside a plain (non-`commands.$`) `commands` array — not exhibiting
+the ASL-escape bug specifically, but the same anti-pattern this fleet is
+retiring fleet-wide in favor of `krepis.ssm_log_capture` (18+ stages now,
+across all three scheduled SF definitions). Fixed in the same PR.
+
+The krepis module's own docstring names this exact failure register
+(`krepis/src/krepis/ssm_log_capture.py`), and is the institutional
+replacement — not a per-state hand patch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_INFRA_DIR = Path(__file__).resolve().parent.parent / "infrastructure"
+
+# alpha-engine-config-I7047's Closes-when line names these three explicitly:
+# "zero occurrences of `trap 'aws s3 cp` remain in any SF definition in
+# nousergon-data." step_function_groom.json is a fourth scheduled SF
+# definition in this repo; included here too since the issue's own
+# deliverable-3 language ("assert the absence of the anti-pattern across
+# ALL stages") does not carve it out, and a future groom-pipeline log-ship
+# state should not get to reintroduce the pattern unnoticed.
+_SF_FILES = [
+    "step_function.json",
+    "step_function_eod.json",
+    "step_function_daily.json",
+    "step_function_groom.json",
+]
+
+# The exact substring that identifies the anti-pattern regardless of
+# surrounding quoting/escaping style (`trap 'aws s3 cp` / `trap \'aws s3 cp`
+# both contain this literal run).
+_ANTI_PATTERN = "trap 'aws s3 cp"
+
+
+def _iter_command_strings(states: dict):
+    """Yield (state_name, command_string) for every SSM command line in
+    every state, descending into Parallel branches and Map iterators.
+    Reads both the static `commands` list and the `commands.$` intrinsic
+    (the raw ASL expression string — sufficient for a substring check,
+    since the anti-pattern's characteristic text survives ASL's escaping
+    either way)."""
+    for name, body in states.items():
+        if not isinstance(body, dict):
+            continue
+        params = (body.get("Parameters") or {}).get("Parameters") or {}
+        cmds = params.get("commands")
+        if isinstance(cmds, list):
+            for c in cmds:
+                if isinstance(c, str):
+                    yield name, c
+        cmds_expr = params.get("commands.$")
+        if isinstance(cmds_expr, str):
+            yield name, cmds_expr
+
+        if body.get("Type") == "Parallel":
+            for branch in body.get("Branches", []):
+                yield from _iter_command_strings(branch.get("States", {}))
+        if body.get("Type") == "Map":
+            proc = body.get("ItemProcessor") or body.get("Iterator") or {}
+            yield from _iter_command_strings(proc.get("States", {}))
+
+
+@pytest.mark.parametrize("sf_file", _SF_FILES)
+def test_no_inline_trap_aws_s3_cp_anywhere(sf_file):
+    path = _INFRA_DIR / sf_file
+    assert path.exists(), f"{sf_file} not found under {_INFRA_DIR}"
+    states = json.loads(path.read_text())["States"]
+
+    offenders = [
+        (name, cmd) for name, cmd in _iter_command_strings(states)
+        if _ANTI_PATTERN in cmd
+    ]
+    assert not offenders, (
+        f"{sf_file}: {len(offenders)} state(s) still carry the inline "
+        f"`trap 'aws s3 cp ... EXIT` log-ship anti-pattern — migrate to "
+        f"krepis.ssm_log_capture (see the 18+ sibling stages across this "
+        f"repo's SF definitions for the idiom): "
+        f"{sorted(n for n, _ in offenders)}"
+    )

--- a/tests/test_sf_deploy_sha_pin_wiring.py
+++ b/tests/test_sf_deploy_sha_pin_wiring.py
@@ -40,6 +40,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.sf_command_utils import extract_commands
+
 _INFRA_DIR = Path(__file__).resolve().parent.parent / "infrastructure"
 _SF_PATH = _INFRA_DIR / "step_function_daily.json"
 _EOD_SF_PATH = _INFRA_DIR / "step_function_eod.json"
@@ -48,7 +50,12 @@ _PIN_FILE = "/home/ec2-user/.frozen_executor_sha"
 
 def _commands(state: str, sf_path: Path = _SF_PATH) -> list[str]:
     doc = json.loads(sf_path.read_text())
-    return doc["States"][state]["Parameters"]["Parameters"]["commands"]
+    # extract_commands() reads through either a static `commands` list or a
+    # `commands.$` States.Array intrinsic — alpha-engine-config-I7047
+    # (2026-08-12) converted RunMorningPlanner to the latter to thread the
+    # krepis.ssm_log_capture correlation id, mirroring the fleet-wide
+    # migration off the inline trap/log-ship wrapper.
+    return extract_commands(doc["States"][state])
 
 
 def test_freshness_gate_freezes_executor_sha_after_verify() -> None:

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -282,21 +282,36 @@ def test_no_runtime_pip_install_anywhere_in_definition(states):
 
 
 def test_constituents_drift_step_is_fail_visible(states):
-    # config#2322: commands moved from a static list to a commands.$
-    # States.Array intrinsic (to thread export RUN_DATE for the new
-    # phase-marker-sweep line) — extract_commands() reads through either.
+    # alpha-engine-config-I7047 (2026-08-12): the three inline commands
+    # (transparency sweep, constituents_drift_check, phase_marker_sweep)
+    # moved out of this SF definition into crucible-dashboard
+    # infrastructure/substrate_health_check.sh, invoked here through
+    # krepis.ssm_log_capture (mirrors the 17 other Saturday SF stages) —
+    # the prior inline `trap 'aws s3 cp ... EXIT'` wrapper collapsed under
+    # ASL's States.Array escape semantics (`trap: s3: invalid signal
+    # specification`, rc=127) on every run using it, which is why the
+    # 2026-08-08 scheduled run finished DEGRADED despite every real work
+    # stage succeeding. The "drift check must not swallow its own exit
+    # code with `|| true`" invariant this test used to pin now lives in
+    # crucible-dashboard's own test suite
+    # (tests/test_substrate_health_check_weekly_wiring.py), since the
+    # command itself is no longer visible in this repo's SF JSON. What
+    # THIS repo can still pin: no runtime `pip install` (unchanged
+    # invariant, config#2276) and that the SF invokes the extracted
+    # script through the krepis wrapper rather than any inline command.
     cmds = extract_commands(states["WeeklySubstrateHealthCheck"])
-    (drift_line,) = [c for c in cmds if "constituents_drift_check" in c]
-    assert "|| true" not in drift_line, (
-        "config#2276: the drift check exits 1 on alert-worthy drift (the "
-        "2026-05-23 BNY/P/SN incident surface) — '|| true' swallowed exactly "
-        "that signal; under set -eo pipefail its failure must fail the "
-        "command so the poll Choice degrades the completion email"
+    assert cmds[0] == "set -eo pipefail"
+    assert not any("pip install" in c for c in cmds)
+    assert not any("trap 'aws s3 cp" in c for c in cmds), (
+        "I7047: the inline trap/log-ship anti-pattern must not return to "
+        "this state — krepis.ssm_log_capture is the sole log-capture path"
     )
-    # the log-upload trap's own '|| true' is fine (best-effort log shipping,
-    # inline-commented failure mode) — pin that the drift WORK line is the
-    # only place we assert on.
-    assert cmds[0].startswith("set -eo pipefail")
+    wrapper_line = next(
+        c for c in cmds if "krepis.ssm_log_capture" in c
+    )
+    assert "--slug substrate-health-check" in wrapper_line
+    assert "bash infrastructure/substrate_health_check.sh --run-date" in wrapper_line
+    assert "$$.Execution.Name" in wrapper_line or "correlation-id" in wrapper_line
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -341,8 +341,10 @@ class TestBranchAContents:
         assert "SetDataPhase2ExhaustedError" in [
             c["Next"] for c in branch_a["DataPhase2RetryGate"]["Choices"]
         ]
+        # alpha-engine-config-I7048 (2026-08-12): targets the defensive
+        # $.error-normalizer chokepoint ahead of PublishResearchFailureImmediate.
         assert branch_a["SetDataPhase2ExhaustedError"]["Next"] == (
-            "PublishResearchFailureImmediate"
+            "NormalizeBranchAFailureContext"
         )
         assert branch_a["SetDataPhase2ExhaustedError"]["ResultPath"] == "$.error"
         assert branch_a["SetDataPhase2ExhaustedError"]["Parameters"]["phase"] == "DataPhase2"
@@ -796,16 +798,26 @@ class TestPerBranchErrorIsolation:
         ExtractSignalsEnvelopeError (renamed from ExtractResearchError) →
         PublishResearchFailureImmediate (the fast-SNS-alert state added
         2026-05-24, shared with RAGIngestion failures) → BranchAFailed —
-        NO non-blocking Catch-to-continue, unlike ChallengerShadow."""
+        NO non-blocking Catch-to-continue, unlike ChallengerShadow.
+
+        alpha-engine-config-I7048 (2026-08-12): ExtractSignalsEnvelopeError now
+        targets NormalizeBranchAFailureContext, a defensive $.error-normalizer
+        Pass chokepoint inserted ahead of PublishResearchFailureImmediate
+        (whose own name/Type/Resource are UNCHANGED — kept off a rename so
+        the nousergon_lib.pipeline_status.registry entry stays valid without
+        a companion nousergon-lib PR)."""
         catch_targets = [
             c["Next"] for c in branch_a["SignalsEnvelope"]["Catch"]
         ]
         assert catch_targets == ["ExtractSignalsEnvelopeError"]
-        # ExtractError → PublishImmediate → BranchAFailed
+        # ExtractError → normalizer → PublishResearchFailureImmediate → BranchAFailed
         assert (
             branch_a["ExtractSignalsEnvelopeError"]["Next"]
-            == "PublishResearchFailureImmediate"
+            == "NormalizeBranchAFailureContext"
         )
+        normalizer = branch_a["NormalizeBranchAFailureContext"]
+        assert normalizer["Type"] == "Pass"
+        assert normalizer["Next"] == "PublishResearchFailureImmediate"
         publish = branch_a["PublishResearchFailureImmediate"]
         assert publish["Type"] == "Task"
         assert publish["Resource"] == "arn:aws:states:::sns:publish"
@@ -889,8 +901,16 @@ class TestPerBranchErrorIsolation:
         ] == ["BranchBFailed"]
         assert (
             branch_b["ExtractPredictorError"]["Next"]
-            == "PublishPredictorFailureImmediate"
+            == "NormalizeBranchBFailureContext"
         )
+        # alpha-engine-config-I7048 (2026-08-12): ExtractPredictorError now
+        # targets NormalizeBranchBFailureContext, a defensive $.error
+        # normalizer Pass chokepoint mirroring NormalizeBranchAFailureContext,
+        # inserted ahead of PublishPredictorFailureImmediate (name/Type/
+        # Resource unchanged — no registry companion PR needed).
+        normalizer = branch_b["NormalizeBranchBFailureContext"]
+        assert normalizer["Type"] == "Pass"
+        assert normalizer["Next"] == "PublishPredictorFailureImmediate"
         publish = branch_b["PublishPredictorFailureImmediate"]
         assert publish["Type"] == "Task"
         assert publish["Resource"] == "arn:aws:states:::sns:publish"
@@ -1072,14 +1092,21 @@ class TestInboundRewireAndDownstreamUnchanged:
         ExtractSignalsEnvelopeError — a branch state pointing at the
         non-branch HandleFailure is an invalid ASL transition AND would re-introduce
         cross-branch cancellation."""
+        # alpha-engine-config-I7048 (2026-08-12): these edges now target
+        # NormalizeBranchAFailureContext, the defensive $.error-normalizer
+        # Pass chokepoint inserted ahead of PublishResearchFailureImmediate.
         assert [c["Next"] for c in branch_a["RAGIngestion"]["Catch"]] == [
-            "PublishResearchFailureImmediate"
+            "NormalizeBranchAFailureContext"
         ]
         assert [
             c["Next"] for c in branch_a["WaitForRAGIngestion"]["Catch"]
-        ] == ["PublishResearchFailureImmediate"]
+        ] == ["NormalizeBranchAFailureContext"]
         assert (
             branch_a["ExtractRAGIngestionError"]["Next"]
+            == "NormalizeBranchAFailureContext"
+        )
+        assert (
+            branch_a["NormalizeBranchAFailureContext"]["Next"]
             == "PublishResearchFailureImmediate"
         )
         assert (

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -194,38 +194,44 @@ class TestCatchSemantics:
 
 
 class TestCommandShape:
-    """The SSM command must invoke the lib CLI with --cadence weekly --alert.
+    """alpha-engine-config-I7047 (2026-08-12): the three inline commands
+    (transparency sweep --cadence weekly --alert, constituents_drift_check,
+    phase_marker_sweep --run-date --alert) moved out of this SF definition
+    into crucible-dashboard infrastructure/substrate_health_check.sh,
+    invoked here through krepis.ssm_log_capture — mirrors the 17 other
+    Saturday SF stages already on that wrapper instead of the inline
+    `trap 'aws s3 cp ... EXIT'` pattern, which collapsed under ASL's
+    States.Array escape semantics on every run using it (`trap: s3: invalid
+    signal specification`, rc=127 — the 2026-08-08 scheduled run finished
+    DEGRADED for exactly this reason despite every real work stage
+    succeeding).
 
-    Drops here would silently neuter the check (e.g. dropping --alert
-    suppresses SNS without changing exit code; dropping --cadence flips
-    to argparse error).
-
-    config#2322: the commands array was converted from a static ``commands``
-    list to a ``commands.$`` ASL intrinsic (``States.Array(...)``) so the
-    phase-marker-sweep command can thread ``export RUN_DATE.$=$.run_date``
-    (same shape as the Backtester/Parity/Evaluator spot stages —
-    tests/test_sf_run_date_threading.py) — extract_commands() reads through
-    either shape.
+    Content-level assertions on the three checks themselves (module names,
+    --cadence/--alert flags, ordering, run-date threading) now live in
+    crucible-dashboard tests/test_substrate_health_check_weekly_wiring.py,
+    the repo that actually owns that content. What THIS repo can still pin
+    is the *wiring*: the SF dispatches through the krepis wrapper to the
+    extracted script, on the dashboard box, with no runtime pip.
     """
 
     @pytest.fixture
     def commands(self, states) -> list[str]:
         return extract_commands(states["WeeklySubstrateHealthCheck"])
 
-    def test_invokes_transparency_module(self, commands):
-        assert any(
-            "python -m nousergon_lib.transparency" in cmd for cmd in commands
+    def test_no_inline_trap_anti_pattern(self, commands):
+        joined = " ".join(commands)
+        assert "trap 'aws s3 cp" not in joined, (
+            "I7047: the inline trap/log-ship anti-pattern must not return — "
+            "krepis.ssm_log_capture is the sole log-capture path"
         )
 
-    def test_passes_cadence_weekly(self, commands):
-        joined = " ".join(commands)
-        assert "--cadence weekly" in joined
+    def test_invokes_krepis_log_capture_wrapper(self, commands):
+        assert any("krepis.ssm_log_capture" in cmd for cmd in commands)
 
-    def test_passes_alert_flag(self, commands):
-        joined = " ".join(commands)
-        assert "--alert" in joined, (
-            "Without --alert, row-level failures emit metrics but no SNS. "
-            "Removing this flag silently degrades the gate."
+    def test_invokes_extracted_script_with_run_date(self, commands):
+        assert any(
+            "bash infrastructure/substrate_health_check.sh --run-date" in cmd
+            for cmd in commands
         )
 
     def test_runs_on_dashboard_ec2(self, commands):
@@ -233,10 +239,16 @@ class TestCommandShape:
         joined = " ".join(commands)
         assert "alpha-engine-dashboard" in joined
 
-    def test_pulls_latest_dashboard_main_before_running(self, commands):
-        # Stale repo on the dispatcher would run an outdated lib pin.
+    def test_pulls_latest_dashboard_and_data_main_before_running(self, commands):
+        # Stale repo on the dispatcher would run an outdated lib pin or an
+        # outdated substrate_health_check.sh. The script itself needs BOTH
+        # alpha-engine-dashboard (transparency module + the script) and
+        # alpha-engine-data (validators.*) checked out fresh — the SF's own
+        # command array pulls both before invoking the script, mirroring
+        # MorningEnrich's convention.
         joined = " ".join(commands)
-        assert "git" in joined and "pull" in joined
+        assert "git -C /home/ec2-user/alpha-engine-dashboard pull" in joined
+        assert "git -C /home/ec2-user/alpha-engine-data pull" in joined
 
     def test_no_runtime_pip_install(self, commands):
         # config#2276: deps are synced at deploy time (crucible-dashboard
@@ -246,63 +258,17 @@ class TestCommandShape:
         joined = " ".join(commands)
         assert "pip install" not in joined
 
-
-class TestPhaseMarkerSweep:
-    """config#2322: post-run phase-marker sweep must run after the
-    constituents-drift check, on the same run_date the backtest chain
-    wrote its `.phases/` markers under, and must not be able to abort the
-    SF (the existing States.ALL Catch on this state already makes any
-    non-zero exit non-blocking — see TestCatchSemantics)."""
-
-    @pytest.fixture
-    def commands(self, states) -> list[str]:
-        return extract_commands(states["WeeklySubstrateHealthCheck"])
-
-    def test_invokes_phase_marker_sweep_module(self, commands):
-        assert any(
-            "python -m validators.phase_marker_sweep" in cmd for cmd in commands
-        )
-
-    def test_phase_marker_sweep_passes_alert_flag(self, commands):
-        sweep_cmd = next(
-            c for c in commands if "validators.phase_marker_sweep" in c
-        )
-        assert "--alert" in sweep_cmd
-
-    def test_phase_marker_sweep_runs_after_constituents_drift(self, commands):
-        drift_idx = next(
-            i for i, c in enumerate(commands)
-            if "validators.constituents_drift_check" in c
-        )
-        sweep_idx = next(
-            i for i, c in enumerate(commands)
-            if "validators.phase_marker_sweep" in c
-        )
-        assert drift_idx < sweep_idx
-
-    def test_run_date_exported_before_phase_marker_sweep(self, commands):
-        rd_idx = next(
-            i for i, c in enumerate(commands)
-            if c.startswith("export RUN_DATE=")
-        )
-        sweep_idx = next(
-            i for i, c in enumerate(commands)
-            if "validators.phase_marker_sweep" in c
-        )
-        assert rd_idx < sweep_idx
-
-    def test_phase_marker_sweep_reads_exported_run_date(self, commands):
-        sweep_cmd = next(
-            c for c in commands if "validators.phase_marker_sweep" in c
-        )
-        assert '--run-date "$RUN_DATE"' in sweep_cmd
-
     def test_run_date_threaded_from_sf_run_date(self, states):
-        # value is threaded from the SF-stamped $.run_date (States.Format),
-        # same contract as tests/test_sf_run_date_threading.py's spot stages.
+        # value is threaded from the SF-stamped $.run_date into the
+        # krepis-wrapped script invocation via States.Format, same contract
+        # as tests/test_sf_run_date_threading.py's spot stages.
         raw_expr = states["WeeklySubstrateHealthCheck"]["Parameters"]["Parameters"]["commands.$"]
-        assert "States.Format('export RUN_DATE=" in raw_expr
         assert "$.run_date" in raw_expr
+        assert "$$.Execution.Name" in raw_expr, (
+            "krepis.ssm_log_capture's --correlation-id must be the SF "
+            "execution name, per the 17-sibling-stage convention (§116 "
+            "rule 6 chokepoint)."
+        )
 
 
 class TestResultPathIsolation:


### PR DESCRIPTION
## Summary

Deliverables 2+3 of `alpha-engine-config-I7047`, plus the I7048 Defect B sweep and a genuine bug it found.

- Migrates `SaturdayHealthCheck` and `WeeklySubstrateHealthCheck` (weekly SF) off the inline `trap 'aws s3 cp ... EXIT'` log-ship wrapper to `krepis.ssm_log_capture`, mirroring the 17 other Saturday SF stages already on that wrapper. `WeeklySubstrateHealthCheck` now invokes the extracted script from `crucible-dashboard-PR657`.
- New guard test `tests/test_no_inline_log_ship_trap_anywhere.py`: asserts the ABSENCE of the anti-pattern across every state of all four SF definitions in this repo (`step_function.json`, `step_function_eod.json`, `step_function_daily.json`, `step_function_groom.json`) — not the presence of the fix on the two named stages.
- That sweep found a THIRD, differently-shaped instance: `RunMorningPlanner` in `step_function_daily.json` (the weekday executor launcher) carried the same textual anti-pattern in a plain `commands` array — not exhibiting the ASL-escape bug specifically, but the same pattern this fleet is retiring. Migrated in the same commit.
- I7048 Defect B sweep: found and fixed `ExtractModelZooResolveSubstrateLostError` / `ExtractModelZooSelectSubstrateLostError` writing their normalized error to `$.error` instead of `$.model_zoo_error` — the field `PublishModelZooFailureImmediate` actually reads. This reintroduces the exact States.Runtime-destroys-the-original-error crash class `config#2160` already fixed for their non-SubstrateLost siblings; never exercised by a healthy run.
- Added a defensive `$.error` normalizer ahead of `PublishResearchFailureImmediate` and `PublishPredictorFailureImmediate` (new `NormalizeBranchAFailureContext`/`NormalizeBranchBFailureContext` Pass states). Every current predecessor already sets `$.error` correctly (verified against the live JSON) — this guards the class against a future predecessor that doesn't, which is exactly how the sibling crashed on the 2026-08-01 run. Inserted as new states rather than renaming the Task states, so `nousergon_lib.pipeline_status.registry` needs no companion `nousergon-lib` PR.

I7048 Defect A (`PipelineContractCheck`/`LibPinDriftCheck` reporting `has_violation`/`has_drift: false` on `fetch_failed` instead of omitting the field) requires **no change in this repo** — see below.

## Why

Measured live 2026-08-08 (execution `9b34ac0f-...-79e4579bcaff`): every work stage succeeded (`ResponseCode: 0`) but the run finished DEGRADED because both health-observe stages died on their own logging wrapper. `WeeklySubstrateHealthCheck`'s trap is nested inside `commands.$`/`States.Array(...)` with `\'` escaping; ASL does not unescape `\'` to `'`, so bash word-split the trap line into bogus signal names (`trap: s3: invalid signal specification`, rc=127).

## Merge order

`crucible-dashboard-PR657` first (the script must exist on the box before the SF's `git pull` + invoke), then this PR.

## Full sweep results — every state audited (I7048 sweep obligation)

**`Publish*FailureImmediate` states, all 3 SF definitions (7 total), predecessor-by-predecessor:**

| State | Predecessors checked | Verdict |
|---|---|---|
| `PublishResearchFailureImmediate` | 7 (RAGIngestion Catch, WaitForRAGIngestion Catch, ExtractRAGIngestionError, ExtractRAGIngestionSubstrateLostError, SetDataPhase2ExhaustedError, ExtractDataPhase2SubstrateLostError, ExtractSignalsEnvelopeError) | All set `$.error` correctly today — hardened defensively anyway (see above) |
| `PublishPredictorFailureImmediate` | 2 (ExtractPredictorError, ExtractPredictorTrainingSubstrateLostError) | Same — hardened defensively |
| `PublishModelZooFailureImmediate` | 9 (7 correct, 2 broken) | **BUG FOUND AND FIXED** — see above |
| `PublishDataSpotFailureImmediate` (EOD) | 1 (SetDataSpotDegradedFlag ← ExtractDataSpotError) | Correct, single scoped field |
| `PublishDaemonFailureImmediate` (daily) | 1 (RunDaemon Catch) | Correct, single scoped field |
| `PublishScannerFailureImmediate` (daily) | 1 (Scanner Catch) | Correct, single scoped field |
| `PublishDataSpotFailureImmediate` (daily) | 1 (SetDataSpotDegradedFlag ← ExtractDataSpotError) | Correct, single scoped field |

**`trap 'aws s3 cp` anti-pattern, all states, all 4 SF definitions:** 3 offenders found (SaturdayHealthCheck, WeeklySubstrateHealthCheck, RunMorningPlanner) — all 3 fixed in this PR. Guard test now asserts zero fleet-wide.

## I7048 Defect A — no nousergon-data change needed

Measured: `LibPinDriftGate` and `PipelineContractGate` (both in `step_function.json`) already have a correctly-designed, IsPresent-guarded Choice branch — an ABSENT `has_drift`/`has_violation` already routes to `LibPinGateDegraded`/`PipelineContractGateDegraded` (visible, SNS-alerted, non-blocking), not the silent-pass `Default`. The bug is entirely in the Python checkers (`crucible-predictor`, which sets the field present-but-`False` on fetch failure instead of omitting it) — fixed in `crucible-predictor-PR469` and `crucible-evaluator-PR188` (separate PRs, same session). No SF JSON change required or made here.

## Test plan

Full suite run before opening this PR: `5101 passed, 9 skipped` (pre-existing skips, unrelated). Ran again after the ModelZoo/normalizer/RunMorningPlanner changes and the new sweep test: still `5101 passed`. Manually verified the new anti-pattern-absence test actually detects a regression (injected the pattern into a scratch copy of `step_function_eod.json`, confirmed the test fails, reverted).

## Verified vs inferred

- **Verified live**: the 2026-08-08 execution's per-stage status fields (from the dispatching session's prior measurement, reused here).
- **Verified against the repo, this session**: every predecessor edge listed in the sweep table above, by direct JSON/AST walk of the SF definitions (not by memory or grep alone).
- **Not verified live**: whether `krepis` is actually importable on the dashboard/trading boxes' deployed venvs beyond `requirements.txt` — inferred from the pin being present and the 17 sibling stages already using it successfully in production.
- A green local test suite is a hypothesis about the SF definition's *shape*; the real verification is I7047's own closes-when (next scheduled Saturday run) and this repo's existing wiring tests, which exercise structure, not live AWS behavior.

## Related

`alpha-engine-config-I7047` · `alpha-engine-config-I7048` · `alpha-engine-config-I6967` (parent epic) · `crucible-dashboard-PR657` (merge first) · `crucible-predictor-PR469` · `crucible-evaluator-PR188`

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

---

## Rehearsal

Rehearsal-path: tests/test_no_inline_log_ship_trap_anywhere.py

That test is the §7.2 route-1 mechanism: it asserts the **absence** of `trap 'aws s3 cp` across every state in all three SF definitions, so it fails if the anti-pattern is reintroduced anywhere — not merely if these two stages regress.

**Stated plainly, because it matters here:** a structural test proves the definitions no longer carry the broken wrapper. It does **not** prove the replacement command runs correctly on the dashboard box. In this fleet a structural test has certified a defect before, so the check that actually closes `alpha-engine-config-I7047` is live:

> **Verified-when:** the next weekly execution (scheduled Saturday, or the exercise run chain-launched by `ne-postclose-trading-pipeline`) shows `health_check_poll.Status == Success` **and** `substrate_check_poll.Status == Success`, with both logs present under `s3://alpha-engine-research/_ssm_logs/health-check/` and `.../substrate-health-check/` for that run's correlation id.

Until that predicate holds, `I7047` stays open regardless of this PR's merge state. The 2026-08-08 run is the baseline it is measured against: every work stage returned `ResponseCode: 0` while `substrate_check_poll` returned `rc=127` at line 5 and `health_check_poll` returned `rc=1` with no log shipped at all.
