### PR TITLE
[P0/mid] fix(spot): port the predictor's bootstrap fixes and guard the divergence in CI (config-I6922)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -39,11 +39,35 @@ SPOT_ATTEMPT="${SPOT_ATTEMPT:-1}"
 SF_EXECUTION_TIMEOUT="${SF_EXECUTION_TIMEOUT:-}"
 SPOT_RETRY_BACKOFF_SECONDS="${SPOT_RETRY_BACKOFF_SECONDS:-20}"
 
-# Per-stage overrides
-_SPOT_NAME="${_SPOT_NAME:-data-weekly}"
-_SSM_SLUG="${_SSM_SLUG:-spot-data}"
-_PROCESS_NAME="${_PROCESS_NAME:-data-weekly}"
-MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"
+# Per-stage identity — DECLARED HERE, NEVER DEFAULTED HERE.
+#
+# This block used to carry `data-weekly` / `spot-data` defaults, and all three
+# per-stage scripts then set their own with the SAME `${VAR:-...}` form AFTER
+# sourcing this file — where the parameter is already non-empty, so the
+# expansion is a NO-OP and the stage identity silently stayed whatever this
+# file said. spot_morning_enrich.sh asks for `morning-enrich`, spot_data_
+# phase1.sh for `data-phase1`, spot_rag_ingestion.sh for `rag-ingestion`, and
+# every one of them ran as `data-weekly`: the instance Name tag, the
+# `Process` dimension on the CloudWatch `Heartbeat` metric, the `Process`
+# dimension on `SpotInterruptionRetry`, and the `run_ssm` command description
+# all carried the wrong stage. Three stages, one identity — so a heartbeat
+# gap could not be attributed and a retry could not be counted per stage.
+#
+# crucible-predictor hit and fixed the identical defect in its twin of this
+# file (measured on `watch-rerun-2026-08-10-9`, 2026-08-11: the heartbeat
+# emitted under slug `spot-spot-training` although the launcher asked for
+# `spot-full-training`). This is the mirror, per alpha-engine-config-I6922 —
+# the same no-op class, unported until now.
+#
+# Declared EMPTY so `set -u` is satisfied at source time and the per-stage
+# `${VAR:-<stage default>}` lines are load-bearing again (an explicit env
+# override still wins, because it is set before this file runs). `spot_launch`
+# asserts all four are non-empty before any instance exists, so a stage that
+# forgets one fails loud and free rather than inheriting a sibling's identity.
+_SPOT_NAME="${_SPOT_NAME:-}"
+_SSM_SLUG="${_SSM_SLUG:-}"
+_PROCESS_NAME="${_PROCESS_NAME:-}"
+MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-}"
 
 # Derived at launch time
 _INSTANCE_ID=""
