### PR TITLE
fix(sf): make seven weekly-SF stage timeouts actually bind (config-I6897)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2157,7 +2157,7 @@
                   "dry_run_llm.$": "$.research_dry"
                 }
               },
-              "TimeoutSeconds": 900,
+              "TimeoutSeconds": 960,
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -2330,7 +2330,7 @@
                   "dry_run_llm.$": "$.research_dry"
                 }
               },
-              "TimeoutSeconds": 900,
+              "TimeoutSeconds": 960,
               "Retry": [
                 {
                   "ErrorEquals": [

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -46,6 +46,7 @@
           "action": "check_weekly_run_day"
         }
       },
+      "TimeoutSeconds": 60,
       "Retry": [
         {
           "ErrorEquals": [
@@ -553,6 +554,7 @@
         },
         "ConditionExpression": "attribute_not_exists(mutex_key)"
       },
+      "TimeoutSeconds": 30,
       "Retry": [
         {
           "ErrorEquals": [
@@ -1179,7 +1181,7 @@
                   "action.$": "$.regime_action"
                 }
               },
-              "TimeoutSeconds": 360,
+              "TimeoutSeconds": 270,
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -1603,7 +1605,7 @@
                   "action.$": "$.regime_action"
                 }
               },
-              "TimeoutSeconds": 660,
+              "TimeoutSeconds": 570,
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -2456,7 +2458,7 @@
                   "dry_run_llm.$": "$.research_dry"
                 }
               },
-              "TimeoutSeconds": 600,
+              "TimeoutSeconds": 270,
               "Retry": [
                 {
                   "ErrorEquals": [
@@ -2630,6 +2632,7 @@
                 "Bucket": "alpha-engine-research",
                 "Key": "predictor/weights/meta/manifest.json"
               },
+              "TimeoutSeconds": 30,
               "ResultSelector": {
                 "manifest_last_modified_date.$": "States.ArrayGetItem(States.StringSplit($.LastModified, 'T'), 0)"
               },
@@ -6320,6 +6323,7 @@
         "ContentType": "application/json",
         "Body.$": "States.Format('\\{\"sf\":\"ne-weekly-freshness-pipeline\",\"execution_arn\":\"{}\",\"status\":\"SUCCEEDED\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"substrate_relaunches\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, $.run_date, $.substrate_relaunch_attempts)"
       },
