### PR TITLE
fix(pause): the two ci-watch reclaim legs are pending, not paused

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -32,14 +32,14 @@
   "pending": {
     "_why": "Triggers that do not exist live yet but MUST be created DISABLED when they first appear. Brian's ruling covers 'everything else', which includes automation that lands after 2026-08-07 \u2014 but automation_pause.py --check requires every `paused` entry to exist live, so a not-yet-created name cannot go there without turning the check red. pause_state() reads BOTH blocks; --check requires existence only for `paused`. Move an entry up to `paused` once it exists live. Found by alpha-engine-config-I6620: nousergon-data#1207 declares three schedules that its (currently broken) deploy would have created ENABLED mid-pause.",
     "alpha-engine-sf-watch-reclaim-sweep-0645-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live",
-    "alpha-engine-sf-watch-reclaim-sweep-1445-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live"
+    "alpha-engine-sf-watch-reclaim-sweep-1445-daily": "nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live",
+    "alpha-engine-ci-watch-instance-terminated": "ci-watch-liveness-probe reclaim leg (EC2 instance-terminated). Codified in lambdas/ci-watch-liveness-probe/deploy.sh, never created live — moved here from `paused` on 2026-08-13 after `--check` reported it [missing-in-aws]. Measured that day: `events describe-rule` 404s for this name and for its twin, while the sf-watch equivalents (alpha-engine-sf-watch-instance-terminated / -spot-interruption) both exist DISABLED; the whole ci-watch-liveness-probe component is codified-but-never-bootstrapped, alongside its IAM role in the nous-ergon-ops IAM drift report. Same situation as the sf-watch-reclaim-sweep pair above, so the same block.",
+    "alpha-engine-ci-watch-spot-interruption": "ci-watch-liveness-probe reclaim leg (EC2 spot-interruption-warning). Codified in lambdas/ci-watch-liveness-probe/deploy.sh, never created live — the second of ci-watch's two reclaim wake legs; see the entry above."
   },
   "paused": {
     "events_rules": {
       "alpha-engine-canary-replay-liveness-probe-tick": "overseer canary-replay liveness probe",
       "alpha-engine-canary-replay-thursday": "canary-replay drill dispatcher (spawns work)",
-      "alpha-engine-ci-watch-instance-terminated": "ci-watch-liveness-probe reclaim leg (EC2 instance-terminated) - added alpha-engine-config-I7174. Mirrors alpha-engine-sf-watch-instance-terminated below, which was already declared paused under the same 2026-08-07 ruling for the same reason (its target dispatches into the paused response plane); this twin was missed at that time. `alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor`'s `paused_alarms` entry watches this name - without it that alarm's declaration would reference a trigger absent from this manifest.",
-      "alpha-engine-ci-watch-spot-interruption": "ci-watch-liveness-probe reclaim leg (EC2 spot-interruption-warning) - added alpha-engine-config-I7174. Same finding as alpha-engine-ci-watch-instance-terminated above: the second of ci-watch's two reclaim/relaunch wake legs, mirroring alpha-engine-sf-watch-spot-interruption.",
       "alpha-engine-daily-heal": "data-spot heal dispatcher (launches spot). CloudFormation-managed - State: DISABLED in alpha-engine-orchestration.yaml",
       "alpha-engine-eod-success-friday-shell-trigger": "Friday shell-run trigger (spawns work)",
       "alpha-engine-friday-shell-run-report": "Friday shell-run report",

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -621,12 +621,23 @@ def test_every_watched_name_is_a_real_manifest_trigger(manifest, module):
         assert not unknown, f"{entry['name']} watches undeclared trigger(s): {unknown}"
 
 
-def test_ci_watch_reclaim_legs_exist_for_its_alarm_to_watch(manifest):
-    # Added by this same change, mirroring sf-watch's identical pair.
-    events = manifest["paused"]["events_rules"]
+def test_ci_watch_reclaim_legs_are_declared_for_its_alarm_to_watch(manifest, module):
+    # The property is that both legs are DECLARED somewhere the alarm's
+    # justification resolves — paused_names() is paused ∪ pending — not that
+    # they sit in one particular block. Which block is a fact about AWS, and
+    # it changed: measured 2026-08-13, neither rule exists live (the whole
+    # ci-watch-liveness-probe component is codified in its deploy.sh and never
+    # bootstrapped), so `paused` would make --check red with [missing-in-aws]
+    # forever. `pending` is the block for exactly that, and pinning the
+    # earlier block here turned a correct manifest correction into a red test.
+    declared = module.paused_names(manifest)
     for name in ("alpha-engine-ci-watch-spot-interruption",
                  "alpha-engine-ci-watch-instance-terminated"):
-        assert name in events, f"{name} missing — the ci-watch alarm entry watches it"
+        assert name in declared, (
+            f"{name} is declared in neither `paused` nor `pending` — the "
+            f"ci-watch alarm entry watches it, so its silencing would rest on "
+            f"a name no checker reads"
+        )
 
 
 def test_alarm_justified_derives_live_from_paused_names_not_a_cached_flag(module):


### PR DESCRIPTION
## What

Moves `alpha-engine-ci-watch-instance-terminated` and `alpha-engine-ci-watch-spot-interruption` from `paused.events_rules` to `pending` in `infrastructure/automation_pause.json`, and rewrites the test that pinned them to the `paused` block.

## Why

`automation_pause.py --check` reports both as `[missing-in-aws]`:

```
✗ [missing-in-aws] events:alpha-engine-ci-watch-instance-terminated
    listed as paused but does not exist live — it was deleted, or renamed.
```

Measured 2026-08-13 (`AWS_PROFILE=ne-admin`):

- `aws events describe-rule` 404s for both names, and neither appears in a full `list-rules` scan.
- The sf-watch equivalents — `alpha-engine-sf-watch-instance-terminated`, `alpha-engine-sf-watch-spot-interruption` — **do** exist, DISABLED.
- The two names are codified in `infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh`, and `alpha-engine-ci-watch-liveness-probe-role` appears in `nous-ergon-ops`' IAM drift report as *"role/policy does not exist on AWS (codified but never deployed)"*.

So they were never deleted or renamed — the whole `ci-watch-liveness-probe` component was codified and never bootstrapped. `paused` requires live existence and would stay red permanently; `pending` is the block written for precisely this, and its existing entries say so in the same words (`"nousergon-data#1207; codified in sf-watch-reclaim-sweep-handler/deploy.sh, never created live"`).

Nothing about the ci-watch alarm's justification changes: `paused_names()` is `paused ∪ pending` by design, so `alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor` still resolves both of its `watches` names.

## The test change

`test_ci_watch_reclaim_legs_exist_for_its_alarm_to_watch` asserted membership in `manifest["paused"]["events_rules"]` while its own comment described the property as *"the ci-watch alarm entry watches it"*. Those are different claims: which block a trigger belongs in is a fact about AWS and it changed. It now asserts against `paused_names()` — the same set the alarm's justification actually resolves against — so a future move between blocks doesn't fail it, but a name declared in *neither* still does.

## Test plan

Run before opening:

- `AWS_PROFILE=ne-admin python3 infrastructure/automation_pause.py --check` → both `[missing-in-aws]` findings gone; header goes from `39 paused / 19 kept` to `37 paused / 19 kept, 9 declared alarm(s) checked`.
- `python3 -m pytest tests/test_automation_pause.py tests/test_pause_reconcile.py -q` → 66 passed.
- Full local suite is unchanged from `main`: 19 collection errors on both, all `ModuleNotFoundError` for optional deps this laptop lacks. CI is the authority for those modules.

## Not fixed here

`--check` also reports nine `alarm-unexpectedly-enabled` findings. Those are correct and need enforcement, not a manifest edit: CloudTrail shows **zero** successful `EnableAlarmActions`/`DisableAlarmActions` in 90 days and one `AccessDenied` attempt, i.e. nothing has ever run `--enforce`. Filed as alpha-engine-config-I7233.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
