### PR TITLE
fix(weekly-sf): one ec2-user-writable git-sync lock inode for all 24 SF pulls (config-I7259)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -679,7 +679,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -890,7 +890,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -1370,7 +1370,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "21600"
                   ]
@@ -1665,7 +1665,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2731,7 +2731,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2918,7 +2918,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','{ sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main; sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main; sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml; } 1>&2','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m training.model_zoo list-rotation-specs --bucket alpha-engine-research 2>/dev/null')",
+                  "commands.$": "States.Array('set -eo pipefail','{ sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main; sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main; sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml; } 1>&2','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m training.model_zoo list-rotation-specs --bucket alpha-engine-research 2>/dev/null')",
                   "executionTimeout": [
                     "600"
                   ]
@@ -3301,7 +3301,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3837,7 +3837,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4002,7 +4002,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4167,7 +4167,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4359,7 +4359,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4575,7 +4575,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4791,7 +4791,7 @@
                   "executionTimeout": [
                     "2700"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 2700
               },
@@ -5053,7 +5053,7 @@
           "executionTimeout": [
             "2700"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 2700
       },
@@ -5271,7 +5271,7 @@
           "executionTimeout": [
             "1800"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1800
       },
@@ -5445,7 +5445,7 @@
           "executionTimeout": [
             "1200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1200
       },
@@ -5636,7 +5636,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
           "executionTimeout": [
             "300"
           ]
@@ -5764,7 +5764,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
           "executionTimeout": [
             "240"
           ]

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -1,7 +1,7 @@
 {
   "Backtester": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -10,22 +10,22 @@
   ],
   "DataPhase1": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
   ],
   "DataPhase2": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "set -a && source /home/ec2-user/.alpha-engine.env && set +a",
@@ -33,7 +33,7 @@
   ],
   "EvaluatorDiagnostics": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -42,7 +42,7 @@
   ],
   "EvaluatorOptimize": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -51,15 +51,15 @@
   ],
   "MorningEnrich": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
   ],
   "ParityReplay": [
     "set -eo pipefail",
-    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -68,7 +68,7 @@
   ],
   "PitParityCompare": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -77,7 +77,7 @@
   ],
   "PitParityLookahead": [
     "set -eo pipefail",
-    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -86,7 +86,7 @@
   ],
   "PitParityWalkforward": [
     "set -eo pipefail",
-    "sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -95,7 +95,7 @@
   ],
   "PortfolioOptimizerBacktest": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -104,7 +104,7 @@
   ],
   "PredictorBacktest": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-backtester",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
@@ -113,8 +113,8 @@
   ],
   "PredictorTraining": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml",
     "cd /home/ec2-user/alpha-engine-predictor",
     "export HOME=/home/ec2-user",
