### PR TITLE
test(sf): generalize the I7165 payload-choice guard across all four SF definitions

### DIFF
--- a/tests/test_sf_payload_choice_guard.py
+++ b/tests/test_sf_payload_choice_guard.py
@@ -1,0 +1,343 @@
+"""alpha-engine-config-I7165 — every raw `lambda:invoke` Payload dereference
+in a Choice state, across ALL FOUR Step Functions definitions, must be
+reachable only once its key's presence is established: either by a
+`ResultSelector` on the producing Task that pins the key, or by a presence
+guard inside the Choice itself.
+
+## The incident this guards
+
+The 2026-08-13 preopen execution (`59c0ce46-d366-45dd-8cd3-acbdc06638c1`)
+failed 48s in with a raw `States.Runtime` at `MarketHoursGateChoice`:
+`Invalid path '$.market_hours_gate.Payload.verdict'`. No SNS alert fired —
+ASL Choice states cannot carry `Catch`, so an absent-key dereference in a
+Choice is UNCATCHABLE even though the producing Task's own `Catch` on
+`States.ALL` is right there. Root trigger (`crucible-predictor-PR474`, out
+of scope here): `alpha-engine-predictor-inference:live` was frozen on a
+version with no `check_market_hours` action and fell through to its default
+predict branch, returning `{"statusCode": 200, ...}` with no `verdict` key
+at all.
+
+`MarketHoursGate` was the ONLY `lambda:invoke` gate in either weekday
+definition with `ResultSelector: null` — every sibling gate (`TradingDayGate`,
+`DeployDriftCheck`, `CheckPredictorCoverage`, ...) already threads its Choice
+comparisons through a presence-guard idiom this repo has used since
+config#2275/I2767 (`WeeklyRunDayGateChoice` in the Saturday definition, and
+`CheckAnyLaunches`/`CheckRetryBudget` in the groom definition). This test
+makes that invariant durable and generic across ALL FOUR definitions instead
+of re-litigating it one Lambda gate, one Choice state, or one SF at a time —
+`nousergon-data-PR1339` fixed the instance (`MarketHoursGateChoice` in the
+weekday + EOD definitions only); this closes the class, per
+`alpha-engine-config-I7165`'s own third `Closes-when` line.
+
+## Two ASL facts this test's model relies on, measured on throwaway state
+machines in this account 2026-08-13 (not assumed):
+
+1. A `ResultSelector` missing-key failure is NOT catchable — so "give the
+   Task a ResultSelector" only relocates the uncatchable failure, it does
+   not by itself make a Choice comparison downstream safe. The
+   ResultSelector must actually PROJECT the key the Choice reads.
+2. `Not`/`IsPresent` evaluates cleanly at any depth, on both a
+   present-parent-absent-leaf and a wholly-absent-root payload. A standalone
+   leading `Choices` rule of the shape
+   `{"Not": {"Variable": V, "IsPresent": true}, "Next": ...}` is therefore
+   sufficient, on its own, to make every LATER rule in the same `Choices`
+   list safe to dereference V unconditionally — ASL evaluates `Choices` in
+   order and this rule fires first whenever V is absent, so no later rule is
+   ever reached in that case. This is the shape `MarketHoursGateChoice` was
+   given in both weekday definitions to fix I7165, and it is a second,
+   equally valid guard idiom alongside the existing And-wrap one (used by
+   `WeeklyRunDayGateChoice` and `CheckRetryBudget`) — this test recognizes
+   both.
+
+## Why all four definitions, not just the two I7165 touched
+
+`nousergon-data-PR1339`/config-I7165 fixed only `MarketHoursGateChoice` in
+`step_function_daily.json` and `step_function_eod.json` — the two states in
+the incident's own path. `step_function.json` (Saturday weekly) already
+carries its own richer structural test, `test_sf_choice_guards.py`, scoped
+to that one file; `step_function_groom.json` had no structural coverage of
+this invariant at all. A scan run against the live tree 2026-08-13 (see
+`alpha-engine-config-I7165`'s own body) found 132 raw nested-Choice
+dereferences across the four definitions and confirmed only the 8
+`MarketHoursGateChoice` comparisons (4 rules × 2 weekday definitions) were
+unguarded; this test proves that count structurally rather than by manual
+scan, and holds it at zero going forward across every definition, not just
+the two that happened to be broken this time.
+
+## Why this file, not an extension of `test_sf_choice_guards.py`
+
+That test already implements a superset of this invariant for
+`step_function.json` alone (it also recognizes upstream-Pass-floored paths,
+which this file does not need to model — Pass-produced fields are never
+wrapped in `.Payload.`). Rather than duplicating that richness, this file
+targets the narrower, mechanically-checkable `.Payload.` pattern specific to
+raw `lambda:invoke` results, and applies it uniformly to all four
+definitions (including `step_function.json` and `step_function_groom.json`,
+both already clean — see the regression tests below, which prove this file's
+model agrees with `test_sf_choice_guards.py`'s richer one on the file they
+overlap on).
+
+## Why zero false positives against the ~100 SSM poll sites is automatic
+
+`aws-sdk:ssm:getCommandInvocation` (and the `ssm-liveness-poller` Lambda)
+never produce a `Payload` wrapper — their raw shape is `{Status, CommandId,
+...}` at the ResultPath root, so a downstream Choice reading
+`$.foo_poll.Status` never matches the `$.<x>.Payload.<...>` pattern this test
+targets at all. Likewise the ~24 Pass-produced sites (`$.*_retry.attempts`,
+`$.branch_outcomes.*`) are never nested under `.Payload.`. The regex excludes
+both classes structurally, not via an exclusion list.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_SF_FILES = {
+    "saturday": _INFRA / "step_function.json",
+    "weekday": _INFRA / "step_function_daily.json",
+    "eod": _INFRA / "step_function_eod.json",
+    "groom": _INFRA / "step_function_groom.json",
+}
+
+_PAYLOAD_VAR_RE = re.compile(r"^\$\.([A-Za-z0-9_]+)\.Payload\.([A-Za-z0-9_]+)")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _walk_states(states: dict):
+    for name, st in states.items():
+        if not isinstance(st, dict):
+            continue
+        yield name, st
+        for sub in ("ItemProcessor", "Iterator"):
+            inner = st.get(sub)
+            if isinstance(inner, dict) and isinstance(inner.get("States"), dict):
+                yield from _walk_states(inner["States"])
+        for b in st.get("Branches", []) or []:
+            if isinstance(b, dict) and isinstance(b.get("States"), dict):
+                yield from _walk_states(b["States"])
+
+
+def _result_selector_keeps(st: dict) -> set[str] | None:
+    """Keys a lambda:invoke Task's ResultSelector pins, or None if the Task
+    has no ResultSelector at all (raw Payload rides through unprojected)."""
+    rs = st.get("ResultSelector")
+    if rs is None:
+        return None
+    return {k[:-2] if k.endswith(".$") else k for k in rs}
+
+
+def _producers_by_result_path(states: dict) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for _, st in _walk_states(states):
+        if "lambda:invoke" not in str(st.get("Resource", "")).lower():
+            continue
+        rp = st.get("ResultPath")
+        if rp:
+            out.setdefault(rp, []).append(st)
+    return out
+
+
+def _leaf_vars(rule: dict) -> list[tuple[str, bool]]:
+    """Every (Variable, is_and_guarded) leaf comparison in this rule
+    subtree. is_and_guarded=True when an EARLIER operand of an enclosing And
+    is exactly {Variable: same path, IsPresent: true} (the config#2275
+    idiom)."""
+    out: list[tuple[str, bool]] = []
+
+    def _walk(r: dict, guarded: frozenset[str]):
+        if "And" in r:
+            acquired = set(guarded)
+            for operand in r["And"]:
+                _walk(operand, frozenset(acquired))
+                if operand.get("IsPresent") is True and "Variable" in operand:
+                    acquired.add(operand["Variable"])
+            return
+        if "Or" in r:
+            for operand in r["Or"]:
+                _walk(operand, guarded)
+            return
+        if "Not" in r:
+            _walk(r["Not"], guarded)
+            return
+        var = r.get("Variable")
+        if var is None:
+            return
+        ops = {k for k in r if k not in ("Variable", "Next", "Comment")}
+        if "IsPresent" in ops:
+            return  # a presence check is always safe to evaluate
+        out.append((var, var in guarded))
+
+    _walk(rule, frozenset())
+    return out
+
+
+def _is_leading_not_ispresent_guard(rule: dict, var: str) -> bool:
+    """True if `rule` is exactly {"Not": {"Variable": var, "IsPresent":
+    true}, "Next": ...} — the standalone leading-guard idiom."""
+    inner = rule.get("Not")
+    if not isinstance(inner, dict):
+        return False
+    return inner.get("Variable") == var and inner.get("IsPresent") is True
+
+
+def _iter_choice_scopes(states: dict):
+    """Yield (label, states_dict) for the top scope and every nested
+    Parallel/Map scope."""
+    yield "", states
+    for name, st in states.items():
+        if not isinstance(st, dict):
+            continue
+        for sub in ("ItemProcessor", "Iterator"):
+            inner = st.get(sub)
+            if isinstance(inner, dict) and isinstance(inner.get("States"), dict):
+                yield from _iter_choice_scopes(inner["States"])
+        for i, b in enumerate(st.get("Branches", []) or []):
+            if isinstance(b, dict) and isinstance(b.get("States"), dict):
+                yield from ((f"{name}[{i}]/{lbl}" if lbl else f"{name}[{i}]", s)
+                            for lbl, s in _iter_choice_scopes(b["States"]))
+
+
+def _find_state(definition: dict, name: str) -> dict:
+    for _, states in _iter_choice_scopes(definition["States"]):
+        if name in states:
+            return states[name]
+    raise AssertionError(f"state {name!r} not found in any scope")
+
+
+def _violations_for_definition(sf: str, definition: dict) -> list[str]:
+    states = definition["States"]
+    producers = _producers_by_result_path(states)
+    violations: list[str] = []
+
+    for scope_name, scope_states in _iter_choice_scopes(states):
+        for name, st in scope_states.items():
+            if st.get("Type") != "Choice":
+                continue
+            rules = st.get("Choices", [])
+            # A leading standalone Not/IsPresent guard rule establishes
+            # presence for every LATER rule in this same Choices list — ASL
+            # evaluates Choices in order and that rule fires first whenever
+            # the variable is absent.
+            established: set[str] = set()
+            for rule in rules:
+                for var, and_guarded in _leaf_vars(rule):
+                    m = _PAYLOAD_VAR_RE.match(var)
+                    if not m:
+                        continue
+                    root, key = m.group(1), m.group(2)
+                    if and_guarded or var in established:
+                        continue
+                    rs_keeps = None
+                    for prod in producers.get(f"$.{root}", []):
+                        keeps = _result_selector_keeps(prod)
+                        if keeps is not None and key in keeps:
+                            rs_keeps = keeps
+                            break
+                    if rs_keeps is not None:
+                        continue  # floored by the producing Task's ResultSelector
+                    violations.append(
+                        f"[{sf}] {scope_name}/{name}: rule dereferences "
+                        f"{var!r} with no ResultSelector projecting {key!r} "
+                        f"off $.{root} and no presence guard in this Choice "
+                        f"(rule={json.dumps(rule)[:200]})"
+                    )
+                # Now that this rule has been evaluated, record any
+                # standalone guard it represents for subsequent rules.
+                inner = rule.get("Not")
+                if isinstance(inner, dict) and inner.get("IsPresent") is True and "Variable" in inner:
+                    established.add(inner["Variable"])
+    return violations
+
+
+@pytest.mark.parametrize("sf", sorted(_SF_FILES))
+def test_choice_payload_dereferences_are_guarded_or_projected(sf: str) -> None:
+    definition = _load(_SF_FILES[sf])
+    violations = _violations_for_definition(sf, definition)
+    assert not violations, (
+        "alpha-engine-config-I7165 — Choice states dereferencing a raw "
+        "lambda:invoke Payload field with no ResultSelector projection and "
+        "no presence guard (this is exactly how MarketHoursGateChoice threw "
+        "an uncatchable States.Runtime on 2026-08-13):\n" + "\n".join(violations)
+    )
+
+
+def test_market_hours_gate_choice_guard_is_present() -> None:
+    """Direct check that the I7165 instance fix (nousergon-data-PR1339)
+    landed: MarketHoursGateChoice's FIRST rule in both weekday definitions
+    is the leading Not/IsPresent guard routing to StampMarketHoursVerdictMissing,
+    and that Pass state floors $.market_hours_gate_error before continuing."""
+    for sf in ("weekday", "eod"):
+        path = _SF_FILES[sf]
+        definition = _load(path)
+        states = definition["States"]
+        choice = states["MarketHoursGateChoice"]
+        first_rule = choice["Choices"][0]
+        assert _is_leading_not_ispresent_guard(
+            first_rule, "$.market_hours_gate.Payload.verdict"
+        ), f"[{sf}] MarketHoursGateChoice's first rule is not the I7165 presence guard"
+        assert first_rule["Next"] == "StampMarketHoursVerdictMissing"
+
+        stamp = states["StampMarketHoursVerdictMissing"]
+        assert stamp["Type"] == "Pass"
+        assert stamp["ResultPath"] == "$.market_hours_gate_error"
+        assert "Error" in stamp.get("Result", {})
+        assert "Cause" in stamp.get("Result", {})
+
+
+def test_regression_pre_fix_tree_is_caught() -> None:
+    """Demonstrates the test actually catches the I7165 defect: with the
+    leading guard rule stripped back out, MarketHoursGateChoice reverts to
+    exactly the shape that produced the live 2026-08-13 States.Runtime, and
+    the structural test above must flag it — in BOTH weekday definitions."""
+    for sf in ("weekday", "eod"):
+        path = _SF_FILES[sf]
+        definition = _load(path)
+        states = definition["States"]
+        choice = states["MarketHoursGateChoice"]
+        first_rule = choice["Choices"][0]
+        assert _is_leading_not_ispresent_guard(
+            first_rule, "$.market_hours_gate.Payload.verdict"
+        )
+        broken = copy.deepcopy(definition)
+        broken["States"]["MarketHoursGateChoice"]["Choices"] = broken["States"][
+            "MarketHoursGateChoice"
+        ]["Choices"][1:]
+        violations = _violations_for_definition(sf, broken)
+        assert any("MarketHoursGateChoice" in v for v in violations), (
+            f"[{sf}] pre-fix tree (guard rule removed) was NOT flagged — "
+            "the test would not have caught the live I7165 incident"
+        )
+
+
+def test_regression_saturday_and_groom_guards_are_also_caught_if_stripped() -> None:
+    """Proves this file's model is not narrowly tuned to MarketHoursGateChoice:
+    stripping the pre-existing presence guards on WeeklyRunDayGateChoice
+    (saturday) and CheckRetryBudget (groom) — guarded by the OTHER idiom,
+    the And-wrap, not the standalone leading Not — is also flagged."""
+    saturday = _load(_SF_FILES["saturday"])
+    broken = copy.deepcopy(saturday)
+    choices = broken["States"]["WeeklyRunDayGateChoice"]["Choices"]
+    # Drop the IsPresent leaf from the first rule's And, leaving a bare
+    # BooleanEquals dereference — the pre-config#2275 shape.
+    and_ops = choices[0]["And"]
+    choices[0]["And"] = [op for op in and_ops if "IsPresent" not in op]
+    violations = _violations_for_definition("saturday", broken)
+    assert any("WeeklyRunDayGateChoice" in v for v in violations)
+
+    groom = _load(_SF_FILES["groom"])
+    broken = copy.deepcopy(groom)
+    check_retry_budget = _find_state(broken, "CheckRetryBudget")
+    and_ops = check_retry_budget["Choices"][0]["And"]
+    check_retry_budget["Choices"][0]["And"] = [
+        op for op in and_ops if "IsPresent" not in op
+    ]
+    violations = _violations_for_definition("groom", broken)
+    assert any("CheckRetryBudget" in v for v in violations)


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7165`. The instance fix — MarketHoursGateChoice's unguarded `$.market_hours_gate.Payload.verdict` dereference, which threw an uncatchable `States.Runtime` on 2026-08-13 (execution `59c0ce46-d366-45dd-8cd3-acbdc06638c1`, no orders placed, no SNS alert) — is **already merged and deployed**: `nousergon-data-PR1339`. Verified against the LIVE `ne-preopen-trading-pipeline` and `ne-postclose-trading-pipeline` definitions via `aws stepfunctions describe-state-machine`: both carry PR1339's `Not`/`IsPresent` guard on `MarketHoursGateChoice` and the `StampMarketHoursVerdictMissing` floor state byte-for-byte identical to the repo copy.

What was **not** delivered is I7165's own third closes-when line: *"The structural test is in CI and fails on a reintroduced unguarded Payload dereference."* A generalized version of that test existed only on `nousergon-data-PR1340` — a duplicate opened 9 minutes after PR1339, closed without merging, whose closing comment explicitly flagged this gap: *"[PR1340] carries a generalizable structural guard that PR1339 does not have... if [PR1339] merges without it, the guard gets its own follow-up so the class fix is not lost."* This PR is that follow-up.

## The fix

`tests/test_sf_payload_choice_guard.py` (new): every `Choice` comparison of the form `$.<x>.Payload.<key>`, across **all four** Step Functions definitions — `step_function.json` (Saturday), `step_function_daily.json` (preopen), `step_function_eod.json` (postclose), `step_function_groom.json` — must be either `ResultSelector`-projected by its producing `lambda:invoke` Task, or presence-guarded in the Choice itself. Recognizes both guard idioms already in use: the standalone leading `Not`/`IsPresent` rule (`MarketHoursGateChoice`'s shape) and the `And`-wrap `IsPresent`-then-compare idiom (`WeeklyRunDayGateChoice`, `CheckRetryBudget`).

- Zero violations on the live tree (all four files).
- Proven to catch the pre-fix `MarketHoursGateChoice` shape in both weekday definitions (guard rule stripped back out).
- Proven the model isn't narrowly tuned to this one gate: also catches a stripped guard on `WeeklyRunDayGateChoice` (saturday) and `CheckRetryBudget` (groom, nested inside `MapLaunches`' `ItemProcessor`) — a different idiom (`And`-wrap) than the one this incident exposed.

`step_function.json` already has a richer, file-scoped version of this invariant (`test_sf_choice_guards.py`, which also models upstream-Pass flooring for non-`.Payload.` paths); this file doesn't duplicate that richness, just extends the narrower `.Payload.`-specific pattern uniformly to all four definitions. `step_function_groom.json` had **no** structural coverage of this invariant before this PR.

## Audit of the wider class (per I7165's own scan)

I7165's body reports a manual 2026-08-13 scan of 132 nested-Choice dereferences across all four definitions, finding only the 8 `MarketHoursGateChoice` comparisons (4 rules × 2 weekday definitions) unguarded — ~100 SSM-poll sites are safe (total `ResultSelector`, never wrapped in `.Payload.`), ~24 Pass-produced sites are safe (floored upstream, never `.Payload.`). This PR's structural scanner reproduces that finding mechanically (zero violations on the live tree) rather than by manual count, and holds it at zero in CI going forward across every definition — not just the two PR1339 touched.

## Test plan

Full suite (`~/Development/nousergon-data/.venv/bin/python3 -m pytest tests/ -q`): **5262 passed, 9 skipped**. 3 pre-existing failures in `tests/test_pipeline_status_registry_source_check.py` (all three SF definitions) are unrelated and predate this change — a `nousergon-lib` registry-drift gap already tracked as `alpha-engine-config-I7173` (needs its own `nousergon-lib` companion PR + lockstep pin bump per that test's own docstring); reproduces identically on `origin/main` before this PR's one-file diff.

`aws stepfunctions validate-state-machine-definition` — OK on all four `infrastructure/*.json` files.

## Deploy mechanism

None needed — this PR adds a test file only, no infrastructure change. `deploy-infrastructure.yml` is unaffected.

## Rehearsal path

`tests/test_sf_payload_choice_guard.py` itself: `test_regression_pre_fix_tree_is_caught` and `test_regression_saturday_and_groom_guards_are_also_caught_if_stripped` both strip a real guard back out in-memory and assert the scanner flags it — proof this test would have caught the 2026-08-13 incident, and that its model generalizes past `MarketHoursGateChoice`.

## Not in scope

- `alpha-engine-config-I7166` (predictor-inference falling through to `predict` on an unrecognised action) — separate defect, separate repo.
- `alpha-engine-config-I7173` (nousergon-lib registry drift causing the 3 pre-existing test failures) — needs its own companion PR.
- A live operator-replay execution against the deployed pipelines with a deliberately malformed gate payload (I7165's closes-when line 2) — not run in this session; the structural test plus the live-definition diff-check above cover the rehearsal path without needing one.

alpha-engine-config-I7165

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)