### PR TITLE
[P1] feat(weekly-sf): a declarative stage-output assertion, fail-loud with honest UNKNOWN (config-I7167)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -5741,7 +5741,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {}',$$.Execution.Name,$.run_date))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
           "executionTimeout": [
             "240"
           ]

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -76,6 +76,19 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # separate PR there — pinned here first so this repo's guard is honest
     # about the new PUT site either way.
     "scripts/fault_injection_run.py": 1,
+    # alpha-engine-config-I7167 — the stage-output assertion's own verdict,
+    # s3://alpha-engine-research/_stage_outputs/{pipeline}/{run_date}.json.
+    # One PUT per weekly run, from the health-observe tail.
+    #
+    # Freshness-relevant, so it is a registry row rather than a grandfathered
+    # prefix: this sweep is what catches a weekly stage that ran, exited 0 and
+    # wrote nothing (five such stages on the 2026-08-08 run, which terminated
+    # SUCCEEDED with none of them visible anywhere). A detector whose own
+    # silence is undetected is that same defect one layer up, so its verdict
+    # key is watched exactly like any other producer's output. The row rides
+    # alpha-engine-config-PR7225; pinned here so this repo's guard is honest
+    # about the new PUT site either way.
+    "validators/stage_output_sweep.py": 1,
     "builders/_price_cache_writeboth.py": 2,
     # universe_freshness.json + weekly/<date>/manifest.json (schema_drift_incidents,
     # config#1150) + feature_store/_freshness.json (ArcticDB freshness-monitor

