### PR TITLE
fix(sf): presence-guard MarketHoursGateChoice before Payload.verdict (config-I7165)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -56,6 +56,14 @@
       "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
       "Choices": [
         {
+          "Not": {
+            "Variable": "$.market_hours_gate.Payload.verdict",
+            "IsPresent": true
+          },
+          "Comment": "alpha-engine-config-I7165: gate Lambda returned a payload WITHOUT Payload.verdict (measured live 2026-08-13, execution 59c0ce46-d366-45dd-8cd3-acbdc06638c1 \u2014 alpha-engine-predictor-inference:live frozen on v455, which has no check_market_hours action, fell through to its default predict branch and returned {\"statusCode\":200,\"body\":\"Predictions written for today\"}). Unguarded, this dereference threw an UNCATCHABLE States.Runtime 48s into the run with no SNS alert \u2014 the Catch above only fires on the Task's own failure, not on this Choice's path-resolution error one state later. Route through the malformed-payload floor into the same fail-closed notifier the Catch above uses.",
+          "Next": "MarketHoursGatePayloadMalformed"
+        },
+        {
           "Variable": "$.market_hours_gate.Payload.verdict",
           "StringEquals": "PROCEED",
           "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
@@ -81,6 +89,16 @@
         }
       ],
       "Default": "HandleFailure"