@@ -60,6 +84,20 @@ fi
 # ── Spot launch (capacity-resilient) ─────────────────────────────────────────
 
 spot_launch() {
+  # Stage identity must be real BEFORE anything is billable. See the
+  # "Per-stage identity" block above for why these can no longer be defaulted
+  # in this file: a default here silently swallows the per-stage assignment.
+  local _unset=""
+  [ -n "$_SPOT_NAME" ] || _unset="${_unset} _SPOT_NAME"
+  [ -n "$_SSM_SLUG" ] || _unset="${_unset} _SSM_SLUG"
+  [ -n "$_PROCESS_NAME" ] || _unset="${_unset} _PROCESS_NAME"
+  [ -n "$MAX_RUNTIME_SECONDS" ] || _unset="${_unset} MAX_RUNTIME_SECONDS"
+  if [ -n "$_unset" ]; then
+    echo "ERROR: per-stage variable(s) unset before spot_launch:${_unset}" >&2
+    echo "       Set them AFTER sourcing _spot_common.sh — see its header." >&2
+    exit 2
+  fi
+
   echo "==> Requesting spot instance (lib CLI rotation: types=[$INSTANCE_TYPES], subnets=[$SUBNETS])..."
 
   _INSTANCE_ID=$("$LIB_PYTHON" -m krepis.ec2_spot launch \
@@ -321,13 +359,49 @@ BOOTSTRAP
 # ── Dependency installation ──────────────────────────────────────────────────
 
 install_deps() {
+  # config-I6949 / config-I6963, ported from crucible-predictor per
+  # alpha-engine-config-I6922: this step used to pipe pip through `tail -1`,
+  # so a run that exited 0 having silently skipped an extra was
+  # indistinguishable from a clean one — and pip reports a dropped extra as a
+  # WARNING on a SUCCESSFUL exit, which is precisely the line `tail -1` could
+  # not keep. The fleet copy is krepis.spot_bootstrap.render_install_deps;
+  # keep the three in step (tests/test_spot_bootstrap_invariants.py).
   echo "==> Installing python deps..."
   run_ssm "deps" "$(cat <<'DEPS'
 set -eo pipefail
 export HOME=/home/ec2-user XDG_CACHE_HOME=/tmp AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1
 cd /home/ec2-user/data
 command -v python3.12 >/dev/null && PY=python3.12 || PY=python3
-$PY -m pip install --quiet --no-warn-script-location -r requirements.txt 2>&1 | tail -1
+_pip_log=/tmp/pip-install-deps.log
+if ! $PY -m pip install --no-warn-script-location -r requirements.txt > "$_pip_log" 2>&1; then
+  echo "ERROR: pip install -r requirements.txt failed" >&2
+  tail -80 "$_pip_log" >&2
+  exit 1
+fi
+grep -E "^Successfully installed" "$_pip_log" || true
+# A dropped extra is a BROKEN ENVIRONMENT, not a note. pip reports it as a
+# WARNING on a SUCCESSFUL exit, so nothing downstream fails until an import
+# does — in another process, minutes later, with the install log long gone.
+# That is exactly how config#6963 reached production in the predictor: the
+# training smoke died on `ModuleNotFoundError: No module named 'flow_doctor'`
+# out of krepis.logging.setup_logging, from an install pip had called a
+# success. This repo's requirements.txt requests four extras on one line
+# (nousergon-lib[arcticdb,flow-doctor,rag,contracts]), and AL2023 ships pip
+# 23.2.1, which predates PEP 685 extras normalisation (measured boundary:
+# 23.2.1 drops, 23.3.2 honours) — so this bootstrap sits on the broken side
+# by default and cannot rely on the resolver to be strict. Fail here, where
+# the log is still in hand and the cause is one line.
+if grep -E "^WARNING: .*does not provide the extra" "$_pip_log" >&2; then
+  echo "ERROR: pip dropped a requested extra (above) — the environment is incomplete." >&2
+  echo "       Extras must be HYPHENATED; pip <23.3 does not normalise '_' to '-'." >&2
+  exit 1
+fi
+# Non-fatal on purpose: an inconsistent environment is reported, not raised.
+# (a) The failure mode left unraised is a pre-existing AMI-baked conflict
+# unrelated to this checkout, which would otherwise fail every stage on every
+# run. (b) It is recorded on stdout of this SSM step, captured with the rest
+# of the deps output.
+$PY -m pip check || echo "WARNING: pip check reports an inconsistent environment (above)"
 DEPS
 )" 600
   echo "  Deps installed."

--- a/tests/test_spot_bootstrap_invariants.py
+++ b/tests/test_spot_bootstrap_invariants.py
@@ -1,0 +1,226 @@
+"""The spot bootstrap in this repo must not drift from the fleet's canonical one.
+
+## Why this test exists
+
+``infrastructure/_spot_common.sh`` exists twice in the fleet — here and in
+``crucible-predictor`` — as two independently-written implementations of the
+same spot bootstrap. Neither was forked from the other; both were built by
+applying the same written standard (ARCHITECTURE.md §111), eight days apart,
+and the standard named a *shape* and no implementation. They then diverged.
+
+What that cost, measured on the weekly Step Function over 2026-08-10/11
+(alpha-engine-config-I6922):
+
+| Defect | Fixed in one copy | Reached the other |
+|---|---|---|
+| watchdog unit ``Type=oneshot`` blocks its own bootstrap | `nousergon-data#1294` | `crucible-predictor#461`, 16h later |
+| bootstrap ASSERTS ``python3.12`` instead of installing it | `nousergon-data#1296` | `crucible-predictor#462`, 23h later |
+
+Both defects live in the two blocks this test guards. Each port cost a failed
+weekly run to discover, because the second copy's defect stays invisible until
+the first copy's is fixed and the pipeline gets far enough to reach it.
+
+## What it asserts, and why it is not a second hardcoded copy
+
+The invariants are **derived from** ``krepis.spot_bootstrap``, the fleet's
+canonical renderer (shipped 0.46.0, alpha-engine-config-I6922 phase 1) — not
+restated here. ``krepis`` is already a pinned dependency of this repo, so the
+check is hermetic and needs no network and no sibling checkout.
+
+Deriving rather than restating is the whole point: a third repo, or a change to
+the canonical renderer, moves this test's expectations automatically. A test
+that hardcoded ``Type=simple`` would be a *third* copy of the invariant and
+would drift exactly like the first two.
+
+## Why the Bash copy still exists at all
+
+``krepis.spot_bootstrap`` cannot simply replace this heredoc yet. The launcher
+resolves its interpreter as::
+
+    LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
+
+— the *shared application host's* venv, whose krepis version is governed by
+``crucible-dashboard/requirements.txt``, a file no merge in this repo can see.
+A cutover therefore carries a runtime dependency this repo cannot pin, and when
+that venv is behind, the bootstrap does not degrade — it dies with
+``ModuleNotFoundError`` on every spot stage of every pipeline. Measured
+2026-08-13 the host is at krepis 0.54.0 and ``krepis.spot_bootstrap`` imports
+cleanly, but nothing *declares* or *enforces* that floor; ``alpha-engine-config
+-I6931`` owns making it a fail-loud, declared version.
+
+So the dependency that cannot safely exist at RUNTIME lives in a TEST instead:
+the Bash copies stay, and CI asserts they agree with the canonical renderer.
+When I6931 lands its version floor, the cutover becomes a deletion and this
+test is what proves the deletion changed nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from krepis.spot_bootstrap import (
+    PYTHON,
+    SYSTEMCTL_ENABLE_TIMEOUT_SEC,
+    SpotBootstrapSpec,
+    render_bootstrap,
+)
+
+_SPOT_COMMON = Path(__file__).resolve().parents[1] / "infrastructure" / "_spot_common.sh"
+
+
+# A spec's values do not matter here: this test compares the parts of the
+# rendered script that are the SAME for every workload — the watchdog unit and
+# the interpreter install. The repo-specific tail (clone target, config
+# destinations) is asserted by the per-repo tests beside this one.
+_CANONICAL = render_bootstrap(
+    SpotBootstrapSpec(repo_url="https://example.invalid/x.git", checkout="/tmp/x")
+)
+
+
+@pytest.fixture(scope="module")
+def bootstrap_block() -> str:
+    """The body of ``bootstrap_spot()`` — launcher glue plus the remote heredoc."""
+    text = _SPOT_COMMON.read_text(encoding="utf-8")
+    m = re.search(r"\nbootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
+    assert m, f"bootstrap_spot() not found in {_SPOT_COMMON.name}"
+    return m.group(1)
+
+
+def _service_directives(script: str) -> set[str]:
+    """``KEY=VALUE`` lines in the systemd unit's ``[Service]`` section."""
+    m = re.search(r"\[Service\]\n(.*?)(?=\n\[|\nUNIT\b)", script, re.S)
+    assert m, "no [Service] section found in the systemd unit"
+    return {
+        line.strip()
+        for line in m.group(1).splitlines()
+        if "=" in line and not line.strip().startswith("#")
+    }
+
+
+# ── The watchdog unit ────────────────────────────────────────────────────────
+
+
+def test_watchdog_unit_carries_every_directive_the_canonical_unit_declares(
+    bootstrap_block: str,
+):
+    """Derived, not restated — krepis owns what the unit must say.
+
+    The 2026-08-10 hang was a missing/incorrect ``Type``. Asserting the whole
+    ``[Service]`` section rather than that one field means the next divergence
+    in this unit — whatever field it lands on — also fails here.
+    """
+    canonical = _service_directives(_CANONICAL)
+    local = _service_directives(bootstrap_block)
+    missing = canonical - local
+    assert not missing, (
+        f"{_SPOT_COMMON.name}'s ec2-spot-watchdog unit is missing "
+        f"{sorted(missing)}, which krepis.spot_bootstrap declares. This is the "
+        "alpha-engine-config-I6922 drift class: the two fleet copies of this "
+        "unit diverged and a weekly run paid for it. Reconcile against "
+        "krepis.spot_bootstrap._watchdog_block()."
+    )
+
+
+def test_watchdog_unit_is_never_oneshot(bootstrap_block: str):
+    """The anchored instance, kept explicit because it cost two weekly runs.
+
+    ``systemctl start`` on a ``Type=oneshot`` unit BLOCKS until ``ExecStart``
+    exits, and ``TimeoutStartSec`` defaults to infinity for oneshot. This
+    unit's ``ExecStart`` is an endless supervision loop, so the unit declared
+    ``Type=oneshot`` + ``RemainAfterExit=yes`` hung every bootstrap until SSM
+    SIGKILLed it at its budget — rc=137 at exactly the timeout, with stderr
+    ending on the ``systemctl enable`` symlink line and nothing after it.
+
+    Scoped to the PARSED ``[Service]`` directives, never a substring search of
+    the script: both copies explain this defect in a comment that contains the
+    literal ``Type=oneshot``, and a naive ``not in`` reports the explanation as
+    the defect. A checker that cannot tell a comment from a directive fails in
+    the alarming direction on the very file that documents the fix.
+    """
+    assert "Type=oneshot" not in _service_directives(bootstrap_block), (
+        "the ec2-spot-watchdog unit declares Type=oneshot; its ExecStart never "
+        "returns, so `systemctl enable --now` blocks forever and the whole "
+        "bootstrap dies under SIGKILL with no output (nousergon-data#1294, "
+        "crucible-predictor#461)"
+    )
+
+
+def test_enabling_the_watchdog_is_bounded_by_the_canonical_timeout(
+    bootstrap_block: str,
+):
+    """A misdeclared unit must fail in seconds WITH a message.
+
+    The bound is what turns "bootstrap is slow" into "systemctl is blocked
+    forever". Its value comes from krepis so the two copies cannot pick
+    different budgets.
+    """
+    assert re.search(
+        rf"timeout\s+{SYSTEMCTL_ENABLE_TIMEOUT_SEC}\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog",
+        bootstrap_block,
+    ), (
+        "`systemctl enable --now ec2-spot-watchdog` must be wrapped in "
+        f"`timeout {SYSTEMCTL_ENABLE_TIMEOUT_SEC}` "
+        "(krepis.spot_bootstrap.SYSTEMCTL_ENABLE_TIMEOUT_SEC), so a future "
+        "unit-shape regression fails fast and loud instead of consuming the "
+        "whole SSM budget in silence"
+    )
+
+
+def test_a_failed_enable_explains_itself_and_aborts(bootstrap_block: str):
+    """Silence is what made the 2026-08-10 hang unreadable for a day."""
+    m = re.search(
+        r"timeout\s+\d+\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog\s*\|\|\s*\{(.*?)\}",
+        bootstrap_block,
+        re.S,
+    )
+    assert m, "the guarded enable must have a `|| { ... }` failure branch"
+    branch = m.group(1)
+    assert "exit 1" in branch, "a watchdog that cannot be enabled must abort the bootstrap"
+    assert ">&2" in branch, "the failure must reach stderr, which is what SSM captures"
+
+
+# ── The interpreter ──────────────────────────────────────────────────────────
+
+
+def test_the_interpreter_is_installed_not_merely_asserted(bootstrap_block: str):
+    """A bootstrap establishes preconditions; it does not require them.
+
+    The per-stage split replaced the monolith's ``dnf install`` with a bare
+    ``command -v`` assertion, encoding an AMI contract nothing provides. The
+    AL2023 spot AMI does not ship python3.12.
+    """
+    assert re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", bootstrap_block), (
+        f"the bootstrap must install {PYTHON} explicitly — the AL2023 spot AMI "
+        f"does not ship it (nousergon-data#1296, crucible-predictor#462)"
+    )
+
+
+def test_the_interpreter_check_is_a_postcondition_not_a_precondition(
+    bootstrap_block: str,
+):
+    """Ordering is the actual invariant — both copies had the check, one had it alone."""
+    install = re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", bootstrap_block)
+    check = re.search(rf"command -v {re.escape(PYTHON)}\b", bootstrap_block)
+    assert install and check, "expected both a dnf install and a command -v guard"
+    assert install.start() < check.start(), (
+        f"`command -v {PYTHON}` appears BEFORE the dnf install that provides it. "
+        "That is a precondition on an image we do not build — which is exactly "
+        "the defect that killed MorningEnrich and PredictorTraining on "
+        "consecutive weekly runs."
+    )
+
+
+def test_a_missing_interpreter_after_install_is_fatal(bootstrap_block: str):
+    """No silent fallback to the AMI's system python3.
+
+    requirements.txt is resolved against 3.12; a fallback resolves different
+    wheels and fails later, elsewhere, with the install log gone.
+    """
+    m = re.search(
+        rf"command -v {re.escape(PYTHON)} >/dev/null \|\| \{{(.*?)\}}", bootstrap_block
+    )
+    assert m, f"the post-install `command -v {PYTHON}` guard is missing its abort branch"
+    assert "exit 1" in m.group(1)

--- a/tests/test_spot_deps_step_keeps_its_evidence.py
+++ b/tests/test_spot_deps_step_keeps_its_evidence.py
@@ -1,0 +1,86 @@
+"""The deps step must not be the only thing that knows what pip did.
+
+Ported from ``crucible-predictor`` per alpha-engine-config-I6922 — this repo's
+``install_deps`` carried the pre-fix form (``pip install --quiet ... | tail -1``)
+for as long as the predictor's did, and the two fixes below (config-I6949,
+config-I6963) were never hand-carried back here.
+
+The failure they pin (2026-08-11, `ne-weekly-freshness-pipeline` execution
+`watch-rerun-2026-08-10-9`, in the predictor's copy of this step)::
+
+    RuntimeError: flow-doctor is not installed but a flow_doctor_yaml was
+    provided ... No module named 'flow_doctor'
+
+The install that was supposed to provide it exited **0**. Its entire surviving
+output, because the step piped pip through ``tail -1``, was::
+
+    WARNING: Running pip as the 'root' user can result in broken permissions
+
+Nothing in that record distinguishes "resolved the extra" from "skipped it"
+from "never saw it", and the import failure lands minutes later in a different
+SSM step with no upstream to read. pip reports a dropped extra as a WARNING on
+a *successful* exit, so the one line ``tail -1`` keeps is the one line
+guaranteed not to carry it.
+
+This repo is squarely exposed: ``requirements.txt`` requests four extras on one
+line (``nousergon-lib[arcticdb,flow-doctor,rag,contracts]``), and AL2023 ships
+pip 23.2.1 — which predates PEP 685 extras normalisation, so it drops an extra
+it does not match rather than failing on it.
+
+The fleet copy of this step is ``krepis.spot_bootstrap.render_install_deps``;
+the three are kept in step until this repo consumes the rendered version
+(see tests/test_spot_bootstrap_invariants.py for why it cannot yet).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_COMMON = Path(__file__).resolve().parents[1] / "infrastructure" / "_spot_common.sh"
+
+
+@pytest.fixture(scope="module")
+def install_deps_body() -> str:
+    text = _COMMON.read_text(encoding="utf-8")
+    # Anchor on the definition, not the header comment that also names it.
+    start = text.index("\ninstall_deps() {")
+    end = text.index("\n}", start)
+    return text[start:end]
+
+
+def test_pip_output_is_not_discarded_by_tail(install_deps_body: str):
+    assert "| tail -1" not in install_deps_body
+
+
+def test_a_failed_install_dumps_the_captured_log(install_deps_body: str):
+    # Preserving the log buys nothing if the failure path does not print it —
+    # the SSM step output is the only surface anyone reads after the fact.
+    assert 'tail -80 "$_pip_log" >&2' in install_deps_body
+    assert "exit 1" in install_deps_body
+
+
+def test_a_dropped_extra_is_surfaced_on_a_successful_exit(install_deps_body: str):
+    # The exact shape of the 2026-08-11 failure: rc=0, extra missing.
+    assert "does not provide the extra" in install_deps_body
+
+
+def test_a_dropped_extra_is_fatal_not_merely_reported(install_deps_body: str):
+    """Reporting it is not enough — the step still passes and the failure moves.
+
+    The whole point of catching it here is that the log is in hand and the
+    cause is one line. A WARNING printed into a step that exits 0 reproduces
+    the original defect with better formatting.
+    """
+    idx = install_deps_body.index("does not provide the extra")
+    assert "exit 1" in install_deps_body[idx:], (
+        "the dropped-extra grep must be followed by `exit 1` — an incomplete "
+        "environment is a broken environment, not a note"
+    )
+
+
+def test_the_environment_is_checked_before_the_import_that_would_fail(
+    install_deps_body: str,
+):
+    assert "pip check" in install_deps_body

--- a/tests/test_spot_stage_identity_is_not_swallowed.py
+++ b/tests/test_spot_stage_identity_is_not_swallowed.py
@@ -1,0 +1,174 @@
+"""A per-stage script's identity must survive sourcing ``_spot_common.sh``.
+
+Ported from ``crucible-predictor`` per alpha-engine-config-I6922 — this repo
+carried the identical defect and it was never hand-carried back.
+
+Each per-stage launcher sources ``_spot_common.sh`` and then declares who it
+is::
+
+    source "$SCRIPT_DIR/_spot_common.sh"
+    _SSM_SLUG="${_SSM_SLUG:-spot-morning-enrich}"
+
+``_spot_common.sh`` used to assign the same parameters itself, with generic
+values (``data-weekly``, ``spot-data``). ``${VAR:-default}`` expands to
+``default`` only when ``VAR`` is unset or empty — so by the time the stage
+script ran, every one of its assignments was a no-op and it silently kept the
+shared value.
+
+Measured on this repo 2026-08-13: ``spot_morning_enrich.sh`` asks for
+``morning-enrich``, ``spot_data_phase1.sh`` for ``data-phase1`` and
+``spot_rag_ingestion.sh`` for ``rag-ingestion`` — and all three ran as
+``data-weekly``. Three stages of the weekly Step Function shared one identity,
+so the instance ``Name`` tag, the ``run_ssm`` command description, the
+``Process`` dimension on the CloudWatch ``Heartbeat`` metric and the ``Process``
+dimension on ``SpotInterruptionRetry`` all named the wrong stage. A heartbeat
+gap could not be attributed to a stage and a spot retry could not be counted
+per stage.
+
+The predictor measured the same class on ``watch-rerun-2026-08-10-9``
+(2026-08-11): the heartbeat emitted under ``spot-spot-training`` although the
+launcher asks for ``spot-full-training``.
+
+This is the rename-blindness class: the identity a tool searches by is not the
+identity the run recorded, and the resulting silence reads as "nothing
+happened" rather than "you looked in the wrong place".
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parents[1] / "infrastructure"
+_COMMON = _INFRA / "_spot_common.sh"
+
+#: Every launcher that sources `_spot_common.sh`, with the identity it declares
+#: for the default invocation (no flags). The expected values here are the
+#: ASSERTION — they are what each stage's own prologue asks for.
+_STAGES = {
+    "spot_morning_enrich.sh": {
+        "_SPOT_NAME": "morning-enrich",
+        "_SSM_SLUG": "spot-morning-enrich",
+        "_PROCESS_NAME": "morning-enrich",
+    },
+    "spot_data_phase1.sh": {
+        "_SPOT_NAME": "data-phase1",
+        "_SSM_SLUG": "spot-data-phase1",
+        "_PROCESS_NAME": "data-phase1",
+    },
+    "spot_rag_ingestion.sh": {
+        "_SPOT_NAME": "rag-ingestion",
+        "_SSM_SLUG": "spot-rag-ingestion",
+        "_PROCESS_NAME": "rag-ingestion",
+    },
+}
+
+_IDENTITY_VARS = ("_SPOT_NAME", "_SSM_SLUG", "_PROCESS_NAME", "MAX_RUNTIME_SECONDS")
+
+#: `_SPOT_NAME="${_SPOT_NAME:-value}"` at the start of a line. This is the
+#: SWALLOWABLE form — the one whose whole failure mode is expanding to nothing
+#: because the parameter is already set — so it is what the no-op assertions
+#: below are written against.
+_ASSIGN_RE = re.compile(
+    r"^(?P<var>_SPOT_NAME|_SSM_SLUG|_PROCESS_NAME|MAX_RUNTIME_SECONDS)="
+    r'"\$\{(?P=var):-(?P<value>[^}]*)\}"',
+    re.MULTILINE,
+)
+
+#: Lines the identity harness must replay to reproduce the stage's prologue.
+#: Not only the `${VAR:-...}` form: `spot_rag_ingestion.sh` sets
+#: `MAX_RUNTIME_SECONDS=21900` unconditionally, and lifting only the
+#: defaultable form would leave it empty in the harness and report a swallowed
+#: identity that is not there.
+_PROLOGUE_ASSIGN_RE = re.compile(
+    r"^(?:_SPOT_NAME|_SSM_SLUG|_PROCESS_NAME|MAX_RUNTIME_SECONDS)=.*$",
+    re.MULTILINE,
+)
+
+
+def test_common_does_not_default_the_stage_identity() -> None:
+    """`_spot_common.sh` must declare the identity empty, never populate it.
+
+    A non-empty value here is invisible at the stage script's own assignment —
+    it is the whole defect, and it reappears the moment someone "restores a
+    sensible default".
+    """
+    source = _COMMON.read_text()
+    for match in _ASSIGN_RE.finditer(source):
+        assert match.group("value") == "", (
+            f"_spot_common.sh defaults {match.group('var')} to "
+            f"{match.group('value')!r}. Any non-empty value makes every "
+            f"per-stage `${{{match.group('var')}:-...}}` a no-op, and the stage "
+            f"silently runs under the shared identity."
+        )
+
+
+@pytest.mark.parametrize("script_name", sorted(_STAGES))
+def test_stage_identity_wins_over_the_shared_defaults(
+    script_name: str, tmp_path: Path
+) -> None:
+    """Sourcing then declaring must yield the STAGE's identity."""
+    script = _INFRA / script_name
+    source = script.read_text()
+    assert _ASSIGN_RE.search(source), f"{script_name}: declares no identity at all"
+    stage_lines = [match.group(0) for match in _PROLOGUE_ASSIGN_RE.finditer(source)]
+
+    harness = tmp_path / "identity.sh"
+    harness.write_text(
+        "#!/usr/bin/env bash\n"
+        f"source {_COMMON}\n"
+        + "\n".join(stage_lines)
+        + "\n"
+        + "".join(f'echo "{var}=${var}"\n' for var in _IDENTITY_VARS)
+    )
+
+    proc = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=60
+    )
+    assert proc.returncode == 0, proc.stderr
+    observed = dict(
+        line.split("=", 1) for line in proc.stdout.strip().splitlines() if "=" in line
+    )
+
+    for var, expected in _STAGES[script_name].items():
+        assert observed.get(var) == expected, (
+            f"{script_name}: {var} resolved to {observed.get(var)!r}, expected "
+            f"{expected!r}. The stage's own assignment was swallowed by a "
+            f"default in _spot_common.sh."
+        )
+    assert observed.get("MAX_RUNTIME_SECONDS"), (
+        f"{script_name}: MAX_RUNTIME_SECONDS is empty — spot_launch will refuse"
+    )
+
+
+def test_spot_launch_refuses_an_unset_identity(tmp_path: Path) -> None:
+    """A stage that forgets to declare itself must fail BEFORE it is billable.
+
+    Removing the defaults trades a silent wrong identity for an unset one. That
+    is only an improvement if the unset case is loud, so the assertion lives in
+    `spot_launch`, ahead of the instance request.
+    """
+    harness = tmp_path / "no_identity.sh"
+    harness.write_text(
+        "#!/usr/bin/env bash\n"
+        f"source {_COMMON}\n"
+        # Every identity parameter left as _spot_common.sh declared it: empty.
+        "spot_launch\n"
+    )
+    proc = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=60
+    )
+    assert proc.returncode == 2, (
+        "spot_launch should exit 2 on an unset stage identity, got "
+        f"{proc.returncode}.\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    combined = proc.stdout + proc.stderr
+    for var in _IDENTITY_VARS:
+        assert var in combined, f"the refusal does not name {var}"
+    assert "Requesting spot instance" not in combined, (
+        "spot_launch reached the instance request before refusing — the whole "
+        "point of asserting here is that nothing is billable yet."
+    )


### PR DESCRIPTION
`infrastructure/_spot_common.sh` exists twice in the fleet — here and in
`crucible-predictor` — as two independently-written implementations of the same
spot bootstrap. Three fixes were hand-carried between them in two days, each
discovered by a failed weekly run. This ports the two that were never carried
BACK to this repo, and adds the CI guard that makes the next divergence fail in
seconds instead of on a Saturday.

## Stage identity was swallowed on all three stages

`_spot_common.sh` defaulted `_SPOT_NAME` / `_SSM_SLUG` / `_PROCESS_NAME`, and
every per-stage script then set its own with the same `${VAR:-...}` form AFTER
sourcing — where the parameter is already non-empty, so the expansion is a
no-op. `spot_morning_enrich.sh` asks for `morning-enrich`, `spot_data_phase1.sh`
for `data-phase1`, `spot_rag_ingestion.sh` for `rag-ingestion`; all three ran as
`data-weekly`. The instance Name tag, the `run_ssm` description, the `Process`
dimension on `Heartbeat` and the `Process` dimension on `SpotInterruptionRetry`
all named the wrong stage, so a heartbeat gap could not be attributed to a stage
and a spot retry could not be counted per stage.

Fixed as the predictor fixed it: declared EMPTY here, asserted non-empty in
`spot_launch` before anything is billable (exit 2, naming the unset variables).

## The deps step discarded the evidence of its own failure

`pip install --quiet ... | tail -1` — a run that exited 0 having silently
skipped an extra was indistinguishable from a clean one, and pip reports a
dropped extra as a WARNING on a SUCCESSFUL exit, which is precisely the line
`tail -1` cannot keep. This repo requests four extras on one line
(`nousergon-lib[arcticdb,flow-doctor,rag,contracts]`) and AL2023 ships pip
23.2.1, which predates PEP 685 extras normalisation — so this bootstrap sits on
the broken side by default.

Ported from `crucible-predictor` (config-I6949, config-I6963): keep the full
install log, dump 80 lines on failure, treat a dropped extra as FATAL rather
than reported, and run `pip check`.

## The guard

`tests/test_spot_bootstrap_invariants.py` derives its expectations from
`krepis.spot_bootstrap` — the fleet's canonical renderer, already a pinned
dependency of this repo — rather than restating them, so a third copy of the
invariant cannot drift the way the first two did. It pins the watchdog unit's
`[Service]` directives, the bounded `systemctl enable`, and the interpreter
install-before-assert ordering: the two blocks where both cross-repo outages
lived.

Verified to FAIL on each regression it exists to catch: the pre-fix file (5
failures), `Type=simple` flipped to `oneshot` (2), and the `timeout` guard
removed (2).

## Why the Bash copy stays

`krepis.spot_bootstrap` cannot replace this heredoc yet. `LIB_PYTHON` resolves
to the shared application host's venv, whose krepis version is governed by
`crucible-dashboard/requirements.txt` — a file no merge in this repo can see.
Measured 2026-08-13 that host is at krepis 0.54.0 and `krepis.spot_bootstrap`
imports cleanly, but nothing DECLARES or ENFORCES that floor, and when the venv
is behind the bootstrap does not degrade — it dies with `ModuleNotFoundError` on
every spot stage. alpha-engine-config-I6931 owns making it a fail-loud declared
version; until then the dependency that cannot safely exist at RUNTIME lives in
a TEST instead.

Tracked by alpha-engine-config-I6922; deliberately no native closing keyword — the issue spans two repos.

---

**Cross-repo (alpha-engine-config-I6922).** Companion: `crucible-predictor-PR485`. The two PRs are **independent** — different repos, no shared artifact, and both depend only on an already-published krepis (>=0.46.0, pinned here at 0.56.0). **Recommended merge order: this PR first**, then the predictor's; either order is safe.

**Tests:** full suite run locally against the pinned krepis 0.56.0 — 5272 passed, 9 skipped. The 3 `test_pipeline_status_registry_source_check.py` failures seen locally are a stale-dev-venv artifact (installed nousergon_lib 0.124.49 vs the pinned v0.124.53; `RelaunchWeeklyFreshnessSpot` was registered in between) and do not reproduce in CI — main is green.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