--- a/tests/test_sf_stage_output_sweep_wiring.py
+++ b/tests/test_sf_stage_output_sweep_wiring.py
@@ -1,0 +1,74 @@
+"""
+Guard the wiring that makes the stage-output assertion actually run
+(alpha-engine-config-I7167).
+
+The module and its 70-odd unit tests prove the assertion is CORRECT. They prove
+nothing about it being INVOKED — and an observability check that is correct and
+unreachable is the failure mode I7167 exists to end, reproduced one layer up.
+These tests assert the SF still hands `WeeklySubstrateHealthCheck` the two
+things the sweep cannot work without.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+SF_PATH = pathlib.Path(__file__).resolve().parent.parent / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def substrate_command() -> str:
+    definition = json.loads(SF_PATH.read_text())
+    state = definition["States"]["WeeklySubstrateHealthCheck"]
+    return state["Parameters"]["Parameters"]["commands.$"]
+
+
+def test_substrate_stage_invokes_the_health_check_script(substrate_command):
+    assert "bash infrastructure/substrate_health_check.sh" in substrate_command
+
+
+def test_execution_arn_is_threaded_to_the_script(substrate_command):
+    """`$$.Execution.Id` is the execution ARN, and it supplies BOTH halves of
+    the sweep's context: the start time (via DescribeExecution) and the
+    entered-stage set (via GetExecutionHistory).
+
+    Without it the sweep cannot tell a gated-out run — which terminates
+    SUCCEEDED in ~5s having done nothing, and is roughly two of every three
+    firings — from a deep run in which every stage went silent. It would report
+    ~30 missing artifacts on the former, and a detector that cries wolf twice a
+    week is a detector that gets muted.
+    """
+    assert "--execution-arn {}" in substrate_command
+    assert "$$.Execution.Id" in substrate_command
+
+
+def test_run_date_is_still_threaded(substrate_command):
+    assert "--run-date {}" in substrate_command
+    assert "$.run_date" in substrate_command
+
+
+def test_format_argument_order_matches_the_placeholders(substrate_command):
+    """`States.Format` is positional, so an argument appended in the wrong
+    order silently swaps the run date and the execution ARN — the sweep would
+    then head keys under a date that is an ARN and report every artifact
+    missing, with no error anywhere.
+    """
+    start = substrate_command.index("States.Format(")
+    fragment = substrate_command[start:]
+    assert fragment.index("$$.Execution.Name") < fragment.index("$.run_date")
+    assert fragment.index("$.run_date") < fragment.index("$$.Execution.Id")
+    # Three placeholders consumed by the format string, three arguments after it.
+    format_string_end = fragment.index("',", fragment.index("run --correlation-id"))
+    assert fragment[:format_string_end].count("{}") == 3
+
+
+def test_the_stage_still_runs_through_the_log_capture_wrapper(substrate_command):
+    """alpha-engine-config-I7047: this stage previously died at rc=127 on an
+    inline `trap 'aws s3 cp ...' EXIT` wrapper, before running a single check.
+    Adding an argument must not walk that back.
+    """
+    assert "krepis.ssm_log_capture" in substrate_command
+    assert "trap 'aws s3 cp" not in substrate_command

--- a/tests/test_stage_output_sweep.py
+++ b/tests/test_stage_output_sweep.py
@@ -1,0 +1,976 @@
+"""
+Tests for validators/stage_output_sweep.py — the stage-level output assertion
+(alpha-engine-config-I7167).
+
+Two obligations shape this file, both from measured fleet failures rather than
+from a coverage target:
+
+1. **The assertion must be PROVEN able to fail.** This fleet has shipped three
+   detectors that could not — an assertion whose failing branch is never
+   exercised is indistinguishable from one that always passes, and the
+   difference only shows up on the run you needed it for. Every verdict here
+   has a test that produces it, and ``test_enforce_exits_1_on_a_defect`` walks
+   the whole path from a stale key to a non-zero process exit.
+
+2. **"Could not measure" must never be reported as "found a defect"**, and
+   never as health either. The ``unmeasured`` verdict has its own tests in both
+   directions, including the one that matters most —
+   ``test_s3_permission_error_is_unmeasured_not_missing``, because a 403
+   rendered as a missing artifact is a detector reporting its own harness fault
+   as a finding about the system, always in the alarming direction.
+
+The five 2026-08-08 instances are replayed in ``TestAugust08Replay`` against
+the live evidence recorded on I7167, each asserting the sweep WOULD have caught
+what no surface reported.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from validators import stage_output_sweep as sos
+
+RUN_DATE = "2026-08-08"
+# The scheduled 2026-08-08 weekly run, execution
+# 9b34ac0f-5e2f-f70b-d668-61b4c4751654_6fb6adf9-55fa-4426-6d06-79e4579bcaff:
+# 02:00:49 → 06:20:44 PDT, terminated SUCCEEDED.
+EXEC_START = datetime(2026, 8, 8, 9, 0, 49, tzinfo=timezone.utc)
+
+PIPELINE = "ne-weekly-freshness-pipeline"
+
+
+def _row(artifact_id, template, stage, pipeline=PIPELINE, **kw):
+    row = {
+        "artifact_id": artifact_id,
+        "s3_key_template": template,
+        "cadence": "eod_sf",
+        "sla_minutes_after_cron": 60,
+        "severity": "warning",
+        "owner_repo": "alpha-engine-data",
+        "created_at": "2026-06-01",
+        "produced_by": [{"pipeline": pipeline, "stage": stage}],
+    }
+    row.update(kw)
+    return row
+
+
+def _head_from(mapping):
+    """Build a ``head`` callable from ``{key: last_modified | 'error:<why>'}``.
+
+    A key absent from the mapping is an absent object; a value beginning
+    ``error:`` is an S3 fault. Injecting the head is what makes every branch —
+    including the ones S3 will not produce on demand — actually reachable.
+    """
+
+    def head(bucket, key):
+        if key not in mapping:
+            return "absent", None
+        value = mapping[key]
+        if isinstance(value, str) and value.startswith("error:"):
+            return "error", value[len("error:"):]
+        return "found", value
+
+    return head
+
+
+# ---------------------------------------------------------------------------
+# resolve_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveKey:
+    @pytest.mark.parametrize("placeholder", ["date", "trading_day", "run_date"])
+    def test_run_date_placeholders_resolve(self, placeholder):
+        got = sos.resolve_key("backtest/{%s}/report.md" % placeholder, run_date=RUN_DATE, cycle_date=RUN_DATE)
+        assert got == f"backtest/{RUN_DATE}/report.md"
+
+    def test_unplaceholdered_template_passes_through(self):
+        assert (
+            sos.resolve_key("market_data/macro_history.parquet", run_date=RUN_DATE, cycle_date=RUN_DATE)
+            == "market_data/macro_history.parquet"
+        )
+
+    def test_unresolvable_placeholder_returns_none(self):
+        """A key this sweep cannot build is not a key that is missing.
+
+        head-ing a literal ``{cycle_label}`` would 404 every time and report a
+        confident, permanent, entirely false `missing` — the most convincing
+        wrong finding this sweep could produce.
+        """
+        assert sos.resolve_key("x/{cycle_label}/y.json", run_date=RUN_DATE, cycle_date=RUN_DATE) is None
+
+    def test_mixed_resolvable_and_unresolvable_is_none(self):
+        assert sos.resolve_key("a/{date}/{cycle_label}.json", run_date=RUN_DATE, cycle_date=RUN_DATE) is None
+
+
+class TestCycleDate:
+    """The regression guard for this module's own worst bug.
+
+    Resolving ``{date}`` / ``{trading_day}`` to ``$.run_date`` produced 28
+    confident false ``missing`` verdicts against the 2026-08-08 run — measured,
+    not hypothetical: that run's ``$.run_date`` was ``2026-08-08`` while every
+    artifact it wrote landed under ``2026-08-07``, and ``backtest/2026-08-08/``
+    does not exist at all.
+
+    A detector wrong in that direction, at that volume, is worse than no
+    detector: it gets muted within a week and takes the real finding with it.
+    """
+
+    def test_saturday_run_resolves_to_the_prior_trading_day(self):
+        assert sos.resolve_cycle_date("2026-08-08") == "2026-08-07"
+
+    def test_a_trading_day_resolves_to_itself(self):
+        assert sos.resolve_cycle_date("2026-08-07") == "2026-08-07"
+
+    def test_cycle_date_is_not_run_date_by_default_in_main(
+        self, monkeypatch, registry_file
+    ):
+        """``main()`` must NOT fall back to run_date for the cycle date.
+
+        Pinned as its own test because every other test in TestMain passes
+        ``--cycle-date`` explicitly, so none of them would notice the default
+        regressing.
+        """
+        captured = {}
+
+        def _fake_sweep(**kw):
+            captured.update(kw)
+            return {"status": "ok", "enforce": False, "defects": [], "unmeasured": [],
+                    "checked": 0}
+
+        monkeypatch.setattr(sos, "sweep", _fake_sweep)
+        sos.main(["--run-date", "2026-08-08", "--registry", registry_file, "--no-alert"])
+        assert captured["cycle_date"] is None, (
+            "main() must pass cycle_date=None so sweep() resolves it via "
+            "expected_last_close rather than silently reusing run_date"
+        )
+
+    def test_unresolved_cycle_date_is_unmeasured_not_missing(self):
+        """When the resolver is unavailable, a dated key is UNMEASURED.
+
+        Falling back to run_date here would reintroduce the 28-false-positive
+        failure in the one situation where nobody would be looking for it.
+        """
+        decls = sos.declared_outputs([_row("a", "b/{date}.json", "S")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({}), cycle_date=None,
+        )[0]
+        assert f["verdict"] == sos.UNMEASURED
+        assert "cycle date unresolved" in f["detail"]
+
+    def test_undated_keys_still_check_without_a_cycle_date(self):
+        """A pointer-pattern key carries no placeholder, so losing the cycle
+        date must not take it down too."""
+        decls = sos.declared_outputs([_row("a", "pointer/latest.json", "S")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({}), cycle_date=None,
+        )[0]
+        assert f["verdict"] == sos.MISSING
+
+
+class TestParseExecutionStart:
+    def test_z_suffix(self):
+        assert sos.parse_execution_start("2026-08-08T09:00:49Z") == EXEC_START
+
+    def test_offset_form(self):
+        assert sos.parse_execution_start("2026-08-08T09:00:49+00:00") == EXEC_START
+
+    def test_naive_is_assumed_utc(self):
+        assert sos.parse_execution_start("2026-08-08T09:00:49") == EXEC_START
+
+    def test_garbage_raises(self):
+        with pytest.raises(ValueError):
+            sos.parse_execution_start("not-a-timestamp")
+
+
+# ---------------------------------------------------------------------------
+# Registry loading — the empty-producer-set trap
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRegistry:
+    def test_local_path_round_trip(self, tmp_path):
+        import yaml
+
+        path = tmp_path / "reg.yaml"
+        path.write_text(yaml.safe_dump({"artifacts": [_row("a", "k", "S")]}))
+        assert len(sos.load_registry_rows(registry_path=str(path))) == 1
+
+    def test_missing_file_raises_rather_than_returning_empty(self, tmp_path):
+        with pytest.raises(sos.RegistryUnreadable):
+            sos.load_registry_rows(registry_path=str(tmp_path / "nope.yaml"))
+
+    def test_empty_artifacts_list_raises(self, tmp_path):
+        """An assertion over an empty producer set always passes.
+
+        Returning ``[]`` here would make an unreadable/misparsed registry
+        indistinguishable from a perfectly clean run — the failure mode this
+        whole module exists to end, reproduced inside the detector.
+        """
+        import yaml
+
+        path = tmp_path / "reg.yaml"
+        path.write_text(yaml.safe_dump({"artifacts": []}))
+        with pytest.raises(sos.RegistryUnreadable):
+            sos.load_registry_rows(registry_path=str(path))
+
+    def test_unparseable_yaml_raises(self, tmp_path):
+        path = tmp_path / "reg.yaml"
+        path.write_text("artifacts: [oops\n  - : :\n")
+        with pytest.raises(sos.RegistryUnreadable):
+            sos.load_registry_rows(registry_path=str(path))
+
+
+class TestDeclaredOutputs:
+    def test_filters_to_the_named_pipeline(self):
+        rows = [
+            _row("weekly", "a/{date}.json", "Backtester"),
+            _row("preopen", "b/{date}.json", "Scanner", pipeline="ne-preopen-trading-pipeline"),
+        ]
+        got = sos.declared_outputs(rows, pipeline=PIPELINE)
+        assert [d["artifact_id"] for d in got] == ["weekly"]
+
+    def test_dual_producer_row_contributes_to_both(self):
+        """The Scanner artifacts are written by the weekday preopen SF AND the
+        weekly SF. A registry that can name only one is why a stopped weekly
+        stage hides behind a live daily one — so both must be emitted.
+        """
+        row = _row("scanner", "scanner/{date}.json", "Scanner")
+        row["produced_by"].append(
+            {"pipeline": "ne-preopen-trading-pipeline", "stage": "Scanner"}
+        )
+        assert len(sos.declared_outputs([row], pipeline=PIPELINE)) == 1
+        assert len(
+            sos.declared_outputs([row], pipeline="ne-preopen-trading-pipeline")
+        ) == 1
+
+    def test_rows_without_produced_by_are_ignored(self):
+        row = _row("x", "k", "S")
+        del row["produced_by"]
+        assert sos.declared_outputs([row], pipeline=PIPELINE) == []
+
+
+# ---------------------------------------------------------------------------
+# evaluate — one test per verdict, both polarities
+# ---------------------------------------------------------------------------
+
+
+class TestVerdicts:
+    def _one(self, template, head_map, **kw):
+        decls = sos.declared_outputs([_row("a", template, "Backtester")], pipeline=PIPELINE)
+        kw.setdefault("execution_start", EXEC_START)
+        kw.setdefault("cycle_date", RUN_DATE)
+        return sos.evaluate(decls, run_date=RUN_DATE, head=_head_from(head_map), **kw)[0]
+
+    def test_wrote_when_written_after_execution_start(self):
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.WROTE
+
+    def test_wrote_on_exact_boundary(self):
+        """LastModified == execution start is INSIDE the window.
+
+        An exclusive boundary would report a stage that wrote in the run's
+        first second as stale — a false defect at the one moment the pipeline
+        is least likely to be watched.
+        """
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": EXEC_START})
+        assert f["verdict"] == sos.WROTE
+
+    def test_stale_when_the_key_predates_the_run(self):
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": EXEC_START - timedelta(days=87)})
+        assert f["verdict"] == sos.STALE
+        assert "87d" in f["detail"]
+
+    def test_missing_when_no_object_exists(self):
+        f = self._one("b/{date}.json", {})
+        assert f["verdict"] == sos.MISSING
+
+    def test_s3_permission_error_is_unmeasured_not_missing(self):
+        """A 403 is not an absent artifact.
+
+        Reporting it as ``missing`` is a detector filing its own harness fault
+        as a defect in the system it watches — this fleet's most-repeated
+        detector bug, and always in the alarming direction.
+        """
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": "error:AccessDenied"})
+        assert f["verdict"] == sos.UNMEASURED
+        assert f["verdict"] != sos.MISSING
+        assert "AccessDenied" in f["detail"]
+
+    def test_transient_s3_fault_is_unmeasured_not_wrote(self):
+        """The other polarity: an unanswerable check is not health either."""
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": "error:SlowDown"})
+        assert f["verdict"] == sos.UNMEASURED
+        assert f["verdict"] != sos.WROTE
+
+    def test_present_key_without_a_window_is_unmeasured_not_wrote(self):
+        """Absence is measurable without an execution window; staleness is not.
+
+        Degrading a present key to ``wrote`` here is exactly how instances 2, 3
+        and 4 stayed invisible for months: the key existed, so everything
+        looked fine.
+        """
+        f = self._one(
+            "b/{date}.json",
+            {f"b/{RUN_DATE}.json": EXEC_START - timedelta(days=87)},
+            execution_start=None,
+        )
+        assert f["verdict"] == sos.UNMEASURED
+
+    def test_absence_is_still_a_defect_without_a_window(self):
+        f = self._one("b/{date}.json", {}, execution_start=None)
+        assert f["verdict"] == sos.MISSING
+
+    def test_missing_last_modified_is_unmeasured(self):
+        f = self._one("b/{date}.json", {f"b/{RUN_DATE}.json": None})
+        assert f["verdict"] == sos.UNMEASURED
+
+    def test_unresolvable_template_is_unmeasured(self):
+        f = self._one("b/{cycle_label}.json", {})
+        assert f["verdict"] == sos.UNMEASURED
+
+    def test_unresolved_producer_row_is_its_own_verdict(self):
+        """config-I7180's ratcheted gap is neither a pass nor a defect.
+
+        Folding UNRESOLVED into ``wrote`` would let 20 unattributed artifacts
+        inflate the green number; folding it into ``missing`` would fail every
+        run for a registry gap that is already tracked and published.
+        """
+        decls = sos.declared_outputs([_row("a", "k", "UNRESOLVED")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, head=_head_from({}), cycle_date=RUN_DATE
+        )[0]
+        assert f["verdict"] == sos.UNRESOLVED
+        assert f["verdict"] not in sos.DEFECT_VERDICTS
+
+
+class TestEnteredStages:
+    def test_stage_not_entered_is_skipped_when_the_set_is_known(self):
+        decls = sos.declared_outputs([_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, cycle_date=RUN_DATE,
+            head=_head_from({}), entered_stages=frozenset({"MorningEnrich"}),
+        )[0]
+        assert f["verdict"] == sos.SKIPPED
+
+    def test_unknown_entered_set_never_excuses_a_stage(self):
+        """"I don't know which stages ran" must not become "the stage was
+        allowed not to run" — that reasoning turns every degraded run into a
+        blanket amnesty and is how a silent stage buys itself cover.
+        """
+        decls = sos.declared_outputs([_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, cycle_date=RUN_DATE,
+            head=_head_from({}), entered_stages=None,
+        )[0]
+        assert f["verdict"] == sos.MISSING
+
+    def test_entered_stage_is_still_asserted(self):
+        decls = sos.declared_outputs([_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE)
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, cycle_date=RUN_DATE,
+            head=_head_from({}), entered_stages=frozenset({"Backtester"}),
+        )[0]
+        assert f["verdict"] == sos.MISSING
+
+
+# ---------------------------------------------------------------------------
+# summarise / exit_code — the enforcement ladder
+# ---------------------------------------------------------------------------
+
+
+class TestSummarise:
+    def test_defect_outranks_unmeasured_in_the_status(self):
+        findings = [
+            {"verdict": sos.MISSING}, {"verdict": sos.UNMEASURED}, {"verdict": sos.WROTE},
+        ]
+        s = sos.summarise(findings)
+        assert s["status"] == "stage_output_missing"
+        assert len(s["defects"]) == 1 and len(s["unmeasured"]) == 1
+
+    def test_unmeasured_alone_is_not_ok(self):
+        """A sweep that could not look has not reported a clean run."""
+        s = sos.summarise([{"verdict": sos.UNMEASURED}, {"verdict": sos.WROTE}])
+        assert s["status"] == "stage_output_unmeasured"
+
+    def test_all_wrote_is_ok(self):
+        assert sos.summarise([{"verdict": sos.WROTE}])["status"] == "ok"
+
+    def test_unresolved_and_skipped_do_not_break_ok(self):
+        s = sos.summarise(
+            [{"verdict": sos.WROTE}, {"verdict": sos.UNRESOLVED}, {"verdict": sos.SKIPPED}]
+        )
+        assert s["status"] == "ok"
+
+
+class TestExitCode:
+    def _doc(self, **kw):
+        base = {
+            "status": "ok", "enforce": False, "defects": [], "unmeasured": [],
+        }
+        base.update(kw)
+        return base
+
+    def test_observe_mode_exits_0_on_a_defect(self):
+        """The I6891 blast radius, encoded.
+
+        A non-zero exit here fails WeeklySubstrateHealthCheck → degraded →
+        DegradedRun (a Fail state) → the whole four-hour run terminates FAILED.
+        Three of I7167's five instances are still open, so an enforcing default
+        would hard-fail the next scheduled run for defects that predate the
+        detector.
+        """
+        assert sos.exit_code(self._doc(status="stage_output_missing", defects=[{}])) == 0
+
+    def test_enforce_exits_1_on_a_defect(self):
+        assert sos.exit_code(
+            self._doc(enforce=True, status="stage_output_missing", defects=[{}])
+        ) == 1
+
+    def test_enforce_exits_2_on_unmeasured(self):
+        """2, not 1 — the operator's next move differs, and collapsing them is
+        how a permissions gap gets filed as a data defect."""
+        assert sos.exit_code(
+            self._doc(enforce=True, status="stage_output_unmeasured", unmeasured=[{}])
+        ) == 2
+
+    def test_unreadable_registry_exits_2_even_in_observe_mode(self):
+        """Observe mode excuses FINDINGS, never a sweep that could not run."""
+        assert sos.exit_code(self._doc(status="registry_unreadable")) == 2
+
+    def test_clean_run_exits_0_in_both_modes(self):
+        assert sos.exit_code(self._doc()) == 0
+        assert sos.exit_code(self._doc(enforce=True)) == 0
+
+
+# ---------------------------------------------------------------------------
+# The five 2026-08-08 instances, replayed
+# ---------------------------------------------------------------------------
+
+
+class TestAugust08Replay:
+    """Each instance from alpha-engine-config-I7167's root-cause table, replayed
+    against the live evidence recorded there. Every one asserts the sweep would
+    have produced a non-``wrote`` verdict on a run that terminated SUCCEEDED
+    with nothing on any surface.
+
+    The point of replaying all five is that they had FIVE DIFFERENT root causes
+    — a shell trap, a caller/contract disagreement, a masked sibling, a
+    wall-kill and a prefix cutover — and the assertion is indifferent to all of
+    them. That indifference is the deliverable: it is what covers the sixth
+    cause, which nobody has found yet.
+    """
+
+    def _verdict(self, artifact_id, template, stage, head_map):
+        decls = sos.declared_outputs(
+            [_row(artifact_id, template, stage)], pipeline=PIPELINE
+        )
+        return sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from(head_map), cycle_date=RUN_DATE,
+        )[0]
+
+    def test_instance_1_substrate_health_check_log_absent(self):
+        """SSM exit 127 at line 5 — ``trap: --only-show-errors: invalid signal
+        specification``. The stage died before its first check ran, so its log
+        object never existed. (Root cause since fixed on main: the stage now
+        runs through ``krepis.ssm_log_capture``.)"""
+        f = self._verdict(
+            "substrate_health_check_log",
+            "_ssm_logs/substrate-health-check/{date}/run.log",
+            "WeeklySubstrateHealthCheck",
+            {},
+        )
+        assert f["verdict"] == sos.MISSING
+
+    def test_instance_2_executor_optimizer_recommendation_87_days_stale(self):
+        """``produce_artifact()`` is documented to write unconditionally; its
+        only caller fires it when ``status == "ok"``. The call site wins, so
+        the key froze at 2026-05-18 — 87 days before this run, and present the
+        whole time."""
+        key = f"config/executor_params/recommendations/{RUN_DATE}/from_executor_optimizer.json"
+        f = self._verdict(
+            "executor_optimizer_recommendation",
+            "config/executor_params/recommendations/{date}/from_executor_optimizer.json",
+            "Backtester",
+            {key: datetime(2026, 5, 18, 12, tzinfo=timezone.utc)},
+        )
+        assert f["verdict"] == sos.STALE
+
+    def test_instance_3_parity_report_masked_by_a_fresh_sibling(self):
+        """``parity_report.json`` last wrote 2026-07-17, but ``report.md`` in
+        the SAME prefix updated on this run. A prefix scan sees recent
+        activity; a per-key, producer-anchored assertion does not.
+        """
+        head = {
+            f"backtest/{RUN_DATE}/parity_report.json":
+                datetime(2026, 7, 17, 12, tzinfo=timezone.utc),
+            f"backtest/{RUN_DATE}/report.md": EXEC_START + timedelta(hours=4),
+        }
+        stale = self._verdict(
+            "parity_report", "backtest/{date}/parity_report.json", "ParityReplay", head
+        )
+        fresh = self._verdict(
+            "backtest_report", "backtest/{date}/report.md", "Backtester", head
+        )
+        assert stale["verdict"] == sos.STALE
+        assert fresh["verdict"] == sos.WROTE, (
+            "the masking sibling must still read healthy — a check that fails "
+            "the whole prefix on one dead key is a check that gets muted"
+        )
+
+    def test_instance_4_replay_concordance_wall_killed(self):
+        """Killed at its 900s ceiling in 22 of 38 observed runs. Killed at the
+        wall means no artifact AND no cause — the stage cannot report its own
+        death, which is precisely why the assertion has to be external to it.
+        """
+        f = self._verdict(
+            "replay_summary",
+            "decision_artifacts/_replay_summary/{date}/summary.json",
+            "ReplayConcordance",
+            {},
+        )
+        assert f["verdict"] == sos.MISSING
+
+    def test_instance_5_aggregate_costs_parquet_absent(self):
+        """``_cost_raw/2026-08-08/`` held zero objects (a prefix cutover skew,
+        per I7179), so the aggregator honestly no-opped and wrote no parquet.
+        The stage was the honest one here — and the assertion still fires,
+        because the assertion is about the ARTIFACT, not about whether the
+        stage had a good reason.
+        """
+        f = self._verdict(
+            "cost_parquet",
+            "decision_artifacts/_cost/{date}/cost.parquet",
+            "AggregateCosts",
+            {},
+        )
+        assert f["verdict"] == sos.MISSING
+
+    def test_the_whole_08_08_run_would_have_been_flagged(self):
+        """End to end: the five instances plus healthy stages, in one sweep.
+
+        The run terminated SUCCEEDED. In enforce mode this sweep exits 1, and
+        in observe mode it exits 0 while still reporting five defects — which
+        is the difference between the two modes stated as a test rather than as
+        a comment.
+        """
+        rows = [
+            _row("substrate_log", "_ssm_logs/substrate-health-check/{date}/run.log",
+                 "WeeklySubstrateHealthCheck"),
+            _row("executor_rec",
+                 "config/executor_params/recommendations/{date}/from_executor_optimizer.json",
+                 "Backtester"),
+            _row("parity_report", "backtest/{date}/parity_report.json", "ParityReplay"),
+            _row("replay_summary", "decision_artifacts/_replay_summary/{date}/summary.json",
+                 "ReplayConcordance"),
+            _row("cost_parquet", "decision_artifacts/_cost/{date}/cost.parquet",
+                 "AggregateCosts"),
+            _row("backtest_report", "backtest/{date}/report.md", "Backtester"),
+            _row("predictor_manifest", "predictor/weights/meta/manifest.json",
+                 "PredictorTraining"),
+        ]
+        head = _head_from({
+            f"config/executor_params/recommendations/{RUN_DATE}/from_executor_optimizer.json":
+                datetime(2026, 5, 18, 12, tzinfo=timezone.utc),
+            f"backtest/{RUN_DATE}/parity_report.json":
+                datetime(2026, 7, 17, 12, tzinfo=timezone.utc),
+            f"backtest/{RUN_DATE}/report.md": EXEC_START + timedelta(hours=4),
+            "predictor/weights/meta/manifest.json": EXEC_START + timedelta(hours=1),
+        })
+        findings = sos.evaluate(
+            sos.declared_outputs(rows, pipeline=PIPELINE),
+            run_date=RUN_DATE, execution_start=EXEC_START, head=head,
+            cycle_date=RUN_DATE,
+        )
+        summary = sos.summarise(findings)
+
+        assert summary["counts"].get(sos.WROTE) == 2
+        assert len(summary["defects"]) == 5
+        assert {f["stage"] for f in summary["defects"]} == {
+            "WeeklySubstrateHealthCheck", "Backtester", "ParityReplay",
+            "ReplayConcordance", "AggregateCosts",
+        }
+        assert sos.exit_code({**summary, "enforce": True}) == 1
+        assert sos.exit_code({**summary, "enforce": False}) == 0
+
+
+# ---------------------------------------------------------------------------
+# sweep() / main() — publish, alert and the end-to-end exit path
+# ---------------------------------------------------------------------------
+
+
+class _FakeS3:
+    def __init__(self, objects=None, put_raises=None):
+        self.objects = objects or {}
+        self.puts = []
+        self.put_raises = put_raises
+
+    def head_object(self, Bucket, Key):  # noqa: N803 - boto3 kwarg casing
+        if Key not in self.objects:
+            err = Exception("not found")
+            err.response = {"Error": {"Code": "404"}}
+            raise err
+        return {"LastModified": self.objects[Key]}
+
+    def put_object(self, **kw):
+        if self.put_raises:
+            raise self.put_raises
+        self.puts.append(kw)
+        return {}
+
+
+@pytest.fixture()
+def registry_file(tmp_path):
+    import yaml
+
+    path = tmp_path / "ARTIFACT_REGISTRY.yaml"
+    path.write_text(yaml.safe_dump({"artifacts": [
+        _row("good", "good/{date}.json", "PredictorTraining"),
+        _row("bad", "bad/{date}.json", "ReplayConcordance"),
+    ]}))
+    return str(path)
+
+
+class TestSweep:
+    def test_finds_the_defect_and_publishes_the_verdict(self, registry_file):
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START, registry_path=registry_file,
+            s3_client=s3, alert=False,
+        )
+        assert doc["status"] == "stage_output_missing"
+        assert [f["stage"] for f in doc["defects"]] == ["ReplayConcordance"]
+        assert len(s3.puts) == 1
+        published = json.loads(s3.puts[0]["Body"])
+        assert published["schema"] == "stage_output_sweep-1.0.0"
+        assert s3.puts[0]["Key"] == f"_stage_outputs/{PIPELINE}/{RUN_DATE}.json"
+
+    def test_verdict_publish_failure_does_not_lose_the_verdict(self, registry_file):
+        """The reporter must not destroy what it reports.
+
+        An exception on the verdict WRITE would convert an observability fault
+        into a pipeline failure — and, in enforce mode, into a hard-failed
+        four-hour run caused by the detector rather than by the pipeline.
+        """
+        s3 = _FakeS3(
+            {f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)},
+            put_raises=RuntimeError("s3 down"),
+        )
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START, registry_path=registry_file,
+            s3_client=s3, alert=False,
+        )
+        assert doc["status"] == "stage_output_missing"
+        assert len(doc["defects"]) == 1
+
+    def test_unreadable_registry_returns_a_document_not_an_exception(self, tmp_path):
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=str(tmp_path / "absent.yaml"),
+            s3_client=_FakeS3(), alert=False, publish=False,
+        )
+        assert doc["status"] == "registry_unreadable"
+        assert sos.exit_code(doc) == 2
+
+    def test_no_publish_writes_nothing(self, registry_file):
+        s3 = _FakeS3()
+        sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=registry_file, s3_client=s3,
+            alert=False, publish=False,
+        )
+        assert s3.puts == []
+
+
+class TestMain:
+    def _run(self, monkeypatch, argv, s3):
+        monkeypatch.setattr(sos, "_alert", lambda doc: None)
+        import boto3
+
+        monkeypatch.setattr(boto3, "client", lambda *a, **k: s3)
+        return sos.main(argv)
+
+    def test_observe_mode_exits_0_with_a_real_defect(self, monkeypatch, registry_file):
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        code = self._run(monkeypatch, [
+            "--run-date", RUN_DATE, "--cycle-date", RUN_DATE, "--registry", registry_file,
+            "--execution-start", "2026-08-08T09:00:49Z", "--no-alert",
+        ], s3)
+        assert code == 0
+
+    def test_enforce_mode_exits_1_with_the_same_defect(self, monkeypatch, registry_file):
+        """The proof the assertion CAN fail, walked end to end from a real
+        absent key to a non-zero process exit."""
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        code = self._run(monkeypatch, [
+            "--run-date", RUN_DATE, "--cycle-date", RUN_DATE, "--registry", registry_file,
+            "--execution-start", "2026-08-08T09:00:49Z", "--enforce", "--no-alert",
+        ], s3)
+        assert code == 1
+
+    def test_enforce_mode_exits_0_on_a_clean_run(self, monkeypatch, registry_file):
+        """The other polarity — an absence-alarm is blind in BOTH directions,
+        and a detector that fires on a healthy run is the one that gets muted.
+        """
+        s3 = _FakeS3({
+            f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1),
+            f"bad/{RUN_DATE}.json": EXEC_START + timedelta(hours=2),
+        })
+        code = self._run(monkeypatch, [
+            "--run-date", RUN_DATE, "--cycle-date", RUN_DATE, "--registry", registry_file,
+            "--execution-start", "2026-08-08T09:00:49Z", "--enforce", "--no-alert",
+        ], s3)
+        assert code == 0
+
+    def test_malformed_execution_start_exits_2_rather_than_dropping_the_window(
+        self, monkeypatch, registry_file
+    ):
+        """A mis-typed timestamp must not silently degrade every assertion to
+        ``unmeasured`` — that is a detector switched off by a typo.
+        """
+        code = self._run(monkeypatch, [
+            "--run-date", RUN_DATE, "--cycle-date", RUN_DATE, "--registry", registry_file,
+            "--execution-start", "08/08/2026", "--no-alert",
+        ], _FakeS3())
+        assert code == 2
+
+    def test_entered_stage_flag_excuses_only_the_absent_stage(
+        self, monkeypatch, registry_file
+    ):
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        code = self._run(monkeypatch, [
+            "--run-date", RUN_DATE, "--cycle-date", RUN_DATE, "--registry", registry_file,
+            "--execution-start", "2026-08-08T09:00:49Z", "--enforce", "--no-alert",
+            "--entered-stage", "PredictorTraining",
+        ], s3)
+        assert code == 0, "ReplayConcordance never entered, so its artifact is not owed"
+
+
+class _FakeSfn:
+    """Step Functions double. ``describe_raises`` / ``history_raises`` exist so
+    each half of the execution context can be failed INDEPENDENTLY — the two
+    degrade separately by design and a shared failure switch would hide that.
+    """
+
+    def __init__(self, start=None, entered=(), describe_raises=None,
+                 history_raises=None, pages=None):
+        self.start = start
+        self.entered = list(entered)
+        self.describe_raises = describe_raises
+        self.history_raises = history_raises
+        self.pages = pages
+
+    def describe_execution(self, executionArn):  # noqa: N803
+        if self.describe_raises:
+            raise self.describe_raises
+        return {"startDate": self.start, "status": "SUCCEEDED"}
+
+    def get_execution_history(self, **kw):
+        if self.history_raises:
+            raise self.history_raises
+        if self.pages is not None:
+            index = 0 if "nextToken" not in kw else int(kw["nextToken"])
+            return self.pages[index]
+        return {
+            "events": [
+                {"type": "TaskStateEntered",
+                 "stateEnteredEventDetails": {"name": n}}
+                for n in self.entered
+            ]
+        }
+
+
+class TestExecutionContext:
+    def test_reads_start_and_entered_stages(self):
+        ctx = sos.read_execution_context(
+            "arn:x", sfn_client=_FakeSfn(start=EXEC_START, entered=["A", "B"]),
+        )
+        assert ctx.start == EXEC_START
+        assert ctx.entered_stages == frozenset({"A", "B"})
+        assert ctx.notes == []
+
+    def test_paginates_the_history(self):
+        """A four-hour weekly run's history runs to thousands of events; a
+        single un-paginated page would silently truncate the entered set and
+        mark late stages skipped — false GREEN, the dangerous polarity."""
+        pages = [
+            {"events": [{"type": "TaskStateEntered",
+                         "stateEnteredEventDetails": {"name": "Early"}}],
+             "nextToken": "1"},
+            {"events": [{"type": "TaskStateEntered",
+                         "stateEnteredEventDetails": {"name": "Late"}}]},
+        ]
+        ctx = sos.read_execution_context("arn:x", sfn_client=_FakeSfn(pages=pages))
+        assert ctx.entered_stages == frozenset({"Early", "Late"})
+
+    def test_only_entered_events_count(self):
+        """Filtering on EXIT events would excuse every stage that entered and
+        died — precisely the population this sweep exists to catch."""
+        class _Sfn(_FakeSfn):
+            def get_execution_history(self, **kw):
+                return {"events": [
+                    {"type": "TaskStateEntered",
+                     "stateEnteredEventDetails": {"name": "Ran"}},
+                    {"type": "TaskStateExited",
+                     "stateExitedEventDetails": {"name": "Exited"}},
+                ]}
+
+        ctx = sos.read_execution_context("arn:x", sfn_client=_Sfn())
+        assert ctx.entered_stages == frozenset({"Ran"})
+
+    def test_describe_denied_still_yields_entered_stages(self):
+        ctx = sos.read_execution_context(
+            "arn:x",
+            sfn_client=_FakeSfn(entered=["A"], describe_raises=RuntimeError("AccessDenied")),
+        )
+        assert ctx.start is None
+        assert ctx.entered_stages == frozenset({"A"})
+        assert any("describe_execution failed" in n for n in ctx.notes)
+
+    def test_history_denied_still_yields_the_start(self):
+        ctx = sos.read_execution_context(
+            "arn:x",
+            sfn_client=_FakeSfn(start=EXEC_START, history_raises=RuntimeError("AccessDenied")),
+        )
+        assert ctx.start == EXEC_START
+        assert ctx.entered_stages is None
+        assert any("UNKNOWN" in n for n in ctx.notes)
+
+    def test_both_denied_degrades_to_nothing_known_and_says_so(self):
+        ctx = sos.read_execution_context(
+            "arn:x",
+            sfn_client=_FakeSfn(describe_raises=RuntimeError("x"),
+                                history_raises=RuntimeError("y")),
+        )
+        assert ctx.start is None and ctx.entered_stages is None
+        assert len(ctx.notes) == 2
+
+
+class TestGatedOutRun:
+    """The 2026-08-13 scheduled run terminated SUCCEEDED in 5.4 seconds,
+    gated out by ``WeeklyRunDayGate`` having done no work. Roughly two of
+    every three firings are such runs.
+
+    Without the entered-stage set this sweep would report every declared
+    artifact missing on those — ~30 false defects, twice a week, which is how
+    a detector earns its mute. With it, the run is correctly silent.
+    """
+
+    def test_gated_out_run_reports_no_defects(self, registry_file):
+        s3 = _FakeS3()
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=registry_file, s3_client=s3,
+            execution_arn="arn:x",
+            sfn_client=_FakeSfn(start=EXEC_START, entered=["WeeklyRunDayGate"]),
+            alert=False, publish=False, enforce=True,
+        )
+        assert doc["defects"] == []
+        assert doc["counts"].get(sos.SKIPPED) == 2
+        assert sos.exit_code(doc) == 0
+
+    def test_a_deep_run_with_a_silent_stage_still_fails(self, registry_file):
+        """The other polarity — the skip excuse must not become a blanket
+        amnesty. A stage that DID enter and wrote nothing is still a defect."""
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=registry_file, s3_client=s3,
+            execution_arn="arn:x",
+            sfn_client=_FakeSfn(
+                start=EXEC_START, entered=["PredictorTraining", "ReplayConcordance"]
+            ),
+            alert=False, publish=False, enforce=True,
+        )
+        assert [f["stage"] for f in doc["defects"]] == ["ReplayConcordance"]
+        assert sos.exit_code(doc) == 1
+
+    def test_history_denied_does_not_excuse_anything(self, registry_file):
+        """Losing the history must fail toward asserting, not toward amnesty."""
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=registry_file, s3_client=s3,
+            execution_arn="arn:x",
+            sfn_client=_FakeSfn(start=EXEC_START, history_raises=RuntimeError("AccessDenied")),
+            alert=False, publish=False, enforce=True,
+        )
+        assert doc["entered_stages_known"] is False
+        assert [f["stage"] for f in doc["defects"]] == ["ReplayConcordance"]
+        assert doc["context_notes"]
+
+    def test_explicit_arguments_win_over_the_api(self, registry_file):
+        """Replaying a historical run whose ARN no longer resolves must still
+        honour an explicitly-supplied window."""
+        s3 = _FakeS3()
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, registry_path=registry_file, s3_client=s3,
+            execution_start=EXEC_START, entered_stages=frozenset({"PredictorTraining"}),
+            execution_arn="arn:x",
+            sfn_client=_FakeSfn(start=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                                entered=["Something", "Else"]),
+            alert=False, publish=False,
+        )
+        assert doc["execution_start"] == EXEC_START.isoformat()
+        assert doc["entered_stage_count"] == 1
+
+
+class TestAlertBody:
+    def test_alert_names_the_mode_and_separates_the_two_finding_classes(
+        self, monkeypatch
+    ):
+        published = {}
+
+        class _Result:
+            any_ok = True
+
+        class _Alerts:
+            @staticmethod
+            def publish(message, **kw):
+                published["message"] = message
+                published["kw"] = kw
+                return _Result()
+
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "nousergon_lib", type("M", (), {"alerts": _Alerts}))
+        monkeypatch.setitem(_sys.modules, "nousergon_lib.alerts", _Alerts)
+
+        sos._alert({
+            "pipeline": PIPELINE, "run_date": RUN_DATE, "enforce": False,
+            "entered_stages_known": False,
+            "defects": [{"stage": "ParityReplay", "artifact_id": "parity_report",
+                         "verdict": sos.STALE}],
+            "unmeasured": [{"stage": "Backtester", "artifact_id": "x",
+                            "verdict": sos.UNMEASURED}],
+        })
+        message = published["message"]
+        assert "OBSERVE" in message
+        assert "DEFECT" in message and "UNMEASURED" in message
+        assert "NOT evidence of health" in message
+        assert published["kw"]["severity"] == "error"
+
+    def test_unmeasured_only_alerts_at_warn_not_error(self, monkeypatch):
+        published = {}
+
+        class _Result:
+            any_ok = True
+
+        class _Alerts:
+            @staticmethod
+            def publish(message, **kw):
+                published["kw"] = kw
+                return _Result()
+
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "nousergon_lib", type("M", (), {"alerts": _Alerts}))
+        monkeypatch.setitem(_sys.modules, "nousergon_lib.alerts", _Alerts)
+
+        sos._alert({
+            "pipeline": PIPELINE, "run_date": RUN_DATE, "enforce": True,
+            "entered_stages_known": True, "defects": [],
+            "unmeasured": [{"stage": "S", "artifact_id": "a", "verdict": sos.UNMEASURED}],
+        })
+        assert published["kw"]["severity"] == "warn"