@@ -125,7 +125,7 @@
   ],
   "RAGIngestion": [
     "set -eo pipefail",
-    "sudo -u ec2-user git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
+    "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -535,6 +535,20 @@ def orig_spot_cmds() -> dict:
       git.lock` so they serialise instead of racing — a deliberate,
       reviewed absent-path change confined to these 3 keys.
 
+    - **Regenerated 2026-08-13 (second pass)**, same incident, two defects in
+      the entry above. (a) `/var/lock` is `0755 root:root` on AL2023, so
+      `sudo -u ec2-user flock /var/lock/<f>` exits 66 `Permission denied` —
+      verified live on i-0fbfe2c1f3d89a835 — which under `set -eo pipefail`
+      would have killed all 3 parity stages on command 0 every week.
+      (b) A per-Parallel lock inode cannot serialise against the concurrent
+      writers OUTSIDE the SF (`boot-pull.service`, `CodeFreshnessGate`,
+      `ChronicGapSelfHeal`), which already lock
+      `/home/ec2-user/.ae-git-sync.lock`. All pulls now use that one inode,
+      and the guard is extended from the 3 ParityParallel branches to ALL 24
+      SF-issued pulls — the race is a property of any two concurrent writers
+      to a checkout, not of the Parallel state that happened to expose it.
+      See `tests/test_sf_git_pull_serialized.py`.
+
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
     resolved spot commands from the new `origin/main` SF.

--- a/tests/test_sf_git_pull_serialized.py
+++ b/tests/test_sf_git_pull_serialized.py
@@ -1,0 +1,156 @@
+"""Every SF-issued `git pull` into a shared box checkout is flock-serialized
+on the ONE fleet-wide lock inode, and that inode is writable by ec2-user.
+
+2026-08-13 weekly run ``watch-rerun-2026-08-13-2``: ``ParityParallel`` fans out
+three SSM commands (``PitParityLookahead``, ``PitParityWalkforward``,
+``ParityReplay``) that each open with
+
+    sudo -u ec2-user git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main
+
+against the SAME checkout at the same instant. Three concurrent writers to one
+``FETCH_HEAD`` produced::
+
+    From https://github.com/nousergon/crucible-backtester
+     * branch            main       -> FETCH_HEAD
+    fatal: Cannot fast-forward to multiple branches.
+    failed to run commands: exit status 128
+
+With ``set -eo pipefail`` as command 0, PitParityLookahead and ParityReplay
+died 0.5s in — before either stage did any work. The lookahead pass artifact
+was therefore never published, and ``PitParityCompare`` emitted verdict UNKNOWN
+on ``{'lookahead': 'missing', 'walkforward': 'failed'}``. The same race killed
+``EvaluatorDiagnostics`` and failed the whole execution.
+
+This is a recurring class, not a new bug: the identical two-writer race was
+diagnosed on the daily SF 2026-06-19 -> 07-11 (see the
+``CheckSaturdayHealthCheckStatus`` comment in ``step_function_daily.json``) and
+on the 2026-07-08 preopen failure (``test_sf_code_freshness_lock_retry_wiring``).
+Both earlier fixes were per-state. Mutual exclusion — not retry-on-message — is
+the fix that covers every signature, including ones not yet observed: the
+``CodeFreshnessGate`` retry helper keys on git's ``index.lock`` phrase
+("Another git process seems to be running") and is structurally blind to the
+``Cannot fast-forward to multiple branches`` variant seen here.
+
+Two clauses, because the first fix of this on the weekly SF (#1366) met one and
+broke on the other:
+
+1. **No bare pull.** Every ``git ... pull`` in every SF definition is behind
+   ``flock``.
+2. **One inode, ec2-user-writable.** All of them use
+   ``/home/ec2-user/.ae-git-sync.lock`` — the same advisory-lock inode
+   ``boot-pull.sh``, ``ChronicGapSelfHeal`` and the daily SF already acquire.
+   Two lock files over one repo serialize nothing against each other, and
+   ``/var/lock`` is root-owned ``0755`` on AL2023 (verified live on
+   i-0fbfe2c1f3d89a835, 2026-08-13): ``sudo -u ec2-user flock
+   /var/lock/<f>`` exits **66** with ``Permission denied``, which under
+   ``set -eo pipefail`` kills the stage on command 0 — every time, for every
+   parity stage.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SF_DIR = _REPO_ROOT / "infrastructure"
+
+# The one fleet-wide git-sync advisory lock. Lives under /home/ec2-user so the
+# `sudo -u ec2-user` open always succeeds (see module docstring clause 2).
+CANONICAL_LOCK = "/home/ec2-user/.ae-git-sync.lock"
+
+_PULL = re.compile(r"git (?:-C \S+ )?pull\b")
+# The guarded form: flock, any -w budget, the canonical inode, then `git`.
+_GUARDED = re.compile(
+    r"flock (?:-w \d+ )?" + re.escape(CANONICAL_LOCK) + r" git\b"
+)
+
+
+def _sf_definitions() -> list[Path]:
+    paths = sorted(_SF_DIR.glob("step_function*.json"))
+    assert paths, f"no SF definitions found under {_SF_DIR}"
+    return paths
+
+
+def _command_strings(node: object) -> list[str]:
+    """Every SSM *command* string in the definition.
+
+    Scoped to ``commands`` / ``commands.$`` values so a ``Comment`` that merely
+    describes a git pull is not mistaken for one. Walks the whole document
+    rather than reaching for known state names: a new state added later must be
+    covered without editing this test.
+    """
+    found: list[str] = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k in ("commands", "commands.$"):
+                found += [s for s in _flatten_strings(v)]
+            else:
+                found += _command_strings(v)
+    elif isinstance(node, list):
+        for v in node:
+            found += _command_strings(v)
+    return found
+
+
+def _flatten_strings(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node]
+    if isinstance(node, list):
+        return [s for v in node for s in _flatten_strings(v)]
+    if isinstance(node, dict):
+        return [s for v in node.values() for s in _flatten_strings(v)]
+    return []
+
+
+def test_no_bare_git_pull_in_any_sf_definition() -> None:
+    """Clause 1: no `git pull` runs outside the lock."""
+    offenders: list[str] = []
+    for path in _sf_definitions():
+        for cmd in _command_strings(json.loads(path.read_text())):
+            # Split on the ASL intrinsic's single-quoted command boundaries so
+            # one flock earlier in a States.Array cannot vouch for a later
+            # unguarded pull in the same string.
+            for piece in cmd.split("','"):
+                if _PULL.search(piece) and not _GUARDED.search(piece):
+                    offenders.append(f"{path.name}: {piece.strip()[:160]}")
+    assert not offenders, (
+        "unserialized `git pull` into a shared box checkout — concurrent SSM "
+        "commands race FETCH_HEAD and the stage dies on command 0. Wrap it as "
+        f"`sudo -u ec2-user flock -w 150 {CANONICAL_LOCK} git -C ... pull ...`:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_git_lock_is_the_single_ec2_user_writable_inode() -> None:
+    """Clause 2: exactly one lock path, and it is under /home/ec2-user."""
+    used: set[str] = set()
+    for path in _sf_definitions():
+        for m in re.finditer(r"flock (?:-w \d+ )?(\S+) git\b", path.read_text()):
+            used.add(m.group(1))
+    assert used, "no flock-guarded git call found in any SF definition"
+    assert used == {CANONICAL_LOCK}, (
+        "git-sync lock inode drift — two lock files over one checkout "
+        "serialize nothing against each other, and a path outside "
+        "/home/ec2-user is not writable by ec2-user on AL2023 "
+        f"(flock exits 66). Expected only {CANONICAL_LOCK}, found: {sorted(used)}"
+    )
+
+
+def test_parity_parallel_branches_share_the_lock() -> None:
+    """The three states whose race produced the 2026-08-13 failure, by name."""
+    doc = json.loads((_SF_DIR / "step_function.json").read_text())
+    text = json.dumps(doc)
+    for slug in ("pit-lookahead", "pit-walkforward", "parity-replay"):
+        # the SSM command that runs this stage, located by its log slug
+        stage_cmds = [
+            c for c in _command_strings(doc) if f"--slug {slug} " in c
+        ]
+        assert stage_cmds, f"no SSM command found for stage slug {slug!r}"
+        for cmd in stage_cmds:
+            assert _GUARDED.search(cmd), (
+                f"{slug}: git pull is not flock-guarded on {CANONICAL_LOCK} — "
+                "this is the exact 2026-08-13 ParityParallel race"
+            )
+    assert "ParityParallel" in text, "ParityParallel state disappeared"

--- a/tests/test_sf_parallel_shared_checkout_lock.py
+++ b/tests/test_sf_parallel_shared_checkout_lock.py
@@ -200,13 +200,34 @@ def test_parity_parallel_branches_are_reachable_by_the_walker():
 
 def test_parity_parallel_pulls_are_flock_wrapped():
     """Direct pin of the fix shape: every ParityParallel branch's
-    backtester-checkout git pull must be wrapped in
-    ``flock /var/lock/alpha-engine-backtester-git.lock``. This is a tighter,
-    file-specific companion to the generic collision walker above — it pins
-    the EXACT lock path so a future edit that locks against a
-    differently-named file (still serialising this Parallel, but drifting
-    the literal used across the 3 branches, or by ResearchPredictorParallel's
-    unrelated backtester-adjacent stages outside this Parallel) is caught."""
+    backtester-checkout git pull must be wrapped in ``flock`` on
+    ``/home/ec2-user/.ae-git-sync.lock``. This is a tighter, file-specific
+    companion to the generic collision walker above — it pins the EXACT lock
+    path so a future edit that locks against a differently-named file (still
+    serialising this Parallel, but drifting the literal used across the 3
+    branches, or by ResearchPredictorParallel's unrelated
+    backtester-adjacent stages outside this Parallel) is caught.
+
+    The lock path moved off ``/var/lock/alpha-engine-backtester-git.lock``
+    (the first form of this fix) for two measured reasons:
+
+    1. ``/var/lock`` is a symlink to ``/run/lock``, mode ``0755 root:root``
+       on AL2023. ``sudo -u ec2-user flock /var/lock/<f>`` therefore exits
+       **66** with ``flock: cannot open lock file ...: Permission denied``
+       (verified live on i-0fbfe2c1f3d89a835, 2026-08-13). As command 0
+       under ``set -eo pipefail`` that kills the stage before it does any
+       work — the same 0.5s death the fix was written to prevent, only now
+       deterministic for all 3 branches instead of 2 of 3.
+    2. The SF's Parallel branches are not the only concurrent writers to
+       these checkouts. ``boot-pull.service`` and the daily SF's
+       ``CodeFreshnessGate``/``ChronicGapSelfHeal`` already serialise on
+       ``/home/ec2-user/.ae-git-sync.lock``. A second lock inode over the
+       same repo serialises nothing against them, so the race survives the
+       fix from outside the Parallel. One repo, one lock inode.
+
+    ``test_sf_git_pull_serialized.py`` enforces both properties across every
+    SF-issued pull, not just this Parallel's three.
+    """
     definition = _load("step_function.json")
     matches = [
         st
@@ -221,7 +242,7 @@ def test_parity_parallel_pulls_are_flock_wrapped():
             if "git -C /home/ec2-user/alpha-engine-backtester pull" in cmd:
                 seen_branches += 1
                 assert (
-                    "flock /var/lock/alpha-engine-backtester-git.lock "
+                    "flock -w 150 /home/ec2-user/.ae-git-sync.lock "
                     "git -C /home/ec2-user/alpha-engine-backtester pull"
                     in cmd
                 ), f"unlocked backtester pull found in a ParityParallel branch: {cmd!r}"


### PR DESCRIPTION
fix(weekly-sf): one ec2-user-writable git-sync lock inode for all 24 SF pulls (config-I7259)

Completes the ParityParallel flock fix (#1366). Two defects in that fix, both
verified live on i-0fbfe2c1f3d89a835 (2026-08-13):

1. `/var/lock` is a symlink to `/run/lock`, mode 0755 root:root on AL2023.
   `sudo -u ec2-user flock /var/lock/alpha-engine-backtester-git.lock ...`
   exits 66 with `Permission denied`. As command 0 under `set -eo pipefail`
   that kills the stage before it does any work — so the fix as merged would
   have failed all THREE parity stages every week, where the original race
   failed two of three.

2. The SF's Parallel branches are not the only concurrent writers to those
   checkouts. `boot-pull.service`, `CodeFreshnessGate` and `ChronicGapSelfHeal`
   already serialise on `/home/ec2-user/.ae-git-sync.lock`. A second lock inode
   over the same repo serialises nothing against them, so the FETCH_HEAD race
   survives from outside the Parallel.

All 24 SF-issued `git pull`s now run behind `flock -w 150
/home/ec2-user/.ae-git-sync.lock` — the one fleet inode. The guard is extended
from ParityParallel's 3 branches to every pull, because the race is a property
of any two concurrent writers to a checkout, not of the Parallel state that
happened to expose it (the daily SF has now hit this class twice: 2026-06-19 to
07-11 and the 2026-07-08 preopen failure).

`tests/test_sf_git_pull_serialized.py` (new) pins both clauses across all four
definitions and fails on each of its three assertions against the pre-fix
definition. `test_sf_parallel_shared_checkout_lock.py`'s exact-path pin and the
byte-identicality fixture move with it.

Verified: 5491 passed, 9 skipped (full suite).

Closes nousergon/alpha-engine-config#7259

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

**Test plan (run before opening):** `pytest tests/` → **5491 passed, 9 skipped, 0 failed**, against the repo's declared pins (krepis==0.56.0, nousergon-lib v0.124.53 — the local venv was below both and manufactured 3 false failures until healed). `tests/test_sf_git_pull_serialized.py` was verified non-vacuous: all three assertions fail against the pre-fix definition.

**Live verification:** `sudo -u ec2-user flock -w 5 /var/lock/alpha-engine-backtester-git.lock true` → exit **66**, `Permission denied`; the same call on `/home/ec2-user/.ae-git-sync.lock` → exit **0**. Measured on i-0fbfe2c1f3d89a835, 2026-08-13.

**Deployability:** no post-merge step — `deploy-infrastructure.yml` deploys the SF definition on merge to `main`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_git_pull_serialized.py
