### PR TITLE
fix(monitoring): weekly silence deadman applies cadence retroactively, not by date (config-I7175)

### DIFF
--- a/infrastructure/weekly_cadence.json
+++ b/infrastructure/weekly_cadence.json
@@ -1,7 +1,18 @@
 {
-  "exercise_cadence": "daily",
+  "exercise_cadence": [
+    {
+      "value": "weekly-only",
+      "effective_from": "2026-01-01",
+      "_why": "no exercise leg existed before the daily debugging cadence — the repo's actual start date is later, but nothing before it can be mistaken for a declared 'daily' era, which is the only property this entry needs to hold."
+    },
+    {
+      "value": "daily",
+      "effective_from": "2026-07-27",
+      "_why": "Brian ruling alpha-engine-config#5489 was recorded 2026-07-29, but the daily exercise-launch behavior was already live and being attempted two trading days earlier: postclose FAILED before reaching LaunchWeeklyExerciseRun on 2026-07-27 and 2026-07-28, which is a real silent exercise slot, not a not-yet-declared one. Measured live 2026-08-13 (alpha-engine-config-I7175): the deadman's own execution history shows these two days as genuinely absent while every trading day 2026-06-29 through 2026-07-24 has NO exercise attempt at all (pre-cadence). Using the ruling's paper date (07-29) here would reclassify 07-27/07-28 as GATED_OFF and silently drop 2 of the 4 real silences this fix exists to keep — the opposite failure this issue was filed to fix. effective_from records when the declaration was IN FORCE, which is what classification needs; '_why' still names the ruling that authorized it."
+    }
+  ],
 
-  "_provenance": "alpha-engine-config#6689 (mechanism: single declared cadence knob, deploy-time SSM sync, silence deadman). The VALUE below is unchanged by that PR — it is set by alpha-engine-config#5489 (Brian ruling 2026-07-29) and this file only relocates where that value lives, from an SF-topology edit to a one-line manifest diff.",
+  "_provenance": "alpha-engine-config#6689 (mechanism: single declared cadence knob, deploy-time SSM sync, silence deadman). The CURRENT value is unchanged by that PR — it is set by alpha-engine-config#5489 (Brian ruling 2026-07-29) and this file only relocates where that value lives, from an SF-topology edit to a one-line manifest diff. alpha-engine-config-I7175 (2026-08-13) turned the single value into a dated history so a backward-looking reader (the silence deadman) never applies today's declaration to a date before it took effect.",
 
   "_meaning": {
     "daily": "infrastructure/step_function_eod.json's LaunchWeeklyExerciseRun fires the FULL weekly pipeline (ne-weekly-freshness-pipeline, pipeline_role=exercise) after every trading day's postclose. alpha-engine-config#5489 (Brian ruling 2026-07-29): a DELIBERATE PUNISHMENT CADENCE, chosen because the weekly pipeline's own iteration rate — 11/60 executions reached a successful terminal state at filing — was the measured failure driver, not compute cost. It carries a stated EXIT CONDITION (sustained weekly-SF health, i.e. this is not meant to run forever) and is NOT the intended steady state. Flip away from 'daily' only on a ruling that the exit condition has been met.",
@@ -9,7 +20,7 @@
     "off": "LaunchWeeklyExerciseRun is skipped on every postclose, identically to 'weekly-only' from this knob's point of view — this parameter has exactly one insertion point (the postclose Choice guarding the exercise launch) and does not touch the Saturday cron at all. 'off' exists as a distinct declared value so the silence deadman can be told 'no exercise launch is expected, full stop' without conflating that with 'weekly-only, but the exercise leg happens to be paused for another reason.' Silencing the Saturday cron itself is a SEPARATE decision made in infrastructure/automation_pause.json (alpha-engine-saturday is explicitly kept there by the 2026-08-07 ruling) — this knob deliberately does not reintroduce a second cron/calendar surface."
   },
 
-  "_mechanism": "Deployed to SSM Parameter Store at /alpha-engine/weekly-sf/exercise-cadence (String) by infrastructure/deploy-infrastructure.sh, in the same step that updates the postclose SF definition (config#6689 deliverable 2) — so the manifest and the live gate can never point at different values for more than one deploy cycle. infrastructure/step_function_eod.json's ReadExerciseCadence task reads that parameter live at execution time; CheckExerciseCadence Choice routes daily -> LaunchWeeklyExerciseRun, {weekly-only, off} -> skip straight to CheckDegradedOutcome (LaunchWeeklyExerciseRun's existing success target), preserving WeeklyExerciseLaunchFailed's routing untouched. Two-directional drift (manifest vs live SSM) is checked by infrastructure/weekly_cadence_drift.py, mirroring automation_pause.py's pattern.",
+  "_mechanism": "The CURRENT entry (the one whose effective_from is the latest date <= today) is deployed to SSM Parameter Store at /alpha-engine/weekly-sf/exercise-cadence (String) by infrastructure/deploy-infrastructure.sh, in the same step that updates the postclose SF definition (config#6689 deliverable 2) — so the manifest's current value and the live gate can never point at different values for more than one deploy cycle. SSM holds exactly that one scalar; it carries no history. infrastructure/step_function_eod.json's ReadExerciseCadence task reads that parameter live at execution time; CheckExerciseCadence Choice routes daily -> LaunchWeeklyExerciseRun, {weekly-only, off} -> skip straight to CheckDegradedOutcome (LaunchWeeklyExerciseRun's existing success target), preserving WeeklyExerciseLaunchFailed's routing untouched. Two-directional drift (manifest's CURRENT entry vs live SSM) is checked by infrastructure/weekly_cadence_drift.py, mirroring automation_pause.py's pattern. The FULL history is read only by scripts/weekly_sf_silence_deadman.py, to resolve which value was in force on each date it is retroactively judging (alpha-engine-config-I7175) — a use SSM structurally cannot serve.",
 
   "allowed_values": ["daily", "weekly-only", "off"]
 }