--- a/validators/stage_output_sweep.py
+++ b/validators/stage_output_sweep.py
@@ -1,0 +1,948 @@
+"""
+validators/stage_output_sweep.py — stage-level OUTPUT assertion for a
+scheduled Step Functions run (alpha-engine-config-I7167).
+
+## The class this exists to catch
+
+The weekly pipeline had **no stage-level output assertion**. A stage that
+runs, exits 0 and writes nothing was indistinguishable from one that did its
+job, because the only thing any surface read was the stage's own exit status.
+
+A full artifact-freshness audit of the scheduled 2026-08-08 run — which
+terminated ``SUCCEEDED`` — found FIVE stages that produced no output for that
+run, none of them visible anywhere. Five different root causes (a shell trap
+that died at line 5, a caller/contract disagreement, a fresh sibling masking a
+dead key, a 900s wall-kill, a prefix cutover) produced **one identical
+observable: nothing**. Fixing five producers leaves the sixth undetectable, so
+the deliverable is the assertion, and the five fixes are its first sweep
+(``engagement-protocol-policy.md`` §5 — the fix survives the class).
+
+It is ``sf-pipeline-policy.md`` §2.3a's decorative-verdict test applied to DATA
+artifacts, and ``principles.md`` §2.7: a stage emitting nothing is not healthy,
+it is **unobserved**, and *no data* is never rendered green.
+
+## Where the declaration lives — deliberately not here
+
+The stage→artifact mapping is ``ARTIFACT_REGISTRY.yaml``'s ``produced_by:``
+(``alpha-engine-config``, config-I7180), read here from the S3 mirror the
+config repo publishes at ``_freshness_monitor/ARTIFACT_REGISTRY.yaml``. This
+module owns **no** artifact declarations of its own. A second registry beside
+one that already exists, already carries producer rows, and is already read by
+the freshness monitor is ``policy-shared-code``'s duplication failure one layer
+up, and I7167 names that trap explicitly.
+
+The division of labour against the freshness monitor is worth stating, because
+the two look similar and answer different questions:
+
+  * the **freshness monitor** asks *"is this key younger than its CADENCE
+    clock?"* — a standing, run-agnostic SLA sweep;
+  * this sweep asks *"did the stage that ran in THIS EXECUTION write the key it
+    declares?"* — an execution-scoped, producer-anchored assertion.
+
+A weekly stage that stopped writing can hide from the first behind a daily
+producer of the same prefix, or behind a grace period wide enough to cover the
+gap. It cannot hide from the second, because the second is anchored to an
+execution start time rather than to a calendar.
+
+## Verdicts, and why "could not measure" is its own answer
+
+This fleet has shipped detectors that report a HARNESS FAULT as a FINDING, and
+always in the alarming direction. The verdict set keeps the two apart:
+
+  ``wrote``       the declared key exists and was written at/after the
+                  execution start — the stage did its job
+  ``stale``       the key exists but PREDATES this execution — the silent-stage
+                  signature. This is the 2026-08-08 observable for the
+                  ``Backtester`` second artifact (87 days old) and
+                  ``ParityReplay`` (3+ weeks old)
+  ``missing``     no object at the declared key at all
+  ``unmeasured``  the check could NOT answer — S3 denied/errored, the key
+                  template carries a placeholder this run cannot resolve, or no
+                  execution window was supplied so staleness is undecidable.
+                  **Never** folded into ``wrote`` and never into ``missing``:
+                  a check that cannot run is not evidence of health and is not
+                  evidence of a defect either
+  ``unresolved``  the registry row declares ``stage: UNRESOLVED`` — the
+                  artifact is real but its producing stage was never
+                  established (config-I7180's published, ratcheted gap). Not a
+                  defect of this run; counted separately so it can never be
+                  quietly absorbed into the green number
+  ``skipped``     the declaring stage did not enter this execution. Only
+                  reachable when an entered-stage set is supplied; without one
+                  no stage is ever declared skipped, because "I don't know
+                  which stages ran" must not become "the stage was allowed not
+                  to run"
+
+``unmeasured`` is deliberately NOT silent. Absence of a measurement is a
+first-class finding with its own exit code and its own alert, because the
+alternative — a sweep that reports 0 defects because it could not look — is the
+exact failure it was written to end.
+
+## Absence is measurable without a window; staleness is not
+
+If no ``--execution-start`` is supplied the sweep still runs, and a
+``missing`` key is still a defect: an object that does not exist did not get
+written by anybody, whatever the window. What becomes undecidable is
+``stale`` — an existing key cannot be attributed to this run or a previous one
+— so every present key degrades to ``unmeasured`` rather than to ``wrote``.
+That degradation is honest and it is loud, and it is what the sweep does on the
+deployment path where the SF has not yet been taught to pass its start time.
+
+## Observe-first, and why enforcement is a separate flip
+
+``alpha-engine-config-I6891`` routes any degraded weekly run through
+``CheckDegradedOutcome`` → ``WriteCompletionMarkerDegraded`` → ``DegradedRun``,
+a **Fail** state. That is correct and must not be undone — but it means any
+non-zero exit from this sweep, invoked as it is from
+``WeeklySubstrateHealthCheck``, terminates a four-hour run as FAILED.
+
+Three of the five instances I7167 records are still open today. Shipping this
+enforcing would therefore hard-fail the next scheduled run for defects that
+were already there — punishing the pipeline for the detector arriving, which is
+exactly the shape ``ruling_detect_before_enforcing_when_the_floor_is_unmeasured``
+(Brian, 2026-08-11) forbids.
+
+So the default is ``observe``: findings ALERT, are written to a durable verdict
+artifact, and the process exits 0. ``--enforce`` makes findings exit non-zero.
+The flip is one flag, and its precondition is one measured number — the first
+scheduled run's finding count. Observe mode is not silent mode: it is loud on
+every surface except the one that kills the run.
+
+The sweep's own verdict artifact
+(``_stage_outputs/{pipeline}/{run_date}.json``) carries a row in
+``ARTIFACT_REGISTRY.yaml``, so this detector going quiet is itself detected —
+``principles.md`` §2.7 applied to the detector rather than only by it.
+
+## Usage
+
+  python -m validators.stage_output_sweep --run-date 2026-08-08 \\
+      --execution-start 2026-08-08T09:00:49Z
+  python -m validators.stage_output_sweep --run-date 2026-08-08 --enforce
+  python -m validators.stage_output_sweep --run-date 2026-08-08 \\
+      --registry ./ARTIFACT_REGISTRY.yaml --no-alert --no-publish
+
+Exit codes:
+  0  no defect found (or observe mode, whatever was found)
+  1  ENFORCE mode and at least one ``missing``/``stale`` verdict
+  2  sweep-infra failure: the registry could not be read, or ENFORCE mode with
+     at least one ``unmeasured`` verdict. Distinct from 1 on purpose — the
+     alert text and the operator's next move differ, and collapsing them is
+     how a harness fault gets filed as a data defect
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUCKET = "alpha-engine-research"
+DEFAULT_PIPELINE = "ne-weekly-freshness-pipeline"
+
+# The config repo mirrors ARTIFACT_REGISTRY.yaml here on merge
+# (.github/workflows/sync-artifact-registry.yml). Reading the mirror rather
+# than a checked-out copy is what lets this run on the dashboard box, which
+# does not clone the private config repo.
+REGISTRY_KEY = "_freshness_monitor/ARTIFACT_REGISTRY.yaml"
+
+# Where this sweep's own verdict lands. Registered in ARTIFACT_REGISTRY.yaml so
+# the detector's SILENCE is detectable — a sweep that stops running must not
+# read as a pipeline with nothing to report.
+VERDICT_KEY_TEMPLATE = "_stage_outputs/{pipeline}/{run_date}.json"
+
+UNRESOLVED_PRODUCER_STAGE = "UNRESOLVED"
+
+# Verdicts. Ordered worst-first for reporting; the ordering is not a severity
+# ladder used for suppression — every non-`wrote` verdict is reported.
+WROTE = "wrote"
+STALE = "stale"
+MISSING = "missing"
+UNMEASURED = "unmeasured"
+UNRESOLVED = "unresolved"
+SKIPPED = "skipped"
+
+#: Verdicts that mean "this run has a data defect".
+DEFECT_VERDICTS = frozenset({MISSING, STALE})
+
+#: Verdicts that mean "the check could not answer". Never merged into
+#: :data:`DEFECT_VERDICTS` — see the module docstring.
+UNMEASURED_VERDICTS = frozenset({UNMEASURED})
+
+_PLACEHOLDER_RE = re.compile(r"\{([a-z_]+)\}")
+
+# Truncate finding lists in the alert body so a worst-case
+# every-stage-silent run does not blow the SNS subject/body limits.
+_ALERT_PREVIEW_LIMIT = 12
+
+
+#: Execution-history event types that mean "this state was entered". Only the
+#: ENTERED events are read: an ``*StateExited`` filter would silently excuse
+#: every stage that entered and died, which is the exact population this sweep
+#: exists to catch.
+_ENTERED_EVENT_SUFFIX = "StateEntered"
+
+
+class ExecutionContext:
+    """What the sweep could establish about the execution it is asserting over.
+
+    Both fields degrade INDEPENDENTLY and honestly. A denied
+    ``GetExecutionHistory`` must not take the start time down with it, and
+    neither failure may be reported as a fact about the pipeline.
+    """
+
+    __slots__ = ("start", "entered_stages", "notes")
+
+    def __init__(
+        self,
+        start: datetime | None = None,
+        entered_stages: frozenset[str] | None = None,
+        notes: list[str] | None = None,
+    ) -> None:
+        self.start = start
+        self.entered_stages = entered_stages
+        self.notes = notes or []
+
+
+def read_execution_context(
+    execution_arn: str,
+    *,
+    sfn_client: Any = None,
+) -> ExecutionContext:
+    """Read this execution's start time and entered-stage set.
+
+    Why this is worth an API call rather than an SF-threaded parameter: a
+    gated-out weekly run terminates ``SUCCEEDED`` in about five seconds
+    (``WeeklyRunDayGate``), and roughly two of every three firings are such
+    runs. Asserting a full artifact set against one of those would report ~30
+    missing artifacts on a run that was correct to do nothing — a detector that
+    cries wolf twice a week is a detector that gets muted, and then the real
+    silent stage goes with it.
+
+    The entered-stage set is what separates "the stage ran and wrote nothing"
+    from "the stage never ran". Only the first is a defect.
+
+    Both halves fail soft into ``None``, which the caller renders as
+    ``unmeasured`` / no-stage-excused rather than as health. The
+    ``alpha-engine-dashboard-role`` already carries ``states:DescribeExecution``
+    and ``states:GetExecutionHistory`` on
+    ``execution:ne-weekly-freshness-pipeline:*`` (policy
+    ``alpha-engine-dashboard-sfn-read``, measured 2026-08-13), so this needs no
+    new grant — but it is written to survive losing one.
+    """
+    context = ExecutionContext()
+    if sfn_client is None:
+        try:
+            import boto3  # noqa: PLC0415
+
+            sfn_client = boto3.client("stepfunctions")
+        except Exception as exc:  # noqa: BLE001
+            context.notes.append(f"stepfunctions client unavailable: {exc}")
+            return context
+
+    try:
+        described = sfn_client.describe_execution(executionArn=execution_arn)
+        start = described.get("startDate")
+        if isinstance(start, datetime):
+            context.start = _utc(start)
+        else:
+            context.notes.append("describe_execution returned no usable startDate")
+    except Exception as exc:  # noqa: BLE001
+        context.notes.append(
+            f"describe_execution failed ({type(exc).__name__}: {exc}) — staleness "
+            f"is undecidable for this run"
+        )
+
+    try:
+        entered: set[str] = set()
+        token = None
+        while True:
+            kwargs = {"executionArn": execution_arn, "maxResults": 1000}
+            if token:
+                kwargs["nextToken"] = token
+            page = sfn_client.get_execution_history(**kwargs)
+            for event in page.get("events", []):
+                event_type = event.get("type", "")
+                if not event_type.endswith(_ENTERED_EVENT_SUFFIX):
+                    continue
+                details = event.get("stateEnteredEventDetails") or {}
+                name = details.get("name")
+                if name:
+                    entered.add(name)
+            token = page.get("nextToken")
+            if not token:
+                break
+        context.entered_stages = frozenset(entered)
+    except Exception as exc:  # noqa: BLE001
+        context.notes.append(
+            f"get_execution_history failed ({type(exc).__name__}: {exc}) — the "
+            f"entered-stage set is UNKNOWN, so no stage is excused as skipped"
+        )
+    return context
+
+
+class RegistryUnreadable(RuntimeError):
+    """The registry could not be read or parsed.
+
+    Raised rather than returned-as-empty: an empty producer set makes every
+    assertion vacuously pass, which is a detector that cannot fail wearing the
+    clothes of a clean run.
+    """
+
+
+def _utc(value: datetime) -> datetime:
+    """Normalise to timezone-aware UTC. Naive input is ASSUMED UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def parse_execution_start(raw: str) -> datetime:
+    """Parse an ISO-8601 execution start, accepting the trailing ``Z`` that
+    Step Functions' ``$$.Execution.StartTime`` emits.
+
+    ``datetime.fromisoformat`` gained ``Z`` support only in 3.11; the dashboard
+    box's venv is pinned below that on at least one fleet host, so the suffix is
+    normalised here rather than relied upon.
+    """
+    text = raw.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    return _utc(datetime.fromisoformat(text))
+
+
+def resolve_cycle_date(run_date: str) -> str | None:
+    """The CYCLE date the registry's key templates are written against.
+
+    This is not the SF's ``$.run_date`` and conflating the two is the single
+    most expensive mistake available here. Measured on the 2026-08-08 run:
+    ``$.run_date`` was ``2026-08-08`` (the calendar Saturday), while every
+    artifact that run produced landed under ``2026-08-07`` — ``backtest/
+    2026-08-08/`` does not exist at all, and ``backtest/2026-08-07/report.md``
+    carries ``LastModified 2026-08-08T06:13``. Resolving ``{date}`` to the run
+    date produced **28 confident false MISSING verdicts** against a run that had
+    written almost everything.
+
+    That is this sweep's own failure mode turned on itself — a detector
+    reporting a harness fault as a finding about the system, in the alarming
+    direction — and it is why this function exists rather than a string
+    substitution at the call site.
+
+    ``krepis.dates.expected_last_close`` is the fleet's canonical resolver and
+    the same notion of "cycle tick" that
+    ``nousergon_lib.artifact_freshness._format_key`` substitutes; it is used
+    here rather than re-derived so the two cannot drift.
+
+    Returns ``None`` when the resolver is unavailable, which the caller renders
+    as ``unmeasured``. Guessing (weekday arithmetic, "probably yesterday")
+    would reintroduce exactly the 28-false-positive failure with no way to see
+    it had happened.
+    """
+    try:
+        from krepis.dates import expected_last_close  # noqa: PLC0415
+
+        return expected_last_close(run_date).isoformat()
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "Cycle-date resolution failed (%s) — every dated key will report "
+            "unmeasured rather than be checked against a guessed date", exc,
+        )
+        return None
+
+
+def resolve_key(
+    template: str, *, run_date: str, cycle_date: str | None
+) -> str | None:
+    """Resolve a registry ``s3_key_template`` for this run.
+
+    ``{date}`` and ``{trading_day}`` both resolve to ``cycle_date`` — they are
+    aliases in the registry convention and in
+    ``artifact_freshness._format_key``, the second being a semantic name for
+    the same tick. ``{run_date}`` resolves to the SF's own ``$.run_date``.
+
+    Returns ``None`` — meaning ``unmeasured``, never ``missing`` — when the
+    template needs a cycle date that could not be resolved, or carries any
+    OTHER placeholder (``{cycle_label}``, an hour bucket, anything added
+    later). Head-ing a literal key containing braces would 404 every time and
+    report a confident, permanent, entirely false ``missing``: the most
+    convincing wrong finding this sweep could produce.
+    """
+    resolved = template
+    for name in set(_PLACEHOLDER_RE.findall(template)):
+        if name in ("date", "trading_day"):
+            if cycle_date is None:
+                return None
+            resolved = resolved.replace("{" + name + "}", cycle_date)
+        elif name == "run_date":
+            resolved = resolved.replace("{run_date}", run_date)
+        else:
+            return None
+    if "{" in resolved or "}" in resolved:
+        return None
+    return resolved
+
+
+def load_registry_rows(
+    *,
+    bucket: str = DEFAULT_BUCKET,
+    registry_path: str | None = None,
+    s3_client: Any = None,
+) -> list[dict]:
+    """Load the artifact registry rows, from a local path or the S3 mirror.
+
+    Raises:
+        RegistryUnreadable: on any read/parse failure, or when the parsed
+            document carries no ``artifacts`` list. Never returns ``[]`` for a
+            failure — see the class docstring.
+    """
+    try:
+        import yaml  # noqa: PLC0415 — optional at import time, required here
+    except ImportError as exc:  # pragma: no cover - environment gap
+        raise RegistryUnreadable(f"PyYAML unavailable: {exc}") from exc
+
+    try:
+        if registry_path:
+            with open(registry_path, "rb") as handle:
+                raw = handle.read()
+        else:
+            if s3_client is None:
+                import boto3  # noqa: PLC0415
+
+                s3_client = boto3.client("s3")
+            raw = s3_client.get_object(Bucket=bucket, Key=REGISTRY_KEY)["Body"].read()
+    except Exception as exc:  # noqa: BLE001 - any read failure is unreadable
+        raise RegistryUnreadable(
+            f"could not read registry "
+            f"({registry_path or f's3://{bucket}/{REGISTRY_KEY}'}): {exc}"
+        ) from exc
+
+    try:
+        document = yaml.safe_load(raw)
+    except Exception as exc:  # noqa: BLE001
+        raise RegistryUnreadable(f"registry is not parseable YAML: {exc}") from exc
+
+    rows = (document or {}).get("artifacts") if isinstance(document, dict) else None
+    if not isinstance(rows, list) or not rows:
+        raise RegistryUnreadable(
+            "registry carries no non-empty 'artifacts' list — refusing to sweep "
+            "against an empty producer set (an assertion over nothing always "
+            "passes)"
+        )
+    return rows
+
+
+def declared_outputs(
+    rows: Iterable[dict],
+    *,
+    pipeline: str,
+    default_bucket: str = DEFAULT_BUCKET,
+) -> list[dict]:
+    """Invert the registry into ``[{stage, artifact_id, bucket, template}]``
+    for one pipeline.
+
+    A row with two real producers (the Scanner artifacts are written by BOTH
+    the weekday preopen SF and the weekly SF) contributes one entry per
+    matching producer — which is the whole point of ``produced_by`` being a
+    list, and the reason a stopped weekly stage stops hiding behind a live
+    daily one.
+    """
+    out: list[dict] = []
+    for row in rows:
+        for producer in row.get("produced_by") or []:
+            if producer.get("pipeline") != pipeline:
+                continue
+            out.append(
+                {
+                    "stage": producer.get("stage") or UNRESOLVED_PRODUCER_STAGE,
+                    "artifact_id": row.get("artifact_id"),
+                    "bucket": row.get("s3_bucket") or default_bucket,
+                    "s3_key_template": row.get("s3_key_template"),
+                    "severity": row.get("severity", "warning"),
+                }
+            )
+    return out
+
+
+def _head(s3_client: Any, bucket: str, key: str) -> tuple[str, Any]:
+    """HEAD one key.
+
+    Returns ``("found", last_modified)``, ``("absent", None)``, or
+    ``("error", reason)``. The three-way return is the whole point: a 403 or a
+    503 is NOT an absent object, and rendering it as one manufactures a defect
+    out of a permissions gap.
+    """
+    try:
+        response = s3_client.head_object(Bucket=bucket, Key=key)
+    except Exception as exc:  # noqa: BLE001
+        code = ""
+        response_meta = getattr(exc, "response", None)
+        if isinstance(response_meta, dict):
+            code = str(response_meta.get("Error", {}).get("Code", ""))
+            status = response_meta.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if code in ("404", "NoSuchKey", "NotFound") or status == 404:
+                return "absent", None
+        return "error", f"{type(exc).__name__}: {code or exc}"
+    return "found", response.get("LastModified")
+
+
+def evaluate(
+    declarations: Sequence[dict],
+    *,
+    run_date: str,
+    execution_start: datetime | None,
+    head: Callable[[str, str], tuple[str, Any]],
+    entered_stages: frozenset[str] | None = None,
+    cycle_date: str | None = None,
+) -> list[dict]:
+    """Assign a verdict to every declared (stage, artifact) pair.
+
+    Args:
+        declarations: output of :func:`declared_outputs`.
+        run_date: the SF-stamped ``$.run_date``, used to resolve key templates.
+        execution_start: this execution's start. ``None`` means staleness is
+            undecidable, so every PRESENT key is ``unmeasured`` rather than
+            ``wrote`` — see the module docstring.
+        head: ``(bucket, key) -> (state, detail)``, injected so the decision
+            logic is testable without S3 and so the failing branch can actually
+            be exercised.
+        entered_stages: the stages that actually entered this execution, when
+            known. ``None`` means unknown, and then NO stage is marked
+            ``skipped`` — "I don't know which stages ran" must never become
+            "the stage was allowed not to run". When supplied, a declaring
+            stage absent from it is ``skipped`` (a degraded run legitimately
+            skips stages, and a detector that cries wolf on those is a detector
+            that gets turned off).
+    """
+    findings: list[dict] = []
+    for declaration in declarations:
+        stage = declaration["stage"]
+        finding = {
+            "stage": stage,
+            "artifact_id": declaration["artifact_id"],
+            "s3_key_template": declaration["s3_key_template"],
+            "bucket": declaration["bucket"],
+            "severity": declaration.get("severity", "warning"),
+            "key": None,
+            "last_modified": None,
+            "detail": None,
+        }
+
+        if stage == UNRESOLVED_PRODUCER_STAGE:
+            finding["verdict"] = UNRESOLVED
+            finding["detail"] = (
+                "registry row declares produced_by stage=UNRESOLVED (config-I7180 "
+                "ratcheted gap) — this artifact cannot be attributed to a stage, "
+                "so this run cannot be held to it"
+            )
+            findings.append(finding)
+            continue
+
+        if entered_stages is not None and stage not in entered_stages:
+            finding["verdict"] = SKIPPED
+            finding["detail"] = "stage did not enter this execution"
+            findings.append(finding)
+            continue
+
+        template = declaration["s3_key_template"] or ""
+        key = resolve_key(template, run_date=run_date, cycle_date=cycle_date)
+        if key is None:
+            finding["verdict"] = UNMEASURED
+            finding["detail"] = (
+                f"key template {template!r} carries a placeholder this sweep "
+                f"could not resolve"
+                + ("" if cycle_date else " (cycle date unresolved)")
+            )
+            findings.append(finding)
+            continue
+
+        finding["key"] = key
+        state, detail = head(declaration["bucket"], key)
+
+        if state == "error":
+            finding["verdict"] = UNMEASURED
+            finding["detail"] = f"S3 head_object could not answer: {detail}"
+        elif state == "absent":
+            finding["verdict"] = MISSING
+            finding["detail"] = "no object at the declared key"
+        else:
+            last_modified = _utc(detail) if isinstance(detail, datetime) else None
+            finding["last_modified"] = (
+                last_modified.isoformat() if last_modified else None
+            )
+            if last_modified is None:
+                finding["verdict"] = UNMEASURED
+                finding["detail"] = (
+                    "object exists but S3 returned no usable LastModified — "
+                    "presence alone cannot distinguish this run's write from a "
+                    "previous one"
+                )
+            elif execution_start is None:
+                finding["verdict"] = UNMEASURED
+                finding["detail"] = (
+                    "object exists but no execution start was supplied, so it "
+                    "cannot be attributed to THIS run"
+                )
+            elif last_modified >= execution_start:
+                finding["verdict"] = WROTE
+            else:
+                age = execution_start - last_modified
+                finding["verdict"] = STALE
+                finding["detail"] = (
+                    f"object predates this execution by {age.days}d "
+                    f"{age.seconds // 3600}h — the declaring stage did not write "
+                    f"it on this run"
+                )
+        findings.append(finding)
+
+    return findings
+
+
+def summarise(findings: Sequence[dict]) -> dict:
+    """Reduce findings to counts plus the two lists that decide the exit code."""
+    counts: dict[str, int] = {}
+    for finding in findings:
+        counts[finding["verdict"]] = counts.get(finding["verdict"], 0) + 1
+    defects = [f for f in findings if f["verdict"] in DEFECT_VERDICTS]
+    unmeasured = [f for f in findings if f["verdict"] in UNMEASURED_VERDICTS]
+    if defects:
+        status = "stage_output_missing"
+    elif unmeasured:
+        status = "stage_output_unmeasured"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "counts": counts,
+        "checked": len(findings),
+        "defects": defects,
+        "unmeasured": unmeasured,
+    }
+
+
+def sweep(
+    *,
+    run_date: str,
+    pipeline: str = DEFAULT_PIPELINE,
+    execution_start: datetime | None = None,
+    entered_stages: frozenset[str] | None = None,
+    bucket: str = DEFAULT_BUCKET,
+    registry_path: str | None = None,
+    s3_client: Any = None,
+    execution_arn: str | None = None,
+    sfn_client: Any = None,
+    cycle_date: str | None = None,
+    alert: bool = True,
+    publish: bool = True,
+    enforce: bool = False,
+) -> dict:
+    """Assert every artifact this pipeline's stages declare was written by this
+    run. Returns the full verdict document; never raises for a finding.
+    """
+    if cycle_date is None:
+        cycle_date = resolve_cycle_date(run_date)
+    context_notes: list[str] = []
+    if execution_arn:
+        context = read_execution_context(execution_arn, sfn_client=sfn_client)
+        context_notes = context.notes
+        # An explicitly-passed value wins over the API read: the caller may be
+        # replaying a historical run whose ARN no longer resolves.
+        if execution_start is None:
+            execution_start = context.start
+        if entered_stages is None:
+            entered_stages = context.entered_stages
+        for note in context_notes:
+            logger.warning("Execution context degraded: %s", note)
+
+    try:
+        rows = load_registry_rows(
+            bucket=bucket, registry_path=registry_path, s3_client=s3_client
+        )
+    except RegistryUnreadable as exc:
+        logger.error("Stage-output sweep could not read the registry: %s", exc)
+        return {
+            "schema": "stage_output_sweep-1.0.0",
+            "status": "registry_unreadable",
+            "pipeline": pipeline,
+            "run_date": run_date,
+            "enforce": enforce,
+            "error": str(exc),
+            "checked": 0,
+            "counts": {},
+            "findings": [],
+            "defects": [],
+            "unmeasured": [],
+        }
+
+    if s3_client is None:
+        import boto3  # noqa: PLC0415
+
+        s3_client = boto3.client("s3")
+
+    declarations = declared_outputs(rows, pipeline=pipeline, default_bucket=bucket)
+    findings = evaluate(
+        declarations,
+        run_date=run_date,
+        execution_start=execution_start,
+        head=lambda b, k: _head(s3_client, b, k),
+        entered_stages=entered_stages,
+        cycle_date=cycle_date,
+    )
+    summary = summarise(findings)
+
+    document = {
+        "schema": "stage_output_sweep-1.0.0",
+        "status": summary["status"],
+        "pipeline": pipeline,
+        "run_date": run_date,
+        "cycle_date": cycle_date,
+        "enforce": enforce,
+        "execution_start": (
+            execution_start.isoformat() if execution_start else None
+        ),
+        "entered_stages_known": entered_stages is not None,
+        "entered_stage_count": len(entered_stages) if entered_stages is not None else None,
+        "execution_arn": execution_arn,
+        "context_notes": context_notes,
+        "declared_stages": sorted(
+            {d["stage"] for d in declarations if d["stage"] != UNRESOLVED_PRODUCER_STAGE}
+        ),
+        "checked": summary["checked"],
+        "counts": summary["counts"],
+        "findings": findings,
+        "defects": summary["defects"],
+        "unmeasured": summary["unmeasured"],
+    }
+
+    logger.info(
+        "Stage-output sweep pipeline=%s run_date=%s enforce=%s: %s",
+        pipeline, run_date, enforce, summary["counts"],
+    )
+
+    if publish:
+        _publish_verdict(s3_client, bucket, document)
+    if alert and summary["status"] != "ok":
+        _alert(document)
+
+    return document
+
+
+def _publish_verdict(s3_client: Any, bucket: str, document: dict) -> None:
+    """Write the verdict artifact.
+
+    Failure to publish is logged and swallowed rather than raised — (a) the
+    failure mode swallowed is an S3 write fault on the REPORTING path, (b) the
+    primary deliverable (the alert and the exit code) has already been decided
+    from the in-memory document and survives intact, (c) the recording surface
+    is this ERROR log line plus the registry row on the verdict key, which goes
+    stale and pages when this write stops landing. An exception here would
+    convert a reporting fault into a pipeline failure — the reporter destroying
+    the thing it reports, a class this fleet has already shipped twice.
+    """
+    key = VERDICT_KEY_TEMPLATE.format(
+        pipeline=document["pipeline"], run_date=document["run_date"]
+    )
+    try:
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(document, indent=2, default=str).encode(),
+            ContentType="application/json",
+        )
+        logger.info("Stage-output verdict written to s3://%s/%s", bucket, key)
+    except Exception as exc:  # noqa: BLE001 - see docstring (a)/(b)/(c)
+        logger.error(
+            "Stage-output verdict publish FAILED for s3://%s/%s: %s — the sweep "
+            "verdict below is still authoritative, but the durable record of it "
+            "is missing and the registry row on this key will go stale",
+            bucket, key, exc,
+        )
+
+
+def _describe(findings: Sequence[dict]) -> str:
+    preview = "; ".join(
+        f"{f['stage']}→{f['artifact_id']} ({f['verdict']})"
+        for f in findings[:_ALERT_PREVIEW_LIMIT]
+    )
+    if len(findings) > _ALERT_PREVIEW_LIMIT:
+        preview += f" ... +{len(findings) - _ALERT_PREVIEW_LIMIT} more"
+    return preview
+
+
+def _alert(document: dict) -> None:
+    """Publish the finding. Loud in observe mode — that is the whole design."""
+    try:
+        from nousergon_lib import alerts  # noqa: PLC0415
+    except ImportError as exc:
+        logger.warning(
+            "Stage-output alert skipped — nousergon_lib.alerts unavailable: %s", exc
+        )
+        return
+
+    defects = document["defects"]
+    unmeasured = document["unmeasured"]
+    mode = "ENFORCE" if document["enforce"] else "OBSERVE (exit 0 by design)"
+
+    parts = [
+        f"Stage-output sweep [{mode}] {document['pipeline']} "
+        f"run_date={document['run_date']}: "
+        f"{len(defects)} stage(s) produced NO output for this run, "
+        f"{len(unmeasured)} could NOT be measured."
+    ]
+    if defects:
+        parts.append(f"DEFECT (stage ran, key absent or predates the run): {_describe(defects)}.")
+    if unmeasured:
+        parts.append(
+            f"UNMEASURED (the check could not answer — NOT evidence of health "
+            f"and NOT evidence of a defect): {_describe(unmeasured)}."
+        )
+    if not document.get("entered_stages_known"):
+        parts.append(
+            "Entered-stage set unknown, so no stage was excused as skipped; a "
+            "legitimately-skipped stage on a degraded run will appear here."
+        )
+    parts.append(f"Full verdict: s3://alpha-engine-research/"
+                 f"{VERDICT_KEY_TEMPLATE.format(**{k: document[k] for k in ('pipeline', 'run_date')})}"
+                 " (alpha-engine-config-I7167).")
+
+    severity = "error" if defects else "warn"
+    try:
+        result = alerts.publish(
+            " ".join(parts),
+            severity=severity,
+            source="alpha-engine-data/validators/stage_output_sweep.py",
+            dedup_key=f"stage_output_sweep_{document['pipeline']}_{document['run_date']}",
+            dedup_window_min=720,
+        )
+        logger.info("Stage-output alert publish: any_ok=%s", result.any_ok)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Stage-output alert publish failed: %s", exc)
+
+
+def exit_code(document: dict) -> int:
+    """Map a verdict document to a process exit code.
+
+    Observe mode is 0 for findings but NOT for an unreadable registry: that is
+    a fault in the sweep itself, and a sweep that cannot run must not report
+    the same exit status as a sweep that ran and found nothing.
+    """
+    if document["status"] == "registry_unreadable":
+        return 2
+    if not document["enforce"]:
+        return 0
+    if document["defects"]:
+        return 1
+    if document["unmeasured"]:
+        return 2
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Stage-level output assertion for a scheduled SF run "
+                    "(alpha-engine-config-I7167)",
+    )
+    parser.add_argument("--run-date", required=True,
+                        help="SF-stamped $.run_date, e.g. 2026-08-08")
+    parser.add_argument("--pipeline", default=DEFAULT_PIPELINE)
+    parser.add_argument(
+        "--execution-start", default=None,
+        help="ISO-8601 execution start ($$.Execution.StartTime). Omitted ⇒ "
+             "staleness is undecidable and every present key reports unmeasured",
+    )
+    parser.add_argument(
+        "--entered-stage", action="append", default=None, dest="entered_stages",
+        help="repeatable; a stage that entered this execution. Omitted entirely "
+             "⇒ the entered set is UNKNOWN and no stage is excused as skipped",
+    )
+    parser.add_argument(
+        "--execution-arn", default=None,
+        help="this execution's ARN ($$.Execution.Id). Supplies BOTH the start "
+             "time and the entered-stage set, so a gated-out run that did no "
+             "work is not asserted against a full artifact set",
+    )
+    parser.add_argument(
+        "--cycle-date", default=None,
+        help="the date the registry's {date}/{trading_day} templates are keyed "
+             "by. Defaults to krepis.dates.expected_last_close(run_date) — NOT "
+             "run_date itself; see resolve_cycle_date()",
+    )
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--registry", default=None,
+                        help="local ARTIFACT_REGISTRY.yaml (default: the S3 mirror)")
+    parser.add_argument(
+        "--enforce", action="store_true",
+        help="findings exit non-zero. Default is OBSERVE — see the module "
+             "docstring on the I6891 degraded-run blast radius",
+    )
+    parser.add_argument("--no-alert", action="store_true")
+    parser.add_argument("--no-publish", action="store_true",
+                        help="skip writing the verdict artifact")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+    execution_start = None
+    if args.execution_start:
+        try:
+            execution_start = parse_execution_start(args.execution_start)
+        except ValueError as exc:
+            logger.error(
+                "--execution-start %r is not ISO-8601 (%s). Refusing to fall back "
+                "to 'no window': a mis-typed timestamp would silently turn every "
+                "assertion into unmeasured.",
+                args.execution_start, exc,
+            )
+            return 2
+
+    document = sweep(
+        run_date=args.run_date,
+        pipeline=args.pipeline,
+        execution_start=execution_start,
+        entered_stages=(
+            frozenset(args.entered_stages) if args.entered_stages else None
+        ),
+        bucket=args.bucket,
+        registry_path=args.registry,
+        execution_arn=args.execution_arn,
+        cycle_date=args.cycle_date,
+        alert=not args.no_alert,
+        publish=not args.no_publish,
+        enforce=args.enforce,
+    )
+
+    code = exit_code(document)
+    if document["status"] == "registry_unreadable":
+        logger.error("Stage-output sweep COULD NOT RUN: %s", document["error"])
+    elif document["defects"]:
+        logger.error(
+            "STAGE OUTPUT MISSING: %d declared artifact(s) absent or stale for "
+            "run_date=%s: %s%s",
+            len(document["defects"]), args.run_date,
+            _describe(document["defects"]),
+            "" if args.enforce else " [OBSERVE mode — exiting 0 by design]",
+        )
+    elif document["unmeasured"]:
+        logger.error(
+            "STAGE OUTPUT UNMEASURED: %d declared artifact(s) could not be "
+            "checked for run_date=%s: %s",
+            len(document["unmeasured"]), args.run_date,
+            _describe(document["unmeasured"]),
+        )
+    else:
+        logger.info(
+            "Stage-output sweep OK: %d declared artifact(s) written by this run",
+            document["checked"],
+        )
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs `alpha-engine-config-I7167`. The tracked issue is on `alpha-engine-config`; this repo carries the assertion mechanism and its SF wiring.

