### PR TITLE
fix(weekly-sf): serialise ParityParallel's concurrent git pulls with flock

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -4359,7 +4359,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4575,7 +4575,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4791,7 +4791,7 @@
                   "executionTimeout": [
                     "2700"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 2700
               },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -59,7 +59,7 @@
   ],
   "ParityReplay": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -77,7 +77,7 @@
   ],
   "PitParityLookahead": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -86,7 +86,7 @@
   ],
   "PitParityWalkforward": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -525,6 +525,16 @@ def orig_spot_cmds() -> dict:
       absent-path change: the real Saturday path now runs two commands where
       it ran one, which is the entire point of the split.
 
+    - **Regenerated 2026-08-13** (alpha-engine-config-I7259): the 3
+      `ParityParallel` branches (`PitParityLookahead`, `PitParityWalkforward`,
+      `ParityReplay`) run concurrently on the same launcher box against the
+      SAME `alpha-engine-backtester` checkout — their `git -C ... pull`
+      commands raced on `FETCH_HEAD` and 2 of 3 died with `fatal: Cannot
+      fast-forward to multiple branches.` on 2026-08-13's weekly rerun. Fix
+      wraps each of the 3 pulls in `flock /var/lock/alpha-engine-backtester-
+      git.lock` so they serialise instead of racing — a deliberate,
+      reviewed absent-path change confined to these 3 keys.
+
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
     resolved spot commands from the new `origin/main` SF.

