### PR TITLE
feat(sf): market-hours gate at the head of both trading pipelines (config-I7111)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,5 +6,5 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,5 +2,5 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,5 +5,5 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 krepis>=0.14.0

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -10,7 +10,184 @@
         "merged.$": "States.JsonMerge(States.JsonMerge(States.StringToJson('{\"sns_topic_arn\":\"arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts\"}'),States.StringToJson(States.Format('\\{\"run_date\":\"{}\"\\}',States.ArrayGetItem(States.StringSplit($$.Execution.StartTime,'T'),0))),false),$$.Execution.Input,false)"
       },
       "OutputPath": "$.merged",
+      "Next": "MarketHoursGate"
+    },
+    "MarketHoursGate": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 (Brian ruling 2026-08-13, option c) \u2014 the \"no trading-pipeline start during NYSE market hours\" boundary, sited on the PIPELINE rather than on one caller's IAM role. alpha-engine-config#2932 ruled it onto alpha-engine-sf-watch-executor-role, enforced by a Lambda flipping that role's inline policy every 5 minutes between two codified variants. The Lambda never existed in account 711398986525 (measured 2026-08-12: no function, no EventBridge rule), so the boundary was never once in force \u2014 and being caller-scoped it could not have covered the in-session operator starts at 09:32 PT on 2026-08-07 or 08:32 PT on 2026-07-27 either. IAM has NO time-of-day condition key; that absence is why the ruled mechanism needed a Lambda to simulate one, and why the simulation could silently not exist for three weeks. A guard state binds every principal: the scheduler, the Overseer's overseer-sf-watch lane, and the operator. Neither existing guard covers this \u2014 AcquireMutex keys on the same UTC MINUTE and TradingDayGate on the calendar DAY; neither is a time-of-day boundary. Same zero-infra posture as TradingDayGate: pure calendar math on alpha-engine-predictor-inference, returning BEFORE PredictorPreflight is constructed, so no S3/ArcticDB/model problem can take out the boundary. `now` is $$.Execution.StartTime rather than the Lambda's own clock, so the verdict is a property of the execution: deterministic, replayable, and immune to a slow cold start pushing a refused run past the close. `execution_input` is passed whole because an ASL \"override.$\": \"$.market_hours_override\" parameter throws States.Runtime on every run that does not carry one.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_market_hours",
+          "now.$": "$$.Execution.StartTime",
+          "execution_input.$": "$$.Execution.Input"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "NotifyMarketHoursUnverified",
+          "ResultPath": "$.market_hours_gate_error"
+        }
+      ],
+      "ResultPath": "$.market_hours_gate",
+      "Next": "MarketHoursGateChoice"
+    },
+    "MarketHoursGateChoice": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
+      "Choices": [
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "PROCEED",
+          "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
+          "Next": "CheckMutexRole"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "PROCEED_OVERRIDE",
+          "Comment": "In-session start with a complete, authored, unexpired, bounded override. Announced and recorded, never silent.",
+          "Next": "RecordMarketHoursOverride"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "BLOCKED",
+          "Comment": "In-session start with no override \u2014 the boundary doing its job.",
+          "Next": "NotifyMarketHoursBlocked"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "OVERRIDE_MALFORMED",
+          "Comment": "An override was offered and is not usable. Fails closed whether or not the market is open: a typo'd override is a mis-authorisation, and surfacing it on the quiet run is the only way it is not discovered on the run that matters.",
+          "Next": "NotifyMarketHoursOverrideMalformed"
+        }
+      ],
+      "Default": "HandleFailure"
+    },
+    "RecordMarketHoursOverride": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 the override's audit surface. A crossed boundary is announced on the alert topic AND left in execution history with who authorised it, why, and until when. Catch continues to the pipeline: the authorisation was already validated and recorded, so a notify-side failure must not silently convert an approved recovery into a refusal.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline \u2014 market-hours boundary OVERRIDDEN (authorised in-session start)",
+        "Message.$": "States.Format('An execution started INSIDE the NYSE regular session under an explicit market-hours override (alpha-engine-config-I7111). Execution: {}. Gate verdict: {}. This is a deliberate, time-boxed authorisation, not a bypass \u2014 the same record is in $.market_hours_gate in execution history.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_override_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "CheckMutexRole"
+        }
+      ],
       "Next": "CheckMutexRole"