## The class, not the five instances

The weekly pipeline had **no stage-level output assertion**. A stage that ran, exited 0 and wrote nothing was indistinguishable from one that did its job. A full artifact audit of the scheduled 2026-08-08 run — which terminated `SUCCEEDED` — found five stages that produced no output, from five unrelated root causes (a shell trap dying at line 5, a caller/contract disagreement, a fresh sibling masking a dead key, a 900s wall-kill, a prefix cutover), producing **one identical observable: nothing**.

Fixing five producers leaves the sixth undetectable. Per `engagement-protocol-policy.md` §5 the fix survives the class, and **detection blindness outranks the defects it hides** — so the deliverable is the assertion and the instances are its first sweep.

## The mechanism

`validators/stage_output_sweep.py` reads the stage→artifact mapping from `ARTIFACT_REGISTRY.yaml`'s `produced_by:` (config-I7180) through the S3 mirror the config repo publishes. **It owns no artifact declarations of its own** — a second registry beside one that already exists, already carries producer rows and is already read by the freshness monitor is `policy-shared-code`'s duplication failure, and I7167 names that trap explicitly.

Against the freshness monitor it answers a different question: the monitor asks *"is this key younger than its cadence clock?"*, this asks *"did the stage that ran in THIS EXECUTION write what it declares?"*. A weekly stage that stopped writing can hide from the first behind a daily producer of the same prefix; it cannot hide from the second.