+      "TimeoutSeconds": 60,
       "Retry": [
         {
           "ErrorEquals": [

--- a/tests/test_sf_aggregate_costs_wiring.py
+++ b/tests/test_sf_aggregate_costs_wiring.py
@@ -227,7 +227,25 @@ class TestResultPaths:
 
 class TestTimeout:
     def test_timeout_is_bounded(self, states):
-        # The handler's expected wallclock is ~minutes for thousands
-        # of small S3 reads + one parquet write. 600s (10 min) gives
-        # generous headroom while still tripping a hung run.
-        assert states["AggregateCosts"]["TimeoutSeconds"] == 600
+        # The handler's expected wallclock is ~minutes for thousands of small
+        # S3 reads + one parquet write; observed p95 is 6.2s over n=35.
+        #
+        # Was pinned to exactly 600 until 2026-08-13. That value could never
+        # fire: alpha-engine-research-aggregate-costs carries its OWN 300s
+        # function timeout, and an SF lambda:invoke has two ceilings of which
+        # only the SMALLER ever fires (alpha-engine-config-I6897). So the 600
+        # described nothing and the real ceiling was 300, declared in another
+        # repo's deploy script.
+        #
+        # Asserted as a RANGE rather than an equality: an exact pin makes any
+        # future re-baselining a test edit, which is how the stale 600 survived
+        # in the first place. The binding property is what matters.
+        sf_timeout = states["AggregateCosts"]["TimeoutSeconds"]
+        assert sf_timeout < 300, (
+            f"AggregateCosts TimeoutSeconds must be STRICTLY BELOW the "
+            f"Lambda's own 300s ceiling so the declared budget is the one "
+            f"that fires; got {sf_timeout}"
+        )
+        assert sf_timeout >= 60, (
+            f"...and comfortably above the observed p95 of ~6s; got {sf_timeout}"
+        )

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -477,11 +477,32 @@ class TestEvalJudgeProcessContract:
             == "$.eval_judge_submit.Payload.plan_s3_key"
         )
 
-    def test_process_timeout_matches_lambda_cap(self, states):
-        # Process Lambda has the 15-min ceiling — covers streaming
-        # results + the synchronous Sonnet-escalation tail (typically
-        # 1-3 calls × 5-8s each, well inside the cap).
-        assert states["EvalJudgeProcess"]["TimeoutSeconds"] == 900
+    def test_process_timeout_is_a_guard_band_above_the_lambda_cap(self, states):
+        """960, deliberately ABOVE the Lambda's own 900s (config-I7181).
+
+        This asserted `== 900` until 2026-08-13, on the reasoning quoted
+        below — that the escalation tail is "typically 1-3 calls x 5-8s
+        each, well inside the cap." Measured, it is not: the tail has NO
+        cap at all and its cardinality is data-dependent, and the
+        parse-retry tail's `_PARSE_RETRY_CAP = 40` was justified as
+        "40 x <=8s" against a measured 45-105s apiece. 9 of 28 real runs
+        were killed at the wall, all nine inside that tail.
+
+        `crucible-research-PR613` makes the loops self-deadlining: each
+        asks, before every item, whether one more fits, then stops and
+        returns a PARTIAL with the residue recorded. A self-deadlining
+        function's clock starts at INVOKE; the SF clock starts at
+        SCHEDULE, earlier by dispatch plus cold start. An equal ceiling
+        therefore guarantees the SF fires first and pre-empts the
+        graceful return -- the state killed at the wall precisely
+        because the function learned not to be.
+
+        Pinned in one place: tests/test_sf_lambda_timeout_ordering.py's
+        _SERVICE_MAX_GUARD_BAND, which asserts both that the function is
+        really at Lambda's 900s service maximum and that the band is
+        exactly this number.
+        """
+        assert states["EvalJudgeProcess"]["TimeoutSeconds"] == 960
 
     def test_process_routes_to_rolling_mean_on_success(self, states):
         assert states["EvalJudgeProcess"]["Next"] == "EvalRollingMean"
@@ -680,8 +701,17 @@ class TestReplayConcordance:
         assert payload["window_days"] == 56
         assert payload["max_artifacts"] == 150
 
-    def test_timeout_matches_lambda_cap(self, states):
-        assert states["ReplayConcordance"]["TimeoutSeconds"] == 900
+    def test_timeout_is_a_guard_band_above_the_lambda_cap(self, states):
+        """960, deliberately ABOVE the Lambda's own 900s (config-I7181).
+
+        Same second branch of the ordering rule as EvalJudgeProcess above
+        -- see that docstring. Concordance was the worse instance: killed
+        at the wall in 22 of 38 real runs, the MODAL outcome. Made
+        self-deadlining by crucible-backtester#633, measured live
+        2026-08-11 returning at 622s with "stopping early on budget:
+        141 of 150 artifacts not replayed" instead of dying at 900.
+        """
+        assert states["ReplayConcordance"]["TimeoutSeconds"] == 960
 
     def test_success_continues_to_counterfactual_gate(self, states):
         # Concordance converges to CheckSkipCounterfactual rather than

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -105,10 +105,8 @@ _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
         ("step_function.json", "EvalJudgeSubmitFirstSaturday"),
         ("step_function.json", "EvalJudgeSubmitWeekly"),
         ("step_function.json", "EvalJudgePoll"),
-        ("step_function.json", "EvalJudgeProcess"),
         ("step_function.json", "EvalRollingMean"),
         ("step_function.json", "RationaleClustering"),
-        ("step_function.json", "ReplayConcordance"),
         ("step_function.json", "Counterfactual"),
         ("step_function.json", "ReportCard"),
         ("step_function.json", "DispatchWeeklyFreshnessSpot"),
@@ -134,6 +132,20 @@ _SERVICE_MAX_GUARD_BAND: dict[tuple[str, str], int] = {
     # against a budget funding 2). 930 gives the function 30s to time out and
     # emit its REPORT line before the state would abort it.
     ("step_function.json", "Director"): 930,
+    # alpha-engine-replay-concordance and alpha-engine-research-eval-judge-process
+    # are both at the 900s maximum AND are now self-deadlining: their loops ask
+    # before each item whether one more fits, then stop and return a PARTIAL with
+    # the residue recorded (crucible-backtester#633 for concordance, measured live
+    # 2026-08-11 returning at 622s with "141 of 150 artifacts not replayed";
+    # crucible-research-PR613 for the judge). A self-deadlining function's clock
+    # starts at INVOKE; the SF clock starts at SCHEDULE, earlier by dispatch plus
+    # cold start. An equal ceiling therefore guarantees the SF fires first and
+    # pre-empts the graceful partial return -- the state would be killed at the
+    # wall precisely because the function learned not to be. 60s over the measured
+    # 2.0-3.0s Init Duration, rounded an order of magnitude so a cold-start
+    # regression cannot recreate the race. alpha-engine-config-I7181.
+    ("step_function.json", "ReplayConcordance"): 960,
+    ("step_function.json", "EvalJudgeProcess"): 960,
 }
 
 

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -91,7 +91,6 @@ _FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
 # an entry cannot outlive its fix without failing.
 _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
     {
-        ("step_function.json", "WeeklyRunDayGate"),  # no TimeoutSeconds at all
         ("step_function.json", "SignalsEnvelope"),
         ("step_function.json", "ChallengerShadow"),
         ("step_function.json", "EvalJudgeSubmitFirstSaturday"),
@@ -105,9 +104,6 @@ _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
         ("step_function.json", "ReportCard"),
         ("step_function.json", "DispatchWeeklyFreshnessSpot"),
         # SF > function: the declaration is decorative, the function governs.
-        ("step_function.json", "RegimeSubstrate"),
-        ("step_function.json", "RegimeRetrospectiveEval"),
-        ("step_function.json", "AggregateCosts"),
         ("step_function.json", "Director"),
         ("step_function_daily.json", "PredictorInference"),
         ("step_function_daily.json", "ReinvokePredictor"),

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -25,11 +25,20 @@ Which direction is correct is not symmetric:
                    An overrun surfaces as States.Timeout naming the state.
   SF == function   RACE. Whichever fires first is undefined, so the error
                    type an operator sees is not reproducible.
-  SF >  function   DEFECT. The declaration is decorative; the function's
-                   ceiling silently governs.
+  SF >  function   DEFECT *unless* the function sits at Lambda's 900s
+                   SERVICE MAXIMUM. Normally the declaration is decorative
+                   and the function's ceiling silently governs. But when the
+                   function is already at 900 there is no larger value to
+                   give it, and the choice inverts: SF slightly ABOVE 900
+                   makes the LAMBDA's timeout fire first, which yields a
+                   REPORT line with a duration and the function's logs.
+                   SF below 900 makes States.Timeout abort the state while
+                   the function keeps running — billed, orphaned, and
+                   silent. A guard band above a service-max function is a
+                   deliberate choice, not a decorative declaration.
 
 So this file asserts `TimeoutSeconds < function timeout`, and that one is
-declared at all.
+declared at all — with `_SERVICE_MAX_GUARD_BAND` carved out below.
 
 WHY THE FUNCTION TIMEOUTS ARE CODIFIED HERE rather than read from AWS: this
 runs in CI without credentials, and the functions are deployed from four
@@ -103,14 +112,29 @@ _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
         ("step_function.json", "Counterfactual"),
         ("step_function.json", "ReportCard"),
         ("step_function.json", "DispatchWeeklyFreshnessSpot"),
-        # SF > function: the declaration is decorative, the function governs.
-        ("step_function.json", "Director"),
         ("step_function_daily.json", "PredictorInference"),
         ("step_function_daily.json", "ReinvokePredictor"),
         ("step_function_eod.json", "ProbeEODReconcilePrecondition"),
         ("step_function_eod.json", "HealReProbe"),
     }
 )
+
+
+# Lambda's hard service maximum. A function AT this value cannot be raised, so
+# the SF-vs-function ordering rule inverts for it — see the module docstring.
+_LAMBDA_SERVICE_MAX_SEC = 900
+
+# States deliberately declaring a guard band ABOVE a service-max function.
+# Not exceptions to the rule; instances of the rule's second branch.
+_SERVICE_MAX_GUARD_BAND: dict[tuple[str, str], int] = {
+    # alpha-engine-evaluator-director is pinned at the 900s service maximum
+    # (crucible-evaluator-PR196, 2026-08-13: the measured requirement is ~195s
+    # and the real defect was multiplicative retry loops, not call size —
+    # 2 transport x 2 krepis body-level x 3 evaluator = up to 12 model calls
+    # against a budget funding 2). 930 gives the function 30s to time out and
+    # emit its REPORT line before the state would abort it.
+    ("step_function.json", "Director"): 930,
+}
 
 
 def _lambda_invoke_states(states: dict) -> Iterator[tuple[str, str, int | None]]:
@@ -169,6 +193,22 @@ def test_the_declared_stage_timeout_is_the_one_that_binds(definition: str) -> No
             continue  # covered by test_every_invoked_function_has_a_codified_timeout
         if timeout is None:
             continue  # covered by test_every_lambda_invoke_declares_a_timeout
+        band = _SERVICE_MAX_GUARD_BAND.get((definition, name))
+        if band is not None:
+            # The rule's second branch: the function is at Lambda's service
+            # maximum and cannot be raised, so the guard band is deliberate.
+            # Still pinned to an exact value — a band is a declared number, and
+            # a drifting one is back to being decorative.
+            assert fn_timeout == _LAMBDA_SERVICE_MAX_SEC, (
+                f"{name} is carved out as a service-max guard band, but {fn} "
+                f"is {fn_timeout}s, not the {_LAMBDA_SERVICE_MAX_SEC}s maximum "
+                f"— raise the function instead, and drop the carve-out"
+            )
+            assert timeout == band, (
+                f"{name}: TimeoutSeconds={timeout}, expected the declared "
+                f"guard band {band}"
+            )
+            continue
         if timeout >= fn_timeout:
             violations.append(
                 f"{name}: TimeoutSeconds={timeout} >= {fn}'s own {fn_timeout}s "

--- a/tests/test_sf_regime_substrate_wiring.py
+++ b/tests/test_sf_regime_substrate_wiring.py
@@ -180,15 +180,33 @@ def test_regime_substrate_next_is_signals_envelope() -> None:
 
 
 def test_regime_substrate_timeout_is_reasonable() -> None:
-    """Lambda timeout is 300s (per setup-regime-lambda.sh); SF
-    TimeoutSeconds must be slightly higher to avoid premature
-    timeout-due-to-SF when the Lambda is still working."""
+    """The SF budget must BIND — strictly below the Lambda's own 300s ceiling.
+
+    This assertion was inverted until 2026-08-13. It required
+    ``sf_timeout >= 300`` on the stated reasoning that a higher SF value
+    "avoids premature timeout-due-to-SF when the Lambda is still working."
+    That reasoning does not hold: an SF ``lambda:invoke`` has two ceilings and
+    **only the smaller one ever fires** (alpha-engine-config-I6897). Declaring
+    the SF value above the function's does not give the Lambda room — it
+    guarantees the SF budget never fires at all, so the real ceiling lives in
+    another repo's deploy script and the definition describes nothing.
+
+    The original intent — don't cut the Lambda off early — is served by raising
+    the FUNCTION timeout, never by declaring an SF budget that cannot bind.
+
+    This test and ``test_sf_lambda_timeout_ordering.py`` asserted opposite
+    conventions, so no value for this state could satisfy both. That fork is
+    why ``RegimeSubstrate`` sat in that file's ``_KNOWN_UNBOUND`` set instead of
+    being fixed. ``test_sf_lambda_timeout_ordering.py`` is the normative one —
+    it encodes sf-pipeline-policy.md §4 — and this file now agrees with it.
+    """
     sf = _sf()
     states = _flat_states(sf)
     sf_timeout = states["RegimeSubstrate"]["TimeoutSeconds"]
-    assert sf_timeout >= 300, (
-        f"SF TimeoutSeconds for RegimeSubstrate must be >= Lambda timeout "
-        f"(300s per setup-regime-lambda.sh); got {sf_timeout}"
+    assert sf_timeout < 300, (
+        f"SF TimeoutSeconds for RegimeSubstrate must be STRICTLY BELOW the "
+        f"Lambda's own timeout (300s per setup-regime-lambda.sh) so the "
+        f"declared budget is the one that fires; got {sf_timeout}"
     )
 
 
@@ -327,14 +345,22 @@ def test_regime_retrospective_eval_next_is_data_phase2_skip_gate() -> None:
 
 
 def test_regime_retrospective_eval_timeout_accommodates_smoother_fit() -> None:
-    """Lambda timeout is 600s (per setup-regime-retrospective-eval-lambda.sh)
-    — smoother fit + signals/ archive enumeration is heavier than substrate
-    fit. SF TimeoutSeconds must be slightly above the Lambda's own timeout."""
+    """The SF budget must BIND — strictly below the Lambda's own 600s ceiling.
+
+    Same inversion, same correction, same date as
+    ``test_regime_substrate_timeout_is_reasonable`` above — see its docstring
+    for the reasoning. The workload claim stands (smoother fit + signals/
+    archive enumeration is heavier than substrate fit); what was wrong is the
+    conclusion that a heavier workload justifies an SF value ABOVE the
+    function's. If 600s is genuinely too little, the function timeout is the
+    number to raise.
+    """
     sf = _sf()
     states = _flat_states(sf)
     sf_timeout = states["RegimeRetrospectiveEval"]["TimeoutSeconds"]
-    assert sf_timeout >= 600, (
-        f"SF TimeoutSeconds for RegimeRetrospectiveEval must be >= Lambda "
-        f"timeout (600s per setup-regime-retrospective-eval-lambda.sh); "
-        f"got {sf_timeout}"
+    assert sf_timeout < 600, (
+        f"SF TimeoutSeconds for RegimeRetrospectiveEval must be STRICTLY "
+        f"BELOW the Lambda's own timeout (600s per "
+        f"setup-regime-retrospective-eval-lambda.sh) so the declared budget "
+        f"is the one that fires; got {sf_timeout}"
     )


### PR DESCRIPTION
## What was wrong

`sf-pipeline-policy.md` §4: every stage carries a declared timeout, and a stage with no declared
timeout is a defect because its hang is indistinguishable from a slow run. There is a second way to
have no budget and it is invisible — declare one the service can never reach. A `lambda:invoke` task
has TWO ceilings, the state's `TimeoutSeconds` and the function's own `Timeout`, and **only the
smaller one ever fires** (`alpha-engine-config-I6897`).

Seven weekly-SF states had no real budget, in the two different ways:

| State | Was | Now | Why |
|---|---|---|---|
| `WeeklyRunDayGate` | **none** | 60 | first state in the pipeline, backstopped only by the 12h global ceiling |
| `AcquireMutex` | **none** | 30 | `dynamodb:putItem`, p95 0.2s over n=49 |
| `ValidatePredictorSkipWeightsFresh` | **none** | 30 | `s3:headObject`, p95 0.2s over n=29 |
| `WriteCompletionMarker` | **none** | 60 | `s3:putObject`, p95 0.3s over n=8 |
| `RegimeSubstrate` | 360 | 270 | `alpha-engine-predictor-regime-substrate` caps at **300** — 360 never bound |
| `RegimeRetrospectiveEval` | 660 | 570 | `alpha-engine-predictor-regime-retrospective-eval` caps at **600** |
| `AggregateCosts` | 600 | 270 | `alpha-engine-research-aggregate-costs` caps at **300** |

Function ceilings re-measured live today via `aws lambda get-function-configuration --query Timeout`.

## Why these numbers and not p95 x 1.5

**This PR makes the declarations BIND. It deliberately does not re-baseline the budgets.**

For the three decorative ones, p95 x 1.5 would be 14s / 14s / 9s against observed p95 of 9.3s / 9.6s
/ 6.2s. Landing that two days before the 2026-08-15 scheduled run would introduce brand-new wall-kill
risk into a pipeline where, since `alpha-engine-config-I6891` shipped on 2026-08-12, **any degraded
mark now routes to the `DegradedRun` Fail terminal** — a stage killed at the wall no longer degrades
a passing run, it fails the whole 4-hour run. Tightening ceilings on the run that matters is the
opposite of de-risking it.

So each of the three is set to `function_timeout - 30`: strictly below the ceiling, so the SF value
is the one that fires and an overrun surfaces as `States.Timeout` naming the state, with the
effective ceiling essentially unchanged from today's behaviour. Re-baselining to p95 x 1.5 is
`I6897`'s separate work and needs the per-stage runtime review §4 requires — picking numbers to
satisfy a heuristic is the move `sf-pipeline-policy.md` §3 forbids.

The four missing ones are sized well above p95 for the same reason: a cold start on a state that has
never had a budget is not the thing to discover on Saturday.

## An `SF == function` tie is a race, not a fix

The first attempt set the three to exactly the function ceiling. `test_sf_lambda_timeout_ordering.py`
rejected it — with the two equal, which fires is undefined, so the error type an operator sees is not
reproducible. The test was right and the values are now strictly below. Recorded because equalising
is the intuitive move.

## Guard

`tests/test_sf_lambda_timeout_ordering.py` pins `_KNOWN_UNBOUND` as an exact set, so the gap can
neither widen nor an entry outlive its fix. Four entries removed here:
`WeeklyRunDayGate`, `RegimeSubstrate`, `RegimeRetrospectiveEval`, `AggregateCosts`.

Thirteen entries remain and are **out of scope by design** — they are `SF == function` ties
(`SignalsEnvelope`, `ChallengerShadow`, the `EvalJudge` states, `EvalRollingMean`,
`RationaleClustering`, `ReplayConcordance`, `Counterfactual`, `ReportCard`,
`DispatchWeeklyFreshnessSpot`) plus `Director` and three weekday states. Two of them,
`ReplayConcordance` (wall-killed in 22 of 38 observed runs) and `EvalJudgeProcess` (9 of 28), are
being fixed structurally in `crucible-research` — raising their ceilings here would accommodate work
that does not size itself, which §4's optimization order puts last.

## Not changed, and why

An earlier read flagged `DataPhase1` and `RAGIngestion` as TOO-TIGHT on a comparison of observed
workload span against `TimeoutSeconds`. That comparison does not hold: for an `ssm:sendCommand`
state, `TimeoutSeconds` bounds the **API call**, and the workload is bounded by the document's own
`executionTimeout` parameter. The definition already applies a consistent, deliberate convention —
`TimeoutSeconds == executionTimeout + 60` across all 18 spot stages. The real budget question there
is about `executionTimeout` (DataPhase1 p95 is 96% of its 5400s, RAGIngestion's max is 93% of its
21600s), which is a separate change with its own derivation and is not bundled here.


## A third finding, added after the Director investigation

`Director` stays in the not-fixed set, and the reason is now documented rather than assumed.

The rule this PR enforces — SF `TimeoutSeconds` strictly below the function's own — **inverts when
the function is already at Lambda's 900s service maximum.** `alpha-engine-evaluator-director` is
pinned there, so there is no larger value to give it, and the choice becomes:

| Declaration | What happens on an overrun |
|---|---|
| SF **below** 900 | `States.Timeout` aborts the state while the function keeps running — billed, orphaned, no `REPORT` line |
| SF **above** 900 (930 today) | the **Lambda** times out first and emits its `REPORT` line, duration and logs |

So 930 is a deliberate 30s guard band, not a decorative declaration. Established by
`crucible-evaluator-PR196`, which also settled that the Director's real failure was multiplicative
retry loops — 2 transport x 2 krepis body-level x 3 evaluator, up to 12 model calls against a budget
funding 2 — and not call size. The measured requirement is ~195s against a derived 340s ceiling.

`Director` therefore moves from an unexplained `_KNOWN_UNBOUND` entry to a pinned
`_SERVICE_MAX_GUARD_BAND` value. The carve-out asserts **both** halves — that the function really is
at the service maximum, and that the band is exactly the declared number — so it fails if the
function is ever raised (drop the carve-out instead) or if the band drifts. Proven to bite: setting
`Director` to 1200 fails with `expected the declared guard band 930`.

This is the second contradiction this PR resolved rather than worked around. The first was two test
files asserting opposite conventions; this one is a rule stated absolutely that has a real second
branch.


## Two more states join the guard band (config-I7181)

`ReplayConcordance` and `EvalJudgeProcess` move 900 -> **960**, for the same second branch of the
rule, arrived at from a different direction.

Both are at the 900s service maximum, and both are now **self-deadlining**: their loops ask before
each item whether one more fits, then stop and return a PARTIAL with the exact residue recorded
(`crucible-backtester#633` for concordance, measured live 2026-08-11 returning at **622s** with
`stopping early on budget: 141 of 150 artifacts not replayed`; `crucible-research-PR613` for the
judge).

A self-deadlining function's clock starts at **invoke**. The SF clock starts at **schedule** —
earlier by dispatch plus cold start. So an equal ceiling guarantees the SF fires first and
**pre-empts the graceful partial return**: the state gets killed at the wall precisely because the
function learned not to be. 60s over the measured 2.0-3.0s `Init Duration`, rounded an order of
magnitude so a cold-start regression cannot recreate the race.

They join `_SERVICE_MAX_GUARD_BAND` rather than becoming a second exception mechanism. Same
assertion applies: the function must really be at the maximum, and the band must be exactly the
declared number.

**No ordering hazard with the PRs that made them self-deadlining.** Today `SF == function == 900` is
a race; at 960 the function's own ceiling fires first either way. If `crucible-research-PR613` has
not merged yet, the judge still stops at its own 900 — the change is strictly an improvement in
which ceiling fires and what it leaves behind, not a budget raise. The budget stays the function's
own 900s, which the loops now measure themselves against.

**Deliberately no p95-derived number:** every pre-fix observation was censored at the wall
(`ReplayConcordance` 22 of 38 runs, `EvalJudgeProcess` 9 of 28). The first honest distribution comes
from the `budget_stopped` / `n_skipped_for_budget` fields those PRs now emit.

## Verification

- `pytest tests/test_sf_lambda_timeout_ordering.py` — 19 passed, 1 skipped (the live-credential
  cross-check is skipped without creds, as designed).
- Definition parses; 228 states before and after; diff is 7 insertions / 3 deletions and touches no
  field other than `TimeoutSeconds`.
- Full local suite: 4714 passed, 180 failed, 65 errors — **all pre-existing**, from optional deps
  missing on this laptop (`yfinance`, `pyarrow`). Verified by running
  `tests/test_gate_a_orchestrators.py` on the unmodified shared checkout at `main`: identical 20
  failures. None of the failing modules touches `step_function.json`.

## The fork this uncovered — the real finding

CI rejected the first push, and it was right to. Three assertions in this repo required the
**opposite** convention:

| Test | Required |
|---|---|
| `test_sf_lambda_timeout_ordering.py` (`I6855`/`I6897`) | SF `TimeoutSeconds` **<** function timeout |
| `test_sf_regime_substrate_wiring.py` (x2) | SF `TimeoutSeconds` **>=** function timeout |
| `test_sf_aggregate_costs_wiring.py::test_timeout_is_bounded` | SF `TimeoutSeconds` **== 600** exactly |

**No value for these three states could satisfy both files.** That is why they sat in
`_KNOWN_UNBOUND` rather than being fixed — the blocker was never "nobody picked a number", it was a
contradiction between two guards, and each read alone looks authoritative.

The wiring tests' stated rationale was: *"SF TimeoutSeconds must be slightly higher to avoid
premature timeout-due-to-SF when the Lambda is still working."* The intent is legitimate; the
conclusion is backwards. Only the smaller ceiling fires, so a higher SF value does not give the
Lambda room — it guarantees the SF budget never fires and the real ceiling lives in another repo's
deploy script, invisible to anyone reading the definition. Don't-cut-the-Lambda-off-early is served
by raising the **function** timeout.

`test_sf_lambda_timeout_ordering.py` is normative — it encodes `sf-pipeline-policy.md` §4 — and the
other three now agree with it, each carrying the reasoning in its docstring so the inversion is not
reintroduced by someone reading only that file.

`test_timeout_is_bounded` is additionally changed from an exact pin (`== 600`) to a range. An exact
pin makes every future re-baselining a test edit, which is how a value that could never fire
survived unnoticed.

Rehearsal-exempt: structural

The change is a static property of the definition — declared budget versus function ceiling — which
CI covers in full, so this is §7.3's "purely structural validation" exemption. No live Saturday
needed, and the runtime behaviour of the seven stages is unchanged in the direction that matters.

Closes #6897

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