--- a/infrastructure/weekly_cadence_drift.py
+++ b/infrastructure/weekly_cadence_drift.py
@@ -45,6 +45,7 @@ import argparse
 import json
 import subprocess
 import sys
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 MANIFEST = Path(__file__).parent.resolve() / "weekly_cadence.json"
@@ -57,15 +58,62 @@ def load_manifest(path: Path = MANIFEST) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def declared_cadence(manifest: dict | None = None) -> str:
-    m = manifest if manifest is not None else load_manifest()
-    value = m.get("exercise_cadence")
-    if value not in ALLOWED_VALUES:
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _cadence_entries(raw: object) -> list[tuple[date, str]]:
+    """Parse ``exercise_cadence``'s dated-history shape (alpha-engine-config-
+    I7175) into ``(effective_from, value)`` pairs sorted ascending.
+
+    Deliberately a small local duplicate of
+    ``scripts/weekly_sf_silence_deadman.py``'s ``CadenceEntry``/
+    ``_parse_cadence_history`` rather than a cross-import: this script is
+    invoked standalone by ``deploy-infrastructure.sh`` and intentionally
+    carries zero non-stdlib dependencies (see module docstring). Both places
+    parse the same manifest shape; a second real adoption is
+    `policy-shared-code`'s trigger to lift this into ``nousergon_lib`` rather
+    than duplicate a third time.
+    """
+    if not isinstance(raw, list) or not raw:
         raise ValueError(
-            f"infrastructure/weekly_cadence.json exercise_cadence={value!r} is not one of "
-            f"{sorted(ALLOWED_VALUES)}"
+            f"infrastructure/weekly_cadence.json exercise_cadence must be a non-empty list of "
+            f"{{value, effective_from}} entries, got {raw!r}"
         )
-    return value
+    entries: list[tuple[date, str]] = []
+    for item in raw:
+        if not isinstance(item, dict) or "value" not in item or "effective_from" not in item:
+            raise ValueError(f"exercise_cadence entry malformed (needs value + effective_from): {item!r}")
+        value = item["value"]
+        if value not in ALLOWED_VALUES:
+            raise ValueError(
+                f"infrastructure/weekly_cadence.json exercise_cadence entry value={value!r} is not one of "
+                f"{sorted(ALLOWED_VALUES)}"
+            )
+        entries.append((date.fromisoformat(item["effective_from"]), value))
+    entries.sort(key=lambda e: e[0])
+    return entries
+
+
+def declared_cadence(manifest: dict | None = None, today: date | None = None) -> str:
+    """The cadence value in force as of ``today`` (default: real wall-clock
+    today) — the single scalar SSM can hold. Historical entries are not
+    reachable from here; only ``scripts/weekly_sf_silence_deadman.py`` reads
+    the full history, to judge past dates SSM was never asked about."""
+    m = manifest if manifest is not None else load_manifest()
+    entries = _cadence_entries(m.get("exercise_cadence"))
+    as_of = today if today is not None else _today()
+    in_force: str | None = None
+    for effective_from, value in entries:
+        if effective_from <= as_of:
+            in_force = value
+        else:
+            break
+    if in_force is None:
+        raise ValueError(
+            f"infrastructure/weekly_cadence.json: no exercise_cadence entry is in force on {as_of.isoformat()}"
+        )
+    return in_force
 
 
 def _aws(args: list[str]) -> tuple[int, str, str]:

