### PR TITLE
fix(sf): an absent market-hours verdict raises States.Runtime, it does not reach Default (config-I7111)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -56,6 +56,14 @@
       "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
       "Choices": [
         {
+          "Not": {
+            "Variable": "$.market_hours_gate.Payload.verdict",
+            "IsPresent": true
+          },
+          "Comment": "alpha-engine-config-I7111 / config-I2767, added 2026-08-13. This rule must come FIRST and must be IsPresent-guarded. A Choice rule comparing a path that does not exist raises States.Runtime \u2014 it does NOT fall through to Default \u2014 so this Choice's own comment claiming an absent verdict 'fails CLOSED via Default' described behaviour ASL does not have. The 2026-08-13 preopen run proved it: verdict absent, States.Runtime at this state, execution dead 48s in with no SNS alert of any kind and no orders placed. Matching here short-circuits before any StringEquals touches the missing path, which is exactly how TradingDayGateChoice has been written since config-I2767.",
+          "Next": "StampMarketHoursVerdictMissing"
+        },
+        {
           "Variable": "$.market_hours_gate.Payload.verdict",
           "StringEquals": "PROCEED",
           "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
@@ -81,6 +89,16 @@
         }
       ],
       "Default": "HandleFailure"
+    },
+    "StampMarketHoursVerdictMissing": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7111. Preopen posture: an unevaluable gate REFUSES. Routes into the existing unverified pair, which ends in the MarketHoursUnverified Fail. Stamping $.market_hours_gate_error is what makes that reachable: NotifyMarketHoursUnverified formats it with States.JsonToString, and on a missing path that call would itself raise States.Runtime \u2014 replacing one silent runtime death with another.",
+      "Result": {
+        "Error": "MarketHoursGateContractViolation",
+        "Cause": "alpha-engine-config-I7111: the market-hours gate Lambda returned successfully but its payload carried no `verdict` key, so this execution cannot establish that it is starting outside the NYSE session. This is a contract violation by our own producer, not an invoke failure, so the Task's Catch never fires and $.market_hours_gate_error would otherwise be absent. Measured 2026-08-13 (execution 59c0ce46): the `live` alias of alpha-engine-predictor-inference was frozen at a version predating action=check_market_hours, so the invoke fell through to the default predict branch and answered the gate with {statusCode, body}. The full payload received is in $.market_hours_gate."
+      },
+      "ResultPath": "$.market_hours_gate_error",
+      "Next": "NotifyMarketHoursUnverified"
     },
     "RecordMarketHoursOverride": {
       "Type": "Task",
@@ -1012,7 +1030,7 @@
     },
     "RunMorningPlanner": {
       "Type": "Task",
-      "Comment": "Run morning order-book planner via SSM. alpha-engine-config-I7047 sweep (2026-08-12): migrated off the inline `trap 'aws s3 cp ... EXIT'` log-ship wrapper to krepis.ssm_log_capture — found by the I7047 guard test, which asserts zero occurrences of the anti-pattern in ANY nousergon-data SF definition, not just the two Saturday health-observe stages the issue named. Unlike WeeklySubstrateHealthCheck's instance, this one was a plain `commands` JSON array (not `commands.$`/States.Array), so it was not exhibiting the ASL `\\'`-escape-collapse bug specifically — but it is the same anti-pattern this fleet is retiring in favor of krepis (17+ sibling stages), so it is migrated for consistency rather than left as a second, differently-shaped copy. Behavior-preserving: `source .venv/bin/activate` is kept (subprocess inherits the activated PATH so a bare `python` invocation still resolves to this venv's interpreter) — only the krepis wrapper binary itself is called by absolute path, per fleet convention.",
+      "Comment": "Run morning order-book planner via SSM. alpha-engine-config-I7047 sweep (2026-08-12): migrated off the inline `trap 'aws s3 cp ... EXIT'` log-ship wrapper to krepis.ssm_log_capture \u2014 found by the I7047 guard test, which asserts zero occurrences of the anti-pattern in ANY nousergon-data SF definition, not just the two Saturday health-observe stages the issue named. Unlike WeeklySubstrateHealthCheck's instance, this one was a plain `commands` JSON array (not `commands.$`/States.Array), so it was not exhibiting the ASL `\\'`-escape-collapse bug specifically \u2014 but it is the same anti-pattern this fleet is retiring in favor of krepis (17+ sibling stages), so it is migrated for consistency rather than left as a second, differently-shaped copy. Behavior-preserving: `source .venv/bin/activate` is kept (subprocess inherits the activated PATH so a bare `python` invocation still resolves to this venv's interpreter) \u2014 only the krepis wrapper binary itself is called by absolute path, per fleet convention.",
       "Resource": "arn:aws:states:::aws-sdk:ssm:sendCommand",
       "Parameters": {
         "DocumentName": "AWS-RunShellScript",

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -47,6 +47,14 @@
       "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
       "Choices": [
         {
+          "Not": {
+            "Variable": "$.market_hours_gate.Payload.verdict",
+            "IsPresent": true
+          },
+          "Comment": "alpha-engine-config-I7111 / config-I2767, added 2026-08-13. This rule must come FIRST and must be IsPresent-guarded. A Choice rule comparing a path that does not exist raises States.Runtime \u2014 it does NOT fall through to Default \u2014 so this Choice's own comment claiming an absent verdict 'fails CLOSED via Default' described behaviour ASL does not have. The 2026-08-13 preopen run proved it: verdict absent, States.Runtime at this state, execution dead 48s in with no SNS alert of any kind and no orders placed. Matching here short-circuits before any StringEquals touches the missing path, which is exactly how TradingDayGateChoice has been written since config-I2767.",
+          "Next": "StampMarketHoursVerdictMissing"
+        },
+        {
           "Variable": "$.market_hours_gate.Payload.verdict",
           "StringEquals": "PROCEED",
           "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
@@ -72,6 +80,16 @@
         }
       ],
       "Default": "HandleFailure"
+    },
+    "StampMarketHoursVerdictMissing": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7111. Postclose posture: an unevaluable gate proceeds DEGRADED \u2014 settlement and reconciliation must still happen, and the boundary's job at 16:00 ET is already satisfied by the schedule. Routes into the existing degraded pair rather than the preopen refusal, preserving the asymmetry the two pipelines already declare. Stamping $.market_hours_gate_error is required: both SetMarketHoursUnverifiedDegraded and NotifyMarketHoursUnverified read it.",
+      "Result": {
+        "Error": "MarketHoursGateContractViolation",
+        "Cause": "alpha-engine-config-I7111: the market-hours gate Lambda returned successfully but its payload carried no `verdict` key, so this execution cannot establish that it is starting outside the NYSE session. This is a contract violation by our own producer, not an invoke failure, so the Task's Catch never fires and $.market_hours_gate_error would otherwise be absent. Measured 2026-08-13 (execution 59c0ce46): the `live` alias of alpha-engine-predictor-inference was frozen at a version predating action=check_market_hours, so the invoke fell through to the default predict branch and answered the gate with {statusCode, body}. The full payload received is in $.market_hours_gate."
+      },
+      "ResultPath": "$.market_hours_gate_error",
+      "Next": "SetMarketHoursUnverifiedDegraded"
     },
     "RecordMarketHoursOverride": {
       "Type": "Task",

--- a/tests/test_sf_market_hours_gate_wiring.py
+++ b/tests/test_sf_market_hours_gate_wiring.py
@@ -87,6 +87,20 @@ def _resolve(path: str, doc: dict):
     return cur
 
 
+class StatesRuntime(Exception):
+    """What real ASL raises when a comparator's path does not resolve.
+
+    This harness previously modelled that case as "the rule does not match",
+    so an absent verdict fell through to Default and
+    test_an_absent_verdict_fails_closed passed — asserting a fail-closed
+    behaviour the deployed pipeline did not have. On 2026-08-13 the preopen
+    execution took that path for real: verdict absent, States.Runtime at
+    MarketHoursGateChoice, execution dead 48s in with no SNS alert and no
+    orders placed. `Default` catches an unrecognised verdict, never a missing
+    one; only an IsPresent-guarded rule ordered ahead of the comparators does.
+    """
+
+
 def _matches(rule: dict, doc: dict) -> bool:
     if "Not" in rule:
         return not _matches(rule["Not"], doc)
@@ -100,7 +114,13 @@ def _matches(rule: dict, doc: dict) -> bool:
     assert len(ops) == 1, f"expected exactly one comparator, got {ops}"
     op = ops[0]
     if op == "IsPresent":
+        # The one operator defined on an absent path — that is its whole job.
         return (value is not _UNSET) is rule[op]
+    if value is _UNSET:
+        raise StatesRuntime(
+            f"Invalid path '{rule['Variable']}': The choice state's condition "
+            f"path references an invalid value."
+        )
     if op == "StringEquals":
         return value == rule[op]
     raise NotImplementedError(
@@ -251,14 +271,89 @@ class TestChoiceRouting:
         )
 
     @pytest.mark.parametrize("name", _BOTH)
-    def test_an_absent_verdict_fails_closed(self, defs, name):
+    def test_an_absent_verdict_routes_to_the_unverified_path(self, defs, name):
         # config-I2767's lesson, which TradingDayGateChoice already carries: a
         # gate payload without its verdict is a contract violation by our own
         # Lambda. Proceeding to trade on an unverifiable answer is the one
         # outcome that must not happen.
+        #
+        # It must route through StampMarketHoursVerdictMissing rather than
+        # Default: Default is unreachable on an absent path (real ASL raises
+        # States.Runtime before it), and the states that report an unevaluable
+        # gate all format $.market_hours_gate_error, which nothing sets on this
+        # path because the Task's Catch never fired — the invoke SUCCEEDED.
         choice = defs[name]["States"]["MarketHoursGateChoice"]
-        assert evaluate(choice, {}) == "HandleFailure"
-        assert evaluate(choice, {"market_hours_gate": {"Payload": {}}}) == "HandleFailure"
+        assert evaluate(choice, {}) == "StampMarketHoursVerdictMissing"
+        assert (
+            evaluate(choice, {"market_hours_gate": {"Payload": {}}})
+            == "StampMarketHoursVerdictMissing"
+        )
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_the_missing_verdict_guard_is_ordered_first(self, defs, name):
+        # Order is the whole mechanism: ASL evaluates rules in sequence and a
+        # StringEquals against an unresolvable path raises immediately, so a
+        # guard placed after the comparators never runs.
+        first = defs[name]["States"]["MarketHoursGateChoice"]["Choices"][0]
+        assert first["Not"]["IsPresent"] is True, first
+        assert first["Not"]["Variable"] == "$.market_hours_gate.Payload.verdict"
+        assert first["Next"] == "StampMarketHoursVerdictMissing"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_the_stamp_state_supplies_what_the_unverified_states_format(
+        self, defs, name
+    ):
+        # The reason the guard cannot simply point at NotifyMarketHoursUnverified:
+        # that state formats States.JsonToString($.market_hours_gate_error), and
+        # on a missing path that call raises States.Runtime itself — swapping one
+        # silent runtime death for another.
+        states = defs[name]["States"]
+        stamp = states["StampMarketHoursVerdictMissing"]
+        assert stamp["Type"] == "Pass"
+        assert stamp["ResultPath"] == "$.market_hours_gate_error"
+        assert stamp["Result"]["Error"] == "MarketHoursGateContractViolation"
+        assert stamp["Result"]["Cause"]
+        # And it must hand off to a state that already exists in this pipeline.
+        assert stamp["Next"] in states
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_an_absent_verdict_reaches_this_pipelines_declared_posture(
+        self, defs, name
+    ):
+        # The two pipelines answer an unevaluable gate differently and both
+        # answers are deliberate: preopen REFUSES (a stale plan against a live
+        # market), postclose proceeds DEGRADED (settlement must still happen).
+        # An absent verdict must land on the same posture as a failed invoke,
+        # not on a generic failure that ignores the distinction.
+        states = defs[name]["States"]
+        nxt = states["StampMarketHoursVerdictMissing"]["Next"]
+        if name.endswith("daily.json"):
+            assert nxt == "NotifyMarketHoursUnverified"
+            assert states[nxt]["Next"] == "MarketHoursUnverified"
+            assert states["MarketHoursUnverified"]["Type"] == "Fail"
+        else:
+            assert nxt == "SetMarketHoursUnverifiedDegraded"
+            assert states[nxt]["Next"] == "NotifyMarketHoursUnverified"
+
+    @pytest.mark.parametrize("name", _BOTH)
+    def test_harness_raises_on_an_unguarded_comparator_like_real_asl(
+        self, defs, name
+    ):
+        # Pins the harness fidelity this suite lacked. Without it, the absent
+        # -verdict test above passes against a definition that dies with
+        # States.Runtime in production — which is precisely what shipped.
+        unguarded = {
+            "Choices": [
+                {
+                    "Variable": "$.market_hours_gate.Payload.verdict",
+                    "StringEquals": "PROCEED",
+                    "Next": "CheckMutexRole",
+                }
+            ],
+            "Default": "HandleFailure",
+        }
+        with pytest.raises(StatesRuntime, match="references an invalid value"):
+            evaluate(unguarded, {"market_hours_gate": {"Payload": {}}})
 
     @pytest.mark.parametrize("name", _BOTH)
     def test_an_unrecognised_verdict_fails_closed(self, defs, name):


### PR DESCRIPTION
## What broke

The 2026-08-13 preopen execution (`59c0ce46`) failed 48s in:

```
States.Runtime: An error occurred while executing the state 'MarketHoursGateChoice'
(entered at the event id #9). Invalid path '$.market_hours_gate.Payload.verdict':
The choice state's condition path references an invalid value.
```

**No orders were placed.** No SNS alert fired — the execution died before reaching any notify state, so the only signal was the pipeline watchdog reporting a failed run.

## Why the documented fail-closed path did not fire

`MarketHoursGateChoice` compares the verdict with four unguarded `StringEquals` rules, and its own comment states that "an absent or unrecognised verdict ... fails **CLOSED** via `Default`". ASL has no such behaviour for an **absent** path: a comparator whose path does not resolve raises `States.Runtime` immediately, before `Default` is considered. `Default` catches an unrecognised verdict; nothing caught a missing one.

The verdict was missing because the gate's Lambda alias was frozen on a version predating `action=check_market_hours`, so the invoke fell through to the default `predict` branch and answered `{statusCode: 200, body: "Predictions written for today"}`. That half is **crucible-predictor-PR474**.

## Fix

- Both pipelines gain an **`IsPresent`-guarded rule ordered first**, routing an absent verdict to a new `StampMarketHoursVerdictMissing` Pass state. Order is the mechanism — a guard placed after the comparators never runs. This is how `TradingDayGateChoice` has been written since config-I2767.
- The stamp state writes `$.market_hours_gate_error` before handing off. Every state that reports an unevaluable gate formats it with `States.JsonToString`, and on a missing path *that* call raises `States.Runtime` too — pointing the guard straight at `NotifyMarketHoursUnverified` would have swapped one silent runtime death for another. The Task's `Catch` never fires on this path: the invoke **succeeded**, it just answered wrongly.
- **Each pipeline keeps its declared posture.** Preopen → `NotifyMarketHoursUnverified` → `MarketHoursUnverified` (Fail): a stale plan against a live market. Postclose → `SetMarketHoursUnverifiedDegraded`: settlement and reconciliation must still happen.

## The reason no test caught this

`tests/test_sf_market_hours_gate_wiring.py` carries `test_an_absent_verdict_fails_closed`, and it **passed on every commit** — its ASL harness modelled a comparator against a missing path as "this rule does not match", falling through to `Default`. It asserted a behaviour the deployed pipeline did not have.

The harness now raises `StatesRuntime` exactly as ASL does. That change alone fails **8 tests** against the definition as shipped (verified by stashing the JSON changes and re-running).

## Test plan

- `pytest tests/test_sf_market_hours_gate_wiring.py` — 59 passed.
- Against the pre-fix definition with the hardened harness: 8 failed, 51 passed.
- `pytest tests/test_sf_*.py` — 1865 passed, 2 failed; both failures are a missing optional `pandas`/`pyarrow` dependency on this laptop and reproduce on clean `main`.

## Cross-repo

- **crucible-predictor-PR474** — unfreezes the Lambda promote so `check_market_hours` reaches `live`. Merge order: PR474 first, then this. This PR is independently correct in either order; it hardens what happens when a verdict is missing for any future reason.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_market_hours_gate_wiring.py