+    },
+    "NotifyMarketHoursBlocked": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 a refusal is loud. sf-pipeline-policy \u00a72.3: a run that did not do its work must not read as a clean success to a status-keyed watcher, so this notifies and then ends in a Fail rather than a Succeed-skip. The message carries the exact override shape so the operator does not have to find it.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline \u2014 REFUSED (start inside NYSE market hours)",
+        "Message.$": "States.Format('Refused to start a trading pipeline inside the NYSE regular session (alpha-engine-config-I7111). Execution: {}. Gate: {}. To authorise one in-session start, add a market_hours_override object to the execution input carrying reason, authorized_by and expires_at. All three are required and non-blank; expires_at must be an ISO-8601 instant AFTER the execution start and no more than 24h after it, so a line pasted into a runbook stops working instead of standing forever.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_blocked_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "MarketHoursBlocked"
+        }
+      ],
+      "Next": "MarketHoursBlocked"
+    },
+    "MarketHoursBlocked": {
+      "Type": "Fail",
+      "Error": "MarketHoursBoundary",
+      "Cause": "alpha-engine-config-I7111: this execution's start time falls inside the NYSE regular session ([09:30, 16:00) ET on a trading day) and carried no market-hours override. Trading pipelines do not start in-session \u2014 the preopen chain boots the trading box and starts the order-placing daemon, and the postclose chain stops the box and reconciles the book; either one, mid-session, acts on a stale plan against a live market. The verdict, the ET clock it was judged against, and the override shape are in $.market_hours_gate and in the SNS alert. To authorise one in-session start, re-run with market_hours_override {reason, authorized_by, expires_at}."
+    },
+    "NotifyMarketHoursOverrideMalformed": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 a rejected override is its own terminal, distinct from MarketHoursBlocked, because it calls for a different operator action: fix the override, not wait for the close. Kept separate rather than folded in so a status-keyed watcher can tell the two apart from the Error alone.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline \u2014 REFUSED (market-hours override is not usable)",
+        "Message.$": "States.Format('A market-hours override was offered and rejected (alpha-engine-config-I7111). Execution: {}. Gate: {}. To authorise one in-session start, add a market_hours_override object to the execution input carrying reason, authorized_by and expires_at. All three are required and non-blank; expires_at must be an ISO-8601 instant AFTER the execution start and no more than 24h after it, so a line pasted into a runbook stops working instead of standing forever.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_override_malformed_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "MarketHoursOverrideMalformed"
+        }
+      ],
+      "Next": "MarketHoursOverrideMalformed"
+    },
+    "MarketHoursOverrideMalformed": {
+      "Type": "Fail",
+      "Error": "MarketHoursOverrideMalformed",
+      "Cause": "alpha-engine-config-I7111: the execution input carried a market_hours_override that is not a usable authorisation \u2014 missing or blank reason/authorized_by/expires_at, a non-object, an unparseable expires_at, an expires_at at or before the execution start, or one more than 24h after it. The specific rejection is in $.market_hours_gate.Payload.override.rejection. Deliberately fails closed even when the market is shut: a half-typed override is a mis-authorisation, and it is better found on the run where it did not matter."
+    },
+    "NotifyMarketHoursUnverified": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 the preopen gate fails CLOSED when it cannot be evaluated. sf-pipeline-policy \u00a71.2 makes the cost of NOT trading a first-class input, and that is exactly why this is safe here: alpha-engine-predictor-inference is also the PredictorInference stage of this same pipeline, so its unavailability already means no predictions and no planner. There is nothing left for a fail-open to rescue, and a boundary that disappears whenever a Lambda is down repeats the failure class I7111 was filed for.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekday Pipeline \u2014 REFUSED (market-hours gate could not be evaluated)",
+        "Message.$": "States.Format('The market-hours gate Lambda failed after retries, so this execution cannot establish that it is starting outside the NYSE session (alpha-engine-config-I7111). Refusing to start. Execution: {}. Error: {}. Note that PredictorInference invokes the SAME Lambda later in this pipeline, so a run admitted here could not have produced predictions anyway \u2014 failing closed at the gate costs no trading day that was not already lost, and keeps the boundary from evaporating whenever its evaluator is unavailable.', $$.Execution.Id, States.JsonToString($.market_hours_gate_error))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_unverified_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "MarketHoursUnverified"
+        }
+      ],
+      "Next": "MarketHoursUnverified"
+    },
+    "MarketHoursUnverified": {
+      "Type": "Fail",
+      "Error": "MarketHoursGateUnverified",
+      "Cause": "alpha-engine-config-I7111: alpha-engine-predictor-inference did not answer action=check_market_hours after 3 retries, so this execution cannot establish that it is starting outside the NYSE session. The invoke error is in $.market_hours_gate_error. The same Lambda serves PredictorInference downstream, so this is an alert about the Lambda, not about the boundary."
     },
     "CheckMutexRole": {
       "Type": "Choice",

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,8 +1,191 @@
 {
   "Comment": "Alpha Engine EOD Pipeline \u2014 post-market data capture, snapshot capture, reconciliation, daily substrate health check, instance shutdown. Triggered by daemon shutdown on trading EC2.",
-  "StartAt": "CheckMutexRole",
+  "StartAt": "MarketHoursGate",
   "TimeoutSeconds": 64800,
   "States": {
+    "MarketHoursGate": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 (Brian ruling 2026-08-13, option c) \u2014 the \"no trading-pipeline start during NYSE market hours\" boundary, sited on the PIPELINE rather than on one caller's IAM role. alpha-engine-config#2932 ruled it onto alpha-engine-sf-watch-executor-role, enforced by a Lambda flipping that role's inline policy every 5 minutes between two codified variants. The Lambda never existed in account 711398986525 (measured 2026-08-12: no function, no EventBridge rule), so the boundary was never once in force \u2014 and being caller-scoped it could not have covered the in-session operator starts at 09:32 PT on 2026-08-07 or 08:32 PT on 2026-07-27 either. IAM has NO time-of-day condition key; that absence is why the ruled mechanism needed a Lambda to simulate one, and why the simulation could silently not exist for three weeks. A guard state binds every principal: the scheduler, the Overseer's overseer-sf-watch lane, and the operator. Neither existing guard covers this \u2014 AcquireMutex keys on the same UTC MINUTE and TradingDayGate on the calendar DAY; neither is a time-of-day boundary. Same zero-infra posture as TradingDayGate: pure calendar math on alpha-engine-predictor-inference, returning BEFORE PredictorPreflight is constructed, so no S3/ArcticDB/model problem can take out the boundary. `now` is $$.Execution.StartTime rather than the Lambda's own clock, so the verdict is a property of the execution: deterministic, replayable, and immune to a slow cold start pushing a refused run past the close. `execution_input` is passed whole because an ASL \"override.$\": \"$.market_hours_override\" parameter throws States.Runtime on every run that does not carry one.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-predictor-inference:live",
+        "Payload": {
+          "action": "check_market_hours",
+          "now.$": "$$.Execution.StartTime",
+          "execution_input.$": "$$.Execution.Input"
+        }
+      },
+      "TimeoutSeconds": 60,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "SetMarketHoursUnverifiedDegraded",
+          "ResultPath": "$.market_hours_gate_error"
+        }
+      ],
+      "ResultPath": "$.market_hours_gate",
+      "Next": "MarketHoursGateChoice"
+    },
+    "MarketHoursGateChoice": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
+      "Choices": [
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "PROCEED",
+          "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
+          "Next": "CheckMutexRole"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "PROCEED_OVERRIDE",
+          "Comment": "In-session start with a complete, authored, unexpired, bounded override. Announced and recorded, never silent.",
+          "Next": "RecordMarketHoursOverride"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "BLOCKED",
+          "Comment": "In-session start with no override \u2014 the boundary doing its job.",
+          "Next": "NotifyMarketHoursBlocked"
+        },
+        {
+          "Variable": "$.market_hours_gate.Payload.verdict",
+          "StringEquals": "OVERRIDE_MALFORMED",
+          "Comment": "An override was offered and is not usable. Fails closed whether or not the market is open: a typo'd override is a mis-authorisation, and surfacing it on the quiet run is the only way it is not discovered on the run that matters.",
+          "Next": "NotifyMarketHoursOverrideMalformed"
+        }
+      ],
+      "Default": "HandleFailure"
+    },
+    "RecordMarketHoursOverride": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 the override's audit surface. A crossed boundary is announced on the alert topic AND left in execution history with who authorised it, why, and until when. Catch continues to the pipeline: the authorisation was already validated and recorded, so a notify-side failure must not silently convert an approved recovery into a refusal.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Pipeline \u2014 market-hours boundary OVERRIDDEN (authorised in-session start)",
+        "Message.$": "States.Format('An execution started INSIDE the NYSE regular session under an explicit market-hours override (alpha-engine-config-I7111). Execution: {}. Gate verdict: {}. This is a deliberate, time-boxed authorisation, not a bypass \u2014 the same record is in $.market_hours_gate in execution history.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_override_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "CheckMutexRole"
+        }
+      ],
+      "Next": "CheckMutexRole"
+    },
+    "NotifyMarketHoursBlocked": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 a refusal is loud. sf-pipeline-policy \u00a72.3: a run that did not do its work must not read as a clean success to a status-keyed watcher, so this notifies and then ends in a Fail rather than a Succeed-skip. The message carries the exact override shape so the operator does not have to find it.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Pipeline \u2014 REFUSED (start inside NYSE market hours)",
+        "Message.$": "States.Format('Refused to start a trading pipeline inside the NYSE regular session (alpha-engine-config-I7111). Execution: {}. Gate: {}. To authorise one in-session start, add a market_hours_override object to the execution input carrying reason, authorized_by and expires_at. All three are required and non-blank; expires_at must be an ISO-8601 instant AFTER the execution start and no more than 24h after it, so a line pasted into a runbook stops working instead of standing forever.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_blocked_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "MarketHoursBlocked"
+        }
+      ],
+      "Next": "MarketHoursBlocked"
+    },
+    "MarketHoursBlocked": {
+      "Type": "Fail",
+      "Error": "MarketHoursBoundary",
+      "Cause": "alpha-engine-config-I7111: this execution's start time falls inside the NYSE regular session ([09:30, 16:00) ET on a trading day) and carried no market-hours override. Trading pipelines do not start in-session \u2014 the preopen chain boots the trading box and starts the order-placing daemon, and the postclose chain stops the box and reconciles the book; either one, mid-session, acts on a stale plan against a live market. The verdict, the ET clock it was judged against, and the override shape are in $.market_hours_gate and in the SNS alert. To authorise one in-session start, re-run with market_hours_override {reason, authorized_by, expires_at}."
+    },
+    "NotifyMarketHoursOverrideMalformed": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 a rejected override is its own terminal, distinct from MarketHoursBlocked, because it calls for a different operator action: fix the override, not wait for the close. Kept separate rather than folded in so a status-keyed watcher can tell the two apart from the Error alone.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Pipeline \u2014 REFUSED (market-hours override is not usable)",
+        "Message.$": "States.Format('A market-hours override was offered and rejected (alpha-engine-config-I7111). Execution: {}. Gate: {}. To authorise one in-session start, add a market_hours_override object to the execution input carrying reason, authorized_by and expires_at. All three are required and non-blank; expires_at must be an ISO-8601 instant AFTER the execution start and no more than 24h after it, so a line pasted into a runbook stops working instead of standing forever.', $$.Execution.Id, States.JsonToString($.market_hours_gate.Payload))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_override_malformed_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "MarketHoursOverrideMalformed"
+        }
+      ],
+      "Next": "MarketHoursOverrideMalformed"
+    },
+    "MarketHoursOverrideMalformed": {
+      "Type": "Fail",
+      "Error": "MarketHoursOverrideMalformed",
+      "Cause": "alpha-engine-config-I7111: the execution input carried a market_hours_override that is not a usable authorisation \u2014 missing or blank reason/authorized_by/expires_at, a non-object, an unparseable expires_at, an expires_at at or before the execution start, or one more than 24h after it. The specific rejection is in $.market_hours_gate.Payload.override.rejection. Deliberately fails closed even when the market is shut: a half-typed override is a mis-authorisation, and it is better found on the run where it did not matter."
+    },
+    "NotifyMarketHoursUnverified": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7111 \u2014 the postclose gate fails OPEN, DEGRADED, where the preopen gate fails closed. Three measured reasons, not a preference: (1) sf-pipeline-policy \u00a71.3 makes NAV continuity non-negotiable \u2014 every trading day terminates with a postclose completion marker and an eod_pnl.csv row, including days the morning failed; (2) unlike preopen, nothing else in this pipeline touches alpha-engine-predictor-inference, so refusing here would newly break settlement on an outage that is otherwise irrelevant to it; (3) the only automated caller \u2014 the daemon at executor/daemon.py, `market_opened and not is_market_hours()` \u2014 applies the IDENTICAL predicate before calling StartExecution, and applies it strictly earlier, which is why every observed eod-* execution starts at 16:00:0x ET. The residual is real and stated: while this Lambda is down, an OPERATOR could start postclose in-session and the gate would not stop them \u2014 it would say so, loudly, and the run would terminate DEGRADED.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        "Subject": "Alpha Engine EOD Pipeline \u2014 DEGRADED (market-hours gate could not be evaluated; settlement proceeds)",
+        "Message.$": "States.Format('The market-hours gate Lambda failed after retries (alpha-engine-config-I7111). This execution proceeds DEGRADED rather than refusing. Execution: {}. Error: {}.', $$.Execution.Id, States.JsonToString($.market_hours_gate_error))"
+      },
+      "TimeoutSeconds": 60,
+      "ResultPath": "$.market_hours_unverified_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "SNS delivery is the announcement, not the record \u2014 the gate verdict and the full override document are in $.market_hours_gate in execution history either way. A publish failure must not change what the boundary decided.",
+          "ResultPath": "$.market_hours_notify_error",
+          "Next": "CheckMutexRole"
+        }
+      ],
+      "Next": "CheckMutexRole"
+    },
+    "SetMarketHoursUnverifiedDegraded": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7111 \u2014 Option-A parity with SetDataSpotDegradedFlag/SetDegradedFlag (config#6692/config-I2702 shape): threads $.degraded_summary onto the market-hours fail-open path WITHOUT changing its continuation, so CheckDegradedOutcome routes this execution's terminal to WriteCompletionMarkerDegraded/DegradedRun. A settlement run that could not verify its own start boundary is not a clean success. Last-write-wins if a later stage also degrades.",
+      "Parameters": {
+        "degraded": true,
+        "reason": "eod_market_hours_gate_unverified",
+        "stage_error.$": "$.market_hours_gate_error"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "NotifyMarketHoursUnverified"
+    },
     "CheckMutexRole": {
       "Type": "Choice",
       "Comment": "L274 SF MutualExclusionGuard \u2014 gate at SF entry point. Allowlist all unattended cadence-roles (currently: daily / weekly / eod / shell-run / exercise) acquire the DynamoDB mutex; absent/operator/recovery/smoke/backfill/operator-replay roles bypass entirely (operator-initiated runs are deliberately concurrent with cadence runs). Daemon-triggered EOD launches set pipeline_role='eod' (executor/daemon.py:1092); operator-launched replays MUST set their own pipeline_role per the taxonomy in pipeline-reporting-revamp-260524.md \u00a76. Closes the architectural hole the L286a/b producer-side universe_writer_lock covers for manual daily_append invocations \u2014 that lock guards the data writer; this Choice guards the SF entry point. Together they cover both halves of single-writer-per-cadence-cell.",

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,12 +61,18 @@ arcticdb>=6.20.0
 # nousergon-lib#226 registered the 9 states this repo's SF JSONs were
 # missing (2 Saturday + 7 EOD) and shipped in v0.124.8 — bumped to that tag
 # here (was v0.124.6) to unblock the new source-check test.
-# alpha-engine-config-I7119: RelaunchWeeklyFreshnessSpot is a new substantive
-# Task state in step_function.json, so the SAME source-check requires its
-# registry entry to exist in the pinned lib. nousergon-lib-PR310 adds it and
-# MUST merge first; v0.124.51 is the patch autobump that merge produces from
-# today's 0.124.50 (auto-version-bump.yml is the single version writer).
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.51
+# alpha-engine-config-I7111: MarketHoursGate + its four notify/record states
+# are new substantive Task states in BOTH weekday definitions, so the SAME
+# source-check requires their registry entries to exist in the pinned lib.
+# nousergon-lib-PR311 adds all five and MUST merge first; v0.124.53 is the
+# patch autobump that merge produces from today's 0.124.52
+# (auto-version-bump.yml is the single version writer). If another lib PR
+# merges between, this pin moves to whatever tag PR311's merge actually
+# produced — the source-check is what tells you, and it is the guard against
+# merging the SF JSON ahead of the registry entry.
+# (Superseded: alpha-engine-config-I7119 / nousergon-lib-PR310, merged as
+# v0.124.51, which registered RelaunchWeeklyFreshnessSpot.)
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_sf_market_hours_gate_wiring.py
+++ b/tests/test_sf_market_hours_gate_wiring.py
@@ -1,0 +1,455 @@
+"""alpha-engine-config-I7111 — the market-hours boundary on both trading pipelines.
+
+Brian ruled option (c) on 2026-08-13: the "no trading-pipeline start during
+NYSE market hours" boundary belongs to the pipeline, not to one caller.
+
+What it replaces. alpha-engine-config#2932 (2026-07-20) ruled the boundary onto
+``alpha-engine-sf-watch-executor-role``'s ``states:StartExecution`` grant,
+enforced by ``alpha-engine-sf-watch-market-hours-toggler`` — a Lambda flipping
+that role's inline policy between two codified variants on a 5-minute schedule.
+Measured 2026-08-12 in account 711398986525: no such function, no such
+EventBridge rule. The Lambda was written, committed, and never bootstrapped, so
+the boundary was **never once in force** in the three weeks it was believed to
+be. It was also caller-scoped, so even fully deployed it could not have covered
+the in-session operator starts at 09:32 PT on 2026-08-07 or 08:32 PT on
+2026-07-27. IAM has no time-of-day condition key; that absence is why the ruled
+mechanism needed a Lambda to simulate one, and why the simulation could
+silently not exist.
+
+What this pins:
+
+  * the gate is the FIRST thing both pipelines do, ahead of the mutex;
+  * the four verdicts route where the ruling says, and anything else fails
+    closed — ``TestChoiceRouting`` evaluates the real ASL Choice rather than
+    reading them;
+  * the override is refusable-deliberately, not bypassable-accidentally;
+  * the two pipelines' unverified-gate postures differ, on purpose, and the
+    difference is asserted in both directions rather than left to a comment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_PREOPEN = "step_function_daily.json"
+_POSTCLOSE = "step_function_eod.json"
+_BOTH = [_PREOPEN, _POSTCLOSE]
+
+_GATE_STATES = {
+    "MarketHoursGate",
+    "MarketHoursGateChoice",
+    "RecordMarketHoursOverride",
+    "NotifyMarketHoursBlocked",
+    "MarketHoursBlocked",
+    "NotifyMarketHoursOverrideMalformed",
+    "MarketHoursOverrideMalformed",
+    "NotifyMarketHoursUnverified",
+}
+
+
+def _sf(name: str) -> dict:
+    return json.loads((_INFRA / name).read_text())
+
+
+@pytest.fixture(scope="module")
+def defs() -> dict:
+    return {name: _sf(name) for name in _BOTH}
+
+
+# ---------------------------------------------------------------------------
+# A minimal ASL Choice evaluator.
+#
+# Structural assertions can only say the rules are SHAPED right. The ruling is
+# about what the pipeline DOES with a verdict, so the rules are executed here
+# against the payloads alpha-engine-predictor-inference actually returns
+# (crucible-predictor inference/trading_day_gate.py::check_market_hours,
+# pinned there by tests/test_market_hours_gate.py).
+#
+# Only the operators this Choice uses are implemented — StringEquals and
+# IsPresent. An unimplemented operator raises rather than silently evaluating
+# false, so a future rule using one cannot quietly slip past this harness.
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+
+
+def _resolve(path: str, doc: dict):
+    assert path.startswith("$."), path
+    cur = doc
+    for part in path[2:].split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return _UNSET
+        cur = cur[part]
+    return cur
+
+
+def _matches(rule: dict, doc: dict) -> bool:
+    if "Not" in rule:
+        return not _matches(rule["Not"], doc)
+    if "And" in rule:
+        return all(_matches(r, doc) for r in rule["And"])
+    if "Or" in rule:
+        return any(_matches(r, doc) for r in rule["Or"])
+
+    value = _resolve(rule["Variable"], doc)
+    ops = [k for k in rule if k not in ("Variable", "Next", "Comment")]
+    assert len(ops) == 1, f"expected exactly one comparator, got {ops}"
+    op = ops[0]
+    if op == "IsPresent":
+        return (value is not _UNSET) is rule[op]
+    if op == "StringEquals":
+        return value == rule[op]
+    raise NotImplementedError(
+        f"{op} is not implemented in this harness — implement it rather than "
+        "letting the rule evaluate as a silent false"
+    )
+
+
+def evaluate(choice: dict, doc: dict) -> str:
+    for rule in choice["Choices"]:
+        if _matches(rule, doc):
+            return rule["Next"]
+    return choice["Default"]
+
+
+def _payload(verdict: str, **extra) -> dict:
+    """The shape the gate Task writes to $.market_hours_gate."""
+    return {"market_hours_gate": {"Payload": {"verdict": verdict, **extra}}}
+
+
+# ---------------------------------------------------------------------------
+# Composition — the gate is the first thing either pipeline does
+# ---------------------------------------------------------------------------
+
+
+class TestGateIsAtTheHead:
+    def test_preopen_entry_state_hands_straight_to_the_gate(self, defs):
+        d = defs[_PREOPEN]
+        assert d["StartAt"] == "InitializeInput"
+        # InitializeInput only layers defaults (it is where $.sns_topic_arn
+        # comes from, which the gate's notify states publish to), so the gate
+        # is the first state that can refuse.
+        assert d["States"]["InitializeInput"]["Type"] == "Pass"
+        assert d["States"]["InitializeInput"]["Next"] == "MarketHoursGate"
+
+    def test_postclose_starts_at_the_gate(self, defs):
+        assert defs[_POSTCLOSE]["StartAt"] == "MarketHoursGate"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_gate_precedes_the_mutex(self, defs, name):
+        # Ordering is deliberate: a run refused for starting in-session must
+        # not first take a minute-bucket mutex key it will never use.
+        choice = defs[name]["States"]["MarketHoursGateChoice"]
+        assert evaluate(choice, _payload("PROCEED")) == "CheckMutexRole"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_gate_precedes_every_state_that_spends(self, defs, name):
+        # Nothing between the entry point and the gate may boot a box, send an
+        # SSM command, launch a spot instance or invoke a worker Lambda.
+        states = defs[name]["States"]
+        entry = defs[name]["StartAt"]
+        seen, cur = [], entry
+        while cur != "MarketHoursGate":
+            seen.append(cur)
+            state = states[cur]
+            assert state["Type"] == "Pass", (
+                f"{name}: {cur} runs before MarketHoursGate and is a "
+                f"{state['Type']}, not a Pass — the boundary must be ahead of "
+                "anything that spends"
+            )
+            cur = state["Next"]
+        assert len(seen) <= 1, seen
+
+
+class TestGateTask:
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_gate_invokes_the_calendar_action_on_the_predictor_lambda(self, defs, name):
+        gate = defs[name]["States"]["MarketHoursGate"]
+        assert gate["Type"] == "Task"
+        assert gate["Resource"] == "arn:aws:states:::lambda:invoke"
+        params = gate["Parameters"]
+        assert params["FunctionName"] == "alpha-engine-predictor-inference:live"
+        assert params["Payload"]["action"] == "check_market_hours"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_verdict_is_judged_on_the_execution_start_not_the_lambda_clock(
+        self, defs, name
+    ):
+        # A property of the execution: deterministic, replayable, and immune to
+        # a slow cold start pushing a refused run past the close.
+        payload = defs[name]["States"]["MarketHoursGate"]["Parameters"]["Payload"]
+        assert payload["now.$"] == "$$.Execution.StartTime"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_override_is_read_from_the_raw_execution_input(self, defs, name):
+        # Passed WHOLE. An ASL "override.$": "$.market_hours_override"
+        # parameter throws States.Runtime on every run that does not carry one
+        # — i.e. on every normal day.
+        payload = defs[name]["States"]["MarketHoursGate"]["Parameters"]["Payload"]
+        assert payload["execution_input.$"] == "$$.Execution.Input"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_gate_declares_a_timeout_retry_and_catch(self, defs, name):
+        gate = defs[name]["States"]["MarketHoursGate"]
+        assert gate["TimeoutSeconds"] == 60
+        assert gate["Retry"][0]["MaxAttempts"] == 3
+        assert gate["Catch"][0]["ErrorEquals"] == ["States.ALL"]
+        assert gate["ResultPath"] == "$.market_hours_gate"
+        assert gate["Next"] == "MarketHoursGateChoice"
+
+
+# ---------------------------------------------------------------------------
+# The boundary itself
+# ---------------------------------------------------------------------------
+
+
+class TestChoiceRouting:
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_a_closed_market_proceeds(self, defs, name):
+        choice = defs[name]["States"]["MarketHoursGateChoice"]
+        assert evaluate(choice, _payload("PROCEED")) == "CheckMutexRole"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_an_in_session_start_is_refused(self, defs, name):
+        states = defs[name]["States"]
+        assert (
+            evaluate(states["MarketHoursGateChoice"], _payload("BLOCKED"))
+            == "NotifyMarketHoursBlocked"
+        )
+        # …and the refusal is announced before it is terminal.
+        notify = states["NotifyMarketHoursBlocked"]
+        assert notify["Resource"] == "arn:aws:states:::sns:publish"
+        assert notify["Next"] == "MarketHoursBlocked"
+        assert states["MarketHoursBlocked"]["Type"] == "Fail"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_a_refused_run_never_reads_as_a_clean_success(self, defs, name):
+        # sf-pipeline-policy §2.3. A Succeed-shaped skip (the shape
+        # NotifyHolidaySkip legitimately uses for a holiday) would tell every
+        # status-keyed watcher the pipeline ran.
+        states = defs[name]["States"]
+        for terminal in ("MarketHoursBlocked", "MarketHoursOverrideMalformed"):
+            assert states[terminal]["Type"] == "Fail"
+            assert states[terminal].get("End") is not True
+        for notify in ("NotifyMarketHoursBlocked", "NotifyMarketHoursOverrideMalformed"):
+            assert states[notify].get("End") is not True
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_the_two_refusals_carry_distinct_errors(self, defs, name):
+        # They call for different operator actions — wait for the close vs fix
+        # the override — so a watcher must be able to tell them apart from the
+        # Error alone.
+        states = defs[name]["States"]
+        assert states["MarketHoursBlocked"]["Error"] == "MarketHoursBoundary"
+        assert (
+            states["MarketHoursOverrideMalformed"]["Error"]
+            == "MarketHoursOverrideMalformed"
+        )
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_an_absent_verdict_fails_closed(self, defs, name):
+        # config-I2767's lesson, which TradingDayGateChoice already carries: a
+        # gate payload without its verdict is a contract violation by our own
+        # Lambda. Proceeding to trade on an unverifiable answer is the one
+        # outcome that must not happen.
+        choice = defs[name]["States"]["MarketHoursGateChoice"]
+        assert evaluate(choice, {}) == "HandleFailure"
+        assert evaluate(choice, {"market_hours_gate": {"Payload": {}}}) == "HandleFailure"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_an_unrecognised_verdict_fails_closed(self, defs, name):
+        choice = defs[name]["States"]["MarketHoursGateChoice"]
+        for junk in ("proceed", "PROCEED ", "OK", "", "MAYBE"):
+            assert evaluate(choice, _payload(junk)) == "HandleFailure", junk
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_every_verdict_the_lambda_can_emit_is_routed(self, defs, name):
+        # The producer's four verdicts, enumerated in crucible-predictor
+        # inference/trading_day_gate.py::check_market_hours. A fifth added
+        # there without a rule here would land on Default (fail closed) — safe,
+        # but this asserts the four known ones are each explicitly handled
+        # rather than falling through.
+        choice = defs[name]["States"]["MarketHoursGateChoice"]
+        handled = {
+            c["StringEquals"] for c in choice["Choices"] if "StringEquals" in c
+        }
+        assert handled == {
+            "PROCEED",
+            "PROCEED_OVERRIDE",
+            "BLOCKED",
+            "OVERRIDE_MALFORMED",
+        }
+
+
+class TestOverrideIsRecorded:
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_an_authorised_in_session_start_proceeds_through_a_notify(self, defs, name):
+        states = defs[name]["States"]
+        assert (
+            evaluate(states["MarketHoursGateChoice"], _payload("PROCEED_OVERRIDE"))
+            == "RecordMarketHoursOverride"
+        )
+        record = states["RecordMarketHoursOverride"]
+        assert record["Resource"] == "arn:aws:states:::sns:publish"
+        assert record["Next"] == "CheckMutexRole"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_the_record_carries_the_whole_gate_payload(self, defs, name):
+        # Who authorised it, why, and until when — not just "overridden".
+        message = defs[name]["States"]["RecordMarketHoursOverride"]["Parameters"][
+            "Message.$"
+        ]
+        assert "States.JsonToString($.market_hours_gate.Payload)" in message
+        assert "$$.Execution.Id" in message
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_a_notify_failure_does_not_convert_an_approval_into_a_refusal(
+        self, defs, name
+    ):
+        # The authorisation was validated and is already in execution history;
+        # SNS is the announcement, not the record.
+        catch = defs[name]["States"]["RecordMarketHoursOverride"]["Catch"][0]
+        assert catch["Next"] == "CheckMutexRole"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_a_rejected_override_is_announced_before_it_is_terminal(self, defs, name):
+        states = defs[name]["States"]
+        assert (
+            evaluate(states["MarketHoursGateChoice"], _payload("OVERRIDE_MALFORMED"))
+            == "NotifyMarketHoursOverrideMalformed"
+        )
+        notify = states["NotifyMarketHoursOverrideMalformed"]
+        assert notify["Resource"] == "arn:aws:states:::sns:publish"
+        assert notify["Next"] == "MarketHoursOverrideMalformed"
+        assert notify["Catch"][0]["Next"] == "MarketHoursOverrideMalformed"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_both_refusal_messages_state_how_to_authorise_one_start(self, defs, name):
+        # An operator who hits the boundary at 09:32 on a broken morning
+        # should not have to find the runbook.
+        states = defs[name]["States"]
+        for notify in ("NotifyMarketHoursBlocked", "NotifyMarketHoursOverrideMalformed"):
+            msg = states[notify]["Parameters"]["Message.$"]
+            assert "market_hours_override" in msg
+            assert "reason" in msg and "authorized_by" in msg and "expires_at" in msg
+            assert "24h" in msg
+
+
+class TestUnverifiedPostureDiffersOnPurpose:
+    """The two pipelines take OPPOSITE routes when the gate cannot be
+    evaluated. Asserted in both directions so neither can be "made
+    consistent" with the other by a later sweep without reading why."""
+
+    def test_preopen_fails_closed(self, defs):
+        states = defs[_PREOPEN]["States"]
+        assert (
+            states["MarketHoursGate"]["Catch"][0]["Next"]
+            == "NotifyMarketHoursUnverified"
+        )
+        assert states["NotifyMarketHoursUnverified"]["Next"] == "MarketHoursUnverified"
+        assert states["MarketHoursUnverified"]["Type"] == "Fail"
+        assert states["MarketHoursUnverified"]["Error"] == "MarketHoursGateUnverified"
+
+    def test_preopen_fail_closed_costs_no_day_that_was_not_already_lost(self, defs):
+        # The load-bearing fact, asserted rather than asserted-in-prose: the
+        # gate and PredictorInference are the SAME Lambda. If it cannot answer
+        # the gate it cannot produce predictions either, so refusing here
+        # forfeits nothing — and it keeps the boundary from evaporating
+        # whenever its evaluator is down, which is precisely the failure class
+        # I7111 was filed for.
+        states = defs[_PREOPEN]["States"]
+        gate_fn = states["MarketHoursGate"]["Parameters"]["FunctionName"]
+        inference_fn = states["PredictorInference"]["Parameters"]["FunctionName"]
+        assert gate_fn.split(":")[0] == inference_fn.split(":")[0]
+
+    def test_postclose_fails_open_degraded(self, defs):
+        # sf-pipeline-policy §1.3: NAV continuity is non-negotiable — every
+        # trading day terminates with a postclose completion marker and an
+        # eod_pnl.csv row. Nothing else in this pipeline touches the predictor
+        # Lambda, so refusing here would newly break settlement on an outage
+        # otherwise irrelevant to it.
+        states = defs[_POSTCLOSE]["States"]
+        assert (
+            states["MarketHoursGate"]["Catch"][0]["Next"]
+            == "SetMarketHoursUnverifiedDegraded"
+        )
+        degraded = states["SetMarketHoursUnverifiedDegraded"]
+        assert degraded["Type"] == "Pass"
+        assert degraded["ResultPath"] == "$.degraded_summary"
+        assert degraded["Parameters"]["degraded"] is True
+        assert degraded["Next"] == "NotifyMarketHoursUnverified"
+        assert states["NotifyMarketHoursUnverified"]["Next"] == "CheckMutexRole"
+
+    def test_postclose_degradation_reaches_the_terminal_selector(self, defs):
+        # A settlement run that could not verify its own start boundary is not
+        # a clean success. $.degraded_summary is the exact path
+        # CheckDegradedOutcome dereferences.
+        states = defs[_POSTCLOSE]["States"]
+        variables = {
+            c["Variable"]
+            for rule in states["CheckDegradedOutcome"]["Choices"]
+            for c in rule.get("And", [rule])
+            if "Variable" in c
+        }
+        assert any(v.startswith("$.degraded_summary") for v in variables)
+
+    def test_postclose_has_no_unverified_fail_state(self, defs):
+        assert "MarketHoursUnverified" not in defs[_POSTCLOSE]["States"]
+
+    def test_preopen_has_no_unverified_degraded_state(self, defs):
+        assert "SetMarketHoursUnverifiedDegraded" not in defs[_PREOPEN]["States"]
+
+
+class TestNotifyStatesAreSafe:
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_every_gate_notify_declares_a_timeout_and_a_catch(self, defs, name):
+        states = defs[name]["States"]
+        for state_name, state in states.items():
+            if state_name not in _GATE_STATES or state.get("Type") != "Task":
+                continue
+            assert state["TimeoutSeconds"] == 60, state_name
+            assert state["Catch"][0]["ErrorEquals"] == ["States.ALL"], state_name
+
+    def test_postclose_notifies_a_hardcoded_topic(self, defs):
+        # Mirrors HandleFailure in the same file: the EOD SF is started by the
+        # daemon and by operators with hand-written input, so a malformed
+        # sns_topic_arn field must never be able to silence a refusal.
+        for name in _GATE_STATES:
+            state = defs[_POSTCLOSE]["States"].get(name, {})
+            if state.get("Resource") != "arn:aws:states:::sns:publish":
+                continue
+            assert state["Parameters"]["TopicArn"].endswith(":alpha-engine-alerts")
+            assert "TopicArn.$" not in state["Parameters"]
+
+    def test_preopen_notifies_the_layered_topic(self, defs):
+        # InitializeInput guarantees $.sns_topic_arn before the gate runs, so
+        # the preopen gate uses it the way TradingDayGateFailed does.
+        for name in _GATE_STATES:
+            state = defs[_PREOPEN]["States"].get(name, {})
+            if state.get("Resource") != "arn:aws:states:::sns:publish":
+                continue
+            assert state["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
+
+
+class TestNoOtherGuardAlreadyCoveredThis:
+    """Recorded as assertions because both guards were, at different points in
+    the I7111 analysis, assumed to cover the time-of-day case. Neither does."""
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_the_mutex_is_a_same_minute_guard_not_a_session_guard(self, defs, name):
+        key = defs[name]["States"]["AcquireMutex"]["Parameters"]["Item"]["mutex_key"][
+            "S.$"
+        ]
+        # Keyed on the execution's UTC minute bucket — two runs a minute apart
+        # both acquire, whatever the ET clock says.
+        assert "$$.Execution.StartTime" in key
+        assert "market" not in key.lower()
+
+    def test_the_trading_day_gate_is_a_calendar_day_guard(self, defs):
+        params = defs[_PREOPEN]["States"]["TradingDayGate"]["Parameters"]
+        assert params["Payload"]["action"] == "check_trading_day"
+        assert params["Payload"].get("now") is None

--- a/tests/test_sf_mutex_wiring.py
+++ b/tests/test_sf_mutex_wiring.py
@@ -52,7 +52,11 @@ This test pins:
   ``MutexConflict``) with correct Type + Resource; the weekly SF
   additionally carries ``ComputeMutexTtl`` (JSONata Pass) between
   ``CheckMutexRole`` and ``AcquireMutex``.
-- Wiring: ``InitializeInput.Next`` (or ``StartAt`` for EOD) → ``CheckMutexRole``;
+- Wiring: ``InitializeInput.Next`` (or ``StartAt`` for EOD) → the
+  ``MarketHoursGate`` pre-spend gate, whose PROCEED branch is
+  ``CheckMutexRole`` (alpha-engine-config-I7111 — a run refused for
+  starting inside the NYSE session must not take a mutex key it will
+  never use);
   ``CheckMutexRole.Default`` → former-first-state;
   ``AcquireMutex.Next`` → former-first-state.
 - ``CheckMutexRole`` gates on ``$.pipeline_role`` in the cadence allowlist.
@@ -245,6 +249,22 @@ class TestMutexStatesPresent:
 # Wiring — entry-point reroute, Choice default, Acquire next-state
 # ---------------------------------------------------------------------------
 
+def _market_hours_proceed_target(states: dict) -> str:
+    """The state a clean (market-closed) verdict routes to.
+
+    alpha-engine-config-I7111. Read out of the Choice rather than hardcoded so
+    this file asserts the mutex is downstream of the gate without also pinning
+    the gate's internal rule order — that contract is owned by
+    tests/test_sf_market_hours_gate_wiring.py.
+    """
+    choice = states["MarketHoursGateChoice"]
+    proceed = [
+        c["Next"] for c in choice["Choices"] if c.get("StringEquals") == "PROCEED"
+    ]
+    assert len(proceed) == 1, proceed
+    return proceed[0]
+
+
 class TestMutexWiring:
     """The mutex chain must sit BETWEEN the SF's entry point and the
     former-first-state, on both the gated path (cadence role acquires)
@@ -282,13 +302,26 @@ class TestMutexWiring:
         assert saturday_sf["States"]["WeeklyPreflightGate"]["Default"] == "CheckMutexRole"
 
     def test_weekday_initialize_input_routes_to_check_mutex_role(self, weekday_sf):
-        assert weekday_sf["States"]["InitializeInput"]["Next"] == "CheckMutexRole"
+        # alpha-engine-config-I7111: MarketHoursGate is now composed ahead of
+        # the mutex on both trading pipelines — deliberately, so a run refused
+        # for starting inside the NYSE session never takes a mutex key it will
+        # not use. The mutex is still the entry point's next gate-free state,
+        # one gate further down, the same way the Saturday SF's four pre-spend
+        # gates sit ahead of it above.
+        states = weekday_sf["States"]
+        assert states["InitializeInput"]["Next"] == "MarketHoursGate"
+        assert states["MarketHoursGate"]["Next"] == "MarketHoursGateChoice"
+        assert _market_hours_proceed_target(states) == "CheckMutexRole"
 
     def test_eod_start_at_routes_to_check_mutex_role(self, eod_sf):
-        assert eod_sf["StartAt"] == "CheckMutexRole", (
-            "EOD SF has no InitializeInput state, so the mutex chain "
-            "must be reachable via StartAt directly."
+        # I7111, same composition: the EOD SF has no InitializeInput, so the
+        # gate IS its StartAt and the mutex chain hangs off the gate's
+        # PROCEED branch.
+        assert eod_sf["StartAt"] == "MarketHoursGate", (
+            "EOD SF has no InitializeInput state, so the market-hours gate "
+            "in front of the mutex chain must be StartAt directly."
         )
+        assert _market_hours_proceed_target(eod_sf["States"]) == "CheckMutexRole"
 
     @pytest.mark.parametrize("sf_name", list(FORMER_FIRST_STATE_BY_SF))
     def test_check_mutex_role_default_routes_to_former_first_state(

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -181,6 +181,17 @@ _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # predictor-inference Lambda and run BEFORE StartExecutorEC2 (replaces the
     # cold-box SSM trading_calendar check whose stdout was unreliably captured).
     "TradingDayGate": frozenset({"action"}),
+    # alpha-engine-config-I7111: the NYSE market-hours boundary, the first
+    # state of both trading pipelines. Unlike every other gate here it passes
+    # two context fields as well as the action. `now.$` is
+    # $$.Execution.StartTime, so the verdict is a property of the execution
+    # rather than of the Lambda's clock — deterministic, replayable, and
+    # immune to a slow cold start pushing a refused run past the close.
+    # `execution_input.$` is $$.Execution.Input passed WHOLE, because an
+    # "override.$": "$.market_hours_override" parameter would throw
+    # States.Runtime on every run that carries no override, i.e. every
+    # normal day.
+    "MarketHoursGate": frozenset({"action", "now.$", "execution_input.$"}),
     "PredictorInference": frozenset({"action"}),
     "CheckPredictorCoverage": frozenset({"action"}),
     "ReinvokePredictor": frozenset({"action", "tickers.$"}),
@@ -475,6 +486,24 @@ class TestEODSFTopLevelFieldsClosed:
             # could not resolve and the run failed States.Runtime instead of
             # DegradedRun. Named to be read by nothing.
             "degraded_marker_result",
+            # alpha-engine-config-I7111 — the MarketHoursGate namespace. The
+            # gate's own ResultPath ($.market_hours_gate) and its Catch's
+            # ($.market_hours_gate_error) are the two load-bearing ones: the
+            # first is what MarketHoursGateChoice keys on and what the notify
+            # states render; the second is what
+            # SetMarketHoursUnverifiedDegraded threads into
+            # $.degraded_summary.stage_error. The four *_notify paths are
+            # sns:publish results, named to be read by nothing (same
+            # convention as degraded_marker_result above) — they exist only so
+            # a publish result cannot replace the state input the way the
+            # I6891 incident did.
+            "market_hours_gate",
+            "market_hours_gate_error",
+            "market_hours_blocked_notify",
+            "market_hours_notify_error",
+            "market_hours_override_malformed_notify",
+            "market_hours_override_notify",
+            "market_hours_unverified_notify",
             "ec2_instance_id",
             "eod_poll",
             "eod_result",

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -290,11 +290,35 @@ _FAILURE_FAMILY: dict[str, frozenset[str]] = {
             "MutexConflict",
         }
     ),
+    # alpha-engine-config-I7111 adds three more real Fail-type terminals to
+    # the two trading pipelines: MarketHoursBlocked (started inside the NYSE
+    # session with no override), MarketHoursOverrideMalformed (an override was
+    # offered and is not usable) and — preopen only — MarketHoursUnverified
+    # (the gate Lambda did not answer, and preopen fails CLOSED there because
+    # PredictorInference invokes the same Lambda downstream, so nothing was
+    # left to rescue). They are enumerated here for the same reason
+    # MutexConflict is: a Catch reaching one of them fails LOUD, so the route
+    # is not "fail-open to a silent SUCCESS" and needs no degraded flag. The
+    # postclose pipeline deliberately has NO MarketHoursUnverified — its
+    # unverified route is a genuine fail-open and sets $.degraded_summary.
     "step_function_daily.json": frozenset(
-        {"HandleFailure", "FailExecution", "MutexConflict"}
+        {
+            "HandleFailure",
+            "FailExecution",
+            "MutexConflict",
+            "MarketHoursBlocked",
+            "MarketHoursOverrideMalformed",
+            "MarketHoursUnverified",
+        }
     ),
     "step_function_eod.json": frozenset(
-        {"HandleFailure", "FailExecution", "MutexConflict"}
+        {
+            "HandleFailure",
+            "FailExecution",
+            "MutexConflict",
+            "MarketHoursBlocked",
+            "MarketHoursOverrideMalformed",
+        }
     ),
 }
 


### PR DESCRIPTION
## What

`MarketHoursGate` + `MarketHoursGateChoice` become the **first states** of both `ne-preopen-trading-pipeline` and `ne-postclose-trading-pipeline` — ahead of the mutex, deliberately, so a refused run never takes a minute-bucket key it will not use.

## Why

Brian ruled option **(c)** on `alpha-engine-config-I7111`, 2026-08-13: the "no trading-pipeline start during NYSE market hours" boundary belongs to the pipeline, not to one caller.

`alpha-engine-config#2932` had ruled it onto `alpha-engine-sf-watch-executor-role`'s `StartExecution` grant, enforced by a Lambda flipping that role's inline policy every 5 minutes. **Measured 2026-08-12 in account 711398986525: no such function, no such EventBridge rule.** Written, committed, never bootstrapped — the boundary was never once in force. Being caller-scoped, even fully deployed it could not have covered the in-session operator starts at **09:32 PT on 2026-08-07** or **08:32 PT on 2026-07-27**. IAM has no time-of-day condition key; that absence is why the ruled mechanism needed a Lambda to simulate one, and why the simulation could silently not exist for three weeks.

And neither existing guard covers it: `AcquireMutex` keys on the same UTC **minute**, `TradingDayGate` on the calendar **day**. Both facts are now assertions in `TestNoOtherGuardAlreadyCoveredThis` rather than comments, because both were assumed to cover it at different points in the I7111 analysis.

## The gate

Invokes `alpha-engine-predictor-inference:live` `action=check_market_hours` with `now = $$.Execution.StartTime` — the verdict is a property of the execution: deterministic, replayable, immune to a slow cold start pushing a refused run past the close — and `$$.Execution.Input` passed whole, because an `"override.$": "$.market_hours_override"` parameter would throw `States.Runtime` on every run carrying no override. Zero-infra, returning before `PredictorPreflight` is constructed.

Four verdicts, enumerated **exhaustively**:

| verdict | route |
|---|---|
| `PROCEED` | `CheckMutexRole` |
| `PROCEED_OVERRIDE` | `RecordMarketHoursOverride` (SNS) -> `CheckMutexRole` |
| `BLOCKED` | `NotifyMarketHoursBlocked` -> `MarketHoursBlocked` (`Fail`) |
| `OVERRIDE_MALFORMED` | `NotifyMarketHoursOverrideMalformed` -> `MarketHoursOverrideMalformed` (`Fail`) |
| absent / anything else | `Default` -> `HandleFailure` |

Absent-or-unrecognised fails **closed** — the config-I2767 lesson: never trade on an unverifiable answer from our own Lambda. The two refusals carry **distinct `Error` values** because they call for different operator actions (wait for the close vs fix the override). A refusal ends in `Fail`, never a Succeed-shaped skip — `sf-pipeline-policy.md` §2.3, a run that did no work must not read green to a status-keyed watcher.

## The override

`market_hours_override` = `reason` + `authorized_by` + `expires_at`, all non-blank, `expires_at` an ISO-8601 instant after the execution start and at most 24h after it — so a line pasted into a runbook stops working instead of standing forever. Recorded three ways: the SNS alert names who authorised it and why; the whole document stays in `$.market_hours_gate` in execution history; and **both refusal messages carry the exact shape**, so an operator hitting the boundary at 09:32 on a broken morning does not have to go find the runbook.

## The two pipelines fail differently when the gate cannot be evaluated — on purpose

Both directions are asserted, so neither can be "made consistent" with the other by a later sweep without reading why.

- **Preopen fails CLOSED.** `alpha-engine-predictor-inference` is also this pipeline's `PredictorInference` stage — asserted, not claimed, by `test_preopen_fail_closed_costs_no_day_that_was_not_already_lost`. Its unavailability already means no predictions and no planner, so nothing is left for a fail-open to rescue, and a boundary that evaporates whenever its evaluator is down repeats exactly the failure class I7111 was filed for.
- **Postclose fails OPEN, DEGRADED**, via `SetMarketHoursUnverifiedDegraded` -> `$.degraded_summary` -> `CheckDegradedOutcome`. §1.3 makes NAV continuity non-negotiable; nothing else in that pipeline touches the predictor Lambda; and its only automated caller — `executor/daemon.py`, `market_opened and not is_market_hours()` — applies the **identical** predicate strictly earlier, which is why every observed `eod-*` execution starts at 16:00:0x ET. The residual is written into the state's own Comment: while that Lambda is down an operator *could* start postclose in-session — the run would say so loudly and terminate DEGRADED.

The session is half-open `[09:30, 16:00)` ET. The exclusive close is load-bearing, not a detail: a close-inclusive boundary would refuse the settlement run that carries NAV continuity.

## Validation

Both definitions pass `aws stepfunctions validate-state-machine-definition --type STANDARD` -> `result: OK`, zero diagnostics. That is the **exact definition path**, not an approximation of it.

`tests/test_sf_market_hours_gate_wiring.py` (new, 51 assertions) carries a minimal ASL `Choice` evaluator that **executes** the real rules against the real producer payloads rather than reading their shape. An operator it does not implement raises rather than evaluating false, so a future rule cannot slip past the harness.

Registry updates CI required, all in this PR: `_FAILURE_FAMILY` (three new real `Fail`-type terminals), `_WEEKDAY_PAYLOAD_KEYS`, `_EXPECTED_EOD_TOP_LEVEL_FIELDS`, and `test_sf_mutex_wiring`'s entry-point assertions — the mutex is now one gate further down, the same way the Saturday SF's four pre-spend gates already sit ahead of it.

## Test plan (run before opening)

- `pytest tests/test_sf_market_hours_gate_wiring.py` -> **51 passed**
- SF-family suites (`structural_contract`, `trading_day_gate_wiring`, `mutex_wiring`, `degraded_paths_page_immediately`, `lambda_existence_check`, `payload_uniqueness`) -> **all green**
- Full suite -> **4713 passed**, 52 more than `origin/main` and **zero new failures**: the 177 failures and 65 collection errors are pre-existing and identical to the baseline measured in the same environment (`comm` diff empty).

Rehearsal-path: tests/test_sf_market_hours_gate_wiring.py

Rehearsal-risk-acceptance: The §7.2-route-1 CI alternative above covers the definition path (real ASL validator) and the gate's runtime routing (the Choice evaluator, driven by the producer's real verdict payloads, which `crucible-predictor/tests/test_market_hours_gate.py` pins from the other side). One thing it cannot cover pre-merge: that the DEPLOYED `alpha-engine-predictor-inference:live` answers `action=check_market_hours` at all — an externally-triggered dependency, since that alias is published by crucible-predictor's own `deploy.yml` on ITS merge. That is covered by the deploy-time canary added in `crucible-predictor-PR472` (`infrastructure/deploy.sh`, invoking the live alias with a fixed in-session `now` and asserting the `is_market_hours` domain key), and it is the reason for the stated merge order rather than a deferral: PR472 merges and deploys first, so by the time this PR merges the action is live and canaried. Merging in the other order would point the gate at an unrecognised action, which falls through to `action=predict`.

## Deployable by the merge button

`deploy-infrastructure.yml` runs `infrastructure/deploy-infrastructure.sh` on every push to `main` — it stamps and `update-state-machine`s both definitions, then `check-definition-drift.py` verifies live against the tree. No post-merge step.

## Cross-repo — merge order

1. `crucible-predictor-PR472` (the evaluator, deploys on merge) — **before this PR**
2. **this PR** (the gate)
3. `nous-ergon-ops-PR` (restores sf-watch's `StartExecution` grant — after the gate is live, or the hole reopens for the window between)

Independent, any order: `krepis-PR139`, `crucible-executor-PR468`.

Refs `alpha-engine-config-I7111`

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)



---

## Update — registry + pin (added after the first CI run)

`test_pipeline_status_registry_source_check.py` failed in CI and **not** locally: the locally installed `nousergon_lib` is older than the pinned tag, so the local run was blind to exactly the drift class that check exists to catch (config#1115/#1120/#2372/#2430). Recorded rather than quietly fixed, because "green locally" was not evidence here.

The finding is correct — the five new Task states have no `STATE_TO_ARCHIVE_PAGE` entry, so `pipeline-status` would render them as unexplained rows. `nousergon-lib-PR311` adds all five as `ArtifactReason` entries (none writes an artifact); this PR moves the pin across all 20 lockstep sites to **`v0.124.53`**, the patch autobump PR311's merge produces from today's `0.124.52`. That is the check's own prescribed sequence: register, merge the lib PR, bump the pin in the same PR that adds the state.

If another lib PR merges in between, this pin moves to whatever tag PR311's merge actually produced; the source-check is what says so. The stale I7119/PR310 comment above the pin is replaced rather than appended to — it described a merge that already happened.

`test_lib_pin_lockstep.py` + `test_ensure_lib_pin_rename_agnostic.py`: 12 passed.

**This makes `nousergon-lib-PR311` the first merge in the arc**, ahead of `crucible-predictor-PR472`.