--- a/scripts/weekly_sf_silence_deadman.py
+++ b/scripts/weekly_sf_silence_deadman.py
@@ -109,9 +109,69 @@ def _validate_cadence(value: object, source: str) -> str:
     return value  # type: ignore[return-value]
 
 
-def load_cadence_from_manifest(path: Path = MANIFEST_PATH) -> str:
+@dataclass(frozen=True)
+class CadenceEntry:
+    """One dated declaration in ``weekly_cadence.json``'s ``exercise_cadence``
+    history (alpha-engine-config-I7175). ``effective_from`` is the first date
+    the value is IN FORCE, inclusive."""
+    value: str
+    effective_from: date
+    why: str = ""
+
+
+def _parse_cadence_history(raw: object, source: str) -> list[CadenceEntry]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(
+            f"{source} exercise_cadence must be a non-empty list of "
+            f"{{value, effective_from}} entries, got {raw!r}"
+        )
+    entries: list[CadenceEntry] = []
+    for item in raw:
+        if not isinstance(item, dict) or "value" not in item or "effective_from" not in item:
+            raise ValueError(f"{source} exercise_cadence entry malformed (needs value + effective_from): {item!r}")
+        value = _validate_cadence(item["value"], source)
+        try:
+            effective_from = date.fromisoformat(item["effective_from"])
+        except ValueError as exc:
+            raise ValueError(
+                f"{source} exercise_cadence entry has an invalid effective_from: {item['effective_from']!r}"
+            ) from exc
+        entries.append(CadenceEntry(value=value, effective_from=effective_from, why=item.get("_why", "")))
+    entries.sort(key=lambda e: e.effective_from)
+    return entries
+
+
+def cadence_for_date(history: list[CadenceEntry], d: date) -> str | None:
+    """The cadence value in force on ``d``, or ``None`` if ``d`` precedes the
+    first declared entry — "the declaration did not exist yet" is a distinct
+    state from "the run was expected and absent" (alpha-engine-config-I7175,
+    sf-pipeline-policy.md §2.6 rule 1's GATED_OFF/CRITICAL distinction)."""
+    in_force: str | None = None
+    for entry in history:  # history is sorted ascending by _parse_cadence_history
+        if entry.effective_from <= d:
+            in_force = entry.value
+        else:
+            break
+    return in_force
+
+
+def load_cadence_history(path: Path = MANIFEST_PATH) -> list[CadenceEntry]:
     manifest = json.loads(path.read_text(encoding="utf-8"))
-    return _validate_cadence(manifest.get("exercise_cadence"), str(path))
+    return _parse_cadence_history(manifest.get("exercise_cadence"), str(path))
+
+
+def load_cadence_from_manifest(path: Path = MANIFEST_PATH) -> str:
+    """The value in force TODAY (real wall-clock today), i.e. the manifest
+    history's last entry as of now — used only for the CLI header/JSON
+    display and as the non-``--live`` current-cadence source. Per-day
+    classification never calls this; it calls ``cadence_for_date`` against
+    the full history instead (see ``compute_expected_slots``)."""
+    history = load_cadence_history(path)
+    today = _today()
+    value = cadence_for_date(history, today)
+    if value is None:
+        raise ValueError(f"{path}: no exercise_cadence entry is in force on {today.isoformat()}")
+    return value
 
 
 def load_cadence_from_ssm(ssm_client) -> str:
@@ -175,32 +235,63 @@ def compute_expected_slots(
     window_days: int,
     is_trading_day: Callable[[date], bool],
     next_trading_day: Callable[[date], date],
+    cadence_history: list[CadenceEntry] | None = None,
 ) -> list[ExpectedSlot]:
     """Derive every run-slot expected in [today - window_days, today].
 
-    Exercise slots: one per trading day in the window, gated_off when
-    ``cadence != "daily"`` — LaunchWeeklyExerciseRun's CheckExerciseCadence
-    only fires the launch on 'daily' (step_function_eod.json).
+    Exercise slots: one per trading day in the window.
+
+    ``cadence_history`` — when given, EVERY exercise day is resolved against
+    it via ``cadence_for_date`` instead of the flat ``cadence`` scalar, so a
+    day before the declaration's first entry is ``GATED_OFF`` rather than
+    judged against a cadence that did not exist yet on that day
+    (alpha-engine-config-I7175). ``None`` (the default) preserves the
+    original flat-``cadence`` behavior unchanged — the pipeline-watchdog
+    Lambda calls this positionally without it and must keep working; it only
+    ever evaluates a window anchored at "now", never retroactively, so the
+    distinction does not apply to it. A day gated on either path is skipped
+    when ``cadence != "daily"`` — LaunchWeeklyExerciseRun's
+    CheckExerciseCadence only fires the launch on 'daily'
+    (step_function_eod.json).
 
     Weekly slots: one per week whose last-trading-session-plus-one-day run
-    date falls within the window. NEVER gated by ``cadence`` — the Saturday
-    cron is a separate trigger this knob deliberately does not touch.
+    date falls within the window. NEVER gated by cadence (declared or
+    historical) — the Saturday cron is a separate trigger this knob
+    deliberately does not touch.
     """
     slots: list[ExpectedSlot] = []
     d = today - timedelta(days=window_days)
     while d <= today:
         if is_trading_day(d):
-            gated = cadence != "daily"
-            slots.append(ExpectedSlot(
-                day=d,
-                role="exercise",
-                gated_off=gated,
-                note=(
-                    f"cadence={cadence} — LaunchWeeklyExerciseRun is skipped on trading days"
-                    if gated else
-                    f"cadence={cadence} — LaunchWeeklyExerciseRun fires after this trading day's postclose"
-                ),
-            ))
+            if cadence_history is not None:
+                day_cadence = cadence_for_date(cadence_history, d)
+            else:
+                day_cadence = cadence
+            if day_cadence is None:
+                first_entry = cadence_history[0]  # non-empty by _parse_cadence_history
+                slots.append(ExpectedSlot(
+                    day=d,
+                    role="exercise",
+                    gated_off=True,
+                    note=(
+                        f"no exercise_cadence declaration was in force on {d.isoformat()} — "
+                        f"the earliest entry takes effect {first_entry.effective_from.isoformat()}. "
+                        "GATED_OFF, not CRITICAL: the declaration did not exist yet, which is a "
+                        "different state from 'expected and absent'."
+                    ),
+                ))
+            else:
+                gated = day_cadence != "daily"
+                slots.append(ExpectedSlot(
+                    day=d,
+                    role="exercise",
+                    gated_off=gated,
+                    note=(
+                        f"cadence={day_cadence} — LaunchWeeklyExerciseRun is skipped on trading days"
+                        if gated else
+                        f"cadence={day_cadence} — LaunchWeeklyExerciseRun fires after this trading day's postclose"
+                    ),
+                ))
         if _is_last_session_of_week(d, is_trading_day, next_trading_day):
             run_day = d + timedelta(days=1)
             if today - timedelta(days=window_days) <= run_day <= today:
@@ -401,10 +492,23 @@ def main(argv: list[str] | None = None) -> int:
     else:
         cadence = load_cadence_from_manifest()
 
+    # The dated history is always read from the repo manifest, --live or not:
+    # SSM holds a single current scalar and structurally cannot answer "what
+    # was declared on 2026-07-15" (alpha-engine-config-I7175). `cadence`
+    # above stays the display/JSON value of TODAY's declaration (live SSM
+    # when --live, else the manifest's current entry); `cadence_history`
+    # drives per-day classification for every day in the window, including
+    # today, so a manifest edit not yet deployed can never desync what the
+    # deadman expects from what --live merely displays.
+    cadence_history = load_cadence_history()
+
     today = _today()
     through = today if args.through == "today" else last_due_day(today)
     executions = fetch_execution_records(sf, args.window_days, today=today)
-    slots = compute_expected_slots(through, cadence, args.window_days, is_trading_day, next_trading_day)
+    slots = compute_expected_slots(
+        through, cadence, args.window_days, is_trading_day, next_trading_day,
+        cadence_history=cadence_history,
+    )
     results = evaluate(slots, executions)
     critical = [r for r in results if r.classification == "CRITICAL"]
 

--- a/tests/test_weekly_cadence_drift.py
+++ b/tests/test_weekly_cadence_drift.py
@@ -55,14 +55,40 @@ def module():
 
 # ── §1: manifest shape ──────────────────────────────────────────────────────
 
