### PR TITLE
fix(unit-drift): discover codified roots per box instead of listing them (config-I6960)

### DIFF
--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -78,18 +78,39 @@ Three rules follow:
     inline), so unreadable means both a convention violation and a hole in
     the coverage claim — it exits 1 until the mode is fixed.
 
-"Codified" means a file of the same name under a `--codified-root`
-(repeatable; default: this script's directory). The unit passes one root per
-repo checkout on the box that is today-authoritative for its units per
-`infrastructure-ownership-policy` §5 — measured 2026-08-09, byte-identical
-for every covered unit: `alpha-engine-dashboard` (21 units), `metron-ops`
-(10), `telos-ops` (1), plus this repo's 6. The roots do NOT decide
-ownership — `infrastructure-ownership-policy` does; they verify hashes
-wherever a unit is already codified, and the baseline remains the register
-of units codified NOWHERE (22 as of 2026-08-09). The original 2026-08-08
-baseline mislabeled the 21 dashboard-owned units "codified in no known
-root" because this script only read its own directory — a coverage gap in
-the checker, not in the codification.
+"Codified" means a file of the same name under a codified root. The roots do
+NOT decide ownership — `infrastructure-ownership-policy` does; they verify
+hashes wherever a unit is already codified, and the baseline remains the
+register of units codified NOWHERE. The original 2026-08-08 baseline
+mislabeled the 21 dashboard-owned units "codified in no known root" because
+this script only read its own directory — a coverage gap in the checker, not
+in the codification.
+
+**Roots are DISCOVERED, not listed (2026-08-13, alpha-engine-config-I6960).**
+They used to be a hand-written `--codified-root` list baked into
+`systemd-unit-drift-check.service` — one unit file, installed on every box,
+carrying only the DASHBOARD box's checkouts. On the trading box that list
+named eleven directories, none of which was
+`/home/ec2-user/alpha-engine/infrastructure/systemd`, where six of the seven
+units the check reported as "installed but codified nowhere" were codified
+all along:
+
+    alpha-engine-daemon.service, alpha-engine-morning.service,
+    ibgateway.service, upstream-gate-dryrun-validation.{service,timer},
+    xvfb.service
+
+So the check reported a CODIFICATION gap while looking at the wrong
+directories — it could not measure, and said it had found a defect. That is
+the failure shape the `unreadable` bucket exists to prevent, arriving through
+the roots instead of through the units.
+
+A hardcoded list cannot be right on two boxes at once, and a third box would
+have inherited the same wrong list. Roots are therefore found by walking
+`CODIFIED_SEARCH_BASES` for `<repo>/infrastructure/systemd/` and
+`<repo>/infrastructure/` — the only two shapes any repo in the fleet uses —
+so a checkout that lands on a box is covered the day it lands, with nothing
+to remember to edit. `--codified-root` still works and is ADDITIVE, for a
+tree outside the search bases.
 """
 
 from __future__ import annotations
@@ -106,6 +127,27 @@ INSTALLED_DIR = Path("/etc/systemd/system")
 UNCODIFIED_BASELINE_FILE = SCRIPT_DIR / "uncodified-units-baseline.txt"
 
 UNIT_SUFFIXES = (".service", ".timer")
+
+#: Where repo checkouts live on a fleet box. Both the dashboard box and the
+#: trading box put every checkout directly under the login user's home, so one
+#: base covers both; a box that ever differs adds its own rather than editing
+#: a per-box list into a shared unit file (which is exactly what I6960 was).
+CODIFIED_SEARCH_BASES: tuple[Path, ...] = (Path("/home/ec2-user"),)
+
+#: How deep below a search base a codified root can sit. Four is measured, not
+#: guessed: the deepest real one on either box is
+#: `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/systemd`, which is
+#: depth 4. Bounding the walk keeps a stray checkout of a monorepo from turning
+#: a read-only check into a full-disk crawl on every run.
+CODIFIED_SEARCH_MAX_DEPTH = 4
+
+#: Directory names never worth descending into. `.git` alone holds thousands of
+#: entries with no unit file among them, and a virtualenv's `site-packages`
+#: ships vendored `.service` samples that are not this fleet's units.
+_SEARCH_PRUNE = frozenset({
+    ".git", "node_modules", "__pycache__", "site-packages", "lib", "lib64",
+    "share", "data", ".venv", ".venv-intraday", ".mypy_cache", ".pytest_cache",
+})
 
 #: CloudWatch namespace for the coverage counts. Shares box-health's actual
 #: namespace deliberately — coverage of the unit set is a property of the box,
@@ -155,6 +197,60 @@ def installed_units(installed_dir: Path | None = None) -> list[str]:
     )
 
 
+def discover_codified_roots(
+    bases: tuple[Path, ...] | list[Path] | None = None,
+    max_depth: int = CODIFIED_SEARCH_MAX_DEPTH,
+) -> list[Path]:
+    """Every `infrastructure/` and `infrastructure/systemd/` dir under `bases`.
+
+    The two shapes are the only ones any repo in the fleet uses, so matching on
+    the directory NAME rather than on a list of repo names is what makes a new
+    checkout covered on arrival instead of on the next time somebody remembers
+    to edit a unit file.
+
+    Read-only and best-effort per directory: a base that does not exist (this
+    script also runs in CI and on a laptop, where `/home/ec2-user` does not) is
+    simply not a source of roots, and one unreadable subtree does not cost the
+    coverage of its siblings. A root that cannot be READ still surfaces — as
+    `unreadable` on the unit, which is a finding.
+    """
+    found: list[Path] = []
+    for base in (bases if bases is not None else CODIFIED_SEARCH_BASES):
+        base = Path(base)
+        if not base.is_dir():
+            continue
+        stack: list[tuple[Path, int]] = [(base, 0)]
+        while stack:
+            current, depth = stack.pop()
+            if depth >= max_depth:
+                continue
+            try:
+                entries = [p for p in current.iterdir() if p.is_dir() and not p.is_symlink()]
+            except (PermissionError, OSError):
+                # Recorded, not swallowed: a subtree we cannot list is a subtree
+                # whose units we cannot claim to have compared.
+                print(
+                    f"[check-systemd-unit-drift] could not list {current} while "
+                    f"discovering codified roots — any unit codified only there "
+                    f"will read as uncodified",
+                    file=sys.stderr,
+                )
+                continue
+            for entry in entries:
+                if entry.name in _SEARCH_PRUNE or entry.name.startswith("."):
+                    continue
+                if entry.name == "infrastructure":
+                    found.append(entry)
+                    systemd_dir = entry / "systemd"
+                    if systemd_dir.is_dir():
+                        found.append(systemd_dir)
+                    # No descent below an `infrastructure/` dir: both shapes are
+                    # already captured, and its subdirs are IaC, not units.
+                    continue
+                stack.append((entry, depth + 1))
+    return sorted(set(found))
+
+
 def codified_units(roots: list[Path] | None = None) -> list[str]:
     """Every unit file present in the codified roots, sorted."""
     rs = roots or [SCRIPT_DIR]
@@ -178,12 +274,37 @@ def load_baseline(path: Path | None = None) -> set[str]:
     return out
 
 
-def codified_path(name: str, roots: list[Path] | None = None) -> Path | None:
-    for root in (roots or [SCRIPT_DIR]):
-        candidate = root / name
-        if candidate.is_file():
-            return candidate
-    return None
+def codified_paths(name: str, roots: list[Path] | None = None) -> list[Path]:
+    """Every codified copy of `name`, in root order."""
+    return [root / name for root in (roots or [SCRIPT_DIR]) if (root / name).is_file()]
+
+
+def codified_path(
+    name: str,
+    roots: list[Path] | None = None,
+    installed_hash: str | None = None,
+) -> Path | None:
+    """The codified copy to compare against, or None.
+
+    With one copy this is that copy. With SEVERAL — possible since roots became
+    discovered rather than listed — first-root-wins would make the verdict
+    depend on directory iteration order, so a copy whose hash MATCHES what is
+    installed is preferred. That is not a way of hiding disagreement: the
+    disagreement is reported separately by `check_unit`, and preferring the
+    match only ensures a box running a correctly-codified unit is never called
+    drifted because an unrelated checkout happened to sort first.
+    """
+    candidates = codified_paths(name, roots)
+    if not candidates:
+        return None
+    if installed_hash is not None:
+        for candidate in candidates:
+            try:
+                if _sha256(candidate) == installed_hash:
+                    return candidate
+            except PermissionError:
+                continue
+    return candidates[0]
 
 
 def check_unit(
@@ -218,7 +339,7 @@ def check_unit(
             f"EnvironmentFile or SSM, never inline); drift is unverifiable "
             f"until the mode is fixed"
         )
-    repo_path = codified_path(name, roots)
+    repo_path = codified_path(name, roots, installed_hash)
 
     if installed_hash is None:
         if repo_path is None:
@@ -290,11 +411,34 @@ def main() -> int:
         "--codified-root",
         action="append",
         default=None,
-        help="directory holding codified unit files (repeatable; default: this script's directory)",
+        help="ADDITIONAL directory holding codified unit files (repeatable); "
+             "added to the discovered roots, never replacing them",
+    )
+    parser.add_argument(
+        "--no-discover-roots",
+        action="store_true",
+        help="do not walk the search bases for codified roots (compare only "
+             "against --codified-root and this script's directory)",
     )
     args = parser.parse_args()
 
-    roots = [Path(r).resolve() for r in args.codified_root] if args.codified_root else [SCRIPT_DIR]
+    # Discovered ∪ explicit ∪ this script's own directory. `--codified-root` is
+    # ADDITIVE rather than a replacement: it exists for a tree outside the
+    # search bases, and a flag that silently narrowed coverage back to a
+    # hand-written list would reintroduce I6960 the first time somebody passed
+    # one. `--no-discover-roots` is the explicit way to ask for the old
+    # behaviour, and it says so in the output rather than looking identical.
+    roots: list[Path] = [] if args.no_discover_roots else discover_codified_roots()
+    roots += [Path(r).resolve() for r in (args.codified_root or [])]
+    if SCRIPT_DIR not in roots:
+        roots.append(SCRIPT_DIR)
+    # Deduplicate, keeping order — a root named explicitly AND discovered would
+    # otherwise make every unit in it look ambiguous with itself.
+    roots = list(dict.fromkeys(roots))
+    print(
+        f"[roots] comparing against {len(roots)} codified root(s)"
+        + (" (discovery DISABLED)" if args.no_discover_roots else "")
+    )
     baseline = load_baseline()
 
     if args.unit:
@@ -316,6 +460,32 @@ def main() -> int:
         label = "uncodified-NEW" if (status == "uncodified" and name not in baseline) else status
         print(f"[{label}] {detail}")
 
+    # Widening the roots makes it possible for one unit name to be codified in
+    # two checkouts that DISAGREE. `codified_path` then prefers the copy
+    # matching what is installed, which is the right verdict for this box and
+    # the wrong thing to leave unsaid — one of the two repos is stale, and
+    # nothing else on the box is looking.
+    #
+    # Reported as a NOTICE, exit 0, deliberately: this bucket has never been
+    # measured on either box, and shipping an unmeasured new failure condition
+    # onto a check whose whole problem was false pages would repeat the defect
+    # in the other direction. It becomes a finding once the count is known to
+    # be zero — tracked on alpha-engine-config-I6960.
+    ambiguous: list[str] = []
+    for name in names:
+        hashes = set()
+        for path in codified_paths(name, roots):
+            try:
+                digest = _sha256(path)
+            except PermissionError:
+                continue
+            if digest is not None:
+                hashes.add(digest)
+        if len(hashes) > 1:
+            where = ", ".join(str(p) for p in codified_paths(name, roots))
+            ambiguous.append(name)
+            print(f"[notice] {name}: codified in {len(hashes)} disagreeing copies — {where}")
+
     uncodified = buckets["uncodified"]
     uncodified_new = [n for n in uncodified if n not in baseline]
     unreadable = buckets["unreadable"]
@@ -331,7 +501,9 @@ def main() -> int:
         f"uncodified={len(uncodified)} "
         f"uncodified_new={len(uncodified_new)} "
         f"unreadable={len(unreadable)} "
-        f"codified_not_installed={len(buckets['not-installed'])}"
+        f"codified_not_installed={len(buckets['not-installed'])} "
+        f"ambiguous={len(ambiguous)} "
+        f"roots={len(roots)}"
     )
 
     if args.metric:
@@ -342,6 +514,8 @@ def main() -> int:
             "Uncodified": len(uncodified),
             "UncodifiedNew": len(uncodified_new),
             "Unreadable": len(unreadable),
+            "Ambiguous": len(ambiguous),
+            "CodifiedRoots": len(roots),
         })
 
     exit_code = 0

--- a/infrastructure/systemd/systemd-unit-drift-check.service
+++ b/infrastructure/systemd/systemd-unit-drift-check.service
@@ -10,7 +10,14 @@ WorkingDirectory=/home/ec2-user/alpha-engine-data
 # emit dies with "You must specify a region" (seen live 2026-08-09).
 Environment=AWS_REGION=us-east-1
 Environment=AWS_DEFAULT_REGION=us-east-1
-ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python /home/ec2-user/alpha-engine-data/infrastructure/systemd/check-systemd-unit-drift.py --report --metric --codified-root /home/ec2-user/alpha-engine-data/infrastructure/systemd --codified-root /home/ec2-user/alpha-engine-dashboard/infrastructure/systemd --codified-root /home/ec2-user/metron-ops/infrastructure/systemd --codified-root /home/ec2-user/telos-ops/infrastructure/systemd --codified-root /home/ec2-user/alpha-engine-dashboard/infrastructure --codified-root /home/ec2-user/alpha-engine-dashboard/live/infrastructure --codified-root /home/ec2-user/nousergon-auth/infrastructure --codified-root /home/ec2-user/nousergon-console/infrastructure --codified-root /home/ec2-user/the-cyphering-ops/infrastructure --codified-root /home/ec2-user/vires/infrastructure --codified-root /home/ec2-user/nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/systemd
+# NO --codified-root list here. This ONE unit file installs on every box, and
+# the list it used to carry was the dashboard box's checkouts — so on the
+# trading box the check compared against eleven directories that box does not
+# have, missed /home/ec2-user/alpha-engine/infrastructure/systemd entirely, and
+# reported six correctly-codified trading units as "codified nowhere" every day
+# (alpha-engine-config-I6960). The roots are discovered per-box now; a list in a
+# shared file cannot be right on two boxes at once.
+ExecStart=/home/ec2-user/alpha-engine-data/.venv/bin/python /home/ec2-user/alpha-engine-data/infrastructure/systemd/check-systemd-unit-drift.py --report --metric
 # Reads /etc/systemd/system/*, no writes — runs as ec2-user like the units
 # it checks, not root.
 StandardOutput=journal

--- a/infrastructure/systemd/uncodified-units-baseline.txt
+++ b/infrastructure/systemd/uncodified-units-baseline.txt
@@ -26,6 +26,16 @@
 # are added the first time the checker runs there and names them, which is
 # exactly what the `uncodified-NEW` bucket is for. Until then this file is
 # incomplete by construction, and says so rather than implying coverage.
+#
+# 2026-08-13 (alpha-engine-config-I6960): the trading box duly named seven,
+# and SIX of them were codified all along in
+# /home/ec2-user/alpha-engine/infrastructure/systemd (crucible-executor) —
+# a directory the checker was never pointed at, because the root list lived
+# in a shared unit file carrying only the dashboard box's checkouts. They are
+# NOT added here: adding a codified unit to the work queue would have made a
+# checker defect permanent as a data entry, which is the failure mode this
+# file's "should only ever get shorter" rule is meant to prevent. Roots are
+# discovered now. Only `boot-pull.service` was genuinely codified nowhere.
 
 # ── alpha-engine / dashboard box services ──────────────────────────────────
 
@@ -39,6 +49,14 @@
 # ── metron ─────────────────────────────────────────────────────────────────
 
 # ── other products co-tenant on this box ───────────────────────────────────
+
+# ── trading box (i-018eb3307a21329bf) ──────────────────────────────────────
+# Found live 2026-08-13 (I6960). Its ExecStart is
+# /home/ec2-user/alpha-engine/infrastructure/boot-pull.sh — the SCRIPT is
+# codified in crucible-executor, the UNIT that runs it was not, so the boot
+# path could be repointed on the box with nothing noticing. Codified by
+# crucible-executor-PR#<n>; this line goes once that lands and the box pulls.
+boot-pull.service # crucible-executor
 
 # ── shared infrastructure ──────────────────────────────────────────────────
 amazon-cloudwatch-agent.service # vendor-installed; likely never codified here

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -401,28 +401,29 @@ class TestCoverageAccounting:
                 f"— a baselined unit is exempt from drift verification"
             )
 
-    def test_the_unit_passes_every_measured_codified_root_and_metric(self):
-        """The roots live in the unit's ExecStart, not in the script — dropping
-        one there silently re-baselines that repo's units on the next deploy."""
+    def test_the_unit_carries_no_hardcoded_root_list(self):
+        """The root list is NOT in the unit any more (alpha-engine-config-I6960).
+
+        It used to be, and this file used to assert its eleven entries were
+        present — which is why the defect survived: the list was the dashboard
+        box's checkouts, the SAME unit file installs on the trading box, and a
+        test pinning the list could only ever confirm the wrong list was
+        faithfully deployed to both. A per-box fact cannot live in a file that
+        is byte-identical on every box; roots are discovered now.
+        """
         unit = (_REPO_ROOT / "infrastructure" / "systemd" / "systemd-unit-drift-check.service").read_text()
         exec_lines = [l for l in unit.splitlines() if l.startswith("ExecStart=")]
         assert len(exec_lines) == 1
         line = exec_lines[0]
         assert "--metric" in line, "coverage counts must be emitted every run"
-        for root in (
-            "/home/ec2-user/alpha-engine-data/infrastructure/systemd",
-            "/home/ec2-user/alpha-engine-dashboard/infrastructure/systemd",
-            "/home/ec2-user/metron-ops/infrastructure/systemd",
-            "/home/ec2-user/telos-ops/infrastructure/systemd",
-            "/home/ec2-user/alpha-engine-dashboard/infrastructure",
-            "/home/ec2-user/alpha-engine-dashboard/live/infrastructure",
-            "/home/ec2-user/nousergon-auth/infrastructure",
-            "/home/ec2-user/nousergon-console/infrastructure",
-            "/home/ec2-user/the-cyphering-ops/infrastructure",
-            "/home/ec2-user/vires/infrastructure",
-            "/home/ec2-user/nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/systemd",
-        ):
-            assert f"--codified-root {root}" in line, f"missing codified root {root}"
+        assert "--report" in line, "a finding must reach an alert, not only the journal"
+        assert "--codified-root" not in line, (
+            "a hardcoded root list in a unit file shared by every box is I6960; "
+            "roots are discovered per-box"
+        )
+        assert "--no-discover-roots" not in line, (
+            "disabling discovery in the shipped unit restores the defect"
+        )
         # boto3 does not infer region from IMDS: without these, --metric dies
         # with "You must specify a region" (seen live 2026-08-09).
         assert "Environment=AWS_REGION=us-east-1" in unit
@@ -479,3 +480,130 @@ class TestUnreadableUnit:
         assert "unreadable=1" in cap.out
         assert "[clean] daily-news.timer" in cap.out
         assert "nousergon-console.service" in cap.err
+
+
+class TestCodifiedRootDiscovery:
+    """Roots are found by walking the box, not read from a list
+    (alpha-engine-config-I6960).
+
+    The regression this closes: on the trading box, six units WERE codified in
+    `/home/ec2-user/alpha-engine/infrastructure/systemd` and the check reported
+    them as "installed but codified nowhere" every day, because that directory
+    was not among the eleven the shared unit file named. A check that cannot
+    see where a unit is codified reports a codification gap — the harness fault
+    arriving dressed as the finding.
+    """
+
+    def _box(self, tmp_path):
+        """A miniature of the real layout: repos under a home, units in both
+        `infrastructure/systemd/` and bare `infrastructure/`."""
+        home = tmp_path / "home" / "ec2-user"
+        (home / "alpha-engine" / "infrastructure" / "systemd").mkdir(parents=True)
+        (home / "alpha-engine-dashboard" / "infrastructure").mkdir(parents=True)
+        (home / "nous-ergon-ops" / "alpha-engine-dashboard" / "live" / "infrastructure" / "systemd").mkdir(parents=True)
+        return home
+
+    def test_discovers_both_layouts_at_every_real_depth(self, cd, tmp_path):
+        module, _, _ = cd
+        home = self._box(tmp_path)
+
+        roots = module.discover_codified_roots(bases=[home])
+
+        assert home / "alpha-engine" / "infrastructure" / "systemd" in roots, (
+            "the trading box's codified root — the one I6960 was missing"
+        )
+        assert home / "alpha-engine" / "infrastructure" in roots
+        assert home / "alpha-engine-dashboard" / "infrastructure" in roots
+        assert home / "nous-ergon-ops" / "alpha-engine-dashboard" / "live" / "infrastructure" / "systemd" in roots, (
+            "depth-4 root: the deepest real one on either box"
+        )
+
+    def test_a_new_checkout_is_covered_with_no_edit_anywhere(self, cd, tmp_path):
+        """The whole point. A repo that lands on a box is compared the same day,
+        rather than on the next time somebody remembers to extend a list."""
+        module, _, _ = cd
+        home = self._box(tmp_path)
+        newcomer = home / "some-new-repo" / "infrastructure" / "systemd"
+        newcomer.mkdir(parents=True)
+
+        assert newcomer in module.discover_codified_roots(bases=[home])
+
+    def test_a_unit_codified_in_a_discovered_root_reads_clean_not_uncodified(
+        self, cd, tmp_path, monkeypatch, capsys
+    ):
+        """End to end, in the exact shape of the live finding."""
+        module, script_dir, installed_dir = cd
+        home = self._box(tmp_path)
+        codified = home / "alpha-engine" / "infrastructure" / "systemd" / "ibgateway.service"
+        codified.write_text("UNIT IBGW\n")
+        (installed_dir / "ibgateway.service").write_text("UNIT IBGW\n")
+
+        monkeypatch.setattr(module, "CODIFIED_SEARCH_BASES", (home,))
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        code = module.main()
+        cap = capsys.readouterr()
+
+        assert code == 0
+        assert "[clean] ibgateway.service" in cap.out
+        assert "uncodified=0" in cap.out
+
+    def test_prune_keeps_the_walk_off_git_and_venvs(self, cd, tmp_path):
+        module, _, _ = cd
+        home = tmp_path / "home"
+        buried = home / "repo" / ".git" / "modules" / "infrastructure"
+        buried.mkdir(parents=True)
+        venv = home / "repo" / ".venv" / "infrastructure"
+        venv.mkdir(parents=True)
+
+        roots = module.discover_codified_roots(bases=[home])
+
+        assert buried not in roots
+        assert venv not in roots
+
+    def test_explicit_roots_are_additive_never_a_replacement(self, cd, tmp_path, monkeypatch, capsys):
+        """`--codified-root` narrowing coverage back to a hand-written list is
+        how I6960 would return through the flag instead of the unit file."""
+        module, script_dir, installed_dir = cd
+        home = self._box(tmp_path)
+        (home / "alpha-engine" / "infrastructure" / "systemd" / "xvfb.service").write_text("X\n")
+        (installed_dir / "xvfb.service").write_text("X\n")
+        extra = tmp_path / "outside-the-bases"
+        extra.mkdir()
+        (extra / "daily-news.timer").write_text("D\n")
+        (installed_dir / "daily-news.timer").write_text("D\n")
+
+        monkeypatch.setattr(module, "CODIFIED_SEARCH_BASES", (home,))
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py", "--codified-root", str(extra)])
+        code = module.main()
+        cap = capsys.readouterr()
+
+        assert code == 0
+        assert "[clean] xvfb.service" in cap.out, "discovered root dropped when a flag was passed"
+        assert "[clean] daily-news.timer" in cap.out, "explicit root ignored"
+
+    def test_disagreeing_copies_are_reported_and_the_installed_one_wins(
+        self, cd, tmp_path, monkeypatch, capsys
+    ):
+        """Two checkouts can codify the same unit name differently once roots
+        are wide. Preferring the copy that matches the box keeps the verdict
+        from depending on iteration order; the disagreement is still said out
+        loud, because one of the two repos is stale."""
+        module, script_dir, installed_dir = cd
+        home = tmp_path / "home"
+        a = home / "repo-a" / "infrastructure" / "systemd"
+        b = home / "repo-b" / "infrastructure" / "systemd"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        (a / "ibgateway.service").write_text("STALE\n")
+        (b / "ibgateway.service").write_text("LIVE\n")
+        (installed_dir / "ibgateway.service").write_text("LIVE\n")
+
+        monkeypatch.setattr(module, "CODIFIED_SEARCH_BASES", (home,))
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        code = module.main()
+        cap = capsys.readouterr()
+
+        assert code == 0, "a box running the correctly-codified unit is not drifted"
+        assert "[clean] ibgateway.service" in cap.out
+        assert "disagreeing copies" in cap.out
+        assert "ambiguous=1" in cap.out


### PR DESCRIPTION
## Problem

`check-systemd-unit-drift` has reported this on the trading box every day:

> 7 unit(s) installed but codified nowhere and absent from the baseline: `alpha-engine-daemon.service`, `alpha-engine-morning.service`, `boot-pull.service`, `ibgateway.service`, `upstream-gate-dryrun-validation.service`, `upstream-gate-dryrun-validation.timer`, `xvfb.service`

**Six of the seven were codified all along**, in `/home/ec2-user/alpha-engine/infrastructure/systemd` (crucible-executor). Measured live on `i-018eb3307a21329bf`.

## Root cause

The root list lived in `systemd-unit-drift-check.service` — **one unit file, installed on every box**, naming eleven directories that were all the *dashboard* box's checkouts. A per-box fact cannot live in a byte-identical file. On the trading box the check compared against directories that box does not have, never looked at the one that mattered, and reported a codification gap it had simply not searched for.

It could not measure, and said it had found a defect — the failure shape the `unreadable` bucket exists to prevent, arriving through the roots instead of the units.

## Change

- **Roots are discovered, not listed.** `discover_codified_roots()` walks `/home/ec2-user` for the only two shapes any repo uses (`infrastructure/`, `infrastructure/systemd/`), bounded at depth 4 (the deepest real root on either box: `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/systemd`), pruning `.git`, venvs and `site-packages`. A checkout that lands on a box is covered the day it lands.
- `--codified-root` is **additive**, never a replacement — otherwise I6960 returns through the flag instead of the unit file. `--no-discover-roots` is the explicit opt-out and labels itself in the output.
- **Ambiguity is surfaced.** Wider roots make it possible for one unit name to be codified in two disagreeing checkouts. `codified_path` prefers the copy matching what is installed, so the verdict cannot depend on iteration order, and the disagreement prints as a `[notice]` with an `ambiguous=` count.
  Notice rather than finding, deliberately: that bucket has never been measured on either box, and shipping an unmeasured new failure condition onto a check whose entire problem was false pages would repeat the defect in the other direction. It becomes a finding once the count is known to be zero.
- `SUMMARY` gains `ambiguous=` and `roots=`; both emit to CloudWatch, zeros included (`principles.md` §2.7).

## Tests

29 pass. The test pinning the eleven roots is **replaced** by one asserting the unit carries no hardcoded list — the old test could only ever confirm the wrong list was faithfully deployed to both boxes, which is why the defect survived it. New `TestCodifiedRootDiscovery` covers both layouts at every real depth, a new checkout needing no edit, the live finding end-to-end, pruning, additive flags, and disagreeing copies.

## Not baselined

`boot-pull.service` was the only unit genuinely codified nowhere — baselined here, and codified in **crucible-executor-PR#469**. The other six are deliberately **not** added: putting a codified unit in the work queue would make a checker defect permanent as a data entry, against this file's own "should only ever get shorter" rule.

## Cross-repo

- `crucible-executor-PR#469` — codifies `boot-pull.service`, retires the stale `metron-intraday` units.
- **Merge order: either; they are independent.** The trading box needs both pulled before the check reads clean.

## Deploy

Not automatic on merge. The trading box picks this up at its next `boot-pull` run; `alpha-engine-config-I6937` tracks that gap.

This PR does not auto-close I6960: the issue also covers the live-box reconcile, verified separately.

Refs: alpha-engine-config-I6960

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