## Could-not-measure is its own answer

Six verdicts: `wrote` · `stale` · `missing` · `unmeasured` · `unresolved` · `skipped`.

- a 403/503 is `unmeasured`, **never** `missing` — a detector reporting its own harness fault as a finding, always in the alarming direction, is this fleet's most-repeated detector bug;
- a present key with no execution window is `unmeasured`, **never** `wrote` — degrading it to healthy is precisely how instances 2, 3 and 4 stayed invisible for months;
- absence stays measurable **without** a window, so `missing` still fires;
- `unresolved` (config-I7180's ratcheted gap) is neither pass nor defect, so 20 unattributed rows can neither inflate the green number nor fail every run.

## Why the execution ARN, and the false-positive floor

`$$.Execution.Id` supplies **both** the start time (`DescribeExecution`) and the entered-stage set (`GetExecutionHistory`). This is not optional polish: the scheduled 2026-08-13 run terminated `SUCCEEDED` **in 5.4 seconds**, gated out by `WeeklyRunDayGate` having done no work, and roughly two of every three firings are such runs. Without the entered set the sweep would report ~30 missing artifacts on those — a detector that cries wolf twice a week is a detector that gets muted, and the real silent stage goes with it.

`alpha-engine-dashboard-role` **already** carries `states:DescribeExecution` + `states:GetExecutionHistory` on `execution:ne-weekly-freshness-pipeline:*` (policy `alpha-engine-dashboard-sfn-read`, measured live 2026-08-13). **No IAM change, no new grant, no fourth repo.**

## The bug this module nearly shipped, and its regression guard

First live run reported **28 confident `missing` verdicts**. They were false. `$.run_date` for the 08-08 execution is `2026-08-08` (the calendar Saturday), while every artifact that run produced landed under `2026-08-07` — `backtest/2026-08-08/` does not exist at all, and `backtest/2026-08-07/report.md` carries `LastModified 2026-08-08T06:13`.

`{date}`/`{trading_day}` are the **cycle** date, not the run date. `resolve_cycle_date()` now defers to `krepis.dates.expected_last_close` — the same notion of cycle tick `artifact_freshness._format_key` substitutes — and returns `unmeasured` rather than guessing when unavailable. `TestCycleDate` is the regression guard, including one test asserting `main()` does not silently reuse `run_date`.

Recorded because it is the finding, not an embarrassment: this module's own worst failure mode was the one it exists to prevent, and only a live measurement caught it.

## Degraded-run blast radius — stated explicitly

Since `alpha-engine-config-I6891` a degraded summary routes the run through `CheckDegradedOutcome` → `WriteCompletionMarkerDegraded` → `DegradedRun`, a **Fail** state. That is correct and **is not touched here**. But it means any non-zero exit from this sweep — invoked from `WeeklySubstrateHealthCheck` under `set -eo pipefail` — **terminates the whole ~4h weekly run as FAILED**.

Three of I7167's five instances are still open. Shipping enforcing would hard-fail the next scheduled run for defects that predate the detector — the shape `ruling_detect_before_enforcing_when_the_floor_is_unmeasured` (Brian, 2026-08-11) forbids.

So **the default is observe**: findings alert, are written to `_stage_outputs/{pipeline}/{run_date}.json`, and exit 0. `--enforce` is a one-word flip whose precondition is one measured number — the first scheduled run's finding count. Observe is not silent: it is loud on every surface except the one that kills the run.

## Measured live — the 08-08 execution, with the corrected resolver

`32 wrote · 13 stale · 7 missing · 20 unresolved · 2 skipped`, cycle date `2026-08-07`, 156 entered stages.

**The 20 defects are NOT yet all confirmed real.** Several `stale` rows (`SignalsEnvelope`, `DataPhase1`) carry `LastModified` on 08-07 evening, before the 08-08 09:00Z start — consistent with the *preopen/postclose* pipeline having written them, i.e. a `produced_by` attribution question rather than a silent weekly stage. That residue is exactly what observe mode exists to triage with evidence instead of by assertion, and it is why this does not enforce.

## SF change — minimal and surgical

One `States.Format` argument on `WeeklySubstrateHealthCheck` (`$$.Execution.Id`). Deliberately **not** a restructuring: `nousergon-data-PR1355` (I7179) and `PR1343` are in flight against this file, and a new Task state would need a nousergon-lib registry entry plus a ~30-site pin bump. Running inside the existing health-observe tail avoids all of it — and the tail is the only point where every stage has either run or been skipped.

## Tests — 77 new

Every verdict has a test that produces it. `TestMain::test_enforce_exits_1_on_a_defect` walks a real absent key to a non-zero process exit; `test_enforce_mode_exits_0_on_a_clean_run` covers the other polarity, because an absence-alarm is blind in both and GREEN is the dangerous one. This fleet has shipped three detectors that could not fail — these are the proof this one can.

`tests/test_sf_stage_output_sweep_wiring.py` guards invocation separately: a correct, unreachable observability check is I7167's own defect one layer up.

## Cross-repo — merge order

1. **`crucible-dashboard-PR679`** — the script must accept `--execution-arn` on the box before the SF sends it (the flag is optional there, so this ordering is safe rather than merely tidy)
2. **this PR** — the sweep module + the SF threading the ARN
3. **`alpha-engine-config-PR7225`** — the registry row for the sweep's own verdict artifact (inert until the sweep writes; may land any time)

## Test plan

- [x] `pytest tests/test_stage_output_sweep.py tests/test_sf_stage_output_sweep_wiring.py` — **77 passed**
- [x] Full suite: 4843 passed / 177 failed / 65 collection errors — the documented pre-existing laptop-env baseline (`yfinance`, `pyarrow`), identical to the baseline `PR1355` records. The 3 non-env failures (`test_sf_preflight.py` ×2, `test_analyst_substrate.py`) reproduce on unmodified `origin/main` in the shared checkout
- [x] Live end-to-end against SF execution `9b34ac0f-…-79e4579bcaff` with real S3 and real Step Functions

## Not fixed here, deliberately

The registry-coverage half of I7167's closes-when — 72 of 87 weekly Task states carry no `produced_by` row and no positive "produces nothing" declaration, `ParityReplay` and `ReplayConcordance` (instances 3 and 4) among them. The assertion cannot see a stage that declares nothing, so that gap is real and named on the issue. It is a separate, larger diff and its triage depends on the observe-mode residue above.

Rehearsal-exempt: structural

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

