### PR TITLE
[P2/low] fix(arctic-migration): stop notifying on a no-op run (config-I7123)

### DIFF
--- a/scripts/run_arctic_migrations.py
+++ b/scripts/run_arctic_migrations.py
@@ -413,15 +413,25 @@ def run(args: argparse.Namespace) -> int:
                 "current_version": current, "at": datetime.now(timezone.utc).isoformat(),
             },
         )
-        notify(
-            outcome="noop_up_to_date", severity="info",
-            text=(
-                f"ArcticDB migration run: nothing pending at head "
-                f"{args.head_migration_number:04d} (already at v{current})."
-            ),
-            dedup_key=f"arctic-migration-noop-{args.head_migration_number}",
-            context=context,
-        )
+        # Deliberately NOT notified (alpha-engine-config-I7123). "Nothing was
+        # pending, so nothing was done" is a no-op, not an event: it carries no
+        # decision, no failure and no state change, and it fires on every run
+        # of a lane that is idle by design most of the time.
+        #
+        # This is a removal of NOTIFICATION, never of OBSERVATION — the run is
+        # still recorded on two durable surfaces, which is what principles.md
+        # #7 actually asks for:
+        #   1. the completion marker written immediately above
+        #      (overseer/_control/completed/arctic-migration-<head>.json),
+        #      carrying state="noop_up_to_date" and current_version;
+        #   2. the lane's own console row — the dispatcher's `publish_lane ok`
+        #      runs on this exit path (config-I7029).
+        # An absent run is therefore still visible as an absent/ageing console
+        # row; silence here does not read as health.
+        #
+        # Every other outcome below still notifies: a migration that APPLIED is
+        # a state change, and a refusal or failure is a decision an operator
+        # has to act on.
         return 0
 
     # ── 3. Apply, strictly in order, abort loud on first failure ───────

--- a/tests/test_run_arctic_migrations.py
+++ b/tests/test_run_arctic_migrations.py
@@ -264,6 +264,20 @@ def test_run_noop_when_nothing_pending(mod, monkeypatch):
     assert marker["payload"]["state"] == "noop_up_to_date"
     assert marker["payload"]["current_version"] == 3
 
+    # alpha-engine-config-I7123: a no-op is not an event. This lane is idle by
+    # design most of the time, so notifying "nothing was pending" on every run
+    # is pure operator noise.
+    assert recorded["notifies"] == [], (
+        "the no-op path must not notify — it carries no decision, no failure "
+        "and no state change"
+    )
+    # ...but the run is still OBSERVED. The removal above is of notification,
+    # never of observation: the marker asserted above is one durable surface,
+    # and the dispatcher's `publish_lane ok` (config-I7029) emits the lane's
+    # console row on this same exit path. An absent run stays visible as an
+    # ageing console row, so silence here does not read as health.
+    assert marker["payload"]["rc"] == 0
+
 
 def test_run_success_applies_all_pending(mod, monkeypatch):
     recorded = _stub_side_effects(mod, monkeypatch)


### PR DESCRIPTION
**Priority:** P2 · **Complexity:** low

Closes nousergon/alpha-engine-config#7123

## What & why

This fires on essentially every run of a lane that is idle by design:

> `⚪ (INFO) arctic-migration — ArcticDB migration run: nothing pending at head 0001 (already at v1).`

Nothing was pending, so nothing was done. No decision, no failure, no state change — it is a no-op, not an event, and it competes for attention with the alerts that mean something.

## This removes notification, not observation

`principles.md` #7 is explicit that a component emitting nothing is unobserved rather than healthy, so the removal only holds because the run stays recorded on two durable surfaces **on this exact exit path**:

1. **The completion marker** written immediately above the removed call — `overseer/_control/completed/arctic-migration-<head>.json`, carrying `state="noop_up_to_date"`, `rc`, `current_version`, `merged_sha`.
2. **The lane's console row** — the dispatcher's `publish_lane ok` (`infrastructure/lambdas/arctic-migration-dispatcher/index.py:475`) runs here, added by config-I7029 in the commit immediately preceding this branch point.

A run that does not happen therefore still shows up as an absent/ageing console row. Silence here does not read as health, which is the only condition under which dropping a notification is legitimate.

## Scope — one outcome only

| outcome | severity | this PR |
|---|---|---|
| `refused_mutex_probe_failed` | critical | unchanged |
| `refused_mutex_active` | warning | unchanged |
| `noop_up_to_date` | info | **removed** |
| `success` | info | unchanged — a migration that APPLIED is a state change |
| `failure` | critical | unchanged |

## Test plan — run BEFORE opening

`tests/test_run_arctic_migrations.py::test_run_noop_when_nothing_pending` extended to assert `recorded["notifies"] == []` alongside the existing completion-marker assertions, so re-adding the notification fails at PR time. Nothing pinned the old behaviour, which is why it was never questioned.

```
$ python3 -m pytest tests/test_run_arctic_migrations.py \
    tests/test_severity_taxonomy_chokepoint.py \
    tests/test_artifact_registry_coverage.py -q
26 passed in 0.77s
```

The severity-taxonomy chokepoint and artifact-registry coverage tests both still pass — the registry entry describes the `notify` call sites as dynamic-per-outcome, which remains true.

## Relationship to the other open PRs from this arc

Independent. `nousergon-data-PR1329` (weekly-SF substrate relaunch) touches `infrastructure/step_function.json` and SF tests only — no file overlap, no merge order required.

## Post-merge

None. The script is cloned fresh at `merged_sha` by the dispatcher on each run.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)