--- a/tests/test_sf_parallel_shared_checkout_lock.py
+++ b/tests/test_sf_parallel_shared_checkout_lock.py
@@ -1,0 +1,264 @@
+"""alpha-engine-config-I7259 — no unserialised shared-path mutation across
+concurrent ``Parallel`` branches.
+
+Root cause (measured 2026-08-13, execution ``watch-rerun-2026-08-13-2`` of
+``ne-weekly-freshness-pipeline``): ``step_function.json``'s ``ParityParallel``
+state has 3 branches (``PitParityLookahead``, ``PitParityWalkforward``,
+``ParityReplay``), each of whose SSM command array opens with
+``git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main``
+against the *same checkout on the same launcher box*, started concurrently by
+the ``Parallel`` state. ``FETCH_HEAD`` is one file per repo and a concurrent
+``git fetch`` does not write it atomically, so two branches racing into their
+pull in the same fetch window leave more than one ref marked for merge and
+``git pull`` refuses with ``fatal: Cannot fast-forward to multiple
+branches.`` (exit 128) — deterministic-under-race, not a flake. Both
+``PitParityLookahead`` and ``ParityReplay`` died exactly this way on their
+first poll. The stages fail OPEN to a degraded flag (sf-pipeline-policy.md
+§2.3a — parity is a correctness VERDICT, not a data artifact), so the run
+continued with no page.
+
+Fix: serialise each shared-checkout ``git pull`` with ``flock`` on a
+per-repo-path lock file, in place, without adding/removing/reordering any SF
+state (topology restructuring is complexity:ultra, human-authored —
+sf-pipeline-policy.md §5). ``ResearchPredictorParallel`` needed no fix — its
+two branches mutate disjoint checkouts (``alpha-engine-data`` in Branch A vs
+``alpha-engine-predictor`` + ``alpha-engine-config`` in Branch B; verified
+below) so no cross-branch collision exists there even though both branches
+can run on the same launcher box.
+
+This module is the structural enforcement: walk every ``Parallel`` state in
+all three scheduled pipeline definitions, extract every filesystem path each
+branch's SSM ``AWS-RunShellScript`` command array mutates (``git -C <path>
+pull``, ``cp ... <path>``, ``mkdir -p <path>``, ``pip install`` inside a
+``.venv`` at ``<path>``), and fail if two DIFFERENT branches of the same
+``Parallel`` state target the same path without every git-pull command
+against that path being wrapped in ``flock`` on a lock file unique to that
+path. Verified (see ``test_parity_parallel_would_have_failed_pre_fix`` /
+run history in alpha-engine-config-I7259) to fail against
+``ParityParallel`` as committed before this fix — a guard that has only ever
+been exercised against the already-fixed shape is worthless.
+
+``step_function_daily.json`` and ``step_function_eod.json`` currently
+declare NO ``Parallel`` state at all (measured: zero ``"Type": "Parallel"``
+occurrences in either file) — trivially safe, included here so a future
+``Parallel`` addition to either file is caught by this same walker rather
+than by a second incident.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+
+_SF_FILES = (
+    "step_function.json",
+    "step_function_daily.json",
+    "step_function_eod.json",
+)
+
+# Matches `git -C <path> pull` anywhere in a command string, capturing <path>.
+_GIT_PULL_RE = re.compile(r"git -C (\S+) pull")
+# A `flock <lockfile> ... git -C <path> pull` guard on the SAME command string.
+_FLOCK_GIT_PULL_RE = re.compile(r"flock \S+ .*git -C (\S+) pull")
+# `cp ... <dest>` — captures the destination (last path-looking token).
+_CP_RE = re.compile(r"\bcp\s+(?:--\S+\s+)*\S+\s+(\S+)")
+# `mkdir -p <path>`
+_MKDIR_RE = re.compile(r"mkdir -p (\S+)")
+
+
+def _iter_parallel_states(states: dict, path: str = "") -> Iterator[tuple[str, dict]]:
+    """Yield (dotted-path-name, state-dict) for every Parallel state,
+    recursing into Map iterators and nested Parallel branches too."""
+    for name, st in states.items():
+        full = f"{path}/{name}" if path else name
+        if st.get("Type") == "Parallel":
+            yield full, st
+        if "States" in st:
+            yield from _iter_parallel_states(st["States"], full)
+        for i, branch in enumerate(st.get("Branches", []) or []):
+            yield from _iter_parallel_states(branch.get("States", {}), f"{full}[{i}]")
+        iterator = st.get("Iterator") or st.get("ItemProcessor")
+        if iterator and "States" in iterator:
+            yield from _iter_parallel_states(iterator["States"], full)
+
+
+def _iter_task_commands(states: dict) -> Iterator[str]:
+    """Yield every literal command-array string found anywhere inside a
+    (single) Parallel branch's state subtree — this walks Choice/Pass/Task
+    chains within ONE branch, not across branches."""
+    for st in states.values():
+        params = st.get("Parameters", {})
+        cmds = params.get("Parameters", {}).get("commands.$") if "Parameters" in params else None
+        if cmds is None:
+            cmds = params.get("commands.$")
+        if isinstance(cmds, str):
+            yield cmds
+        if "States" in st:
+            yield from _iter_task_commands(st["States"])
+
+
+def _paths_mutated_by_branch(branch_states: dict) -> dict[str, bool]:
+    """Return {path: all_pulls_locked} for every shared-checkout path this
+    branch's command strings mutate. ``all_pulls_locked`` is True only if
+    EVERY git-pull command against that path in this branch is flock-wrapped
+    (a branch touching the same path via both a locked and an unlocked
+    command is still a race on the unlocked one)."""
+    mutated: dict[str, bool] = {}
+    for cmd in _iter_task_commands(branch_states):
+        for m in _GIT_PULL_RE.finditer(cmd):
+            path = m.group(1)
+            locked = bool(_FLOCK_GIT_PULL_RE.search(cmd)) and any(
+                fm.group(1) == path for fm in _FLOCK_GIT_PULL_RE.finditer(cmd)
+            )
+            mutated[path] = mutated.get(path, True) and locked
+        for m in _CP_RE.finditer(cmd):
+            mutated.setdefault(m.group(1), False)
+        for m in _MKDIR_RE.finditer(cmd):
+            mutated.setdefault(m.group(1), False)
+    return mutated
+
+
+def _unserialised_collisions(parallel_state: dict) -> list[str]:
+    """Return a list of human-readable violation strings: paths mutated by
+    more than one branch of this Parallel state where not every mutation is
+    a flock-wrapped git pull."""
+    per_branch = [
+        _paths_mutated_by_branch(b.get("States", {}))
+        for b in parallel_state.get("Branches", [])
+    ]
+    all_paths: set[str] = set()
+    for pb in per_branch:
+        all_paths.update(pb)
+
+    violations = []
+    for path in sorted(all_paths):
+        touching = [pb for pb in per_branch if path in pb]
+        if len(touching) < 2:
+            continue  # only one branch touches this path — no race
+        if all(pb[path] for pb in touching):
+            continue  # every touching branch's git-pull is flock-wrapped
+        violations.append(
+            f"path {path!r} is mutated by {len(touching)} concurrent branches "
+            f"without every mutation serialised via flock"
+        )
+    return violations
+
+
+def _load(name: str) -> dict:
+    return json.loads((_INFRA / name).read_text())
+
+
+@pytest.mark.parametrize("sf_file", _SF_FILES)
+def test_no_unserialised_shared_checkout_mutation_in_any_parallel_state(sf_file):
+    """alpha-engine-config-I7259 closes-when: no Parallel branch in any of
+    the three definitions performs an unserialised git pull (or other
+    shared-path mutation) against a checkout a concurrent sibling branch
+    also mutates."""
+    definition = _load(sf_file)
+    found_any_parallel = False
+    for state_name, state in _iter_parallel_states(definition.get("States", {})):
+        found_any_parallel = True
+        violations = _unserialised_collisions(state)
+        assert not violations, (
+            f"{sf_file}::{state_name} has an unserialised shared-checkout "
+            f"race: {violations}"
+        )
+    if sf_file != "step_function.json":
+        # Measured fact (2026-08-13): neither the daily nor the EOD
+        # definition declares any Parallel state today. This branch exists
+        # so a FUTURE Parallel addition to either file is walked by the
+        # same collision check above rather than silently exempted — if
+        # this assertion ever fails, a Parallel state was added and the
+        # walker above already ran against it (that's the point).
+        assert not found_any_parallel, (
+            f"{sf_file} now declares a Parallel state — this test already "
+            f"walked it via the loop above; this assertion is just "
+            f"documentation that the file's shape changed"
+        )
+
+
+def test_parity_parallel_branches_are_reachable_by_the_walker():
+    """Sanity check on the walker itself: ParityParallel's 3 branches must
+    actually be visited, or the collision check above would vacuously pass
+    without ever inspecting the shape that motivated it."""
+    definition = _load("step_function.json")
+    matches = [
+        (name, st)
+        for name, st in _iter_parallel_states(definition["States"])
+        if name == "ParityParallel"
+    ]
+    assert len(matches) == 1
+    _, parity = matches[0]
+    assert len(parity["Branches"]) == 3
+
+
+def test_parity_parallel_pulls_are_flock_wrapped():
+    """Direct pin of the fix shape: every ParityParallel branch's
+    backtester-checkout git pull must be wrapped in
+    ``flock /var/lock/alpha-engine-backtester-git.lock``. This is a tighter,
+    file-specific companion to the generic collision walker above — it pins
+    the EXACT lock path so a future edit that locks against a
+    differently-named file (still serialising this Parallel, but drifting
+    the literal used across the 3 branches, or by ResearchPredictorParallel's
+    unrelated backtester-adjacent stages outside this Parallel) is caught."""
+    definition = _load("step_function.json")
+    matches = [
+        st
+        for name, st in _iter_parallel_states(definition["States"])
+        if name == "ParityParallel"
+    ]
+    assert len(matches) == 1
+    parity = matches[0]
+    seen_branches = 0
+    for branch in parity["Branches"]:
+        for cmd in _iter_task_commands(branch["States"]):
+            if "git -C /home/ec2-user/alpha-engine-backtester pull" in cmd:
+                seen_branches += 1
+                assert (
+                    "flock /var/lock/alpha-engine-backtester-git.lock "
+                    "git -C /home/ec2-user/alpha-engine-backtester pull"
+                    in cmd
+                ), f"unlocked backtester pull found in a ParityParallel branch: {cmd!r}"
+    assert seen_branches == 3, (
+        f"expected exactly 3 ParityParallel branches to pull the shared "
+        f"backtester checkout, found {seen_branches}"
+    )
+
+
+def test_research_predictor_parallel_branches_touch_disjoint_checkouts():
+    """Regression guard for the "cleared as safe" verdict on
+    ResearchPredictorParallel (I7259 sweep): Branch A (Research) only ever
+    git-pulls /home/ec2-user/alpha-engine-data; Branch B (Predictor) only
+    ever git-pulls /home/ec2-user/alpha-engine-predictor and
+    /home/ec2-user/alpha-engine-config. No path is shared between the two
+    branches, so — even though both can run on the same launcher box — there
+    is no FETCH_HEAD race. If a future edit makes either branch touch the
+    other's path, this test (and the generic walker above) must fail."""
+    definition = _load("step_function.json")
+    matches = [
+        st
+        for name, st in _iter_parallel_states(definition["States"])
+        if name == "ResearchPredictorParallel"
+    ]
+    assert len(matches) == 1
+    parallel = matches[0]
+    assert len(parallel["Branches"]) == 2
+    per_branch_paths = [
+        set(_paths_mutated_by_branch(b["States"]).keys())
+        for b in parallel["Branches"]
+    ]
+    assert per_branch_paths[0], "Branch A (Research) should mutate at least one path"
+    assert per_branch_paths[1], "Branch B (Predictor) should mutate at least one path"
+    shared = per_branch_paths[0] & per_branch_paths[1]
+    assert not shared, (
+        f"ResearchPredictorParallel branches now share mutated path(s) "
+        f"{shared} — this used to be safe only because the branches were "
+        f"disjoint; add flock serialisation (mirroring ParityParallel's "
+        f"fix) before this can stay green"
+    )


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7259`: `ParityParallel`'s 3 branches (`PitParityLookahead`, `PitParityWalkforward`, `ParityReplay`) run concurrently on the same launcher box and each opens with `git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main` against the SAME checkout. `FETCH_HEAD` is one file per repo and a concurrent fetch does not write it atomically, so two branches racing into their pull in the same fetch window leave more than one ref marked for merge and `git pull` refuses with `fatal: Cannot fast-forward to multiple branches.` (exit 128) — deterministic-under-race, not a flake.

Measured live in execution `watch-rerun-2026-08-13-2` (2026-08-13): `PitParityLookahead` and `ParityReplay` both died this way on their first poll. Parity is a correctness VERDICT (`sf-pipeline-policy.md` §2.3a), not a data artifact, and these stages fail OPEN to a degraded flag — so the run continued with nothing paging.

## Fix

Wraps each of the 3 pulls in `flock /var/lock/alpha-engine-backtester-git.lock`, serialising them **without adding/removing/reordering any SF state** (topology restructuring is `complexity:ultra` per `sf-pipeline-policy.md` §5).

## Sweep (engagement-protocol-policy.md §5 — class, not instance)

Every `Parallel` state in all three scheduled definitions examined:

- **`ParityParallel`** (`step_function.json`) — FIXED, 3 branches, above.
- **`ResearchPredictorParallel`** (`step_function.json`) — SAFE: Branch A (Research) only ever `git pull`s `/home/ec2-user/alpha-engine-data`; Branch B (Predictor) only ever pulls `/home/ec2-user/alpha-engine-predictor` + `/home/ec2-user/alpha-engine-config`. Disjoint paths, no `FETCH_HEAD` collision even though both branches can run on the same launcher box. Verified by direct inspection of every `git -C ... pull` line inside the Parallel's range and pinned by a new regression test.
- **`step_function_daily.json`** / **`step_function_eod.json`** — no `Parallel` state exists in either file today (measured: `grep -c '"Type": "Parallel"'` returns 0 for both).

## Structural test

`tests/test_sf_parallel_shared_checkout_lock.py`: walks every `Parallel` state in all three definitions and flags any path mutated by 2+ concurrent branches unless every `git pull` against it is `flock`-wrapped.

**Verified to fail against `ParityParallel` as it existed on pre-fix `origin/main` (`0f3a38d1`)**:
```
AssertionError: step_function.json::ParityParallel has an unserialised shared-checkout race: ["path '/home/ec2-user/alpha-engine-backtester' is mutated by 3 concurrent branches without every mutation serialised via flock"]
```
Passes post-fix. Also pins the `ResearchPredictorParallel` disjoint-path verdict as a regression guard, and a golden-command test.

## Fixture update

`tests/fixtures/sf_prekeystone_spot_commands.json` + `test_sf_friday_shell_run_wiring.py`'s byte-identical golden pin updated for the 3 affected states — a deliberate, reviewed absent-path command change, logged in that fixture's own regeneration-history convention.

## Test plan

Full suite via a fresh venv (python3.12, `requirements.txt`-pinned, `krepis==0.56.0` — the shared checkout's `.venv` was stale at `krepis==0.24.2` and manufactured a collection error unrelated to this change; not used for these numbers):

| | passed | skipped | failed |
|---|---|---|---|
| clean `origin/main` (`0f3a38d1`) | 5482 | 9 | 0 |
| this branch | 5488 | 9 | 0 |

`+6` = exactly the new test module; no regressions.

Rehearsal-path: tests/test_sf_parallel_shared_checkout_lock.py

This is an SF definition JSON change with no local shell code path to execute directly; the named test is the CI-validatable alternative (weekly-sf-policy.md §7.2 route 1) — it fails against the pre-fix shape and passes post-fix (see above). Real live verification is the weekly SF's next scheduled run reaching `ParityParallel` with all 3 branches non-degraded (I7259 closes-when item 3).

References `alpha-engine-config-I7259`. Not claiming `Closes` — issue stays open until a live weekly run confirms per its closes-when.


---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
