### PR TITLE
fix(observability): deploy the watch-plane alarm fixes that were never applied + onboard sf-watch-liveness-probe

### DIFF
--- a/.github/workflows/deploy-watch-plane-alarms.yml
+++ b/.github/workflows/deploy-watch-plane-alarms.yml
@@ -1,0 +1,100 @@
+name: Deploy watch-plane alarms
+
+# Auto-apply infrastructure/setup_watch_plane_alarms.sh on merge to main.
+#
+# alpha-engine-config-I7045. MEASURED 2026-08-12: this script's own source
+# already carries a slow-cadence Errors/Throttles override for
+# overseer-liveness-probe (config#4477, written 2026-07-29) and a generic
+# Invocations-floor alarm for every *liveness* label (config-I5567) — but
+# NOTHING invoked the script after either was written. Live AWS still showed
+# alpha-engine-watch-plane-overseer-liveness-probe-errors on the DEFAULT
+# 300s/notBreaching shape, and ZERO `*-invocations-floor` alarms existed
+# anywhere in the account. Two already-designed fixes for "a dead probe reads
+# as a healthy one" sat inert in source for two weeks because this script had
+# no merge trigger — the same gap lambda-deploy-on-merge.yml closed for
+# per-Lambda deploy.sh scripts, one layer up, for a script that isn't a
+# per-Lambda deploy.sh.
+#
+# This workflow makes `setup_watch_plane_alarms.sh` behave like every other
+# alarm-provisioning script in this repo: merge == live, no operator step.
+# `put-metric-alarm` upserts by name, so a re-run is idempotent — safe to run
+# on every push that touches this file, including this workflow's own first
+# run, which is expected to bring account state up to what the script has
+# said for two weeks.
+#
+# IAM: no new grant needed. github-actions-lambda-deploy's InfraDeployResourceCRUD
+# statement already grants cloudwatch:PutMetricAlarm/DeleteAlarms + events/
+# scheduler/sns CRUD with Resource "*" (this is the same role
+# deploy-ssm-reachability-probe.yml uses for its --apply-alarms step); this
+# script needs nothing beyond that.
+#
+# Expected result of the first run: several of these alarms will read ALARM
+# immediately, not OK — overseer-liveness-probe and sf-watch-liveness-probe
+# are BOTH currently paused by Brian's 2026-08-07 ruling
+# (nousergon-data/infrastructure/automation_pause.json), so their new
+# Invocations-floor alarms and breaching-override Errors/Throttles alarms
+# have no invocations to report. That is the correct, intended behavior this
+# issue exists to produce — a paused probe must not read green — not a
+# regression to revert. See alpha-engine-config-I7045's PR body for the
+# coordination note with alpha-engine-config-I7023 (the pause-alarm-
+# suppression dimension that will eventually silence these ALARM states for
+# the duration of a declared pause, without weakening TreatMissingData).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/setup_watch_plane_alarms.sh'
+      - '.github/workflows/deploy-watch-plane-alarms.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-watch-plane-alarms-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Apply watch-plane CloudWatch alarms
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Apply watch-plane alarms
+        working-directory: alpha-engine-data
+        run: bash infrastructure/setup_watch_plane_alarms.sh
+
+      - name: Report current alarm states
+        if: always()
+        run: |
+          aws cloudwatch describe-alarms \
+            --alarm-name-prefix alpha-engine-watch-plane- \
+            --query 'MetricAlarms[].[AlarmName,StateValue]' \
+            --output table
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-watch-plane-alarms.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -95,6 +95,16 @@ BACKSTOP_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${BACKSTOP_TOPIC_NAME}"
 # (mid-run spot-reclaim checkers for the ci-watch and alert-drain families,
 # mirroring sf-watch-reclaim-sweep-handler's config#2270 mechanism) — onboarded in
 # the SAME PR that ships them, per this file's own header convention.
