### PR TITLE
[P1/mid] fix(weekly-spot): widen the launcher pool 4 -> 10 types so a capacity dip is survivable (config-I7133)

### DIFF
--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -127,10 +127,36 @@ DISPATCH_ENABLED = (
 # spot_backtest.sh — same AMI/instance-type family/subnets the nested spots
 # THIS box itself launches already use, so a c5.large-class launcher is
 # consistent with the rest of the fleet's Saturday spend). ───────────────────
+# Widened 4 -> 10 types across 6 families (alpha-engine-config-I7133).
+#
+# The four originals are all 2-vCPU x86 compute/general types of adjacent
+# generations, which is a NARROW capacity surface: `launch_with_fallback`
+# rotates instance_type x subnet, so the number of distinct pools it can fall
+# through is what decides whether a capacity dip is survivable. Measured
+# 2026-08-12: 3 of 11 recent spot requests in this account died
+# `instance-terminated-no-capacity`, one of them mid-DataPhase1 on the
+# scheduled weekly run (config-I7119).
+#
+# I7119 makes a mid-run reclaim RECOVERABLE. This makes it RARER, which is the
+# better half — a recovery still costs a relaunch, a re-bootstrap and the
+# stage's runtime. Recovery is the floor, not the goal.
+#
+# Every addition is x86_64 (the AMI below is x86_64 AL2023 — an arm64 type
+# would fail the architecture check at launch), 2 vCPU, and >= the 4 GiB of
+# the c5.large that already runs this workload successfully; the m/r families
+# are strictly more memory. All 10 verified offered in 5 of the 6 subnets'
+# AZs on 2026-08-12.
+#
+# No IAM change needed: this Lambda's LaunchWeeklyFreshnessSpot statement is
+# `ec2:RunInstances` on `Resource: "*"` with no instance-type Condition, so
+# there is no config#2271-style enumeration to keep in lockstep here (unlike
+# alert-drain-dispatcher / ci-watch-dispatcher, which do enumerate).
 INSTANCE_TYPES = [
     t.strip()
     for t in os.environ.get(
-        "WEEKLY_SPOT_INSTANCE_TYPES", "c5.large,m5.large,c6i.large,c5a.large"
+        "WEEKLY_SPOT_INSTANCE_TYPES",
+        "c5.large,m5.large,c6i.large,c5a.large,m6i.large,"
+        "m5a.large,c6a.large,m6a.large,r5.large,r6i.large",
     ).split(",")
     if t.strip()
 ]

--- a/tests/test_weekly_spot_pool_breadth.py
+++ b/tests/test_weekly_spot_pool_breadth.py
@@ -1,0 +1,121 @@
+"""The weekly launcher spot's capacity surface (alpha-engine-config-I7133).
+
+`spot_dispatch.launch_with_fallback` rotates instance_type x subnet on a
+capacity error, so the number of DISTINCT pools it can fall through is what
+decides whether a capacity dip is survivable. The pool was 4 types of adjacent
+generations in two families.
+
+Measured 2026-08-12: 3 of 11 recent spot requests in this account died
+`instance-terminated-no-capacity`, one of them mid-`DataPhase1` on the
+scheduled weekly run (config-I7119).
+
+config-I7119 makes a mid-run reclaim RECOVERABLE. This pins the properties
+that make it RARER — recovery still costs a relaunch, a re-bootstrap and the
+stage's runtime, so it is the floor rather than the goal.
+
+These assert PROPERTIES, not a literal list: adding a type should not require
+editing a test, but adding an arm64 or a 1-vCPU type must fail loudly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISPATCHER = (
+    Path(__file__).resolve().parents[1]
+    / "infrastructure"
+    / "lambdas"
+    / "weekly-freshness-spot-dispatcher"
+    / "index.py"
+)
+
+# x86_64, 2 vCPU, >= 4 GiB — the floor is c5.large, which already runs this
+# workload successfully. arm64 families are EXCLUDED on purpose: the dispatcher
+# pins an x86_64 AL2023 AMI, so an arm64 type fails the architecture check at
+# launch. That failure is the reason this is a test and not a comment.
+_X86_2VCPU_FAMILIES = {
+    "c5", "c5a", "c5n", "c6i", "c6a", "c6in",
+    "m5", "m5a", "m5n", "m6i", "m6a",
+    "r5", "r5a", "r5n", "r6i", "r6a",
+}
+_ARM64_FAMILIES = {"c6g", "c7g", "m6g", "m7g", "r6g", "r7g", "t4g", "c8g", "m8g"}
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location(
+        "weekly_freshness_spot_dispatcher", _DISPATCHER
+    )
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _families(types: list[str]) -> set[str]:
+    return {t.split(".", 1)[0] for t in types}
+
+
+def test_the_pool_spans_enough_distinct_capacity_pools(mod):
+    """Pool COUNT is the mechanism — one type per family is one pool."""
+    types = mod.INSTANCE_TYPES
+    assert len(types) >= 8, (
+        f"only {len(types)} instance types; launch_with_fallback has too few "
+        f"pools to rotate through on a capacity dip: {types}"
+    )
+    assert len(_families(types)) >= 5, (
+        f"types cluster into too few families {sorted(_families(types))} — "
+        f"capacity events correlate WITHIN a family, so 10 types across 2 "
+        f"families is not 10 pools"
+    )
+
+
+def test_every_type_is_x86_64(mod):
+    """The AMI is x86_64 AL2023; an arm64 type fails at launch, not at review."""
+    arm = _families(mod.INSTANCE_TYPES) & _ARM64_FAMILIES
+    assert not arm, (
+        f"arm64 families {sorted(arm)} in the pool, but WEEKLY_SPOT_AMI_ID is "
+        f"x86_64 — every rotation onto one of these fails the architecture check"
+    )
+
+
+def test_every_type_is_a_known_2vcpu_x86_family_at_or_above_the_floor(mod):
+    """c5.large (2 vCPU / 4 GiB) is the measured floor — it already runs this
+    workload. A smaller type would fail somewhere inside a multi-hour stage."""
+    unknown = _families(mod.INSTANCE_TYPES) - _X86_2VCPU_FAMILIES
+    assert not unknown, (
+        f"unrecognised families {sorted(unknown)}; add them to "
+        f"_X86_2VCPU_FAMILIES only after confirming x86_64 + >= c5.large specs"
+    )
+    sizes = {t.split(".", 1)[1] for t in mod.INSTANCE_TYPES}
+    assert sizes == {"large"}, (
+        f"mixed sizes {sorted(sizes)} — a rotation onto a smaller size changes "
+        f"the workload's resources silently mid-pipeline"
+    )
+
+
+def test_the_subnets_span_multiple_azs(mod):
+    """Type rotation is only half the surface; a single AZ re-enters the same
+    physical capacity pool however many types are tried."""
+    assert len(mod.SUBNETS) >= 3, f"too few subnets to rotate: {mod.SUBNETS}"
+
+
+def test_the_pool_is_env_overridable(mod, monkeypatch):
+    """The override is the operator's escape hatch during a capacity event —
+    it must not have been hardcoded away while widening the default."""
+    src = _DISPATCHER.read_text()
+    assert 'os.environ.get(\n        "WEEKLY_SPOT_INSTANCE_TYPES"' in src or (
+        '"WEEKLY_SPOT_INSTANCE_TYPES"' in src and "os.environ.get" in src
+    )
+
+
+def test_on_demand_fallback_is_still_reachable(mod):
+    """Widening the pool must not become a REPLACEMENT for the on-demand
+    escape: capacity can be exhausted across every pool at once."""
+    src = _DISPATCHER.read_text()
+    assert "force_on_demand" in src
+    assert "launch_with_fallback" in src


### PR DESCRIPTION
**Priority:** P1 · **Complexity:** mid

Closes nousergon/alpha-engine-config#7133

## What & why

`alpha-engine-weekly-freshness-spot-dispatcher`'s launcher pool was **4 instance types** — `c5.large, m5.large, c6i.large, c5a.large` — all 2-vCPU x86 compute/general types of adjacent generations. `nousergon_lib.spot_dispatch.launch_with_fallback` rotates `instance_type x subnet` on a capacity error, so **the number of distinct pools it can fall through is what decides whether a capacity dip is survivable**. Four adjacent types in two families is not four pools.

**Measured 2026-08-12:** 3 of 11 recent spot requests in this account died `instance-terminated-no-capacity`, one of them mid-`DataPhase1` on the scheduled weekly run (config-I7119).

## Why this is not redundant with I7119

I7119 (merged, `nousergon-data-PR1329`) makes a mid-run reclaim **recoverable**. This makes it **rarer**, which is the better half:

- a recovery still costs a relaunch, a re-bootstrap, and the interrupted stage's runtime;
- it spends the execution's **one** bounded relaunch, so a second reclaim is then terminal.

Recovery is the floor. Not being reclaimed is the goal.

## Widened default

```
c5.large, m5.large, c6i.large, c5a.large, m6i.large,
m5a.large, c6a.large, m6a.large, r5.large, r6i.large
```

Every addition satisfies, all verified against the live account 2026-08-12:

| constraint | why it matters |
|---|---|
| **x86_64** | `WEEKLY_SPOT_AMI_ID` is x86_64 AL2023 — an arm64 type fails the architecture check *at launch*, i.e. during a capacity event, when the rotation is the thing keeping the run alive |
| **2 vCPU, >= 4 GiB** | `c5.large` is the measured floor and already runs this workload; m/r families are strictly more memory |
| **offered in 5 of the 6 subnets' AZs** | `aws ec2 describe-instance-type-offerings`, all 10 |
| **no IAM change** | this Lambda's `LaunchWeeklyFreshnessSpot` statement is `ec2:RunInstances` on `Resource: "*"` with **no** instance-type `Condition` |

⚠️ That last row is specific to this Lambda. `alert-drain-dispatcher` and `ci-watch-dispatcher` **do** enumerate instance types in their scoped IAM policies (config#2271 lockstep) — do not copy this change into them without updating their policies, or the launch fails AccessDenied at the worst moment.

`WEEKLY_SPOT_INSTANCE_TYPES` remains the operator override, which is the escape hatch during a live capacity event.

## Test plan — run BEFORE opening

New `tests/test_weekly_spot_pool_breadth.py`, 6 tests asserting **properties, not a literal list** — adding a type needs no test edit, but adding an arm64 or a smaller size fails loudly:

- pool count >= 8 **and** families >= 5 (capacity events correlate *within* a family, so 10 types across 2 families is not 10 pools)
- no arm64 family, against the x86_64 AMI
- every family in a known-good x86 2-vCPU set; all sizes `.large`, so a rotation cannot silently change the workload's resources mid-pipeline
- subnets span >= 3 AZs — type rotation is only half the surface
- **on-demand fallback still reachable**: widening must not become a *replacement* for the escape, since capacity can be exhausted across every pool at once

```
$ python3 -m pytest tests/test_weekly_spot_pool_breadth.py \
    infrastructure/lambdas/weekly-freshness-spot-dispatcher/test_handler.py -q
26 passed
```

Full suite compared against `origin/main` on this machine — **identical failure sets, 177 both sides**, all from `pyarrow`/`yfinance` being absent locally. This change introduces none:

```
$ comm -13 /tmp/base_full.txt /tmp/mine_full.txt
(empty)
```

## Post-merge

None. `deploy-weekly-freshness-spot-dispatcher.yml` triggers on `infrastructure/lambdas/weekly-freshness-spot-dispatcher/**` and deploys it.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)