### PR TITLE
fix(pipeline-watchdog): enroll weekly SF in failed-day check (I7036)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -195,6 +195,7 @@ from nousergon_lib.flow_doctor_fleet import PIPELINE_OBSERVER_TELEGRAM_TOPICS
 # ``main``), so this costs the Lambda no cold-start weight beyond the file.
 try:  # deployed layout: flat next to index.py in /var/task
     from weekly_sf_silence_deadman import (  # noqa: E402
+        _is_gate_noop,
         compute_expected_slots,
         evaluate,
         fetch_execution_records,
@@ -206,6 +207,7 @@ except ModuleNotFoundError:  # in-repo layout (pytest, ci.yml glob runner)
         0, str(Path(__file__).resolve().parents[3] / "scripts")
     )
     from weekly_sf_silence_deadman import (  # noqa: E402
+        _is_gate_noop,
         compute_expected_slots,
         evaluate,
         fetch_execution_records,
@@ -1090,18 +1092,40 @@ def _check_preopen_buffer(
 # visible-degrade terminal, which status-keyed watchers already engage on,
 # config#6692), page. Zero-execution days are deliberately excluded — that
 # is the never-fired case the ``_check_sf`` liveness checks above own.
+#
+# alpha-engine-config-I7036: the weekly SF (``ne-weekly-freshness-pipeline``)
+# joins this check now that ``WriteCompletionMarkerDegraded`` exists for it
+# (alpha-engine-config-I6891 / nousergon-data-PR1319, merged 2026-08-12). Its
+# cadence is NOT weekday-trading-day like the two entries above — the
+# expected cycle day is "day after the week's last trading session" (usually
+# Saturday, Friday/Thursday on a holiday-shortened week per real precedent
+# 2026-07-03), and the SF is ALSO chain-launched daily as a
+# ``pipeline_role=exercise`` dry exercise run and self-gates a 2s
+# ``WeeklyRunDayGateChoice`` SUCCEEDED no-op on every THU/FRI cron firing
+# that isn't the real day. Neither an exercise run nor a gate-skip may be
+# counted as the weekly cycle — see ``_weekly_real_statuses_for_day``, which
+# reuses ``weekly_sf_silence_deadman``'s own role/gate-noop discrimination
+# (``_is_gate_noop``) rather than re-deriving it, so this check and the
+# silence deadman below can never disagree about what a real weekly cycle
+# execution looks like.
 
 MARKER_BUCKET = os.environ.get("COMPLETION_MARKER_BUCKET", "alpha-engine-research")
 
-# (sf_label suffix, SF ARN, marker pipeline segment). Marker keys follow the
-# definitions' WriteCompletionMarker states: the {date} segment is the UTC
-# date-part of $$.Execution.StartTime — for both pipelines every legal start
-# (preopen 12:15 UTC, postclose ~20:15–23:00 UTC incl. the backstop path)
-# lands on the same UTC calendar date as the PT trading date, so a lookup by
-# PT trading date is exact.
+# (sf_label suffix, SF ARN, marker pipeline segment, cadence). Marker keys
+# follow the definitions' WriteCompletionMarker states: the {date} segment
+# is the UTC date-part of $$.Execution.StartTime — for the two
+# ``trading_day``-cadence pipelines every legal start (preopen 12:15 UTC,
+# postclose ~20:15–23:00 UTC incl. the backstop path) lands on the same UTC
+# calendar date as the PT trading date, so a lookup by PT trading day is
+# exact. The ``weekly``-cadence entry's target date is instead derived by
+# ``_last_due_weekly_day`` (the real cycle day, not a trading day) and its
+# execution count comes from ``_weekly_real_statuses_for_day`` instead of
+# the generic ``_statuses_for_day`` — see ``_check_failed_day``'s
+# ``cadence`` branch.
 _FAILED_DAY_PIPELINES = (
-    ("Weekday SF", WEEKDAY_SF_ARN, "ne-preopen-trading-pipeline"),
-    ("EOD SF", EOD_SF_ARN, "ne-postclose-trading-pipeline"),
+    ("Weekday SF", WEEKDAY_SF_ARN, "ne-preopen-trading-pipeline", "trading_day"),
+    ("EOD SF", EOD_SF_ARN, "ne-postclose-trading-pipeline", "trading_day"),
+    ("Weekly SF", SATURDAY_SF_ARN, "ne-weekly-freshness-pipeline", "weekly"),
 )
 
 
@@ -1204,22 +1228,89 @@ def _completion_marker_status(
         return "UNREADABLE"
 
 
+def _last_due_weekly_day(now_utc: datetime) -> Optional[date]:
+    """Most recent weekly-role run-slot day that is fully due, per the
+    silence deadman's own slot derivation (alpha-engine-config-I7036) — the
+    day AFTER the week's last trading session, never assumed to be Saturday
+    (a holiday-shortened week lands the real cycle on Friday or Thursday;
+    real precedent 2026-07-03). ``cadence`` is passed as ``"off"`` here
+    because ``compute_expected_slots`` only uses it to gate EXERCISE slots
+    (never-gated weekly slots per that function's own docstring) — this
+    call cares about weekly slots only, so no SSM read is needed here and
+    this check does not race the separate weekly-silence check's own SSM
+    fetch. Returns ``None`` only if the 14-day lookback contains no weekly
+    slot at all (should not happen in steady state; defensive).
+    """
+    through = last_due_day(now_utc.date())
+    slots = compute_expected_slots(
+        through,
+        cadence="off",
+        window_days=14,
+        is_trading_day=is_trading_day,
+        next_trading_day=next_trading_day,
+    )
+    weekly_days = sorted(s.day for s in slots if s.role == "weekly" and s.day <= through)
+    return weekly_days[-1] if weekly_days else None
+
+
+def _weekly_real_statuses_for_day(client: object, target_date: date) -> "dict[str, int]":
+    """Status counts of REAL (``pipeline_role="weekly"``, non-gate-noop)
+    executions on ``target_date`` (alpha-engine-config-I7036).
+
+    Reuses ``weekly_sf_silence_deadman.fetch_execution_records`` (role read
+    from each execution's own input, never inferred from name — no launch
+    path passes an explicit SF ``Name``) and ``_is_gate_noop`` (excludes a
+    SUCCEEDED execution that finished in under
+    ``GATE_NOOP_MAX_SECONDS`` — ``WeeklyRunDayGateChoice``'s designed ~2s
+    skip on a THU/FRI cron firing that isn't the real cycle day). An
+    ``exercise``-role execution never matches ``role != "weekly"``; a
+    ``shell-run`` (Friday-PM preflight) execution's role normalizes to
+    ``None`` and is excluded the same way. window_days=10 comfortably
+    covers ``target_date`` even on the longest holiday-shortened weeks
+    while capping the ``describe_execution`` fan-out this makes.
+    """
+    since_anchor = target_date + timedelta(days=2)
+    records = fetch_execution_records(client, window_days=10, today=since_anchor)
+    counts: "dict[str, int]" = {}
+    for record in records:
+        if record.role != "weekly":
+            continue
+        if record.start.astimezone(timezone.utc).date() != target_date:
+            continue
+        if _is_gate_noop(record):
+            continue
+        counts[record.status] = counts.get(record.status, 0) + 1
+    return counts
+
+
 def _check_failed_day(
     *,
     sf_label: str,
     sf_arn: str,
     pipeline_name: str,
     target_date: date,
+    cadence: str = "trading_day",
     client: Optional[object] = None,
     s3_client: Optional[object] = None,
 ) -> FailedDayCheckResult:
-    """Page when ``target_date`` (the most recent closed trading day) had
-    executions for this SF but none SUCCEEDED and no DEGRADED marker was
-    written. See the block comment above for why this exists."""
+    """Page when ``target_date`` had executions for this SF but none
+    SUCCEEDED (as a REAL cycle — see ``cadence``) and no DEGRADED marker was
+    written. See the block comment above for why this exists.
+
+    ``cadence="trading_day"`` (Weekday/EOD SFs): ``target_date`` is the most
+    recent closed trading day, and any execution starting that day counts.
+    ``cadence="weekly"`` (Weekly SF, alpha-engine-config-I7036):
+    ``target_date`` is the real weekly cycle day (see
+    ``_last_due_weekly_day``), and only ``pipeline_role="weekly"``,
+    non-gate-noop executions count — see ``_weekly_real_statuses_for_day``.
+    """
     if client is None:  # pragma: no cover — production path
         client = boto3.client("stepfunctions", region_name=REGION)
 
-    counts = _statuses_for_day(client, sf_arn, target_date)
+    if cadence == "weekly":
+        counts = _weekly_real_statuses_for_day(client, target_date)
+    else:
+        counts = _statuses_for_day(client, sf_arn, target_date)
     total = sum(counts.values())
     succeeded = counts.get("SUCCEEDED", 0)
 
@@ -1233,6 +1324,11 @@ def _check_failed_day(
             skip_reason=(
                 "no executions on the target day — never-fired is the "
                 "liveness checks' case, not this one's"
+                if cadence != "weekly"
+                else
+                "no real (non-gate-skip, pipeline_role=weekly) execution on "
+                "the target cycle day — deferred to the weekly-SF silence "
+                "deadman (never-fired), not double-paged here"
             ),
         )
     if succeeded > 0:
@@ -1244,6 +1340,8 @@ def _check_failed_day(
             succeeded_on_day=succeeded,
         )
 
+    day_label = "cycle day" if cadence == "weekly" else "trading day"
+
     running = counts.get("RUNNING", 0)
     if running > 0:
         # A prior-day execution still RUNNING at 14:00 UTC the next day is
@@ -1253,7 +1351,7 @@ def _check_failed_day(
         # silently deferring: an 18h run is itself a hang in the making.
         message = (
             f"{sf_label} ({pipeline_name}) still has {running} RUNNING "
-            f"execution(s) from trading day {target_date} at watchdog time — "
+            f"execution(s) from {day_label} {target_date} at watchdog time — "
             f"no SUCCEEDED execution for that day yet. This is at or beyond "
             f"the definition's top-level timeout horizon; investigate: "
             f"`aws stepfunctions list-executions --state-machine-arn {sf_arn} "
@@ -1302,14 +1400,21 @@ def _check_failed_day(
         "ABSENT": "no completion marker was written",
         "UNREADABLE": "the completion marker could not be read/parsed (UNKNOWN ≠ pass)",
     }.get(marker_status, f"completion marker status={marker_status!r}")
+    rerun_clause = (
+        "Recover with `python scripts/weekly_sf_rerun.py "
+        "--execution-arn <failed execution arn> --dry-run` (then `--start`)"
+        if cadence == "weekly"
+        else
+        "Recover mechanically with the rerun helper: "
+        "`python scripts/weekday_sf_rerun.py "
+        "--execution-arn <failed execution arn> --dry-run` (then `--start`)"
+    )
     message = (
-        f"{sf_label} ({pipeline_name}) FAILED trading day {target_date}: "
+        f"{sf_label} ({pipeline_name}) FAILED {day_label} {target_date}: "
         f"{total} execution(s) started, none SUCCEEDED, and {marker_clause}. "
         f"This is the independent started-but-never-succeeded detector "
         f"(sf-pipeline-policy §4.1, alpha-engine-config#6732) — do not assume "
-        f"the SF's own failure notification fired. Recover mechanically with "
-        f"the rerun helper: `python scripts/weekday_sf_rerun.py "
-        f"--execution-arn <failed execution arn> --dry-run` (then `--start`); "
+        f"the SF's own failure notification fired. {rerun_clause}; "
         f"list candidates: `aws stepfunctions list-executions "
         f"--state-machine-arn {sf_arn} --max-results 10`."
     )
@@ -1579,20 +1684,38 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         is_watch_day=is_trading_today,
     )
 
-    # Prior-day failed-run checks (config#6732). The target is the most
+    # Prior-day failed-run checks (config#6732, extended to the weekly SF by
+    # alpha-engine-config-I7036). The trading_day-cadence target is the most
     # recent CLOSED trading day, which exists on every calendar day — so
     # these run on weekends and holidays too (a Friday failure pages
-    # Saturday 14:00 UTC, not Monday).
-    failed_day_target = last_closed_trading_day(now_utc)
-    failed_day = [
-        _check_failed_day(
+    # Saturday 14:00 UTC, not Monday). The weekly-cadence target is instead
+    # the most recent DUE weekly cycle day (see ``_last_due_weekly_day`` —
+    # not a trading day, and not always Saturday).
+    failed_day_trading_target = last_closed_trading_day(now_utc)
+    failed_day_weekly_target = _last_due_weekly_day(now_utc)
+    failed_day: list = []
+    for label, arn, pipeline, cadence in _FAILED_DAY_PIPELINES:
+        if cadence == "weekly":
+            if failed_day_weekly_target is None:  # pragma: no cover — defensive
+                failed_day.append(FailedDayCheckResult(
+                    sf_label=label,
+                    checked=False,
+                    skip_reason=(
+                        "no weekly run-slot found in the 14-day lookback — "
+                        "cannot derive a target cycle day"
+                    ),
+                ))
+                continue
+            target_date = failed_day_weekly_target
+        else:
+            target_date = failed_day_trading_target
+        failed_day.append(_check_failed_day(
             sf_label=label,
             sf_arn=arn,
             pipeline_name=pipeline,
-            target_date=failed_day_target,
-        )
-        for label, arn, pipeline in _FAILED_DAY_PIPELINES
-    ]
+            target_date=target_date,
+            cadence=cadence,
+        ))
 
     # Weekly-SF silence deadman (config#6738). Runs on EVERY calendar day —
     # its own slot derivation is the trading-calendar gate, so there is no

--- a/tests/test_pipeline_watchdog_weekly_failed_day.py
+++ b/tests/test_pipeline_watchdog_weekly_failed_day.py
@@ -1,0 +1,330 @@
+"""Weekly-SF enrollment into the pipeline-watchdog prior-day failed-run
+check (alpha-engine-config-I7036).
+
+``_FAILED_DAY_PIPELINES`` (infrastructure/lambdas/pipeline-watchdog/
+index.py) reads S3 completion markers to catch a Step Function that started
+but never succeeded. Until alpha-engine-config-I6891 (nousergon-data-PR1319)
+the weekly SF (``ne-weekly-freshness-pipeline``) had no DEGRADED marker to
+read, so it was never enrolled. I6891 shipped ``WriteCompletionMarkerDegraded``
+and the ``DegradedRun`` Fail terminal for it; this enrolls it.
+
+The weekly SF's cadence is NOT weekday-trading-day like the two pre-existing
+entries: it fires via a self-gating THU-SAT cron (real cycle day = the day
+after the week's last trading session, not always Saturday) and is ALSO
+chain-launched daily as a ``pipeline_role=exercise`` dry run. Counting a
+``WeeklyRunDayGateChoice`` no-op skip (~2s SUCCEEDED) or an exercise run as
+the weekly cycle would silently hide a genuinely failed real run — exactly
+the defect class I7036 deliverable 2 warns against. This module tests that
+``_check_failed_day(cadence="weekly")`` / ``_weekly_real_statuses_for_day``
+reuse ``weekly_sf_silence_deadman._is_gate_noop`` (imported, not
+re-derived) to make that discrimination, via the three cases named in the
+issue's Deliverable 3 / Closes-when:
+
+  1. a weekly marker DEGRADED clears the failed day (no page)
+  2. a weekly marker ABSENT on an expected cycle day pages
+  3. a gate-skip execution is not counted as the cycle (no false-clear,
+     no false-page — deferred to the silence deadman instead)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LAMBDA_DIR = REPO_ROOT / "infrastructure" / "lambdas" / "pipeline-watchdog"
+LAMBDAS_ROOT = REPO_ROOT / "infrastructure" / "lambdas"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_module():
+    # index.py imports `from flow_doctor_telegram import notify_via_flow_doctor`
+    # as a bare top-level module (deployed flat next to index.py in prod;
+    # in-repo it lives one directory up at infrastructure/lambdas/) and
+    # falls back to inserting SCRIPTS_DIR itself for the
+    # weekly_sf_silence_deadman import (in-repo layout branch already
+    # coded in index.py) — both paths need to be importable before exec.
+    for p in (str(LAMBDAS_ROOT), str(SCRIPTS_DIR)):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    spec = importlib.util.spec_from_file_location(
+        "pipeline_watchdog_index", LAMBDA_DIR / "index.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["pipeline_watchdog_index"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+TARGET_DATE = date(2026, 8, 15)  # a Saturday — a real weekly cycle day
+MARKER_BUCKET = "alpha-engine-research"
+MARKER_KEY = f"_sf_completion/ne-weekly-freshness-pipeline/{TARGET_DATE.isoformat()}.json"
+
+
+def _utc(d: date, hour: int, minute: int = 0) -> datetime:
+    return datetime(d.year, d.month, d.day, hour, minute, 0, tzinfo=timezone.utc)
+
+
+class _FakeSFClient:
+    """Minimal stepfunctions client stub covering the two calls
+    ``weekly_sf_silence_deadman.fetch_execution_records`` makes:
+    ``list_executions`` (single page — small fixtures, no pagination
+    needed) and ``describe_execution`` (role comes from execution INPUT,
+    never the name — mirrors every real launch path)."""
+
+    def __init__(self, executions: list[dict]):
+        self._executions = executions
+
+    def list_executions(self, **kwargs):
+        return {"executions": self._executions, "nextToken": None}
+
+    def describe_execution(self, *, executionArn: str):
+        for ex in self._executions:
+            if ex["executionArn"] == executionArn:
+                return {"input": json.dumps(ex["_input"])}
+        raise AssertionError(f"no fixture execution for {executionArn}")  # pragma: no cover
+
+
+def _execution(
+    *, name: str, role: str | None, status: str, start: datetime, duration_s: float
+) -> dict:
+    return {
+        "executionArn": f"arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:{name}",
+        "name": name,
+        "status": status,
+        "startDate": start,
+        "stopDate": start + timedelta(seconds=duration_s) if status != "RUNNING" else None,
+        "_input": {"pipeline_role": role} if role is not None else {},
+    }
+
+
+class _FakeS3Client:
+    def __init__(self, *, status: str | None):
+        """``status=None`` simulates ABSENT (NoSuchKey)."""
+        self._status = status
+
+    def get_object(self, *, Bucket: str, Key: str):
+        assert Bucket == MARKER_BUCKET
+        assert Key == MARKER_KEY
+        if self._status is None:
+
+            class _NoSuchKey(Exception):
+                response = {"Error": {"Code": "NoSuchKey"}}
+
+            raise _NoSuchKey("not found")
+        body = json.dumps({"status": self._status, "degraded_summary": {"reason": "test"}}).encode()
+        return {"Body": io.BytesIO(body)}
+
+
+@pytest.fixture(autouse=True)
+def _no_real_alerts(mod, monkeypatch):
+    """Never let a test reach SNS/Telegram — assert on the recorded calls
+    instead. Mirrors the module's own dedup_key/severity contract without
+    depending on live AWS credentials being present in CI."""
+    calls: list[dict] = []
+
+    def _fake_publish(message, *, severity, dedup_key, context, dedup_window_min=12 * 60):
+        calls.append({"message": message, "severity": severity, "dedup_key": dedup_key})
+        return f"published:{dedup_key}"
+
+    monkeypatch.setattr(mod, "_publish_watchdog_alert", _fake_publish)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# The three I7036 Deliverable-3 cases
+# ---------------------------------------------------------------------------
+
+class TestWeeklyFailedDayDegradedMarkerClears:
+    def test_degraded_marker_clears_the_failed_day(self, mod, _no_real_alerts):
+        # Real weekly-role execution, terminated FAILED (the DegradedRun
+        # Fail-state terminal is a real AWS FAILED status), long enough not
+        # to be a gate-noop. Noise: an unrelated same-day exercise-role
+        # execution must not influence the outcome (role filtering).
+        executions = [
+            _execution(
+                name="real-weekly-run",
+                role="weekly",
+                status="FAILED",
+                start=_utc(TARGET_DATE, 9, 0),
+                duration_s=5400,  # 90 minutes — nowhere near GATE_NOOP_MAX_SECONDS
+            ),
+        ]
+        sf_client = _FakeSFClient(executions)
+        s3_client = _FakeS3Client(status="DEGRADED")
+
+        result = mod._check_failed_day(
+            sf_label="Weekly SF",
+            sf_arn=mod.SATURDAY_SF_ARN,
+            pipeline_name="ne-weekly-freshness-pipeline",
+            target_date=TARGET_DATE,
+            cadence="weekly",
+            client=sf_client,
+            s3_client=s3_client,
+        )
+
+        assert result.checked is True
+        assert result.executions_on_day == 1
+        assert result.succeeded_on_day == 0
+        assert result.marker_status == "DEGRADED"
+        assert result.alert_emitted is False
+        assert _no_real_alerts == []  # no page — Option-A visible degrade
+
+
+class TestWeeklyFailedDayAbsentMarkerPages:
+    def test_absent_marker_on_expected_cycle_day_pages(self, mod, _no_real_alerts):
+        executions = [
+            _execution(
+                name="real-weekly-run-failed-hard",
+                role="weekly",
+                status="FAILED",
+                start=_utc(TARGET_DATE, 9, 0),
+                duration_s=1800,
+            ),
+        ]
+        sf_client = _FakeSFClient(executions)
+        s3_client = _FakeS3Client(status=None)  # ABSENT
+
+        result = mod._check_failed_day(
+            sf_label="Weekly SF",
+            sf_arn=mod.SATURDAY_SF_ARN,
+            pipeline_name="ne-weekly-freshness-pipeline",
+            target_date=TARGET_DATE,
+            cadence="weekly",
+            client=sf_client,
+            s3_client=s3_client,
+        )
+
+        assert result.checked is True
+        assert result.executions_on_day == 1
+        assert result.succeeded_on_day == 0
+        assert result.marker_status == "ABSENT"
+        assert result.alert_emitted is True
+        assert len(_no_real_alerts) == 1
+        assert _no_real_alerts[0]["severity"] == "error"
+        assert "ne-weekly-freshness-pipeline" in _no_real_alerts[0]["message"]
+        assert "no completion marker was written" in _no_real_alerts[0]["message"]
+
+
+class TestWeeklyFailedDayGateSkipIsNotACycle:
+    def test_gate_skip_execution_is_not_counted_as_the_cycle(self, mod, _no_real_alerts):
+        # WeeklyRunDayGateChoice's designed no-op: SUCCEEDED, ~2s duration,
+        # well under GATE_NOOP_MAX_SECONDS (90s). Must not read as either a
+        # real SUCCEEDED cycle (which would silently hide a genuine miss)
+        # NOR as a "0 executions" never-fired case that some OTHER
+        # non-weekly execution masks — this is the exact ambiguity I7036
+        # deliverable 2 exists to resolve. Also includes a same-day
+        # exercise-role execution as noise to prove role filtering holds
+        # even when gate-noop filtering wouldn't have excluded it alone.
+        executions = [
+            _execution(
+                name="gate-skip",
+                role="weekly",
+                status="SUCCEEDED",
+                start=_utc(TARGET_DATE, 9, 0),
+                duration_s=2,
+            ),
+            _execution(
+                name="same-day-exercise-noise",
+                role="exercise",
+                status="SUCCEEDED",
+                start=_utc(TARGET_DATE, 9, 5),
+                duration_s=3600,
+            ),
+        ]
+        sf_client = _FakeSFClient(executions)
+        s3_client = _FakeS3Client(status=None)  # must never be consulted
+
+        result = mod._check_failed_day(
+            sf_label="Weekly SF",
+            sf_arn=mod.SATURDAY_SF_ARN,
+            pipeline_name="ne-weekly-freshness-pipeline",
+            target_date=TARGET_DATE,
+            cadence="weekly",
+            client=sf_client,
+            s3_client=s3_client,
+        )
+
+        assert result.checked is True
+        assert result.executions_on_day == 0
+        assert result.succeeded_on_day == 0
+        assert result.marker_status is None  # never consulted — total==0 short-circuits first
+        assert result.alert_emitted is False
+        assert _no_real_alerts == []
+        assert "gate-skip" in (result.skip_reason or "") or "weekly" in (result.skip_reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the generic (trading_day-cadence) path is unchanged by the new
+# ``cadence`` parameter's default.
+# ---------------------------------------------------------------------------
+
+class TestTradingDayCadenceUnaffected:
+    def test_weekday_sf_default_cadence_still_uses_plain_date_counting(self, mod, _no_real_alerts):
+        class _FakeStatusesClient:
+            def list_executions(self, *, stateMachineArn, statusFilter, maxResults, nextToken=None):
+                if statusFilter != "SUCCEEDED":
+                    return {"executions": []}
+                return {
+                    "executions": [
+                        {
+                            "executionArn": "arn:x",
+                            "startDate": _utc(TARGET_DATE, 12, 45),
+                        }
+                    ]
+                }
+
+        result = mod._check_failed_day(
+            sf_label="Weekday SF",
+            sf_arn=mod.WEEKDAY_SF_ARN,
+            pipeline_name="ne-preopen-trading-pipeline",
+            target_date=TARGET_DATE,
+            client=_FakeStatusesClient(),
+        )
+        assert result.checked is True
+        assert result.succeeded_on_day == 1
+        assert result.alert_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# Target-date derivation: the real cycle day is not always Saturday
+# ---------------------------------------------------------------------------
+
+class TestLastDueWeeklyDay:
+    def test_normal_week_returns_the_saturday(self, mod):
+        # Evaluated Sunday 2026-08-16 (14:00 UTC watchdog firing) — the
+        # week's last session was Friday 2026-08-14, so the real cycle day
+        # is Saturday 2026-08-15.
+        now = _utc(date(2026, 8, 16), 14)
+        assert mod._last_due_weekly_day(now) == date(2026, 8, 15)
+
+    def test_holiday_shortened_week_returns_friday_not_saturday(self, mod):
+        # Real precedent (weekly_sf_silence_deadman docstring): the week
+        # containing Independence Day 2026 (observed Friday 2026-07-03)
+        # ends its trading on Thursday 2026-07-02, so the real cycle day is
+        # Friday 2026-07-03 — a naive "always Saturday" assumption would
+        # derive 2026-07-04 and find nothing there.
+        now = _utc(date(2026, 7, 4), 14)
+        assert mod._last_due_weekly_day(now) == date(2026, 7, 3)
+
+
+# ---------------------------------------------------------------------------
+# _FAILED_DAY_PIPELINES enrollment
+# ---------------------------------------------------------------------------
+
+def test_weekly_sf_is_enrolled_in_failed_day_pipelines(mod):
+    labels = {(row[0], row[3]) for row in mod._FAILED_DAY_PIPELINES}
+    assert ("Weekly SF", "weekly") in labels
+    assert ("Weekday SF", "trading_day") in labels
+    assert ("EOD SF", "trading_day") in labels


### PR DESCRIPTION
## Summary

Closes alpha-engine-config-I7036.

`_FAILED_DAY_PIPELINES` (`infrastructure/lambdas/pipeline-watchdog/index.py`) reads S3 completion markers to catch a Step Function that started but never succeeded. `ne-weekly-freshness-pipeline` was absent because until `alpha-engine-config-I6891` / `nousergon-data-PR1319` (merged 2026-08-12) the weekly pipeline had no DEGRADED marker to read. That precondition is now met and the weekly SF is enrolled here.

## What changed

- `_check_failed_day` gains a `cadence` parameter (`"trading_day"` default — unchanged behavior for Weekday/EOD SFs; `"weekly"` — new).
- `_last_due_weekly_day(now_utc)`: derives the real weekly cycle day (the day after the week's last trading session — **not always Saturday**; holiday-shortened weeks land it on Friday/Thursday, real precedent 2026-07-03), reusing `weekly_sf_silence_deadman.compute_expected_slots`/`last_due_day` rather than re-deriving calendar math.
- `_weekly_real_statuses_for_day(client, target_date)`: counts only real `pipeline_role="weekly"`, non-gate-noop executions on `target_date`, reusing `weekly_sf_silence_deadman._is_gate_noop` and `fetch_execution_records` (imported, not re-derived) — so a `WeeklyRunDayGateChoice` no-op skip (~2s SUCCEEDED) or a chained `pipeline_role=exercise` daily dry run can never be misread as the weekly cycle. Same discrimination the silence deadman already uses, so the two checks can't disagree.
- `_FAILED_DAY_PIPELINES` becomes 4-tuples `(label, arn, pipeline, cadence)`; the handler computes a trading-day target and a weekly target separately and dispatches per-entry.

## Cadence rule / discrimination

Weekly target date = `_last_due_weekly_day` (day after the week's last trading session, from the trading calendar — never assumed to be Saturday). Execution counting = `pipeline_role="weekly"` AND not a gate-noop (`stop - start < 90s` on a SUCCEEDED execution). A THU/FRI cron firing that self-gates off lands on a different calendar date than the real cycle day and is additionally filtered by role/gate-noop even if it somehow shared the date; a chained `exercise` run never matches `role == "weekly"`.

## Tests (`tests/test_pipeline_watchdog_weekly_failed_day.py`)

- `TestWeeklyFailedDayDegradedMarkerClears::test_degraded_marker_clears_the_failed_day` — weekly marker DEGRADED clears, no page.
- `TestWeeklyFailedDayAbsentMarkerPages::test_absent_marker_on_expected_cycle_day_pages` — weekly marker ABSENT on an expected cycle day pages (severity=error).
- `TestWeeklyFailedDayGateSkipIsNotACycle::test_gate_skip_execution_is_not_counted_as_the_cycle` — a gate-skip execution (SUCCEEDED, ~2s) is not counted as the cycle; defers rather than false-clearing or false-paging.
- Plus: `_last_due_weekly_day` normal-week/holiday-week derivation, generic `trading_day` cadence unaffected, `_FAILED_DAY_PIPELINES` enrollment.

7/7 new tests pass. Full suite: 4724 passed, 177 failed, 65 collection errors — matches the pre-existing laptop baseline (missing optional deps `yfinance`/`pyarrow`; `alpha-engine-config-I7173` tracks 3 unrelated registry-drift failures). No new failures introduced by this change.

## Deploy mechanism
**Deploy-mechanism:** `deploy-pipeline-watchdog.yml` (auto-deploys this Lambda's code on merge to `main`). The pipeline-watchdog is one of the few triggers deliberately un-paused during the automation pause (`alpha-engine-config-I6697`), so this change goes live immediately on merge.

## Scope note

Confined to `infrastructure/lambdas/pipeline-watchdog/index.py` and `tests/` per instruction — does not touch `infrastructure/step_function*.json` or `infrastructure/_spot_common.sh`, which other concurrent tracks own.

---

**Prepared by:** claude-sonnet-5