+# sf-watch-liveness-probe added alpha-engine-config-I7045: it was NEVER in
+# this roster despite being Active and scheduled twice daily 06:45/14:45 UTC
+# -- the exact onboarding-checklist miss this file's header warns about.
+# Without this entry the Invocations-floor alarm (section 3, config-I5567)
+# and the slow-cadence override (section 2, config#4477) both silently
+# skipped it, so a dead sf-watch-liveness-probe schedule read identically to
+# a healthy one -- measured live 2026-08-12: no report since 2026-08-07,
+# every alarm still OK. (Comment kept OUT of the array literal below so the
+# tests/test_watch_plane_alarms_script.py block-parser isn't confused by a
+# stray `)` inside the block.)
 declare -A WATCH_PLANE_FUNCTIONS=(
   ["saturday-sf-watch-dispatcher"]="alpha-engine-saturday-sf-watch-dispatcher"
   ["sf-watch-spot-dispatcher"]="alpha-engine-sf-watch-spot-dispatcher"
@@ -102,6 +112,7 @@ declare -A WATCH_PLANE_FUNCTIONS=(
   ["ci-watch-liveness-probe"]="alpha-engine-ci-watch-liveness-probe"
   ["sf-watch-reclaim-sweep-handler"]="alpha-engine-sf-watch-reclaim-sweep-handler"
   ["overseer-liveness-probe"]="alpha-engine-overseer-liveness-probe"
+  ["sf-watch-liveness-probe"]="alpha-engine-sf-watch-liveness-probe"
   ["overseer-dispatcher"]="alpha-engine-overseer-dispatcher"
   ["alert-drain-dispatcher"]="alpha-engine-alert-drain-dispatcher"
   ["alert-drain-liveness-probe"]="alpha-engine-alert-drain-liveness-probe"
@@ -160,6 +171,14 @@ declare -A _LAMBDA_CADENCE_SECONDS=(
   # (dead EventBridge schedule, deleted Lambda, IAM blackout) pages as ALARM
   # within 8h instead of reading OK indefinitely while failing every invocation.
   ["overseer-liveness-probe"]=28800
+  # alpha-engine-sf-watch-liveness-probe: same twice-daily cadence as the
+  # overseer probe above, 06:45 / 14:45 UTC, ~8h apart -- added
+  # alpha-engine-config-I7045 alongside the WATCH_PLANE_FUNCTIONS entry.
+  # Without this override the default 300s/notBreaching Errors/Throttles
+  # alarms cannot distinguish "ran clean" from "has not run in five days",
+  # which is the exact silent-green condition config-I7045 measured live on
+  # 2026-08-12: last report 2026-08-07, every alarm still OK.
+  ["sf-watch-liveness-probe"]=28800
 )
 
 DEFAULT_ALARM_PERIOD=300

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -2,7 +2,12 @@
 extended to 8 functions + an intake-queue age alarm by config-I2900/I2910;
 extended to 9 functions by alpha-engine-config-I3242's arctic-migration-
 dispatcher onboarding; extended to 11 functions by config#3173's
-ci-watch-liveness-probe + alert-drain-liveness-probe onboarding).
+ci-watch-liveness-probe + alert-drain-liveness-probe onboarding; extended to
+12 functions by alpha-engine-config-I7045's sf-watch-liveness-probe
+onboarding — it was Active and scheduled twice daily but had never been added
+to this roster, so its dead-schedule condition (measured live 2026-08-12: no
+report since 2026-08-07, every alarm still OK) was invisible to both the
+Errors/Throttles cadence override and the Invocations-floor alarm below).
 
 setup_watch_plane_alarms.sh puts CloudWatch Errors + Throttles alarms on each
 of the watch-plane Lambdas — the components whose job is to notice fleet
@@ -91,6 +96,9 @@ class TestWatchPlaneCoverage:
             # ArcticDB migration runner — onboarded in the SAME PR that ships it,
             # per this file's own header convention.
             "alpha-engine-arctic-migration-dispatcher",
+            # Added alpha-engine-config-I7045: was Active and scheduled twice
+            # daily, never onboarded — see module docstring.
+            "alpha-engine-sf-watch-liveness-probe",
         ],
     )
     def test_lambda_is_present(self, script_text, fn_name):
@@ -105,7 +113,7 @@ class TestWatchPlaneCoverage:
                 ")", script_text.find("declare -A WATCH_PLANE_FUNCTIONS=(")
             )
         ]
-        assert block.count('"alpha-engine-') == 16
+        assert block.count('"alpha-engine-') == 17
 
     def test_both_errors_and_throttles_alarmed(self, script_text):
         assert "for metric in Errors Throttles" in script_text
