### PR TITLE
fix(iam): split unconditioned ssm:SendCommand/ec2:CreateTags on 3 spot dispatchers (config-I7254)

### DIFF
--- a/infrastructure/lambdas/data-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/data-spot-dispatcher/iam-policy.json
@@ -16,11 +16,32 @@
       "Effect": "Allow",
       "Action": [
         "ec2:RunInstances",
-        "ec2:CreateTags",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-data-spot"
+        }
+      }
     },
     {
       "Sid": "PassExecutorProfileRoleToEc2",
@@ -32,12 +53,26 @@
       }
     },
     {
-      "Sid": "SsmRunDataBootstrap",
+      "Sid": "SsmRunDataBootstrapDocument",
       "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:DescribeInstanceInformation"
-      ],
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ssm:us-east-1::document/AWS-RunShellScript"
+    },
+    {
+      "Sid": "SsmRunDataBootstrapToOwnBoxOnly",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ssm:resourceTag/Name": "alpha-engine-data-spot"
+        }
+      }
+    },
+    {
+      "Sid": "SsmDescribeInstanceInformation",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeInstanceInformation",
       "Resource": "*"
     },
     {

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json
@@ -93,12 +93,26 @@
       }
     },
     {
-      "Sid": "SsmRunSfWatchBootstrap",
+      "Sid": "SsmRunSfWatchBootstrapDocument",
       "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:DescribeInstanceInformation"
-      ],
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ssm:us-east-1::document/AWS-RunShellScript"
+    },
+    {
+      "Sid": "SsmRunSfWatchBootstrapToOwnBoxOnly",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ssm:resourceTag/Name": "alpha-engine-sf-watch-spot"
+        }
+      }
+    },
+    {
+      "Sid": "SsmDescribeInstanceInformation",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeInstanceInformation",
       "Resource": "*"
     },
     {

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
@@ -35,11 +35,13 @@
 # Usage:
 #   bash infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh             # update code + env only (CI auto-deploy path)
 #   bash infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh --bootstrap # operator-only: create/update the execution role + create the Lambda
+#   bash infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh --apply-iam # re-apply iam-policy.json only (no bootstrap side effects, config#2825)
 #   bash infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh --dry-run   # show actions, do not apply
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-weekly-freshness-spot-dispatcher"
 ROLE_NAME="alpha-engine-weekly-freshness-spot-dispatcher-role"
 POLICY_NAME="alpha-engine-weekly-freshness-spot-dispatcher-policy"
@@ -68,10 +70,12 @@ case "${DRY_RUN:-false}" in
   *) DRY_RUN=false ;;
 esac
 BOOTSTRAP=false
+APPLY_IAM=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --bootstrap) BOOTSTRAP=true ;;
+    --apply-iam) APPLY_IAM=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
 done
@@ -109,6 +113,14 @@ ZIP="${PKG}/function.zip"
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
 
 # ----- 2. Bootstrap (first-time only, operator-run) --------------------------