+    },
+    "MarketHoursGatePayloadMalformed": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7165 \u2014 floors $.market_hours_gate_error before NotifyMarketHoursUnverified, whose Message.$ calls States.JsonToString($.market_hours_gate_error); that field is otherwise written only by MarketHoursGate's Catch ResultPath and would itself throw States.Runtime on this path were it absent. Mirrors WeeklyRunDayGateMalformed in step_function.json for the identical hazard (unguarded nested Choice dereference on a lambda:invoke Payload with no ResultSelector).",
+      "Result": {
+        "Error": "MarketHoursGateMalformedPayload",
+        "Cause": "check_market_hours returned a payload without Payload.verdict \u2014 the gate could not be evaluated; failing CLOSED (mirrors the gate's own Catch posture, since preopen refuses rather than trades on an unverifiable answer)."
+      },
+      "ResultPath": "$.market_hours_gate_error",
+      "Next": "NotifyMarketHoursUnverified"
     },
     "RecordMarketHoursOverride": {
       "Type": "Task",

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -47,6 +47,14 @@
       "Comment": "alpha-engine-config-I7111 \u2014 the boundary itself. Keys on the gate's verdict, which is enumerated EXHAUSTIVELY: an absent or unrecognised verdict is a contract violation by our own Lambda and fails CLOSED via Default rather than proceeding to trade on an unverifiable answer (the config-I2767 lesson TradingDayGateChoice already carries). PROCEED_OVERRIDE is the ruling's second requirement \u2014 the boundary must be refusable deliberately, never bypassable accidentally \u2014 and it routes through a notify state so a crossed boundary is announced rather than silent.",
       "Choices": [
         {
+          "Not": {
+            "Variable": "$.market_hours_gate.Payload.verdict",
+            "IsPresent": true
+          },
+          "Comment": "alpha-engine-config-I7165: gate Lambda returned a payload WITHOUT Payload.verdict (same class as the live 2026-08-13 preopen failure, execution 59c0ce46-d366-45dd-8cd3-acbdc06638c1 \u2014 alpha-engine-predictor-inference:live frozen on v455, no check_market_hours action, fell through to its default predict branch and returned a bare 200). Unguarded, this dereference throws an UNCATCHABLE States.Runtime one state after the Task's own Catch, which only fires on Task failure. Route through the malformed-payload floor into SetMarketHoursUnverifiedDegraded \u2014 the same fail-open, DEGRADED path the Catch above already uses for this Lambda's failure.",
+          "Next": "MarketHoursGatePayloadMalformed"
+        },
+        {
           "Variable": "$.market_hours_gate.Payload.verdict",
           "StringEquals": "PROCEED",
           "Comment": "Market closed. The scheduled trigger of both pipelines lands here every day: preopen at 05:15 PT (pre-open) and postclose at 13:00:0x PT, which is 16:00:0x ET \u2014 the session window is half-open [09:30, 16:00) so the close instant itself is already outside it.",
@@ -72,6 +80,16 @@
         }
       ],
       "Default": "HandleFailure"
+    },
+    "MarketHoursGatePayloadMalformed": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7165 \u2014 floors $.market_hours_gate_error before SetMarketHoursUnverifiedDegraded, which threads it onward as $.degraded_summary.stage_error, and before NotifyMarketHoursUnverified, whose Message.$ calls States.JsonToString($.market_hours_gate_error); that field is otherwise written only by MarketHoursGate's Catch ResultPath and would itself throw States.Runtime on this path were it absent. Mirrors WeeklyRunDayGateMalformed in step_function.json for the identical hazard, adapted to this pipeline's fail-open-degraded posture for the market-hours gate (unlike preopen's fail-closed).",
+      "Result": {
+        "Error": "MarketHoursGateMalformedPayload",
+        "Cause": "check_market_hours returned a payload without Payload.verdict \u2014 the gate could not be evaluated; proceeding fail-open DEGRADED (mirrors the gate's own Catch posture for this pipeline)."
+      },
+      "ResultPath": "$.market_hours_gate_error",
+      "Next": "SetMarketHoursUnverifiedDegraded"
     },
     "RecordMarketHoursOverride": {
       "Type": "Task",

--- a/tests/test_sf_market_hours_gate_payload_guard.py
+++ b/tests/test_sf_market_hours_gate_payload_guard.py
@@ -1,0 +1,286 @@
+"""alpha-engine-config-I7165 — every raw `lambda:invoke` Payload dereference
+in a Choice state must be reachable only once its key's presence is
+established, either by a `ResultSelector` on the producing Task that pins
+the key, or by a presence guard inside the Choice itself.
+
+## The incident this guards
+
+The 2026-08-13 preopen execution (`59c0ce46-d366-45dd-8cd3-acbdc06638c1`)
+failed 48s in with a raw `States.Runtime` at `MarketHoursGateChoice`:
+`Invalid path '$.market_hours_gate.Payload.verdict'`. No SNS alert fired —
+ASL Choice states cannot carry `Catch`, so an absent-key dereference in a
+Choice is UNCATCHABLE even though the producing Task's own `Catch` on
+`States.ALL` is right there. Root trigger (`crucible-predictor-PR474`,
+out of scope here): `alpha-engine-predictor-inference:live` was frozen on a
+version with no `check_market_hours` action and fell through to its default
+predict branch, returning `{"statusCode": 200, ...}` with no `verdict` key
+at all.
+
+`MarketHoursGate` was the ONLY `lambda:invoke` gate in either weekday
+definition with `ResultSelector: null` — every sibling gate
+(`TradingDayGate`, `DeployDriftCheck`, `CheckPredictorCoverage`, ...)
+already threads its Choice comparisons through the And-with-earlier-
+IsPresent guard idiom this repo has used since config#2275/I2767. This test
+makes that invariant durable and generic, instead of re-litigating it one
+Lambda gate at a time.
+
+## Two ASL facts this test's model relies on, measured on throwaway state
+machines in this account 2026-08-13 (not assumed):
+
+1. A `ResultSelector` missing-key failure is NOT catchable — so "give the
+   Task a ResultSelector" only relocates the uncatchable failure, it does
+   not by itself make a Choice comparison downstream safe. The
+   ResultSelector must actually PROJECT the key the Choice reads.
+2. `Not`/`IsPresent` evaluates cleanly at any depth, on both a present-
+   parent-absent-leaf and a wholly-absent-root payload. A standalone
+   leading `Choices` rule of the shape
+   `{"Not": {"Variable": V, "IsPresent": true}, "Next": ...}` is therefore
+   sufficient, on its own, to make every LATER rule in the same `Choices`
+   list safe to dereference V unconditionally — ASL evaluates `Choices` in
+   order and this rule fires first whenever V is absent, so no later rule
+   is ever reached in that case. This is the shape `MarketHoursGateChoice`
+   was given in both weekday definitions to fix I7165, and it is a second,
+   equally valid guard idiom alongside the existing And-wrap one — this
+   test recognizes both.
+
+## Why this file, not an extension of `test_sf_choice_guards.py`
+
+That test already implements this invariant, more richly (it also drills
+partial-payload routing), but scoped to `step_function.json` (the Saturday
+weekly definition) alone. `step_function.json` is out of scope for I7165 —
+it is being edited concurrently by another change — so this file covers
+the two definitions I7165 actually touches, `step_function_daily.json`
+(preopen) and `step_function_eod.json` (postclose), without depending on
+or racing that concurrent edit. `test_sf_poll_resultselector.py` already
+established the pattern of a `_SF_FILES`-keyed walk across multiple
+definitions; this file follows it.
+
+## Why zero false positives against the ~100 SSM poll sites is automatic
+
+`aws-sdk:ssm:getCommandInvocation` (and the `ssm-liveness-poller` Lambda)
+never produce a `Payload` wrapper — their raw shape is `{Status, Command
+Id, ...}` at the ResultPath root, so a downstream Choice reading
+`$.foo_poll.Status` never matches the `$.<x>.Payload.<...>` pattern this
+test targets at all. Likewise the ~24 Pass-produced sites
+(`$.*_retry.attempts`, `$.branch_outcomes.*`) are never nested under
+`.Payload.`. The regex excludes both classes structurally, not via an
+exclusion list.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_SF_FILES = {
+    "weekday": _INFRA / "step_function_daily.json",
+    "eod": _INFRA / "step_function_eod.json",
+}
+
+_PAYLOAD_VAR_RE = re.compile(r"^\$\.([A-Za-z0-9_]+)\.Payload\.([A-Za-z0-9_]+)")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _walk_states(states: dict):
+    for name, st in states.items():
+        if not isinstance(st, dict):
+            continue
+        yield name, st
+        for sub in ("ItemProcessor", "Iterator"):
+            inner = st.get(sub)
+            if isinstance(inner, dict) and isinstance(inner.get("States"), dict):
+                yield from _walk_states(inner["States"])
+        for b in st.get("Branches", []) or []:
+            if isinstance(b, dict) and isinstance(b.get("States"), dict):
+                yield from _walk_states(b["States"])
+
+
+def _result_selector_keeps(st: dict) -> set[str] | None:
+    """Keys a lambda:invoke Task's ResultSelector pins, or None if the Task
+    has no ResultSelector at all (raw Payload rides through unprojected)."""
+    rs = st.get("ResultSelector")
+    if rs is None:
+        return None
+    return {k[:-2] if k.endswith(".$") else k for k in rs}
+
+
+def _producers_by_result_path(states: dict) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for _, st in _walk_states(states):
+        if "lambda:invoke" not in str(st.get("Resource", "")).lower():
+            continue
+        rp = st.get("ResultPath")
+        if rp:
+            out.setdefault(rp, []).append(st)
+    return out
+
+
+def _leaf_vars(rule: dict) -> list[tuple[str, bool]]:
+    """Every (Variable, is_and_guarded) leaf comparison in this rule
+    subtree. is_and_guarded=True when an EARLIER operand of an enclosing
+    And is exactly {Variable: same path, IsPresent: true} (the existing
+    config#2275 idiom)."""
+    out: list[tuple[str, bool]] = []
+
+    def _walk(r: dict, guarded: frozenset[str]):
+        if "And" in r:
+            acquired = set(guarded)
+            for operand in r["And"]:
+                _walk(operand, frozenset(acquired))
+                if operand.get("IsPresent") is True and "Variable" in operand:
+                    acquired.add(operand["Variable"])
+            return
+        if "Or" in r:
+            for operand in r["Or"]:
+                _walk(operand, guarded)
+            return
+        if "Not" in r:
+            _walk(r["Not"], guarded)
+            return
+        var = r.get("Variable")
+        if var is None:
+            return
+        ops = {k for k in r if k not in ("Variable", "Next", "Comment")}
+        if "IsPresent" in ops:
+            return  # a presence check is always safe to evaluate
+        out.append((var, var in guarded))
+
+    _walk(rule, frozenset())
+    return out
+
+
+def _is_leading_not_ispresent_guard(rule: dict, var: str) -> bool:
+    """True if `rule` is exactly {"Not": {"Variable": var, "IsPresent":
+    true}, "Next": ...} — the standalone leading-guard idiom."""
+    inner = rule.get("Not")
+    if not isinstance(inner, dict):
+        return False
+    return inner.get("Variable") == var and inner.get("IsPresent") is True
+
+
+def _violations_for_definition(sf: str, definition: dict) -> list[str]:
+    states = definition["States"]
+    producers = _producers_by_result_path(states)
+    violations: list[str] = []
+
+    for scope_name, scope_states in _iter_choice_scopes(states):
+        for name, st in scope_states.items():
+            if st.get("Type") != "Choice":
+                continue
+            rules = st.get("Choices", [])
+            # A leading standalone Not/IsPresent guard rule establishes
+            # presence for every LATER rule in this same Choices list —
+            # ASL evaluates Choices in order and that rule fires first
+            # whenever the variable is absent.
+            established: set[str] = set()
+            for rule in rules:
+                for var, and_guarded in _leaf_vars(rule):
+                    m = _PAYLOAD_VAR_RE.match(var)
+                    if not m:
+                        continue
+                    root, key = m.group(1), m.group(2)
+                    if and_guarded or var in established:
+                        continue
+                    rs_keeps = None
+                    for prod in producers.get(f"$.{root}", []):
+                        keeps = _result_selector_keeps(prod)
+                        if keeps is not None and key in keeps:
+                            rs_keeps = keeps
+                            break
+                    if rs_keeps is not None:
+                        continue  # floored by the producing Task's ResultSelector
+                    violations.append(
+                        f"[{sf}] {scope_name}/{name}: rule dereferences "
+                        f"{var!r} with no ResultSelector projecting "
+                        f"{key!r} off $.{root} and no presence guard in "
+                        f"this Choice (rule={json.dumps(rule)[:200]})"
+                    )
+                # Now that this rule has been evaluated, record any
+                # standalone guard it represents for subsequent rules.
+                inner = rule.get("Not")
+                if isinstance(inner, dict) and inner.get("IsPresent") is True and "Variable" in inner:
+                    established.add(inner["Variable"])
+    return violations
+
+
+def _iter_choice_scopes(states: dict):
+    """Yield (label, states_dict) for the top scope and every nested
+    Parallel/Map scope — same traversal as _walk_states but returning the
+    dict itself for a fresh top-level Choices scan."""
+    yield "", states
+    for name, st in states.items():
+        if not isinstance(st, dict):
+            continue
+        for sub in ("ItemProcessor", "Iterator"):
+            inner = st.get(sub)
+            if isinstance(inner, dict) and isinstance(inner.get("States"), dict):
+                yield from _iter_choice_scopes(inner["States"])
+        for i, b in enumerate(st.get("Branches", []) or []):
+            if isinstance(b, dict) and isinstance(b.get("States"), dict):
+                yield from ((f"{name}[{i}]/{lbl}" if lbl else f"{name}[{i}]", s)
+                            for lbl, s in _iter_choice_scopes(b["States"]))
+
+
+@pytest.mark.parametrize("sf", sorted(_SF_FILES))
+def test_choice_payload_dereferences_are_guarded_or_projected(sf: str) -> None:
+    definition = _load(_SF_FILES[sf])
+    violations = _violations_for_definition(sf, definition)
+    assert not violations, (
+        "alpha-engine-config-I7165 — Choice states dereferencing a raw "
+        "lambda:invoke Payload field with no ResultSelector projection and "
+        "no presence guard (this is exactly how MarketHoursGateChoice threw "
+        "an uncatchable States.Runtime on 2026-08-13):\n" + "\n".join(violations)
+    )
+
+
+def test_market_hours_gate_choice_guard_is_present() -> None:
+    """Direct check that the specific fix landed: MarketHoursGateChoice's
+    FIRST rule in both weekday definitions is the leading Not/IsPresent
+    guard routing to MarketHoursGatePayloadMalformed, and that Pass state
+    floors $.market_hours_gate_error before continuing."""
+    for sf, path in _SF_FILES.items():
+        definition = _load(path)
+        states = definition["States"]
+        choice = states["MarketHoursGateChoice"]
+        first_rule = choice["Choices"][0]
+        assert _is_leading_not_ispresent_guard(
+            first_rule, "$.market_hours_gate.Payload.verdict"
+        ), f"[{sf}] MarketHoursGateChoice's first rule is not the I7165 presence guard"
+        assert first_rule["Next"] == "MarketHoursGatePayloadMalformed"
+
+        malformed = states["MarketHoursGatePayloadMalformed"]
+        assert malformed["Type"] == "Pass"
+        assert malformed["ResultPath"] == "$.market_hours_gate_error"
+        assert "Error" in malformed.get("Result", {})
+        assert "Cause" in malformed.get("Result", {})
+
+
+def test_regression_pre_fix_tree_is_caught() -> None:
+    """Demonstrates the test actually catches the I7165 defect: with the
+    leading guard rule stripped back out, MarketHoursGateChoice reverts to
+    exactly the shape that produced the live 2026-08-13 States.Runtime, and
+    the structural test above must flag it."""
+    for sf, path in _SF_FILES.items():
+        definition = _load(path)
+        states = definition["States"]
+        choice = states["MarketHoursGateChoice"]
+        first_rule = choice["Choices"][0]
+        assert _is_leading_not_ispresent_guard(
+            first_rule, "$.market_hours_gate.Payload.verdict"
+        )
+        broken = copy.deepcopy(definition)
+        broken["States"]["MarketHoursGateChoice"]["Choices"] = broken["States"][
+            "MarketHoursGateChoice"
+        ]["Choices"][1:]
+        violations = _violations_for_definition(sf, broken)
+        assert any("MarketHoursGateChoice" in v for v in violations), (
+            f"[{sf}] pre-fix tree (guard rule removed) was NOT flagged — "
+            "the test would not have caught the live I7165 incident"
+        )

--- a/tests/test_sf_market_hours_gate_wiring.py
+++ b/tests/test_sf_market_hours_gate_wiring.py
@@ -251,14 +251,27 @@ class TestChoiceRouting:
         )
 
     @pytest.mark.parametrize("name", _BOTH)
-    def test_an_absent_verdict_fails_closed(self, defs, name):
-        # config-I2767's lesson, which TradingDayGateChoice already carries: a
-        # gate payload without its verdict is a contract violation by our own
-        # Lambda. Proceeding to trade on an unverifiable answer is the one
-        # outcome that must not happen.
+    def test_an_absent_verdict_routes_to_the_malformed_payload_floor(self, defs, name):
+        # alpha-engine-config-I7165 (measured live 2026-08-13, execution
+        # 59c0ce46-d366-45dd-8cd3-acbdc06638c1): a gate payload without its
+        # verdict is a contract violation by our own Lambda, and this
+        # harness's evaluate() previously asserted it landed on Default
+        # ("HandleFailure") — which is NOT what real ASL does. A raw
+        # StringEquals comparison against an absent Variable throws an
+        # UNCATCHABLE States.Runtime in AWS (Choice states carry no Catch),
+        # which is exactly what happened live: no HandleFailure, no SNS
+        # alert, just an unannounced ExecutionFailed 48s in. The fix is a
+        # LEADING presence guard (`Not`/`IsPresent`) ahead of every
+        # StringEquals rule, routing an absent verdict to
+        # MarketHoursGatePayloadMalformed before any comparison that could
+        # crash is ever evaluated — see test_sf_market_hours_gate_payload_
+        # guard.py for the structural proof this can't regress silently.
         choice = defs[name]["States"]["MarketHoursGateChoice"]
-        assert evaluate(choice, {}) == "HandleFailure"
-        assert evaluate(choice, {"market_hours_gate": {"Payload": {}}}) == "HandleFailure"
+        assert evaluate(choice, {}) == "MarketHoursGatePayloadMalformed"
+        assert (
+            evaluate(choice, {"market_hours_gate": {"Payload": {}}})
+            == "MarketHoursGatePayloadMalformed"
+        )
 
     @pytest.mark.parametrize("name", _BOTH)
     def test_an_unrecognised_verdict_fails_closed(self, defs, name):


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7165`. The 2026-08-13 preopen execution
`59c0ce46-d366-45dd-8cd3-acbdc06638c1` failed 48s in with a raw
`States.Runtime`:

```
An error occurred while executing the state 'MarketHoursGateChoice' (entered at the event id #9).
Invalid path '$.market_hours_gate.Payload.verdict': The choice state's condition path references an invalid value.
```

No SNS alert fired. `MarketHoursGate` carries `Catch: [States.ALL] -> NotifyMarketHoursUnverified`
— the gate's own fail-closed ladder, built in the same PR that introduced the gate
(`nousergon-data-PR1338`, config-I7111) for exactly this hazard. It never fired, because the Lambda
**succeeded**: `alpha-engine-predictor-inference:live` was frozen on v455, which has no
`check_market_hours` action, fell through to its default predict branch, and returned
`{"statusCode":200,"body":"Predictions written for today"}`. The absent `verdict` key was only
discovered one state later, in `MarketHoursGateChoice` — where no `Catch` exists and none can (ASL
Choice states cannot carry `Catch`). The root trigger (the frozen alias) is
`crucible-predictor-PR474`, out of scope here; this PR is "the other half".

`MarketHoursGate` is the **only** `lambda:invoke` gate in either weekday definition with
`ResultSelector: null` — every sibling gate (`TradingDayGate`, `DeployDriftCheck`,
`CheckPredictorCoverage`) already threads its Choice comparisons through the presence-guard idiom
this repo has used since config#2275/I2767.

## Two ASL facts, measured on throwaway state machines in this account 2026-08-13 (not assumed),
run against the pipelines' own role, then deleted

1. A `ResultSelector` missing-key failure is **not catchable** — a Task with `ResultSelector:
   {"verdict.$": "$.NoSuchKey"}` and `Catch: [States.ALL]` went straight to `ExecutionFailed` with
   `States.Runtime`; the Catch never fired. So "give `MarketHoursGate` a `ResultSelector`" would
   only relocate the uncatchable failure from the Choice into the Task — it does not fix
   reachability.
2. `Not`/`IsPresent` evaluates cleanly at depth, for both a missing-leaf-under-present-parent shape
   and a wholly-absent-root shape, and the execution **succeeds**. A presence guard is therefore
   sufficient on its own; no floor `Pass` is needed *ahead* of the guard.

## The fix

In both `infrastructure/step_function_daily.json` and `infrastructure/step_function_eod.json`,
`MarketHoursGateChoice` gets a **leading** rule:

```json
{ "Not": { "Variable": "$.market_hours_gate.Payload.verdict", "IsPresent": true },
  "Next": "MarketHoursGatePayloadMalformed" }
```

ASL evaluates `Choices` in order, so this rule intercepts an absent verdict before any of the 4
`StringEquals` comparisons after it can ever be reached — those 4 are therefore safe to leave
unguarded, exactly as before. A new `MarketHoursGatePayloadMalformed` `Pass` state (mirroring
`WeeklyRunDayGateMalformed` in `step_function.json` for the identical hazard) floors
`$.market_hours_gate_error` before continuing — this floor is load-bearing because
`NotifyMarketHoursUnverified`'s `Message.$` calls `States.JsonToString($.market_hours_gate_error)`,
which is otherwise written only by `MarketHoursGate`'s own `Catch` `ResultPath` and would itself
throw `States.Runtime` on this path if absent.

The two definitions route differently past the floor, **mirroring each definition's own existing
Catch-path posture** rather than a single copied shape:

- **preopen** (`step_function_daily.json`): `MarketHoursGatePayloadMalformed` → `NotifyMarketHoursUnverified`
  → `MarketHoursUnverified` (`Fail` state) — fail **closed**, same as the gate's own `Catch`.
- **postclose** (`step_function_eod.json`): `MarketHoursGatePayloadMalformed` →
  `SetMarketHoursUnverifiedDegraded` (threads `$.degraded_summary`) → `NotifyMarketHoursUnverified` →
  `CheckMutexRole` — fail **open, degraded**, same as the gate's own `Catch` (NAV continuity,
  sf-pipeline-policy.md §1.3).

`infrastructure/step_function.json` (the weekly definition) is **not** touched — it is out of scope
for this issue and is being edited concurrently by another change; its own
`WeeklyRunDayGateChoice`/`WeeklyRunDayGateMalformed` pair already carries this exact guard shape and
is unaffected.

## Why the other 124 of 132 raw scanned nested-Choice dereferences are NOT touched here

- ~100 are `$.*_poll.Status` off `ssm:getCommandInvocation` (or the `ssm-liveness-poller` Lambda)
  behind a **total** `ResultSelector` — a miss there fails inside the polling Task, whose `Catch`
  routes normally. They also never match a `.Payload.` path at all (SSM poll results are never
  wrapped in `Payload`), which is why the new structural test below produces zero false positives
  against them without an exclusion list.
- ~24 are Pass-produced (`$.*_retry.attempts`, `$.branch_outcomes.*`), floored by an immediate
  upstream `Pass`.

Only the 8 `MarketHoursGateChoice` comparisons (4 × 2 weekday definitions) were the anomaly.

## Test plan

New `tests/test_sf_market_hours_gate_payload_guard.py`: a structural test across both weekday
definitions asserting every `Choice` comparison of the form `$.<x>.Payload.<key>` is either
projected through the producing Task's `ResultSelector` or presence-guarded in the `Choice`. It:

- **passes on the fixed tree** (`test_choice_payload_dereferences_are_guarded_or_projected`,
  `test_market_hours_gate_choice_guard_is_present`);
- **fails on the pre-fix tree** — `test_regression_pre_fix_tree_is_caught` strips the guard rule
  back out in-memory and asserts the general scan flags `MarketHoursGateChoice`, proving the test
  would have caught the live 2026-08-13 incident;
- has **zero false positives** against the ~100 SSM-poll and ~24 Pass-produced sites, structurally
  (they never match the `.Payload.` pattern), not via an exclusion list.

Updated `tests/test_sf_market_hours_gate_wiring.py`: its `test_an_absent_verdict_fails_closed` (now
`test_an_absent_verdict_routes_to_the_malformed_payload_floor`) previously asserted an absent verdict
lands on `Default` (`"HandleFailure"`) — that harness's `evaluate()` does not raise on an absent
`StringEquals` dereference, unlike real ASL, which is exactly the blind spot that let this incident
through undetected by any existing test. Now asserts routing to `MarketHoursGatePayloadMalformed`.

Full local suite: `~/Development/nousergon-data/.venv/bin/python3 -m pytest tests/ -q` →
**5201 passed, 9 skipped**. 3 pre-existing failures in
`tests/test_pipeline_status_registry_source_check.py` (all three SF definitions, including
`step_function.json` which this PR never touches) are unrelated — a cross-repo `nousergon-lib`
registry-drift gap from `nousergon-data-PR1338`/config-I7111, predating and independent of this
change. Filed as `alpha-engine-config-I7173` rather than folded into this PR (needs its own
`nousergon-lib` companion PR + lockstep pin bump, per that test's own docstring).

## Deploy mechanism

**Deploy-mechanism:** `deploy-infrastructure.yml` — re-stamps and redeploys both SF definitions on
every push to `main`; `check-definition-drift.py` blocks the workflow unless live matches repo
(sf-pipeline-policy.md §2.4/§6).

## Rehearsal path

Rehearsal-path: tests/test_sf_market_hours_gate_payload_guard.py — structural, proven against both
the fixed and the pre-fix tree in the same file (see Test plan above). Also rehearsable via an
operator-replay execution against the live weekday definitions with a deliberately malformed gate
payload — both weekday definitions already carry per-stage skip gates for exactly this, per
sf-pipeline-policy.md §7.1a. No live trading morning needed.

Closes #7165

**Prepared by:** claude-sonnet-5 via [Claude Code](https://claude.com/claude-code)