-def test_manifest_declares_an_allowed_value(manifest):
-    assert manifest["exercise_cadence"] in ALLOWED_VALUES
+def test_manifest_declares_a_dated_cadence_history(manifest):
+    """alpha-engine-config-I7175: exercise_cadence is a dated history, not a
+    bare scalar, so a backward-looking reader can tell 'not declared yet'
+    from 'declared and silent'."""
+    history = manifest["exercise_cadence"]
+    assert isinstance(history, list) and history
+    for entry in history:
+        assert entry["value"] in ALLOWED_VALUES
+        # raises if malformed
+        __import__("datetime").date.fromisoformat(entry["effective_from"])
 
 
-def test_manifest_declares_daily_unchanged_by_this_change(manifest):
-    """config#6689 changes the MECHANISM, never the cadence itself — the
-    value stays 'daily' (alpha-engine-config#5489, Brian ruling 2026-07-29)."""
-    assert manifest["exercise_cadence"] == "daily"
+def test_manifest_history_is_sorted_ascending_by_effective_from(manifest):
+    dates = [e["effective_from"] for e in manifest["exercise_cadence"]]
+    assert dates == sorted(dates)
+
+
+def test_manifest_current_entry_is_daily_unchanged_by_this_change(manifest):
+    """config#6689 changed the MECHANISM, never the cadence itself — the
+    value in force today stays 'daily' (alpha-engine-config#5489, Brian
+    ruling 2026-07-29). I7175 only adds the dated history around it."""
+    assert manifest["exercise_cadence"][-1]["value"] == "daily"
+
+
+def test_daily_entry_effective_from_precedes_the_ruling_date(manifest):
+    """Measured live 2026-08-13 (alpha-engine-config-I7175): postclose FAILED
+    before reaching LaunchWeeklyExerciseRun on 2026-07-27/07-28 — two real
+    silent exercise slots — while the ruling recorded in #5489 is dated
+    2026-07-29. effective_from must be <= 2026-07-27 or those two real
+    silences reclassify as GATED_OFF, which is the opposite of what this
+    issue exists to fix."""
+    daily_entries = [e for e in manifest["exercise_cadence"] if e["value"] == "daily"]
+    assert daily_entries
+    assert daily_entries[0]["effective_from"] <= "2026-07-27"
 
 
 def test_allowed_values_field_matches_the_real_allowed_set(manifest):
@@ -92,6 +118,26 @@ def test_declared_cadence_rejects_an_invalid_value(module, tmp_path):
     bad.write_text(json.dumps({"exercise_cadence": "hourly"}), encoding="utf-8")
     with pytest.raises(ValueError):
         module.declared_cadence(module.load_manifest(bad))
+
+
+def test_declared_cadence_resolves_the_entry_in_force_on_a_given_today(module):
+    from datetime import date
+    history = {
+        "exercise_cadence": [
+            {"value": "weekly-only", "effective_from": "2026-01-01"},
+            {"value": "daily", "effective_from": "2026-07-27"},
+        ]
+    }
+    assert module.declared_cadence(history, today=date(2026, 7, 20)) == "weekly-only"
+    assert module.declared_cadence(history, today=date(2026, 7, 27)) == "daily"
+    assert module.declared_cadence(history, today=date(2026, 8, 13)) == "daily"
+
+
+def test_declared_cadence_raises_when_today_precedes_the_first_entry(module):
+    from datetime import date
+    history = {"exercise_cadence": [{"value": "daily", "effective_from": "2026-07-27"}]}
+    with pytest.raises(ValueError):
+        module.declared_cadence(history, today=date(2026, 1, 1))
 
 
 def test_check_reports_missing_in_aws_when_param_absent(module, monkeypatch):

--- a/tests/test_weekly_sf_silence_deadman.py
+++ b/tests/test_weekly_sf_silence_deadman.py
@@ -101,6 +101,47 @@ class TestComputeExpectedSlots:
             weekly = [s for s in slots if s.role == "weekly"]
             assert weekly and all(not s.gated_off for s in weekly), cadence
 