+
+# ----- Apply IAM only (config#2825, no bootstrap side effects) -------------
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  echo "  ✓ IAM applied."
+fi
 
 if $BOOTSTRAP; then
   echo "Bootstrapping ${FUNCTION_NAME}..."

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/iam-policy.json
@@ -16,11 +16,32 @@
       "Effect": "Allow",
       "Action": [
         "ec2:RunInstances",
-        "ec2:CreateTags",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "CreateTagsAtLaunchOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "CreateDiscriminatorTagsOnOwnBoxesOnly",
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Name": "alpha-engine-weekly-freshness-spot"
+        }
+      }
     },
     {
       "Sid": "PassExecutorProfileRoleToEc2",
@@ -32,12 +53,26 @@
       }
     },
     {
-      "Sid": "SsmRunWeeklyFreshnessBootstrap",
+      "Sid": "SsmRunWeeklyFreshnessBootstrapDocument",
       "Effect": "Allow",
-      "Action": [
-        "ssm:SendCommand",
-        "ssm:DescribeInstanceInformation"
-      ],
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ssm:us-east-1::document/AWS-RunShellScript"
+    },
+    {
+      "Sid": "SsmRunWeeklyFreshnessBootstrapToOwnBoxOnly",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ssm:resourceTag/Name": "alpha-engine-weekly-freshness-spot"
+        }
+      }
+    },
+    {
+      "Sid": "SsmDescribeInstanceInformation",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeInstanceInformation",
       "Resource": "*"
     },
     {

--- a/tests/test_dispatcher_iam_instance_scope.py
+++ b/tests/test_dispatcher_iam_instance_scope.py
@@ -1,0 +1,175 @@
+"""No dispatcher/probe role may reach an instance it does not own.
+
+Generalises `test_preflight_sweep_dispatcher_iam_scope.py` (from
+`nousergon-data-PR1365` / `alpha-engine-config-I7249`) across EVERY
+`infrastructure/lambdas/*/iam-policy.json` in this repo, discovered by glob
+rather than enumerated by hand — a new dispatcher directory is covered the
+moment it exists, with no test-file edit required.
+
+The bug class (`alpha-engine-config-I7254`, filed after
+`nousergon-data-PR1365` fixed one instance of it): `ssm:SendCommand`,
+`ec2:CreateTags`, and `ec2:TerminateInstances` are all instance-scoped
+actions. Granted against `instance/*` — or, worse, against a bare `"*"`
+Resource, which reaches instance/* just as surely and is the shape all three
+of I7254's roles actually shipped — with no `Condition`, each is arbitrary
+root shell (`SendCommand`), a self-granted discriminator tag that defeats a
+sibling terminate condition (`CreateTags`), or an unconditioned kill switch
+(`TerminateInstances`) reaching every SSM-managed instance in the account,
+including the trading box.
+
+Non-inferable gotcha this guard also pins (I7254's root cause): an IAM
+`Condition` applies to every `Resource` in its statement. The
+`ssm:SendCommand` document ARN (`arn:...:document/AWS-RunShellScript`)
+carries no such tag, so a fix that adds the instance-tag condition IN PLACE
+on a statement that also lists the document ARN denies the document and
+breaks every send — a failure invisible to a policy-shape review, only
+observable on the next live dispatch. The grant must be split into a
+document statement (unconditioned) and an instance statement (conditioned)
+first; see `nousergon-data-PR1365` and this test's own module for the worked
+shape.
+
+KNOWN_GAPS_I7265: this same scan, run once across the whole repo while
+building this guard, found the identical unconditioned pattern live in seven
+MORE roles not in I7254's scope (`alert-drain-dispatcher`,
+`arctic-migration-dispatcher`, `canary-replay-dispatcher`,
+`ci-watch-dispatcher`, `scheduled-groom-dispatcher`,
+`thinktank-spot-dispatcher`, `substrate-health-gate`). Fixing those needs its
+own per-role live-dispatch rehearsal (same reason I7254 was filed separately
+from PR1365) and is tracked as `alpha-engine-config-I7265`, not silently
+widened into this PR. Each is `xfail(strict=True)` here rather than skipped:
+the marker fails loudly the moment I7265 fixes one without clearing its
+entry, and any OTHER unconditioned grant anywhere in the repo — including a
+brand-new dispatcher — still fails this test immediately.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+LAMBDAS_DIR = Path(__file__).resolve().parents[1] / "infrastructure" / "lambdas"
+
+# Actions that must never be grantable against an instance a role does not own.
+INSTANCE_SCOPED_ACTIONS = {"ec2:CreateTags", "ec2:TerminateInstances", "ssm:SendCommand"}
+
+# Pre-existing violations of this exact class, measured 2026-08-13 while
+# building this guard as part of alpha-engine-config-I7254. Out of scope for
+# that issue (different roles; each needs its own rehearsal) and tracked
+# separately as alpha-engine-config-I7265.
+KNOWN_GAPS_I7265: set[tuple[str, str]] = {
+    ("alert-drain-dispatcher", "ssm:SendCommand"),
+    ("arctic-migration-dispatcher", "ec2:CreateTags"),
+    ("arctic-migration-dispatcher", "ssm:SendCommand"),
+    ("canary-replay-dispatcher", "ssm:SendCommand"),
+    ("ci-watch-dispatcher", "ssm:SendCommand"),
+    ("scheduled-groom-dispatcher", "ec2:CreateTags"),
+    ("scheduled-groom-dispatcher", "ssm:SendCommand"),
+    ("thinktank-spot-dispatcher", "ec2:CreateTags"),
+    ("thinktank-spot-dispatcher", "ssm:SendCommand"),
+    ("substrate-health-gate", "ssm:SendCommand"),
+}
+
+# Dispatchers already known to split the document grant from the instance
+# grant correctly (I7254 + PR1365) — pinned against the split regressing.
+DOCUMENT_SPLIT_DISPATCHERS = (
+    "weekly-freshness-spot-dispatcher",
+    "data-spot-dispatcher",
+    "sf-watch-spot-dispatcher",
+    "preflight-sweep-dispatcher",
+)
+
+
+def _discover_policies() -> list[Path]:
+    return sorted(LAMBDAS_DIR.glob("*/iam-policy.json"))
+
+
+def _statements(policy: Path) -> list[dict]:
+    return json.loads(policy.read_text())["Statement"]
+
+
+def _actions(stmt: dict) -> list[str]:
+    action = stmt["Action"]
+    return [action] if isinstance(action, str) else list(action)
+
+
+def _resources(stmt: dict) -> list[str]:
+    resource = stmt["Resource"]
+    return [resource] if isinstance(resource, str) else list(resource)
+
+
+def _targets_any_instance(stmt: dict) -> bool:
+    # A bare "*" Resource reaches every instance in the account exactly as
+    # surely as an explicit instance/* ARN does — three of I7254's four roles
+    # shipped precisely this shape, so a check for ":instance/" alone would
+    # have missed all three.
+    return any(r == "*" or ":instance/" in r for r in _resources(stmt))
+
+
+def _cases() -> list:
+    cases = []
+    for policy in _discover_policies():
+        lambda_name = policy.parent.name
+        for action in sorted(INSTANCE_SCOPED_ACTIONS):
+            case_id = f"{lambda_name}::{action}"
+            marks = []
+            if (lambda_name, action) in KNOWN_GAPS_I7265:
+                marks.append(
+                    pytest.mark.xfail(
+                        reason=(
+                            f"pre-existing, tracked in alpha-engine-config-I7265: {case_id}"
+                        ),
+                        strict=True,
+                    )
+                )
+            cases.append(pytest.param(policy, lambda_name, action, id=case_id, marks=marks))
+    return cases
+
+
+@pytest.mark.parametrize("policy,lambda_name,action", _cases())
+def test_instance_scoped_action_is_never_unconditioned(
+    policy: Path, lambda_name: str, action: str
+) -> None:
+    """No grant of an instance-scoped action may reach `instance/*` (or `*`) unconditioned."""
+    for stmt in _statements(policy):
+        if action not in _actions(stmt) or not _targets_any_instance(stmt):
+            continue
+        assert stmt.get("Condition"), (
+            f"{lambda_name}: {stmt.get('Sid')!r} grants {action} reaching every "
+            "instance in the account (Resource '*' or an instance/* ARN) with no "
+            "Condition. This is arbitrary shell (ssm:SendCommand), a self-grantable "
+            "discriminator tag that defeats a sibling terminate condition "
+            "(ec2:CreateTags), or an unconditioned kill switch (ec2:TerminateInstances) "
+            "reaching any SSM-managed instance, including the trading box."
+        )
+
+
+@pytest.mark.parametrize("dispatcher", DOCUMENT_SPLIT_DISPATCHERS)
+def test_sendcommand_document_grant_stays_unconditioned_and_separate(dispatcher: str) -> None:
+    """Regression guard for I7254's split gotcha on the roles that already have it right.
+
+    A Condition applies to every Resource in its statement. Folding the
+    `AWS-RunShellScript` document ARN into the tag-conditioned instance
+    statement denies the document (it carries no such tag) and breaks every
+    send — a failure that only appears at runtime, never in a policy-shape
+    review.
+    """
+    policy = LAMBDAS_DIR / dispatcher / "iam-policy.json"
+    doc_grants = [
+        s
+        for s in _statements(policy)
+        if "ssm:SendCommand" in _actions(s) and any(":document/" in r for r in _resources(s))
+    ]
+    assert len(doc_grants) == 1, (
+        f"{dispatcher}: expected exactly one statement granting SendCommand on the document"
+    )
+    stmt = doc_grants[0]
+    assert not _targets_any_instance(stmt), (
+        f"{dispatcher}: {stmt.get('Sid')!r} must not mix the document ARN with instance "
+        "ARNs — they need different conditions, so they need different statements."
+    )
+    assert "Condition" not in stmt, (
+        f"{dispatcher}: the document grant must stay unconditioned; an instance tag "
+        "condition here denies the document itself."
+    )


### PR DESCRIPTION
## What

Closes `alpha-engine-config-I7254`. Three Lambda dispatcher roles granted `ssm:SendCommand` and (for two of them) `ec2:CreateTags` against instance ARNs — or a bare `"*"` Resource, which reaches every instance in the account exactly as surely — with **no `Condition`**: arbitrary root shell / a self-grantable discriminator tag on any SSM-managed instance, including the trading box.

| Role | File | Fixed |
|---|---|---|
| `weekly-freshness-spot-dispatcher` | `infrastructure/lambdas/weekly-freshness-spot-dispatcher/iam-policy.json` | `SsmRunWeeklyFreshnessBootstrap*` split; `ec2:CreateTags` split out of `LaunchWeeklyFreshnessSpot` |
| `data-spot-dispatcher` | `infrastructure/lambdas/data-spot-dispatcher/iam-policy.json` | `SsmRunDataBootstrap*` split; `ec2:CreateTags` split out of `LaunchDataSpot` |
| `sf-watch-spot-dispatcher` | `infrastructure/lambdas/sf-watch-spot-dispatcher/iam-policy.json` | `SsmRunSfWatchBootstrap*` split (its `ec2:CreateTags` was already correctly split — the reference shape this PR mirrors) |

Each `ssm:SendCommand` grant is split into two statements (the I7254 gotcha: a `Condition` applies to every `Resource` in its statement, and the `AWS-RunShellScript` document ARN carries no tag, so conditioning in place denies the document and breaks every send — review-clean, fails only live):
- `...Document` — unconditioned, `Resource: arn:aws:ssm:us-east-1::document/AWS-RunShellScript`
- `...ToOwnBoxOnly` — `Resource: instance/*`, `Condition: {"StringEquals": {"ssm:resourceTag/Name": "<dispatcher's Name tag>"}}`

`ec2:CreateTags` for the two roles that had it bundled into their `RunInstances` statement is split the same way `sf-watch-spot-dispatcher` already does it: `CreateTagsAtLaunchOnly` (unconditioned, keyed on `ec2:CreateAction == RunInstances`) + `CreateDiscriminatorTagsOnOwnBoxesOnly` (`ec2:ResourceTag/Name` pinned).

## Live invocation path traced per dispatcher (condition-match verification)

All three tag their box atomically at `RunInstances` via `TagSpecifications` (never a post-launch `create_tags` call — no untagged window), then call `ssm:send_command` with `InstanceIds=[<that same instance_id>]`. The Name tag is therefore always present before the send:

- `weekly-freshness-spot-dispatcher`: `index.py:344` `tag_name="alpha-engine-weekly-freshness-spot"`, `_launch_instance` → `instance_id` → `_send_bootstrap(instance_id, ...)` (line 443/357).
- `data-spot-dispatcher`: `index.py:265` `tag_name="alpha-engine-data-spot"`, `_launch_instance` → `instance_id` → `_send_bootstrap(instance_id, ...)` → `ssm.send_command(InstanceIds=[instance_id], ...)` (line 416/423/327-329).
- `sf-watch-spot-dispatcher`: `index.py:138` `SF_WATCH_TAG_NAME = "alpha-engine-sf-watch-spot"`, `_launch_instance` → `instance_id` → `_send_bootstrap(fields, instance_id, ...)` (line 773/798-799).

## Test — verified to fail pre-fix

Added `tests/test_dispatcher_iam_instance_scope.py`, parametrised over `infrastructure/lambdas/*/iam-policy.json` (glob-discovered — a new dispatcher is covered automatically, no enumeration). Ran it against the pre-fix policies (baseline worktree at `origin/main`, i.e. right after `nousergon-data-PR1365` merged) before applying any fix:

```
FAILED ...[data-spot-dispatcher::ec2:CreateTags]
FAILED ...[data-spot-dispatcher::ssm:SendCommand]
FAILED ...[sf-watch-spot-dispatcher::ssm:SendCommand]
FAILED ...[weekly-freshness-spot-dispatcher::ec2:CreateTags]
FAILED ...[weekly-freshness-spot-dispatcher::ssm:SendCommand]
FAILED test_sendcommand_document_grant_stays_unconditioned_and_separate[weekly-freshness-spot-dispatcher]
FAILED test_sendcommand_document_grant_stays_unconditioned_and_separate[data-spot-dispatcher]
FAILED test_sendcommand_document_grant_stays_unconditioned_and_separate[sf-watch-spot-dispatcher]
8 failed, 109 passed, 10 xfailed in 0.14s
```

Post-fix: `117 passed, 10 xfailed in 0.13s` — the 10 xfails are a wider instance of the same class found live in 7 OTHER roles while building this guard (`alert-drain-dispatcher`, `arctic-migration-dispatcher`, `canary-replay-dispatcher`, `ci-watch-dispatcher`, `scheduled-groom-dispatcher`, `thinktank-spot-dispatcher`, `substrate-health-gate`) — out of I7254's scope (different roles, each needs its own live-dispatch rehearsal), filed separately as `alpha-engine-config-I7265` and referenced by each `xfail(strict=True)` marker so the guard stays honest without blocking this PR.

## IAM applied — LIVE, before merge (preferred path; CI guard's ALREADY-LIVE branch)

Also added the missing `--apply-iam` flag to `weekly-freshness-spot-dispatcher/deploy.sh` (config#2825 pattern every sibling already has — this script never got it, so IAM re-apply required the heavier `--bootstrap` path). Ran all three under `AWS_PROFILE=ne-admin`:

```
bash infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh --apply-iam   # IAM applied; code+env reconverged (unchanged code)
bash infrastructure/lambdas/data-spot-dispatcher/deploy.sh --apply-iam               # IAM applied; code+env reconverged (unchanged code)
bash infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh --apply-iam           # IAM applied; code+env reconverged (unchanged code); 43 handler unit tests passed pre-package
```

Verified live == repo via `aws iam get-role-policy` + `jq -S` normalised diff for all three roles: **MATCH**.

## Test baselines (fresh venv from requirements.txt, `.venv/` — a differently-named venv trips a known scanner false-positive, `alpha-engine-config-I6675`)

- `origin/main` (post-PR1365) baseline: `5495 passed, 9 skipped, 0 failed` (84.84s)
- This branch: `5612 passed, 9 skipped, 10 xfailed, 0 failed` (83.66s) — +117 from the new guard test, no regressions.

## Closes-when (from I7254)

- [x] All three `iam-policy.json` files split document/instance grants and condition the instance grant.
- [x] `ec2:CreateTags` conditioned on all three.
- [x] Test added, parametrised, verified to fail pre-fix.
- [x] Each dispatcher's `--apply-iam` run above IS the live application — a code+env reconverge with unchanged code counts as the code path exercising the current build, but a REAL end-to-end dispatch (a Saturday weekly-freshness run, a data-spot collector run, an sf-watch spot launch) still needs to happen on its normal schedule to prove the tag condition matches at send time under real launch timing, not just by static trace. Flagging this rather than claiming it's done: the invocation-path trace above is code-level verification, not a live dispatch.

Closes-when the code-level items; the live-dispatch exercise happens on each pipeline's own normal cadence (sf-watch fires continuously, data-spot daily, weekly-freshness next Saturday) — no separate operator action needed.

Related: `alpha-engine-config-I7254`, `nousergon-data-PR1365`, `alpha-engine-config-I7265` (new, same class in 7 other roles).


---

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
