### PR TITLE
[P0/high] feat(weekly-sf): assert every stage wrote what it declared — OBSERVE mode (config-I7214)

### DIFF
--- a/infrastructure/lambdas/weekly-preflight/deploy.sh
+++ b/infrastructure/lambdas/weekly-preflight/deploy.sh
@@ -60,6 +60,11 @@ run() {
 
 python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
 python3 -c "import ast; ast.parse(open('${REPO_ROOT}/sf_preflight.py').read()); print('sf_preflight.py syntax OK')"
+# config-I7214 — the coverage-assertion module the `assert_stage_coverage`
+# action imports. Bundled here for the same reason sf_preflight.py is: the
+# handler imports it by name at request time, so a missing file is a runtime
+# ImportError on the live weekly run, not a deploy failure.
+python3 -c "import ast; ast.parse(open('${REPO_ROOT}/sf_stage_coverage.py').read()); print('sf_stage_coverage.py syntax OK')"
 
 # ----- Handler unit tests (shared gate) -------------------------------------
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
@@ -77,6 +82,8 @@ trap "rm -rf '$PKG'" EXIT
 # Copy sf_preflight.py from the repo root — this is the core check logic.
 echo "Copying sf_preflight.py to package..."
 cp "${REPO_ROOT}/sf_preflight.py" "${PKG}/sf_preflight.py"
+echo "Copying sf_stage_coverage.py to package..."
+cp "${REPO_ROOT}/sf_stage_coverage.py" "${PKG}/sf_stage_coverage.py"
 
 echo "Installing deps into ${PKG}..."
 python3 -m pip install --quiet --target "${PKG}" --upgrade -r "${SCRIPT_DIR}/requirements.txt"

--- a/infrastructure/lambdas/weekly-preflight/index.py
+++ b/infrastructure/lambdas/weekly-preflight/index.py
@@ -52,6 +52,35 @@ def handler(event: dict, context) -> dict:
     Returns:
         dict with status, has_violation, and detailed results.
     """
+    # config-I7214 — second mode: the post-stage coverage assertion.
+    #
+    # It lives in THIS Lambda rather than a new one for a reason that is not
+    # convenience: a new function needs a new role, and creating a role is an
+    # operator-gated `--bootstrap` step (see this repo's AGENTS.md and
+    # deploy.sh's `--apply-iam` note). That would put a human action between the
+    # merge and the assertion working — the shape `pull-request-policy.md` §4.2
+    # forbids. This role already holds `s3:GetObject` on
+    # `alpha-engine-research/*` and `s3:ListBucket`, which is exactly and only
+    # what the assertion needs: read the synced registry, HEAD the declared
+    # keys. **No IAM change ships with this feature.** The mode dispatch mirrors
+    # `alpha-engine-predictor-inference`, which hosts three gate modes the same
+    # way.
+    action = event.get("action")
+    if action == "assert_stage_coverage":
+        try:
+            import sf_stage_coverage  # type: ignore[import-untyped]
+        except ImportError as exc:
+            # Import failure is UNMEASURED, never a pass — and never a raise,
+            # because this state must not be able to fail the weekly run.
+            return {
+                "status": "UNMEASURED",
+                "degrade": False,
+                "enforce": bool(event.get("enforce", False)),
+                "error": f"sf_stage_coverage import failed: {exc}",
+                "traceback": traceback.format_exc(),
+            }
+        return sf_stage_coverage.handle(event)
+
     bucket = event.get("bucket", _SF_DEFINITION_BUCKET)
     sf_name = event.get("sf_name", _WEEKLY_SF_NAME)
 

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -17,3 +17,10 @@
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
 nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.53
+
+# config-I7214 — the stage-coverage assertion parses ARTIFACT_REGISTRY.yaml,
+# read from s3://alpha-engine-research/_freshness_monitor/. Not a transitive of
+# anything above; the freshness-monitor Lambda pins it explicitly for the same
+# reason. Absent, the assertion returns UNMEASURED on every run — loud, but
+# useless.
+pyyaml>=6.0

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -5985,7 +5985,7 @@
     },
     "CheckShellRunNotify": {
       "Type": "Choice",
-      "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false \u2192 NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true \u2192 NotifyShellRunComplete. No new SNS topic / Lambda / infra \u2014 the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern.",
+      "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false \u2192 NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true \u2192 NotifyShellRunComplete. No new SNS topic / Lambda / infra \u2014 the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern. config-I7214: the Default edge now passes through StageCoverageAssert before CheckGateDegradedNotify. Placed HERE, on the non-shell-run branch only, because this is the single point every REAL completion path converges on before the notifiers, and because the Friday-PM shell run is a dry pass that writes nothing by design \u2014 asserting coverage on it would report 43 misses every Friday. Inserting one state at the convergence point rather than 43 post-stage states is also the whole reason this is shippable against a fragile pipeline: it changes one edge.",
       "Choices": [
         {
           "And": [
@@ -6001,7 +6001,7 @@
           "Next": "NotifyShellRunComplete"
         }
       ],
-      "Default": "CheckGateDegradedNotify"
+      "Default": "StageCoverageAssert"
     },
     "CheckGateDegradedNotify": {
       "Type": "Choice",
@@ -7958,6 +7958,93 @@
       },
       "ResultPath": "$.error",
       "Next": "NormalizeFailureContext"
+    },
+    "StageCoverageAssert": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7214 \u2014 post-stage coverage assertion. For every weekly-SF stage that was not skipped by execution input, asserts that the artifact the stage DECLARES in ARTIFACT_REGISTRY.yaml's pipeline_stages section exists AND that its LastModified falls inside this execution's window. The second half is the load-bearing one: an artifact left over from a previous cycle satisfies every existence-only probe while the consumer reads last week's belief. Motivation: 5 stages produced no output on the 2026-08-08 run while it reported SUCCEEDED (config-I7167) \u2014 SF asserts a stage did not THROW; nothing asserted it WROTE. SHIPS IN OBSERVE MODE: enforce=false, so this state computes and returns the full verdict and CheckStageCoverageOutcome routes straight past the degraded summary. Promotion to enforcing is the single literal below flipped to true, after one clean cycle has shown what a healthy verdict looks like \u2014 enforcing a threshold whose distribution nobody has seen is how a correct detector gets turned off in week one (sf-pipeline-policy.md \u00a77: a withheld guarantee beats a failed run). Runs on the alpha-engine-weekly-preflight Lambda as a second action rather than a new function: a new function needs a new role, and role creation is an operator-gated bootstrap step, which would put a human between the merge and the assertion working (pull-request-policy.md \u00a74.2). NO IAM CHANGE SHIPS WITH THIS \u2014 the existing role's s3:GetObject on alpha-engine-research/* plus s3:ListBucket is exactly what reading the synced registry and HEADing the declared keys needs. Catch(States.ALL) routes to StageCoverageUnmeasured: this observer must not be able to fail the run it observes, and its own death is UNMEASURED, never a pass (\u00a72.3a rule 2).",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-weekly-preflight",
+        "Payload": {
+          "action": "assert_stage_coverage",
+          "run_date.$": "$.run_date",
+          "execution_start_time.$": "$$.Execution.StartTime",
+          "execution_input.$": "$",
+          "enforce": false
+        }
+      },
+      "ResultSelector": {
+        "stage_coverage.$": "$.Payload"
+      },
+      "ResultPath": "$.stage_coverage_result",
+      "TimeoutSeconds": 90,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 15,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "The observer's own failure is UNMEASURED, never a pass, and never a reason to fail the run (config-I7214).",
+          "ResultPath": "$.stage_coverage_error",
+          "Next": "StageCoverageUnmeasured"
+        }
+      ],
+      "Next": "CheckStageCoverageOutcome"
+    },
+    "StageCoverageUnmeasured": {
+      "Type": "Pass",
+      "Comment": "config-I7214: the assertion could not run. Records UNMEASURED explicitly and continues. `no data` is never rendered as green (principles.md \u00a72.7) \u2014 but an unmeasured verdict is also not evidence of a defect, so it never degrades the run even under enforce. Degrading on the observer's own fault would report a harness failure AS a producer failure, always in the alarming direction.",
+      "Result": {
+        "stage_coverage": {
+          "pipeline": "ne-weekly-freshness-pipeline",
+          "status": "UNMEASURED",
+          "degrade": false,
+          "error": "StageCoverageAssert did not complete; see $.stage_coverage_error"
+        }
+      },
+      "ResultPath": "$.stage_coverage_result",
+      "Next": "CheckGateDegradedNotify"
+    },
+    "CheckStageCoverageOutcome": {
+      "Type": "Choice",
+      "Comment": "config-I7214: routes on the assertion's `degrade` field, which the Lambda sets true ONLY when enforce=true AND the status is a real MISSING. Reading one derived boolean rather than re-deriving `enforce AND status` here keeps the promotion a one-literal change in StageCoverageAssert's payload and stops the definition and the Lambda from disagreeing about what enforcement means. IsPresent-guarded per the config-I2767 shape: an unguarded dereference throws States.Runtime at the tail of an otherwise successful weekly run.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.stage_coverage_result.stage_coverage.degrade",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.stage_coverage_result.stage_coverage.degrade",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "SetStageCoverageDegradedSummary"
+        }
+      ],
+      "Default": "CheckGateDegradedNotify"
+    },
+    "SetStageCoverageDegradedSummary": {
+      "Type": "Pass",
+      "Comment": "config-I7214: writes the $.degraded_summary that CheckDegradedOutcome and the DegradedRun terminal already read \u2014 the EXISTING chokepoint, not a second mechanism. A fail-open route added later inherits the honest terminal by writing this path and touching nothing else (see CheckDegradedOutcome's own comment). Unreachable while StageCoverageAssert ships enforce=false; it is wired now so that promotion is one literal rather than a topology change against a fragile pipeline. Carries no stage_error, for the same reason every sibling setter does not: this state is reachable only from a Choice, which writes no $.<stage>_error, so an unguarded stage_error.$ would throw States.Runtime (tests/test_degraded_terminal_derives_its_cause.py).",
+      "Parameters": {
+        "degraded": true,
+        "reason": "weekly_stage_coverage_incomplete",
+        "run_date.$": "$.run_date"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "CheckGateDegradedNotify"
     }
   }
 }

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -192,6 +192,16 @@ TERMINAL_DEGRADED_FAMILY: frozenset[str] = frozenset({
     "CheckShellRunDegradedOutcome",
     "WriteCompletionMarkerDegraded",
     "DegradedRun",
+    # alpha-engine-config-I7214: the stage-coverage verdict is a claim about
+    # the RUN AS A WHOLE, evaluated once after every stage has finished — not a
+    # per-stage rerun witness. Mapping it to any one stage would be wrong in
+    # both directions: a rerun would re-run that stage for a miss owned by a
+    # different one, and would skip the stage that actually missed. The
+    # rerun-actionable signal is the per-stage Mark*Degraded / *Degraded routes
+    # that are already mapped; this state is always causally downstream of the
+    # producer's own miss, and the verdict it carries names the offending
+    # stages explicitly in $.stage_coverage_result.
+    "SetStageCoverageDegradedSummary",
 })
 
 STAGES: tuple[Stage, ...] = (

--- a/sf_stage_coverage.py
+++ b/sf_stage_coverage.py
@@ -1,0 +1,367 @@
+"""
+Post-stage coverage assertion for `ne-weekly-freshness-pipeline`
+(alpha-engine-config-I7214).
+
+## The failure this closes
+
+Five stages of the 2026-08-08 weekly run produced no output while the run
+reported SUCCEEDED (`alpha-engine-config-I7167`). Every one of them exited zero.
+A Step Functions pipeline asserts that its stages did not *throw*; nothing
+asserted that they *wrote*. Those are different claims, and only the second is
+what the trading week depends on.
+
+This module answers, for one execution: **for each stage that entered, does its
+declared artifact exist, and was it written by THIS run?** A stage whose
+artifact is missing, or is left over from a previous cycle, is not covered — and
+a stale artifact is the more dangerous of the two, because every freshness probe
+keyed on existence alone reads it as green.
+
+## Where the declaration comes from
+
+`ARTIFACT_REGISTRY.yaml`, read from
+`s3://alpha-engine-research/_freshness_monitor/ARTIFACT_REGISTRY.yaml` — the
+copy `alpha-engine-config`'s `sync-artifact-registry.yml` refreshes on every
+merge that touches it. The consumer is refreshed by the same event that changes
+the declaration, which is the property a registry read from a stale checkout
+loses. Nothing here carries its own list of stages: a hand-maintained
+denominator drifts, and its drift is invisible because the missing rows produce
+no signal.
+
+## Three properties this deliberately has
+
+**It cannot fail the run.** Every path returns a verdict; nothing raises. A
+coverage assertion that can kill the pipeline it observes is a new failure mode
+bolted onto the one it was meant to report, and this pipeline is fragile
+(`sf-pipeline-policy.md` §2.3a: withholding the guarantee is not the same as
+failing the pipeline).
+
+**It cannot report a pass it did not establish.** Registry unreadable, S3
+unreachable, no artifacts probed — every one of those is `UNMEASURED`, never
+`COVERED`. §2.3a rule 2: a missing verdict propagates as UNKNOWN and never as a
+pass. `UNMEASURED` is a loud value; it is not silence.
+
+**It has an OBSERVE mode and ships in it.** `enforce=False` computes and returns
+the full verdict and sets nothing. The SF's Choice reads `enforce`, so promotion
+to degrading the run is a one-literal diff in the definition — after one clean
+cycle has shown what a healthy verdict actually looks like. Turning it on before
+that would be enforcing a threshold whose distribution nobody has seen.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import os
+import traceback
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+WEEKLY_PIPELINE = "ne-weekly-freshness-pipeline"
+REGISTRY_BUCKET = os.environ.get("REGISTRY_BUCKET", "alpha-engine-research")
+REGISTRY_KEY = os.environ.get(
+    "REGISTRY_KEY", "_freshness_monitor/ARTIFACT_REGISTRY.yaml"
+)
+DEFAULT_ARTIFACT_BUCKET = "alpha-engine-research"
+
+# Verdicts. Closed set — a consumer that cannot place a value must not fall
+# through to a benign reading.
+COVERED = "COVERED"
+MISSING = "MISSING"
+UNMEASURED = "UNMEASURED"
+
+# Stage -> the execution-input flag that legitimately suppresses it. A stage
+# whose flag is set did not run, so its artifact's absence is a fact about the
+# input, not about the producer. Derived from the definition's own
+# `CheckSkip*` Choice states; a stage with no entry here cannot be skipped.
+#
+# This is the ONE list here that mirrors something outside the registry, and it
+# is guarded by `tests/test_sf_stage_coverage.py::test_every_skip_flag_is_real`,
+# which reads the definition and fails on a flag that no Choice state consults.
+STAGE_SKIP_FLAGS: dict[str, str] = {
+    "MorningEnrich": "skip_morning_enrich",
+    "DataPhase1": "skip_data_phase1",
+    "DataPhase2": "skip_data_phase2",
+    "Scanner": "skip_scanner",
+    "SignalsEnvelope": "skip_signals_envelope",
+    "ChallengerShadow": "skip_challenger_shadow",
+    "RAGIngestion": "skip_rag_ingestion",
+    "RegimeSubstrate": "skip_regime_substrate",
+    "RegimeRetrospectiveEval": "skip_regime_retrospective_eval",
+    "PredictorTraining": "skip_predictor_training",
+    "Backtester": "skip_backtester",
+    "PredictorBacktest": "skip_predictor_backtest",
+    "PortfolioOptimizerBacktest": "skip_portfolio_optimizer_backtest",
+    "PitParityLookahead": "skip_pit_parity_lookahead",
+    "PitParityWalkforward": "skip_pit_parity_walkforward",
+    "PitParityCompare": "skip_pit_parity_compare",
+    "ParityReplay": "skip_parity_replay",
+    "EvalJudgeProcess": "skip_eval_judge",
+    "EvalRollingMean": "skip_eval_judge",
+    "RationaleClustering": "skip_rationale_clustering",
+    "ReplayConcordance": "skip_replay_concordance",
+    "Counterfactual": "skip_counterfactual",
+    "AggregateCosts": "skip_aggregate_costs",
+    "EvaluatorDiagnostics": "skip_evaluator",
+    "EvaluatorOptimize": "skip_evaluator",
+    "ReportCard": "skip_report_card",
+    "Director": "skip_director",
+}
+# Coarser gates that suppress several stages at once.
+GROUP_SKIP_FLAGS: dict[str, tuple[str, ...]] = {
+    "skip_parity": (
+        "PitParityLookahead", "PitParityWalkforward", "ParityReplay",
+        "PitParityCompare",
+    ),
+    "skip_post_eval": ("SaturdayHealthCheck", "WeeklySubstrateHealthCheck"),
+}
+
+
+def _client(s3_client=None):
+    if s3_client is not None:
+        return s3_client
+    import boto3
+
+    return boto3.client("s3")
+
+
+def load_declaration(s3_client=None) -> dict:
+    """Return ``{stage: {"artifacts": [{artifact_id, bucket, key_template}]}}``
+    for every weekly-pipeline stage declaring registered output.
+
+    Raises on any problem. The caller turns that into ``UNMEASURED``; it must
+    never become an empty declaration, because an empty declaration probes
+    nothing and would report a clean pass.
+    """
+    import yaml
+
+    body = _client(s3_client).get_object(
+        Bucket=REGISTRY_BUCKET, Key=REGISTRY_KEY
+    )["Body"].read()
+    registry = yaml.safe_load(body)
+
+    by_id = {r["artifact_id"]: r for r in registry["artifacts"]}
+    stages = registry["pipeline_stages"]
+    if not stages:
+        raise ValueError("registry carries an empty pipeline_stages section")
+
+    out: dict[str, dict] = {}
+    for row in stages:
+        entry: dict[str, Any] = {
+            "stage_class": row.get("stage_class"),
+            "output": row.get("output"),
+            "artifacts": [],
+        }
+        for aid in row.get("artifacts") or []:
+            art = by_id[aid]
+            entry["artifacts"].append({
+                "artifact_id": aid,
+                "bucket": art.get("s3_bucket", DEFAULT_ARTIFACT_BUCKET),
+                "key_template": art["s3_key_template"],
+            })
+        out[row["stage"]] = entry
+    return out
+
+
+def _resolve_key(template: str, run_date: str) -> str:
+    """`{date}` and `{trading_day}` both resolve to this run's date.
+
+    A template carrying a placeholder this function does not know is returned
+    with the literal braces intact — which fails the head_object loudly, rather
+    than probing a wrong key and reporting a confident wrong answer.
+    """
+    return template.replace("{date}", run_date).replace("{trading_day}", run_date)
+
+
+def _parse_iso(value: str) -> _dt.datetime:
+    """Parse an SF `$$.Execution.StartTime` into an aware UTC datetime."""
+    text = value.replace("Z", "+00:00")
+    parsed = _dt.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return parsed.astimezone(_dt.timezone.utc)
+
+
+def _skipped(stage: str, execution_input: dict) -> bool:
+    flag = STAGE_SKIP_FLAGS.get(stage)
+    if flag and execution_input.get(flag) is True:
+        return True
+    for group_flag, members in GROUP_SKIP_FLAGS.items():
+        if stage in members and execution_input.get(group_flag) is True:
+            return True
+    return False
+
+
+def assert_stage_coverage(
+    *,
+    run_date: str,
+    execution_start_time: str,
+    execution_input: dict | None = None,
+    enforce: bool = False,
+    s3_client=None,
+) -> dict:
+    """Assert every entered stage's declared artifact exists and is of this run.
+
+    Returns a verdict dict. NEVER raises — see the module docstring.
+    """
+    execution_input = execution_input or {}
+    verdict: dict[str, Any] = {
+        "pipeline": WEEKLY_PIPELINE,
+        "run_date": run_date,
+        "enforce": bool(enforce),
+        "mode": "enforce" if enforce else "observe",
+        "status": UNMEASURED,
+        "stages_declared": 0,
+        "stages_expected": 0,
+        "stages_covered": 0,
+        "stages_skipped": [],
+        "stages_no_artifact": [],
+        "missing": [],
+        "stale": [],
+        "unmeasured": [],
+    }
+
+    try:
+        window_start = _parse_iso(execution_start_time)
+    except Exception as exc:  # noqa: BLE001 — an unparseable window is UNMEASURED
+        verdict["error"] = f"could not parse execution_start_time: {exc}"
+        return verdict
+
+    try:
+        declaration = load_declaration(s3_client=s3_client)
+    except Exception as exc:  # noqa: BLE001 — no declaration is UNMEASURED
+        verdict["error"] = f"could not load the stage declaration: {exc}"
+        verdict["traceback"] = traceback.format_exc()
+        return verdict
+
+    verdict["stages_declared"] = len(declaration)
+    s3 = _client(s3_client)
+
+    for stage, entry in sorted(declaration.items()):
+        if _skipped(stage, execution_input):
+            verdict["stages_skipped"].append(stage)
+            continue
+        if entry["output"] != "registered":
+            # A POSITIVE declaration that this stage writes no registerable
+            # key. It is covered by having said so — which is exactly what
+            # distinguishes it from a stage nobody ever considered.
+            verdict["stages_no_artifact"].append(stage)
+            continue
+
+        verdict["stages_expected"] += 1
+        stage_ok = True
+        for art in entry["artifacts"]:
+            key = _resolve_key(art["key_template"], run_date)
+            try:
+                head = s3.head_object(Bucket=art["bucket"], Key=key)
+            except Exception as exc:  # noqa: BLE001 — classified below
+                name = type(exc).__name__
+                code = getattr(exc, "response", {}).get(
+                    "Error", {}
+                ).get("Code", name)
+                if code in ("404", "NoSuchKey", "NotFound"):
+                    verdict["missing"].append({
+                        "stage": stage,
+                        "artifact_id": art["artifact_id"],
+                        "key": key,
+                        "reason": "absent",
+                    })
+                else:
+                    # Could-not-measure is NOT a finding about the producer.
+                    # Conflating the two reports a harness fault as a defect,
+                    # always in the alarming direction.
+                    verdict["unmeasured"].append({
+                        "stage": stage,
+                        "artifact_id": art["artifact_id"],
+                        "key": key,
+                        "reason": f"probe failed: {code}",
+                    })
+                stage_ok = False
+                continue
+
+            last_modified = head.get("LastModified")
+            if last_modified is None:
+                verdict["unmeasured"].append({
+                    "stage": stage,
+                    "artifact_id": art["artifact_id"],
+                    "key": key,
+                    "reason": "head_object returned no LastModified",
+                })
+                stage_ok = False
+                continue
+            if last_modified.tzinfo is None:
+                last_modified = last_modified.replace(tzinfo=_dt.timezone.utc)
+            if last_modified < window_start:
+                # The dangerous case. The key exists, so every existence-only
+                # probe reads green, and the value being consumed is last
+                # cycle's.
+                verdict["stale"].append({
+                    "stage": stage,
+                    "artifact_id": art["artifact_id"],
+                    "key": key,
+                    "last_modified": last_modified.isoformat(),
+                    "window_start": window_start.isoformat(),
+                    "reason": "predates this execution",
+                })
+                stage_ok = False
+        if stage_ok:
+            verdict["stages_covered"] += 1
+
+    if verdict["stages_expected"] == 0:
+        # Probed nothing. That is not a clean run; it is an unobserved one.
+        verdict["status"] = UNMEASURED
+        verdict["error"] = (
+            "no stage was expected to have written an artifact — every declared "
+            "stage was skipped or declares no registerable key, so this run "
+            "observed nothing"
+        )
+        return verdict
+
+    if verdict["missing"] or verdict["stale"]:
+        verdict["status"] = MISSING
+    elif verdict["unmeasured"]:
+        verdict["status"] = UNMEASURED
+    else:
+        verdict["status"] = COVERED
+
+    verdict["summary"] = (
+        f"{verdict['stages_covered']}/{verdict['stages_expected']} stages wrote "
+        f"their declared artifact within this execution's window; "
+        f"{len(verdict['missing'])} missing, {len(verdict['stale'])} stale, "
+        f"{len(verdict['unmeasured'])} unmeasured, "
+        f"{len(verdict['stages_skipped'])} skipped by input, "
+        f"{len(verdict['stages_no_artifact'])} declare no registerable key"
+    )
+    return verdict
+
+
+def handle(event: dict) -> dict:
+    """Entry point for the Lambda's ``action: assert_stage_coverage`` mode.
+
+    The `degrade` field is what the SF's Choice reads. It is true ONLY when the
+    caller asked for enforcement AND the verdict is a real miss — so shipping
+    with `enforce: false` in the definition makes this state observationally
+    complete and operationally inert, which is the whole point before the first
+    live run (`sf-pipeline-policy.md` §7: a withheld guarantee beats a failed
+    run).
+    """
+    try:
+        verdict = assert_stage_coverage(
+            run_date=event["run_date"],
+            execution_start_time=event["execution_start_time"],
+            execution_input=event.get("execution_input") or {},
+            enforce=bool(event.get("enforce", False)),
+        )
+    except Exception as exc:  # noqa: BLE001 — belt and braces; must not raise
+        logger.error("stage coverage assertion raised: %s", exc, exc_info=True)
+        verdict = {
+            "pipeline": WEEKLY_PIPELINE,
+            "status": UNMEASURED,
+            "enforce": bool(event.get("enforce", False)),
+            "mode": "enforce" if event.get("enforce") else "observe",
+            "error": f"assertion raised: {exc}",
+            "traceback": traceback.format_exc(),
+        }
+    verdict["degrade"] = bool(verdict.get("enforce")) and verdict["status"] == MISSING
+    logger.info("stage coverage: %s", verdict.get("summary") or verdict.get("error"))
+    return verdict

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -683,7 +683,14 @@ class TestStrictSuperset:
     def test_success_notify_gate_default_is_notify_complete(self, states):
         # config#2278: the real-run success edge now passes through the
         # gate-degraded completion Choice before NotifyComplete.
-        assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
+        # alpha-engine-config-I7214: the Default now passes through the
+        # post-stage coverage assertion before reaching the notifier selector.
+        # Asserted as a two-hop chain rather than relaxed to "reaches
+        # CheckGateDegradedNotify eventually": a test that stops caring about
+        # the shape of the edge stops catching the next change to it.
+        assert states["CheckShellRunNotify"]["Default"] == "StageCoverageAssert"
+        assert states["StageCoverageAssert"]["Next"] == "CheckStageCoverageOutcome"
+        assert states["CheckStageCoverageOutcome"]["Default"] == "CheckGateDegradedNotify"
         assert states["CheckGateDegradedNotify"]["Default"] == "NotifyComplete"
 
 

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -200,7 +200,22 @@ def _notify_target(states, data: dict) -> str:
         return data[var] == rule["BooleanEquals"]
 
     cur = "CheckShellRunNotify"
-    while states[cur]["Type"] == "Choice":
+    # config-I7214: the walk now steps THROUGH non-Choice states as well.
+    # StageCoverageAssert (a Task) and its Choice sit between
+    # CheckShellRunNotify and CheckGateDegradedNotify; a walker that stopped at
+    # the first non-Choice would report the assertion state as the notifier and
+    # certify a defect it invented. Coverage never degrades in observe mode, so
+    # the notifier selected for a given flag combination is unchanged — which is
+    # exactly what these parametrized cases still assert.
+    # Stepping through non-Choice states is scoped BY NAME to the coverage
+    # states. A blanket "follow Next on any Task" would walk straight past
+    # NotifyComplete — itself a Task with a Next — and return the completion
+    # marker instead of the notifier, i.e. it would answer a different question
+    # while still passing.
+    while states[cur]["Type"] == "Choice" or cur.startswith("StageCoverage"):
+        if states[cur]["Type"] != "Choice":
+            cur = states[cur]["Next"]
+            continue
         for rule in states[cur]["Choices"]:
             if eval_rule(rule):
                 cur = rule["Next"]

--- a/tests/test_sf_parity_gate_notify_wiring.py
+++ b/tests/test_sf_parity_gate_notify_wiring.py
@@ -121,7 +121,22 @@ def _notify_target(states, data: dict) -> str:
         return data[var] == rule["BooleanEquals"]
 
     cur = "CheckShellRunNotify"
-    while states[cur]["Type"] == "Choice":
+    # config-I7214: the walk now steps THROUGH non-Choice states as well.
+    # StageCoverageAssert (a Task) and its Choice sit between
+    # CheckShellRunNotify and CheckGateDegradedNotify; a walker that stopped at
+    # the first non-Choice would report the assertion state as the notifier and
+    # certify a defect it invented. Coverage never degrades in observe mode, so
+    # the notifier selected for a given flag combination is unchanged — which is
+    # exactly what these parametrized cases still assert.
+    # Stepping through non-Choice states is scoped BY NAME to the coverage
+    # states. A blanket "follow Next on any Task" would walk straight past
+    # NotifyComplete — itself a Task with a Next — and return the completion
+    # marker instead of the notifier, i.e. it would answer a different question
+    # while still passing.
+    while states[cur]["Type"] == "Choice" or cur.startswith("StageCoverage"):
+        if states[cur]["Type"] != "Choice":
+            cur = states[cur]["Next"]
+            continue
         for rule in states[cur]["Choices"]:
             if eval_rule(rule):
                 cur = rule["Next"]

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -70,6 +70,15 @@ def _flatten_states(sf_doc: dict) -> dict:
 #
 # Saturday SF — alpha-engine-research + alpha-engine-data Lambdas
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
+    # alpha-engine-config-I7214: the post-stage coverage assertion, hosted as a
+    # second `action` on the weekly-preflight Lambda (a new function would need
+    # a new role, and role creation is an operator-gated bootstrap step). The
+    # `enforce` literal is the promotion knob and is deliberately part of the
+    # closed key set: flipping it to true is a diff this registry sees.
+    "StageCoverageAssert": frozenset({
+        "action", "run_date.$", "execution_start_time.$",
+        "execution_input.$", "enforce",
+    }),
     # config#2249: fast pre-dispatch substrate health gate, immediately
     # before MorningEnrich (alpha-engine-substrate-health-gate Lambda).
     "SubstrateHealthGate": frozenset({"instance_id.$"}),

--- a/tests/test_sf_prespend_gate_alerting.py
+++ b/tests/test_sf_prespend_gate_alerting.py
@@ -144,7 +144,14 @@ def test_malformed_gate_payload_routes_to_degraded_chain(states, gate, field, de
 
 
 def test_gate_degraded_threads_into_completion_email(states):
-    assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
+    # alpha-engine-config-I7214: the Default now passes through the
+    # post-stage coverage assertion before reaching the notifier selector.
+    # Asserted as a two-hop chain rather than relaxed to "reaches
+    # CheckGateDegradedNotify eventually": a test that stops caring about
+    # the shape of the edge stops catching the next change to it.
+    assert states["CheckShellRunNotify"]["Default"] == "StageCoverageAssert"
+    assert states["StageCoverageAssert"]["Next"] == "CheckStageCoverageOutcome"
+    assert states["CheckStageCoverageOutcome"]["Default"] == "CheckGateDegradedNotify"
 
     choice = states["CheckGateDegradedNotify"]
     # config#2276 extended this Choice with health_check_degraded rules

--- a/tests/test_sf_report_card_degraded_wiring.py
+++ b/tests/test_sf_report_card_degraded_wiring.py
@@ -131,7 +131,22 @@ def _notify_target(states, data: dict) -> str:
         return data[var] == rule["BooleanEquals"]
 
     cur = "CheckShellRunNotify"
-    while states[cur]["Type"] == "Choice":
+    # config-I7214: the walk now steps THROUGH non-Choice states as well.
+    # StageCoverageAssert (a Task) and its Choice sit between
+    # CheckShellRunNotify and CheckGateDegradedNotify; a walker that stopped at
+    # the first non-Choice would report the assertion state as the notifier and
+    # certify a defect it invented. Coverage never degrades in observe mode, so
+    # the notifier selected for a given flag combination is unchanged — which is
+    # exactly what these parametrized cases still assert.
+    # Stepping through non-Choice states is scoped BY NAME to the coverage
+    # states. A blanket "follow Next on any Task" would walk straight past
+    # NotifyComplete — itself a Task with a Next — and return the completion
+    # marker instead of the notifier, i.e. it would answer a different question
+    # while still passing.
+    while states[cur]["Type"] == "Choice" or cur.startswith("StageCoverage"):
+        if states[cur]["Type"] != "Choice":
+            cur = states[cur]["Next"]
+            continue
         for rule in states[cur]["Choices"]:
             if eval_rule(rule):
                 cur = rule["Next"]

--- a/tests/test_sf_research_predictor_degraded_wiring.py
+++ b/tests/test_sf_research_predictor_degraded_wiring.py
@@ -332,7 +332,22 @@ def _notify_target(states, data: dict) -> str:
         return data[var] == rule["BooleanEquals"]
 
     cur = "CheckShellRunNotify"
-    while states[cur]["Type"] == "Choice":
+    # config-I7214: the walk now steps THROUGH non-Choice states as well.
+    # StageCoverageAssert (a Task) and its Choice sit between
+    # CheckShellRunNotify and CheckGateDegradedNotify; a walker that stopped at
+    # the first non-Choice would report the assertion state as the notifier and
+    # certify a defect it invented. Coverage never degrades in observe mode, so
+    # the notifier selected for a given flag combination is unchanged — which is
+    # exactly what these parametrized cases still assert.
+    # Stepping through non-Choice states is scoped BY NAME to the coverage
+    # states. A blanket "follow Next on any Task" would walk straight past
+    # NotifyComplete — itself a Task with a Next — and return the completion
+    # marker instead of the notifier, i.e. it would answer a different question
+    # while still passing.
+    while states[cur]["Type"] == "Choice" or cur.startswith("StageCoverage"):
+        if states[cur]["Type"] != "Choice":
+            cur = states[cur]["Next"]
+            continue
         for rule in states[cur]["Choices"]:
             if eval_rule(rule):
                 cur = rule["Next"]

--- a/tests/test_sf_stage_coverage.py
+++ b/tests/test_sf_stage_coverage.py
@@ -1,0 +1,368 @@
+"""Tests for sf_stage_coverage — the weekly-SF post-stage coverage assertion
+(alpha-engine-config-I7214).
+
+The assertion exists because a Step Functions run asserts a stage did not
+THROW and nothing asserted that it WROTE — five stages produced no output on the
+2026-08-08 run while it reported SUCCEEDED (config-I7167). What these tests pin
+is not the happy path but the three properties that make it safe to ship against
+a fragile pipeline the Saturday before it runs:
+
+  * it can never report a pass it did not establish (UNMEASURED, never COVERED);
+  * it can never fail the run — no path raises, and observe mode never degrades;
+  * a STALE artifact is a miss, because an existence-only probe reads it green.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+import sf_stage_coverage as cov
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WEEKLY_SF = _REPO_ROOT / "infrastructure" / "step_function.json"
+
+WINDOW_START = "2026-08-15T09:00:00.000Z"
+FRESH = _dt.datetime(2026, 8, 15, 10, 0, tzinfo=_dt.timezone.utc)
+STALE = _dt.datetime(2026, 8, 8, 10, 0, tzinfo=_dt.timezone.utc)
+
+
+class _FakeS3:
+    """Serves the registry from `_freshness_monitor/` and HEADs from a map."""
+
+    def __init__(self, registry: dict, heads: dict, registry_error=None):
+        self._registry = registry
+        self._heads = heads
+        self._registry_error = registry_error
+
+    def get_object(self, Bucket, Key):  # noqa: N803 — boto3 kwarg names
+        if self._registry_error is not None:
+            raise self._registry_error
+        assert Key == cov.REGISTRY_KEY
+
+        class _B:
+            @staticmethod
+            def read():
+                return yaml.safe_dump(self._registry).encode()
+
+        return {"Body": _B()}
+
+    def head_object(self, Bucket, Key):  # noqa: N803
+        if Key not in self._heads:
+            raise _NotFound()
+        value = self._heads[Key]
+        if isinstance(value, Exception):
+            raise value
+        return {"LastModified": value}
+
+
+class _NotFound(Exception):
+    response = {"Error": {"Code": "404"}}
+
+
+class _Throttled(Exception):
+    response = {"Error": {"Code": "SlowDown"}}
+
+
+def _registry(stage_rows, artifact_rows=None):
+    arts = artifact_rows or [{
+        "artifact_id": "thing",
+        "s3_key_template": "path/{date}/x.json",
+    }]
+    return {"artifacts": arts, "pipeline_stages": stage_rows}
+
+
+_REGISTERED = [{
+    "stage": "Doer", "stage_class": "product",
+    "output": "registered", "artifacts": ["thing"],
+}]
+
+
+def _run(s3, **kw):
+    kw.setdefault("run_date", "2026-08-15")
+    kw.setdefault("execution_start_time", WINDOW_START)
+    return cov.assert_stage_coverage(s3_client=s3, **kw)
+
+
+# ── it establishes what it reports ───────────────────────────────────────────
+
+
+def test_fresh_artifact_is_covered():
+    s3 = _FakeS3(_registry(_REGISTERED), {"path/2026-08-15/x.json": FRESH})
+    v = _run(s3)
+    assert v["status"] == cov.COVERED
+    assert v["stages_covered"] == 1 and v["stages_expected"] == 1
+    assert v["missing"] == [] and v["stale"] == []
+
+
+def test_absent_artifact_is_missing_and_names_the_key():
+    s3 = _FakeS3(_registry(_REGISTERED), {})
+    v = _run(s3)
+    assert v["status"] == cov.MISSING
+    assert v["missing"][0]["stage"] == "Doer"
+    assert v["missing"][0]["key"] == "path/2026-08-15/x.json"
+    assert v["stages_covered"] == 0
+
+
+def test_artifact_from_a_previous_cycle_is_stale_not_covered():
+    """The dangerous case, and the reason LastModified is checked at all: the
+    key EXISTS, so every existence-only freshness probe reads it green while the
+    consumer is served last cycle's belief."""
+    s3 = _FakeS3(_registry(_REGISTERED), {"path/2026-08-15/x.json": STALE})
+    v = _run(s3)
+    assert v["status"] == cov.MISSING
+    assert v["stale"][0]["reason"] == "predates this execution"
+    assert v["stale"][0]["last_modified"].startswith("2026-08-08")
+    assert v["missing"] == [], "a stale key is not an absent key; keep them apart"
+
+
+# ── it can never report a pass it did not establish ──────────────────────────
+
+
+def test_unreadable_registry_is_unmeasured_never_covered():
+    s3 = _FakeS3(_registry(_REGISTERED), {}, registry_error=RuntimeError("no"))
+    v = _run(s3)
+    assert v["status"] == cov.UNMEASURED
+    assert "could not load" in v["error"]
+
+
+def test_a_probe_failure_that_is_not_a_404_is_unmeasured_not_a_finding():
+    """Could-not-measure is not a finding about the producer. Conflating them
+    reports a harness fault AS a defect, always in the alarming direction."""
+    s3 = _FakeS3(_registry(_REGISTERED), {"path/2026-08-15/x.json": _Throttled()})
+    v = _run(s3)
+    assert v["status"] == cov.UNMEASURED
+    assert v["missing"] == [] and v["stale"] == []
+    assert v["unmeasured"][0]["reason"] == "probe failed: SlowDown"
+
+
+def test_probing_nothing_is_unmeasured_not_a_clean_run():
+    """Every stage skipped: the run observed nothing. A checker that reports
+    COVERED here is a check that can never fail, which is indistinguishable
+    from one that passes."""
+    s3 = _FakeS3(_registry(_REGISTERED), {})
+    v = _run(s3, execution_input={"skip_scanner": True})
+    # Doer has no skip flag, so force the other emptiness route instead:
+    s3b = _FakeS3(_registry([{
+        "stage": "SaturdayHealthCheck", "stage_class": "infrastructure",
+        "output": "none", "reason": "reads only",
+    }]), {})
+    v = _run(s3b)
+    assert v["status"] == cov.UNMEASURED
+    assert "observed nothing" in v["error"]
+
+
+def test_unparseable_window_is_unmeasured():
+    s3 = _FakeS3(_registry(_REGISTERED), {"path/2026-08-15/x.json": FRESH})
+    v = _run(s3, execution_start_time="not-a-time")
+    assert v["status"] == cov.UNMEASURED
+
+
+def test_a_missing_registry_never_yields_an_empty_clean_declaration():
+    """An empty declaration probes nothing and would report a clean pass. The
+    loader raises instead, and the caller turns that into UNMEASURED."""
+    s3 = _FakeS3({"artifacts": [], "pipeline_stages": []}, {})
+    v = _run(s3)
+    assert v["status"] == cov.UNMEASURED
+
+
+# ── declared-nothing is COVERAGE, not an absence ─────────────────────────────
+
+
+def test_a_stage_declaring_no_artifact_is_recorded_not_ignored():
+    """The whole reason the registry grew a stage-side section: 'writes
+    nothing' must be a positive declaration. Such a stage is neither expected
+    nor missing — it is accounted for, by name."""
+    s3 = _FakeS3(_registry(_REGISTERED + [{
+        "stage": "WeeklyRunDayGate", "stage_class": "infrastructure",
+        "output": "none", "reason": "calendar arithmetic only",
+    }]), {"path/2026-08-15/x.json": FRESH})
+    v = _run(s3)
+    assert v["status"] == cov.COVERED
+    assert v["stages_no_artifact"] == ["WeeklyRunDayGate"]
+    assert v["stages_expected"] == 1
+
+
+def test_a_stage_skipped_by_input_is_not_a_miss():
+    """Absence after a skip flag is a fact about the input, not the producer.
+    A detector that pages on a deliberate skip gets turned off."""
+    s3 = _FakeS3(_registry([{
+        "stage": "Scanner", "stage_class": "product",
+        "output": "registered", "artifacts": ["thing"],
+    }, {
+        "stage": "Backtester", "stage_class": "product",
+        "output": "registered", "artifacts": ["thing"],
+    }]), {"path/2026-08-15/x.json": FRESH})
+    v = _run(s3, execution_input={"skip_scanner": True})
+    assert v["stages_skipped"] == ["Scanner"]
+    assert v["status"] == cov.COVERED
+
+
+def test_a_group_skip_flag_suppresses_every_member():
+    s3 = _FakeS3(_registry([{
+        "stage": s, "stage_class": "product",
+        "output": "registered", "artifacts": ["thing"],
+    } for s in ("PitParityLookahead", "PitParityWalkforward", "Backtester")]),
+        {"path/2026-08-15/x.json": FRESH})
+    v = _run(s3, execution_input={"skip_parity": True})
+    assert set(v["stages_skipped"]) == {"PitParityLookahead", "PitParityWalkforward"}
+
+
+def test_a_skip_flag_that_is_not_true_does_not_suppress():
+    """`skip_x: false` and an absent key must both mean 'it ran'. A truthiness
+    test would let the string 'false' suppress a stage."""
+    s3 = _FakeS3(_registry([{
+        "stage": "Scanner", "stage_class": "product",
+        "output": "registered", "artifacts": ["thing"],
+    }]), {})
+    assert _run(s3, execution_input={"skip_scanner": False})["status"] == cov.MISSING
+    assert _run(s3, execution_input={"skip_scanner": "false"})["status"] == cov.MISSING
+
+
+# ── it can never fail the run ────────────────────────────────────────────────
+
+
+def test_handle_never_raises_even_on_a_malformed_event():
+    v = cov.handle({})
+    assert v["status"] == cov.UNMEASURED
+    assert v["degrade"] is False
+
+
+def test_observe_mode_never_degrades_however_bad_the_verdict(monkeypatch):
+    """The hard constraint. OBSERVE records the full verdict and sets nothing,
+    so the state is observationally complete and operationally inert until the
+    enforce literal is flipped — after one clean cycle."""
+    monkeypatch.setattr(cov, "assert_stage_coverage", lambda **kw: {
+        "status": cov.MISSING, "enforce": False, "missing": [{"stage": "X"}],
+    })
+    v = cov.handle({"run_date": "d", "execution_start_time": WINDOW_START,
+                    "enforce": False})
+    assert v["status"] == cov.MISSING
+    assert v["degrade"] is False
+
+
+def test_enforce_mode_degrades_only_on_a_real_miss(monkeypatch):
+    for status, expected in ((cov.MISSING, True), (cov.UNMEASURED, False),
+                             (cov.COVERED, False)):
+        def _stub(_s=status, **kw):
+            return {"status": _s, "enforce": True}
+
+        monkeypatch.setattr(cov, "assert_stage_coverage", _stub)
+        v = cov.handle({"run_date": "d", "execution_start_time": WINDOW_START,
+                        "enforce": True})
+        assert v["degrade"] is expected, status
+    # UNMEASURED never degrades even under enforcement: that would report the
+    # observer's own fault as the producer's.
+
+
+# ── key resolution ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("template,expected", [
+    ("path/{date}/x.json", "path/2026-08-15/x.json"),
+    ("backtest/{trading_day}/pit_parity.json", "backtest/2026-08-15/pit_parity.json"),
+    ("config/apply_audit/latest.json", "config/apply_audit/latest.json"),
+])
+def test_both_date_placeholders_resolve_to_the_run_date(template, expected):
+    assert cov._resolve_key(template, "2026-08-15") == expected
+
+
+def test_an_unknown_placeholder_is_left_intact_so_the_probe_fails_loud():
+    """Silently dropping a placeholder would probe a WRONG key and return a
+    confident wrong answer. Leaving the braces makes the head_object miss."""
+    assert "{cycle_label}" in cov._resolve_key("a/{cycle_label}/b", "2026-08-15")
+
+
+# ── the skip map mirrors the definition ──────────────────────────────────────
+
+
+def test_every_skip_flag_is_real():
+    """The one list here that mirrors something outside the registry. A flag no
+    Choice state consults would silently suppress a stage forever."""
+    text = _WEEKLY_SF.read_text()
+    flags = set(cov.STAGE_SKIP_FLAGS.values()) | set(cov.GROUP_SKIP_FLAGS)
+    for flag in sorted(flags):
+        assert f'"$.{flag}"' in text, f"{flag} is consulted by no state"
+
+
+def test_every_mapped_stage_is_a_real_state():
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    names: set[str] = set()
+
+    def walk(s):
+        for k, v in s.items():
+            names.add(k)
+            if v.get("Type") == "Parallel":
+                for b in v["Branches"]:
+                    walk(b["States"])
+            if v.get("Type") == "Map":
+                for key in ("ItemProcessor", "Iterator"):
+                    if key in v:
+                        walk(v[key]["States"])
+
+    walk(states)
+    mapped = set(cov.STAGE_SKIP_FLAGS) | {
+        m for members in cov.GROUP_SKIP_FLAGS.values() for m in members
+    }
+    assert mapped <= names, sorted(mapped - names)
+
+
+# ── the definition wires the assertion the way the module expects ────────────
+
+
+def test_the_sf_ships_in_observe_mode():
+    """The hard constraint, asserted against the artifact that actually runs.
+    Flipping this to true is a deliberate promotion, and it must be a diff this
+    test sees."""
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    payload = states["StageCoverageAssert"]["Parameters"]["Payload"]
+    assert payload["enforce"] is False, (
+        "StageCoverageAssert must ship in OBSERVE mode — promote only after one "
+        "clean scheduled run (alpha-engine-config-I7214)"
+    )
+    assert payload["action"] == "assert_stage_coverage"
+
+
+def test_the_assertion_cannot_fail_the_run():
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    catches = states["StageCoverageAssert"]["Catch"]
+    assert any(c["ErrorEquals"] == ["States.ALL"] for c in catches)
+    assert catches[0]["Next"] == "StageCoverageUnmeasured"
+    assert states["StageCoverageUnmeasured"]["Result"]["stage_coverage"]["status"] \
+        == "UNMEASURED"
+    assert states["StageCoverageUnmeasured"]["Next"] == "CheckGateDegradedNotify", (
+        "the observer's own failure must not route through the degraded summary"
+    )
+
+
+def test_it_degrades_through_the_existing_chokepoint():
+    """Not a second mechanism: $.degraded_summary is the path CheckDegradedOutcome
+    and the DegradedRun terminal already read."""
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    setter = states["SetStageCoverageDegradedSummary"]
+    assert setter["ResultPath"] == "$.degraded_summary"
+    assert setter["Parameters"]["degraded"] is True
+    assert setter["Parameters"]["reason"] == "weekly_stage_coverage_incomplete"
+    assert states["CheckStageCoverageOutcome"]["Choices"][0]["Next"] \
+        == "SetStageCoverageDegradedSummary"
+
+
+def test_the_enforce_choice_is_ispresent_guarded():
+    """An unguarded dereference throws States.Runtime at the tail of an
+    otherwise successful weekly run — the config-I2767 shape."""
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    rule = states["CheckStageCoverageOutcome"]["Choices"][0]["And"]
+    assert any("IsPresent" in r for r in rule)
+
+
+def test_the_friday_shell_run_is_not_asserted():
+    """The Friday-PM dry pass writes nothing by design; asserting coverage on it
+    would report every stage as a miss, every Friday."""
+    states = json.loads(_WEEKLY_SF.read_text())["States"]
+    shell = states["CheckShellRunNotify"]
+    assert shell["Choices"][0]["Next"] == "NotifyShellRunComplete"
+    assert shell["Default"] == "StageCoverageAssert"

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -385,6 +385,18 @@ _NOTIFY_RESOURCE = "arn:aws:states:::sns:publish"
 #     needing its own tracker issue, not a leftover.
 _DEGRADED_FLAG_EXEMPT: dict[str, dict[str, str]] = {
     "step_function.json": {
+        "StageCoverageAssert": (
+            "alpha-engine-config-I7214: this Catch handles the OBSERVER's own "
+            "failure, not a producer's. Degrading the run because the coverage "
+            "assertion could not run would report a harness fault AS a defect "
+            "— always in the alarming direction, and the fastest way to get a "
+            "correct detector switched off. The route writes an explicit "
+            "UNMEASURED verdict to $.stage_coverage_result instead, which is a "
+            "loud value and not silence (principles.md §2.7). The flag this "
+            "stage CAN set, on a real miss, is $.degraded_summary via "
+            "SetStageCoverageDegradedSummary — the existing chokepoint — and "
+            "that path is gated on the enforce knob, not on this Catch."
+        ),
         "WeeklyRunDayGate": (
             "sf-pipeline-policy.md §5 carve-out: 'The weekly run-day gate "
             "fails open — missing a weekly run is worse than a duplicate; "

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -137,7 +137,14 @@ class TestChainOrdering:
         )
         # config#2278: the real-run success edge now passes through the
         # gate-degraded completion Choice before NotifyComplete.
-        assert states["CheckShellRunNotify"]["Default"] == "CheckGateDegradedNotify"
+        # alpha-engine-config-I7214: the Default now passes through the
+        # post-stage coverage assertion before reaching the notifier selector.
+        # Asserted as a two-hop chain rather than relaxed to "reaches
+        # CheckGateDegradedNotify eventually": a test that stops caring about
+        # the shape of the edge stops catching the next change to it.
+        assert states["CheckShellRunNotify"]["Default"] == "StageCoverageAssert"
+        assert states["StageCoverageAssert"]["Next"] == "CheckStageCoverageOutcome"
+        assert states["CheckStageCoverageOutcome"]["Default"] == "CheckGateDegradedNotify"
         assert states["CheckGateDegradedNotify"]["Default"] == "NotifyComplete"
 
     def test_wait_for_substrate_routes_via_status_choice(self, states):


### PR DESCRIPTION
Refs `alpha-engine-config-I7214` (the governing register) and `alpha-engine-config-I7167` (the five silent stages). The tracker is `alpha-engine-config`; this is the code half. Branched from `fix/i7179-cost-fanin-coverage` (`nousergon-data-PR1355`) — both edit `infrastructure/step_function.json`.

## The finding

**A Step Functions run asserts that a stage did not THROW. Nothing asserts that it WROTE.** Those are different claims, and only the second is what the trading week depends on. On 2026-08-08 five stages produced no output while the run reported SUCCEEDED (`config-I7167`) — every one of them exited zero.

## `StageCoverageAssert`

Reads `ARTIFACT_REGISTRY.yaml`'s `pipeline_stages` section from `s3://alpha-engine-research/_freshness_monitor/ARTIFACT_REGISTRY.yaml` — the copy `alpha-engine-config`'s `sync-artifact-registry.yml` refreshes on **every merge that touches it**, so the consumer is refreshed by the same event that changes the declaration. Nothing here carries its own list of stages: a hand-maintained denominator drifts, and its drift is invisible because the missing rows produce no signal.

For each stage not suppressed by a skip flag it asserts the declared artifact **exists** and that its **LastModified falls inside this execution's window**. The second half is the load-bearing one: an artifact left over from a previous cycle satisfies every existence-only probe while the consumer reads last week's belief. `missing` and `stale` are reported as separate lists — they are different defects.

## SHIPS IN OBSERVE MODE — and how to promote it

`"enforce": false` is a literal in the state's Payload. The Lambda returns a single derived `degrade` boolean, true **only** when `enforce` is true AND the status is a real `MISSING`; `CheckStageCoverageOutcome` reads that one field. So:

> **To promote to enforcing:** in `infrastructure/step_function.json`, `States.StageCoverageAssert.Parameters.Payload.enforce` → `true`. One literal, one diff, nothing else. `tests/test_sf_stage_coverage.py::test_the_sf_ships_in_observe_mode` fails on that change, so the flip is deliberate and reviewed rather than incidental.
>
> **Do it after one clean scheduled run** — read `$.stage_coverage_result.stage_coverage` from the 2026-08-15 execution and confirm `status: COVERED` with an empty `unmeasured` list. Enforcing a threshold whose distribution nobody has seen is how a correct detector gets switched off in week one.

Reading a derived boolean rather than re-deriving `enforce AND status` in the Choice is deliberate: it stops the definition and the Lambda from disagreeing about what enforcement means.

## Three properties, each tested

- **It cannot fail the run.** `Catch(States.ALL)` → `StageCoverageUnmeasured`, an explicit UNMEASURED verdict that continues; and no path in `sf_stage_coverage.py` raises. An observer that can kill the pipeline it observes is a new failure mode bolted onto the one it reports.
- **It cannot report a pass it did not establish.** Unreadable registry, non-404 probe failure, unparseable window, or *nothing probed* are all `UNMEASURED`, never `COVERED` (`sf-pipeline-policy.md` §2.3a rule 2). A non-404 probe failure is explicitly **not** counted as a producer finding — conflating could-not-measure with found-a-defect reports a harness fault AS the defect, always in the alarming direction.
- **It degrades through the EXISTING chokepoint.** `SetStageCoverageDegradedSummary` writes `$.degraded_summary`, which `CheckDegradedOutcome` and the `DegradedRun` terminal already read. No second mechanism. It carries no `stage_error` for the same reason every sibling setter does not — it is reachable only from a Choice, and an unguarded `stage_error.$` would throw `States.Runtime` (`test_degraded_terminal_derives_its_cause.py`).

A stage declaring `output: none` is scored **COVERED by having said so.** That is the entire point of the registry's new section: it is what distinguishes a stage that writes nothing from a stage nobody ever considered.

## NO IAM CHANGE

It runs as a second `action` on `alpha-engine-weekly-preflight` rather than a new function. A new function needs a new role, and role creation is an operator-gated `--bootstrap` step (this repo's AGENTS.md; `deploy.sh --apply-iam`) — a human standing between the merge and the feature working, which `pull-request-policy.md` §4.2 does not permit. That role already holds **exactly** what the assertion needs and nothing more: `s3:GetObject` on `alpha-engine-research/*` (registry read + `HeadObject`) and `s3:ListBucket`. The mode dispatch mirrors `alpha-engine-predictor-inference`, which hosts three gate modes the same way.

`pyyaml` added to that Lambda's requirements — not transitive of anything present; the freshness-monitor pins it explicitly for the same reason. Absent it, the assertion returns `UNMEASURED` every run: loud, but useless.

## One edge changes

`CheckShellRunNotify.Default`: `CheckGateDegradedNotify` → `StageCoverageAssert` → `CheckStageCoverageOutcome` → `CheckGateDegradedNotify`.

Chosen because it is the single point every REAL completion path converges on before the notifiers. **Inserting one state at the convergence point rather than 43 post-stage states is what makes this shippable against a fragile pipeline three days before it runs.** It also excludes the Friday-PM shell run by construction — that is a dry pass which writes nothing by design, and asserting it would report 43 misses every Friday.

Four existing notify-path walkers stopped at the first non-Choice state and would have returned `StageCoverageAssert` as the notifier. They now step through — **scoped by name to the `StageCoverage*` states**, because a blanket "follow `Next` on any Task" walks straight past `NotifyComplete` (itself a Task with a `Next`) and returns the completion marker, i.e. answers a different question while still passing.

`SetStageCoverageDegradedSummary` is added to `weekly_sf_rerun.TERMINAL_DEGRADED_FAMILY`: the coverage verdict is a claim about the run as a whole, not a per-stage rerun witness. Mapping it to any one stage would be wrong in both directions — a rerun would re-run that stage for a miss owned by another, and skip the one that actually missed.

## Test plan

- [x] `python3 -m pytest tests/ -q -p no:randomly --continue-on-collection-errors` — **4773 passed**, 177 failed / 65 collection errors. Branch-point baseline is 4745 / 178 / 65 (`yfinance`, `pyarrow` laptop-env gaps); +28 passes are this PR's new tests, and no failure is new.
- [x] `pytest tests/ -k "sf_ or step_function or degraded or notifier or weekly_sf" -q` — the two `test_sf_preflight.py` and the `test_corpus_freshness_assertion.py` failures reproduce on a stashed tree and are unrelated
- [x] `tests/test_sf_stage_coverage.py` — 26 new tests: stale-vs-absent kept apart, every UNMEASURED route, `skip_x: "false"` not suppressing a stage, group skip flags, unknown placeholders left intact so the probe fails loud rather than probing a wrong key, `handle({})` not raising, observe-never-degrades, enforce-degrades-only-on-MISSING, and six assertions read off the **shipped definition** (observe mode, the Catch, the chokepoint, the IsPresent guard, the Friday exclusion)
- [x] `tests/test_sf_stage_coverage.py::test_every_skip_flag_is_real` — the one list mirroring something outside the registry, checked against the definition; a flag no Choice consults would silently suppress a stage forever
- [x] Graph integrity: zero dangling `Next`/`Default`/`Catch` targets across all 232 states including Parallel branches and the Map iterator

## Cross-repo — merge order

1. `crucible-backtester-PR655` — the two producers whose keys the registry registers
2. `alpha-engine-config-PR7229` — the 43-stage declaration; syncs to S3 on merge
3. **this PR**

`nousergon-data-PR1355` merges before this one (it is this branch's base). Landing this before 2 is safe but inert — the assertion returns `UNMEASURED` until the section is on S3, which is loud and correct rather than a false pass.

Rehearsal-path: infrastructure/run_weekly_offcycle.sh

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