@@ -300,7 +308,7 @@ class TestLivenessInvocationsFloorAlarms:
         dec_end = script_text.find(")", dec_start)
         dec_block = script_text[dec_start:dec_end]
         liveness_labels = [line for line in dec_block.split("\n") if "liveness" in line]
-        assert len(liveness_labels) >= 4, f"Expected >=4 liveness labels, found {len(liveness_labels)}"
+        assert len(liveness_labels) >= 5, f"Expected >=5 liveness labels, found {len(liveness_labels)}"
         # Verify the for loop exists with *liveness* pattern (catches all at runtime).
         invoc_block = script_text[script_text.find("Per-liveness-probe Invocations-floor"):]
         assert "for label in \"${!WATCH_PLANE_FUNCTIONS[@]}\"" in invoc_block
@@ -308,6 +316,35 @@ class TestLivenessInvocationsFloorAlarms:
         assert "put-metric-alarm" in invoc_block
         # Verify uniqueness: the alarm name uses ${label} so each iteration creates a distinct name.
         assert 'alpha-engine-watch-plane-${label}-invocations-floor' in invoc_block
+
+
+class TestSlowCadenceOverrideCoversBothLivenessSchedulers:
+    """alpha-engine-config-I7045: the overseer probe got the slow-cadence
+    breaching override (config#4477, 2026-07-29) but sf-watch-liveness-probe
+    — same twice-daily schedule shape — never did, so its Errors/Throttles
+    alarms stayed on the default notBreaching/300s shape and could not
+    distinguish a dead schedule from a clean run. A probe emitting nothing
+    must not evaluate to the same alarm shape as a probe emitting only
+    successes; this pins that both liveness probes get the breaching
+    override, not just one of them."""
+
+    def test_both_liveness_probes_have_cadence_override(self, script_text):
+        block_start = script_text.find("declare -A _LAMBDA_CADENCE_SECONDS=(")
+        # The block's comment lines legitimately contain parenthesised asides
+        # (e.g. "(5 min)"), so a naive search for the first ")" closes too
+        # early — the array literal's actual close is a ")" alone on its own
+        # line, same gotcha the WATCH_PLANE_FUNCTIONS block documents.
+        block_end = script_text.find("\n)", block_start)
+        block = script_text[block_start:block_end]
+        assert '["overseer-liveness-probe"]=28800' in block
+        assert '["sf-watch-liveness-probe"]=28800' in block
+
+    def test_override_period_within_cloudwatch_cap(self, script_text):
+        # #7024: EvaluationPeriods * Period must be <= 604800 for any alarm
+        # with period >= 3600. Both overrides use a single evaluation period
+        # (_effective_evals returns "1" whenever a cadence override is set),
+        # so 28800 * 1 is comfortably under the weekly cap.
+        assert 28800 * 1 <= 604800
 
 
 class TestOverseerIntakeDlqAlarm:


### PR DESCRIPTION
## Summary

`alpha-engine-config#7045`: the Overseer/sf-watch liveness probes' schedules
were disabled 2026-08-07 and every alarm watching them still read OK — the
`Errors`-with-`notBreaching` construction cannot distinguish a probe that ran
clean from one that has not run at all.

**Root cause, measured live 2026-08-12**: the actual fix for this class
already existed in source and was never deployed. `setup_watch_plane_alarms.sh`
carries:
- An Invocations-floor liveness alarm (`config-I5567`) for every `*liveness*`
  label — 0 of these exist anywhere in the account.
- A slow-cadence breaching override for `overseer-liveness-probe`
  (`config#4477`, written 2026-07-29) — live AWS still shows its
  Errors/Throttles alarms on the default 300s/notBreaching shape.

Nothing ever ran this script on merge, so two already-designed fixes sat
inert in source for two weeks while the issue they solve stayed open in
production.

`sf-watch-liveness-probe` was additionally never in `WATCH_PLANE_FUNCTIONS` at
all, despite being Active on the same twice-daily schedule shape as
`overseer-liveness-probe` — so even a manual script run would not have
covered it.

## What changed

- `infrastructure/setup_watch_plane_alarms.sh`: add `sf-watch-liveness-probe`
  to `WATCH_PLANE_FUNCTIONS` and `_LAMBDA_CADENCE_SECONDS` (28800s, matching
  its 06:45/14:45 UTC cadence).