+    def test_a_slot_predating_the_first_declared_entry_is_gated_off(self, mod):
+        """alpha-engine-config-I7175: a slot on a date before any
+        exercise_cadence declaration existed is GATED_OFF ('the declaration
+        did not exist yet'), never CRITICAL ('expected and absent') — the
+        two are different states even though both are exit-0/non-paging."""
+        history = [mod.CadenceEntry(value="daily", effective_from=date(2026, 7, 27))]
+        today = date(2026, 7, 20)  # entirely before the only entry
+        slots = mod.compute_expected_slots(today, "daily", 3, is_trading_day, next_trading_day, cadence_history=history)
+        exercise = [s for s in slots if s.role == "exercise"]
+        assert exercise
+        assert all(s.gated_off for s in exercise)
+        results = mod.evaluate(slots, executions=[])
+        assert all(r.classification != "CRITICAL" for r in results if r.slot.role == "exercise")
+        assert all(r.classification == "GATED_OFF" for r in results if r.slot.role == "exercise")
+
+    def test_a_slot_on_or_after_the_first_entry_is_judged_normally(self, mod):
+        history = [
+            mod.CadenceEntry(value="weekly-only", effective_from=date(2026, 1, 1)),
+            mod.CadenceEntry(value="daily", effective_from=date(2026, 7, 27)),
+        ]
+        today = date(2026, 7, 28)
+        slots = mod.compute_expected_slots(today, "daily", 5, is_trading_day, next_trading_day, cadence_history=history)
+        by_day = {s.day: s for s in slots if s.role == "exercise"}
+        # 07-24 (Fri) predates the 'daily' entry -> gated off under weekly-only
+        assert by_day[date(2026, 7, 24)].gated_off is True
+        # 07-27/07-28 are on/after the daily entry -> ungated, a real slot
+        assert by_day[date(2026, 7, 27)].gated_off is False
+        assert by_day[date(2026, 7, 28)].gated_off is False
+        results = {r.slot.day: r.classification for r in mod.evaluate(slots, executions=[])}
+        assert results[date(2026, 7, 24)] == "GATED_OFF"
+        assert results[date(2026, 7, 27)] == "CRITICAL"
+        assert results[date(2026, 7, 28)] == "CRITICAL"
+
+    def test_omitting_cadence_history_preserves_the_flat_cadence_behavior(self, mod):
+        """The pipeline-watchdog Lambda calls compute_expected_slots
+        positionally without this argument — must be indistinguishable from
+        before I7175 when omitted."""
+        today = date(2026, 8, 9)
+        slots = mod.compute_expected_slots(today, "daily", 5, is_trading_day, next_trading_day)
+        assert all(not s.gated_off for s in slots if s.role == "exercise")
+
     def test_weekly_slot_lands_the_day_after_the_last_session(self, mod):
         """Friday 2026-08-07 is the week's last session; the real weekly run
         (WeeklyRunDayGateChoice self-gated true) lands 2026-08-08 (Saturday) —
@@ -177,6 +218,119 @@ class TestEvaluateSlot:
         execs = [mod.ExecutionRecord(name="w1", role="weekly", status="FAILED",
                                       start=start, stop=start + timedelta(hours=1))]
         assert mod.evaluate_slot(slot, execs).classification == "OK"
+
+
+class TestCadenceHistory:
+    """alpha-engine-config-I7175: the dated exercise_cadence history and its
+    date -> value resolver, independent of AWS or the calendar."""
+
+    def test_cadence_for_date_returns_none_before_the_first_entry(self, mod):
+        history = [mod.CadenceEntry(value="daily", effective_from=date(2026, 7, 27))]
+        assert mod.cadence_for_date(history, date(2026, 7, 26)) is None
+
+    def test_cadence_for_date_returns_the_entry_in_force(self, mod):
+        history = [
+            mod.CadenceEntry(value="weekly-only", effective_from=date(2026, 1, 1)),
+            mod.CadenceEntry(value="daily", effective_from=date(2026, 7, 27)),
+        ]
+        assert mod.cadence_for_date(history, date(2026, 7, 26)) == "weekly-only"
+        assert mod.cadence_for_date(history, date(2026, 7, 27)) == "daily"
+        assert mod.cadence_for_date(history, date(2026, 12, 31)) == "daily"
+
+    def test_parse_cadence_history_sorts_out_of_order_entries(self, mod):
+        raw = [
+            {"value": "daily", "effective_from": "2026-07-27"},
+            {"value": "weekly-only", "effective_from": "2026-01-01"},
+        ]
+        entries = mod._parse_cadence_history(raw, "test")
+        assert [e.effective_from for e in entries] == [date(2026, 1, 1), date(2026, 7, 27)]
+
+    def test_parse_cadence_history_rejects_a_bare_scalar(self, mod):
+        with pytest.raises(ValueError):
+            mod._parse_cadence_history("daily", "test")
+
+    def test_parse_cadence_history_rejects_an_empty_list(self, mod):
+        with pytest.raises(ValueError):
+            mod._parse_cadence_history([], "test")
+
+    def test_load_cadence_history_reads_the_real_manifest(self, mod):
+        history = mod.load_cadence_history()
+        assert history
+        assert history == sorted(history, key=lambda e: e.effective_from)
+        assert history[-1].value == "daily"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance regression: the real 45-day window (alpha-engine-config-I7175)
+# ---------------------------------------------------------------------------
+
+class TestMeasuredFortyFiveDayShape:
+    """Replays the exact live run measured 2026-08-13
+    (``--live --no-notify --window-days 45 --through today``): 23 CRITICAL
+    before this fix (19 false positives 2026-06-29..2026-07-24, predating the
+    exercise cadence, plus the 4 real silences), 4 after. Uses the REAL
+    checked-in manifest history, not a synthetic one, so a future edit to
+    ``weekly_cadence.json`` that reintroduces the retroactivity bug fails
+    this test."""
+
+    TODAY = date(2026, 8, 13)
+    REAL_CRITICAL_DAYS = {date(2026, 7, 27), date(2026, 7, 28), date(2026, 8, 5), date(2026, 8, 6)}
+
+    def _executions(self, mod):
+        # Every trading day from the first real exercise run (2026-07-29)
+        # onward EXCEPT the two real silences (08-05/08-06) got a matching
+        # exercise-role execution, per the live output measured 2026-08-13.
+        execs = []
+        d = date(2026, 7, 29)
+        while d <= self.TODAY:
+            if is_trading_day(d) and d not in self.REAL_CRITICAL_DAYS:
+                execs.append(_record(mod, f"e{d.isoformat()}", "exercise", "SUCCEEDED", d))
+            d += timedelta(days=1)
+        # Every weekly-role run that actually landed in this window, per the
+        # live output measured 2026-08-13 — the weekly leg is not itself
+        # silent here and is out of scope for this regression (it is a
+        # separate, unaffected code path: never gated by cadence at all).
+        for w in (
+            date(2026, 7, 3), date(2026, 7, 11), date(2026, 7, 18),
+            date(2026, 7, 25), date(2026, 8, 1), date(2026, 8, 8),
+        ):
+            execs.append(_record(mod, f"w{w.isoformat()}", "weekly", "SUCCEEDED", w, hours=3))
+        return execs
+
+    def test_exactly_four_critical_and_they_are_the_named_four(self, mod):
+        history = mod.load_cadence_history()
+        slots = mod.compute_expected_slots(
+            self.TODAY, "daily", 45, is_trading_day, next_trading_day, cadence_history=history,
+        )
+        results = mod.evaluate(slots, self._executions(mod))
+        critical = [r for r in results if r.classification == "CRITICAL"]
+        assert {r.slot.day for r in critical} == self.REAL_CRITICAL_DAYS
+        assert len(critical) == 4
+
+    def test_pre_cadence_days_are_gated_off_not_critical(self, mod):
+        history = mod.load_cadence_history()
+        slots = mod.compute_expected_slots(
+            self.TODAY, "daily", 45, is_trading_day, next_trading_day, cadence_history=history,
+        )
+        results = mod.evaluate(slots, self._executions(mod))
+        pre_cadence = [
+            r for r in results
+            if r.slot.role == "exercise" and r.slot.day < date(2026, 7, 27)
+        ]
+        assert pre_cadence  # the window does reach back that far
+        assert all(r.classification == "GATED_OFF" for r in pre_cadence)
+
+    def test_2026_07_04_derives_no_weekly_slot(self, mod):
+        """NOT a missed Saturday: NYSE observed July 4th on Friday 07-03, so
+        WeeklyRunDayGate selects 07-03 and the deadman correctly derives no
+        weekly slot for 07-04 at all. Confirmed unchanged by this fix."""
+        history = mod.load_cadence_history()
+        slots = mod.compute_expected_slots(
+            self.TODAY, "daily", 45, is_trading_day, next_trading_day, cadence_history=history,
+        )
+        weekly_days = {s.day for s in slots if s.role == "weekly"}
+        assert date(2026, 7, 4) not in weekly_days
+        assert date(2026, 7, 3) in weekly_days
 
 
 class TestNormalizeRole:


### PR DESCRIPTION
## Summary

`infrastructure/weekly_cadence.json`'s `exercise_cadence` becomes a dated history — `[{value, effective_from, _why}, ...]` — instead of a bare scalar. `scripts/weekly_sf_silence_deadman.py` resolves the cadence in force on EACH day it judges (`cadence_for_date`) instead of applying today's declaration uniformly across the whole lookback window. A trading day before any cadence declaration existed now classifies `GATED_OFF` ("the declaration did not exist yet"), never `CRITICAL` ("expected and absent") — the distinction `sf-pipeline-policy.md` §2.6 rule 1 requires.

**Measured, live, 2026-08-13** (`--live --no-notify --window-days 45 --through today`):

| | Before | After |
|---|---|---|
| CRITICAL count | 23 | **4** |
| Which | 19 false positives (2026-06-29..2026-07-24, predating the exercise cadence) + the 4 real | exactly 2026-07-27, 07-28, 08-05, 08-06 |

2026-07-04 still derives no weekly slot at all (confirmed unchanged, covered by `test_2026_07_04_derives_no_weekly_slot`).

## Deviation from the issue's proposed seed data

`alpha-engine-config-I7175`'s example seeds `{"value": "daily", "effective_from": "2026-07-29"}`, matching Brian's ruling date (`alpha-engine-config#5489`). The live run above shows this is wrong for this repo's data: postclose FAILED before reaching `LaunchWeeklyExerciseRun` on **2026-07-27 and 07-28** — a real, expected-and-silent exercise slot two trading days before the ruling was recorded. Seeding `2026-07-29` would push those two days behind the `weekly-only` entry and reclassify them `GATED_OFF`, silently dropping 2 of the required 4 CRITICALs — the exact failure mode (a real silence disappearing) this issue exists to prevent, just triggered from the other side of the boundary.

`effective_from` is set to **2026-07-27**: the date the "daily" behavior was actually in force (attempted, failing before the launch state), which is what per-day classification needs. The entry's `_why` field still names the 2026-07-29 ruling that authorized keeping it.

## Design choice: manifest history is the sole source for slot classification, `--live` stays cosmetic

SSM (`/alpha-engine/weekly-sf/exercise-cadence`) holds exactly one scalar and structurally cannot answer "what was declared on 2026-07-15." So `cadence_history` is always loaded from the repo manifest, `--live` or not; the `--live`-sourced value is used only for the CLI header / JSON `"cadence"` field (today's declaration, read live instead of from the manifest's current entry) — never for historical classification. `weekly_cadence_drift.py`'s two-directional check is unaffected in shape: it still compares one manifest value against one live SSM value, now resolving that manifest value as "the entry in force as of today" (`declared_cadence(manifest, today=...)`, defaulting to real wall-clock today) rather than reading a bare field.

## Compatibility with the concurrent watchdog PR (PR1342)

`infrastructure/lambdas/pipeline-watchdog/index.py` is untouched — it imports `compute_expected_slots` and calls it positionally with 5 args (no `cadence_history`). `compute_expected_slots` gained `cadence_history: list[CadenceEntry] | None = None` as a 6th, keyword-only-by-convention parameter; omitting it (as the watchdog does) reproduces the exact prior flat-`cadence` behavior — verified in this PR by loading the module standalone and calling it the same way the Lambda does (`test_omitting_cadence_history_preserves_the_flat_cadence_behavior` plus a manual positional-call check during development). The watchdog's own small, near-"now" evaluation window never reaches back before the cadence's first entry in practice, so this is a compatibility guarantee, not a live behavior change for it.

## Tests

- `tests/test_weekly_sf_silence_deadman.py`: `cadence_for_date` / `_parse_cadence_history` / `load_cadence_history` unit tests; `TestComputeExpectedSlots` GATED_OFF-before-first-entry cases; `TestMeasuredFortyFiveDayShape` replays the real 45-day window against the checked-in manifest history end to end (4 CRITICAL, the named 4, pre-cadence days GATED_OFF, 07-04 still slot-less) — a future manifest edit reintroducing the retroactivity bug fails this test.
- `tests/test_weekly_cadence_drift.py`: manifest dated-history shape, ascending order, current-entry-is-daily, `daily` `effective_from` <= 2026-07-27; `declared_cadence(manifest, today=...)` resolution incl. pre-first-entry `ValueError`.

Full suite run locally: 177 failed / 65 collection errors, matching the documented laptop-env baseline (`yfinance`, `pyarrow` missing) plus the 3 registry-drift failures tracked as `alpha-engine-config-I7173`. None of the failures are in the files this PR touches.

Rehearsal-path: tests/test_weekly_sf_silence_deadman.py::TestMeasuredFortyFiveDayShape

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)

Closes #7175