- `.github/workflows/deploy-watch-plane-alarms.yml` (new): applies this
  script on every push that touches it — closes the "written but never run"
  gap structurally, per `pull-request-policy.md` §4.2 (a PR must be
  deployable by the merge button alone). No new IAM grant needed:
  `github-actions-lambda-deploy`'s `InfraDeployResourceCRUD` statement
  already grants `cloudwatch:PutMetricAlarm`/`DeleteAlarms` + events/
  scheduler/sns CRUD on `Resource: "*"`.
- `tests/test_watch_plane_alarms_script.py`: roster count 16→17, new
  `TestSlowCadenceOverrideCoversBothLivenessSchedulers` pinning that BOTH
  liveness probes carry the breaching override, not just one — the test that
  a probe emitting nothing does not produce a green verdict.

## Disposition of the four paused schedules — NOT changed here

Confirmed deliberate, not accidental drift, from two independent sources:

- **CloudTrail**: Brian's own `AdministratorAccess` SSO session issued
  `UpdateSchedule ... state=DISABLED` for all four
  (`alpha-engine-overseer-liveness-{0650,1450}-daily`,
  `alpha-engine-sf-watch-liveness-{0645,1445}-daily`) at
  2026-08-07T09:16:32-09:16:43 PT.
- **`nousergon-data/infrastructure/automation_pause.json`**: both probes'
  schedules are listed under `paused.scheduler_schedules`, part of the
  2026-08-07 "shut down all automatic AWS processes except the weekly SF, the
  daily preopen/postclose SFs, and the 24/7 box" ruling — five days before
  `config#6984`'s unrelated groomer/Overseer deactivation.

This PR does not enable any schedule and does not run `automation_pause.py
--enforce`. That is Brian's call.

## Expected effect on merge

The new alarms will read **ALARM**, not OK, for as long as the two schedules
stay paused — both probes have zero invocations to report. That is the
**correct, intended** result (`principles.md` §2.7: no data must never render
as green), not a regression to revert.

**Coordination with `alpha-engine-config#7023`** (the pause-alarm-suppression
dimension, same root cause — `automation_pause.json` has no alarm
dimension): once #7023's `cloudwatch_alarms` pause block exists, these new
`*-invocations-floor` alarms and the now-breaching Errors/Throttles alarms
for both liveness probes should be added to its suppression list, the same
way `alpha-engine-ssm-reachability-probe-dead`/`-unreachable` are handled
today. Until then, expect these specific alarms in ALARM as a declared,
expected condition — visible on the console via the observability-registry
`lifecycle: disabled` rows in `nous-ergon-ops-PR<TBD>` (companion PR), not
via the alarm's own color, which CloudWatch cannot make paused and broken
look different.

## Scoped out, already tracked

- `alpha-engine-groom-liveness-probe-errors` watches
  `alpha-engine-groom-liveness-probe`, which no longer exists live
  (`ResourceNotFoundException`, confirmed 2026-08-12) — the Lambda was
  retired and its wiring-check folded into `overseer-liveness-probe`
  (`config#2831`, closed). Giving it a liveness-floor alarm would create an
  alarm that can never clear. Disposition handled in the companion
  `nous-ergon-ops` PR (registry `lifecycle: retired`); the orphaned alarm
  itself needs deletion, filed separately (see companion PR).
- One pre-existing, unrelated test failure found while running the full
  suite: `test_pipeline_status_registry_source_check.py` —
  `RelaunchWeeklyFreshnessSpot` missing from `nousergon_lib`'s
  `STATE_TO_ARCHIVE_PAGE` registry. Already tracked under open
  `alpha-engine-config-I7120` (same state name, active arc). Not touched
  here.

## Test plan

- [x] `bash -n infrastructure/setup_watch_plane_alarms.sh`
- [x] `pytest tests/test_watch_plane_alarms_script.py` — 53/53 passing
- [x] Full `pytest tests/` — 5128 passed, 9 skipped, 1 pre-existing unrelated
      failure (see above)
- [ ] Post-merge: confirm the new alarms exist via `aws cloudwatch
      describe-alarms --alarm-name-prefix alpha-engine-watch-plane-` (done
      automatically by the workflow's own reporting step)

Refs: `alpha-engine-config#7045`, `alpha-engine-config#7023`,
`alpha-engine-config#7024`, `alpha-engine-config#2831`,
`alpha-engine-config-I5567`, `alpha-engine-config#4477`

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)