### PR TITLE
fix(weekly-sf-rerun): stop inheriting skip_* flags from the source execution (config-I7259)

### DIFF
--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -617,8 +617,43 @@ class RerunPlan:
     warnings: list = field(default_factory=list)
     notes: list = field(default_factory=list)
 
+    # skip_* keys inherited from the source execution's own input, dropped by
+    # rerun_input() and reported by the plan printer. See its docstring.
+    dropped_inherited_skips: list = field(default_factory=list)
+
     def rerun_input(self) -> dict:
-        out = dict(self.original_input)
+        """The emitted StartExecution input.
+
+        Non-``skip_*`` keys pass through from the source execution
+        (``sns_topic_arn``, ``ec2_instance_id``, …). Every ``skip_*`` key does
+        NOT: the skip set is *derived* from what the source execution actually
+        completed, and that derivation is the whole product of this script.
+
+        Inheriting them was a silent stage-disabler (alpha-engine-config-I7259,
+        observed 2026-08-13). ``watch-rerun-2026-08-13-3``'s input carried
+        ``skip_pit_parity_compare: true``; the derivation did NOT produce that
+        flag — ``pit_parity_compare`` appears in neither the completed nor the
+        degraded set — yet ``dict(self.original_input)`` carried it into
+        ``-4``'s input. The plan printed *"3 parity passes re-run"* while the
+        emitted input disabled the compare stage that consumes them, and the
+        printed ``derived skips`` line did not mention it, so the operator had
+        no way to see it from the plan. Because each rerun starts from the
+        previous rerun's input, one such flag survives every subsequent
+        recovery indefinitely.
+
+        Derived flags are ADDITIVE — they only ever set True — so they could
+        never clear an inherited one. Dropping them is what makes the emitted
+        input equal the printed plan. A skip the operator genuinely wants is
+        re-passed explicitly, which is also the only form that leaves a record.
+        """
+        out = {
+            k: v for k, v in self.original_input.items()
+            if not k.startswith("skip_")
+        }
+        self.dropped_inherited_skips = sorted(
+            k for k in self.original_input
+            if k.startswith("skip_") and k not in self.skip_flags
+        )
         out["run_date"] = self.run_date
         out["pipeline_role"] = EMITTED_ROLE
         out.update(self.skip_flags)
@@ -757,7 +792,10 @@ def derive_plan(events: list[dict], start_time: datetime | None = None) -> Rerun
             "already-written artifacts) instead of re-burning it. config#2362."
         )
 
-    reachable = _simulate_reachable_works(plan.skip_flags, original_input)
+    # Simulate the EMITTED input, not the source input. rerun_input() drops
+    # inherited skip_* keys, so passing original_input here would check a
+    # different flag set than the one actually started (config-I7259).
+    reachable = _simulate_reachable_works(plan.skip_flags, {})
     unreachable = [f for f in must_rerun if f not in reachable]
     if unreachable:
         raise SystemExit(
@@ -933,17 +971,25 @@ def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str,
     print(f"degraded stages  : {', '.join(plan.degraded) or '(none)'}")
     print(f"failed stages    : {', '.join(plan.failed) or '(none identified)'}")
     print(f"derived skips    : {', '.join(sorted(plan.skip_flags)) or '(none)'}")
+    # Populates plan.dropped_inherited_skips as a side effect; call before
+    # reporting them.
+    _emitted = plan.rerun_input()
+    if plan.dropped_inherited_skips:
+        print(
+            f"dropped skips    : {', '.join(plan.dropped_inherited_skips)} "
+            "[carried by the source execution's own input, NOT derived from "
+            "what it completed — re-pass explicitly if still wanted]"
+        )
     for n in plan.notes:
         print(f"NOTE : {n}")
     for w in plan.warnings:
         print(f"WARN : {w}", file=sys.stderr)
-    rerun_input = json.dumps(plan.rerun_input(), indent=2, sort_keys=True)
     print("\nStartExecution input:")
-    print(rerun_input)
+    print(json.dumps(_emitted, indent=2, sort_keys=True))
     print("\nequivalent CLI:")
     print(
         f"aws stepfunctions start-execution --state-machine-arn {sm_arn} "
-        f"--name {name} --input '{json.dumps(plan.rerun_input(), sort_keys=True)}'"
+        f"--name {name} --input '{json.dumps(_emitted, sort_keys=True)}'"
     )
 
 

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -205,17 +205,77 @@ class TestDerivePlan:
         assert plan.run_date == "2026-07-11"
         assert "FALLBACK" in plan.run_date_provenance
 
-    def test_refuses_to_skip_a_failed_stage(self, mod):
-        """Anti-swallow guard: if the preserved original input carries a
-        skip flag whose route would bypass a stage that FAILED, the helper
-        must refuse rather than emit an input that silently skips it."""
+    def test_inherited_skip_of_a_failed_stage_is_dropped_not_carried(self, mod):
+        """A skip flag on the SOURCE execution's own input never reaches the
+        emitted input (alpha-engine-config-I7259).
+
+        This previously raised ``SystemExit(... unreachable ...)``: the helper
+        preserved the source input wholesale, so an inherited
+        ``skip_backtester`` would have bypassed a stage that must re-run, and
+        refusing was the only safe answer. Dropping inherited skips removes the
+        condition rather than detecting it — dropping a skip can only cause
+        MORE stages to run, never fewer, so it can never strand a must-rerun
+        stage. The reachability guard is retained for DERIVED skips, where an
+        overshadowing route is still possible (see the
+        ``skip_backtester`` -> ``skip_backtester_stage_only`` demotion).
+
+        The motivating instance was quieter than this one and is why detection
+        was not enough: ``watch-rerun-2026-08-13-3`` carried
+        ``skip_pit_parity_compare``, which the derivation never produced.
+        ``pit_parity_compare`` was neither failed nor degraded, so it was not
+        in ``must_rerun`` and the guard above could not see it — the flag rode
+        into the next rerun's input, disabling the stage that consumes the
+        three parity passes that same rerun existed to recompute.
+        """
         events = _events("tail_stage_failure")
         started = next(e for e in events if "executionStartedEventDetails" in e)
         inp = json.loads(started["executionStartedEventDetails"]["input"])
         inp["skip_backtester"] = True  # would jump the degraded branch's gate
         started["executionStartedEventDetails"]["input"] = json.dumps(inp)
-        with pytest.raises(SystemExit, match="unreachable"):
-            mod.derive_plan(events)
+
+        plan = mod.derive_plan(events)
+        emitted = plan.rerun_input()
+
+        assert emitted.get("skip_backtester") is not True, (
+            "an inherited skip_backtester reached the emitted input — it would "
+            "bypass a stage that must re-run"
+        )
+        assert "skip_backtester" in plan.dropped_inherited_skips, (
+            "the dropped flag is not reported, so the operator cannot see that "
+            "the emitted input differs from the source input"
+        )
+
+    def test_dropped_inherited_skips_excludes_derived_ones(self, mod):
+        """A flag that is BOTH inherited and derived is emitted, and is not
+        reported as dropped — it belongs to the plan on its own merit."""
+        events = _events("tail_stage_failure")
+        started = next(e for e in events if "executionStartedEventDetails" in e)
+        inp = json.loads(started["executionStartedEventDetails"]["input"])
+        plan = mod.derive_plan(events)
+        derived = sorted(plan.skip_flags)
+        assert derived, "fixture derived no skips — test would be vacuous"
+        inp[derived[0]] = True
+        started["executionStartedEventDetails"]["input"] = json.dumps(inp)
+
+        plan = mod.derive_plan(events)
+        emitted = plan.rerun_input()
+        assert emitted[derived[0]] is True
+        assert derived[0] not in plan.dropped_inherited_skips
+
+    def test_non_skip_keys_still_pass_through(self, mod):
+        """Only ``skip_*`` is dropped. ``sns_topic_arn`` / ``ec2_instance_id``
+        passthrough is the reason the emitted input starts from the source
+        input at all."""
+        events = _events("tail_stage_failure")
+        started = next(e for e in events if "executionStartedEventDetails" in e)
+        inp = json.loads(started["executionStartedEventDetails"]["input"])
+        inp["sns_topic_arn"] = "arn:aws:sns:us-east-1:1:topic"
+        inp["ec2_instance_id"] = "i-abc123"
+        started["executionStartedEventDetails"]["input"] = json.dumps(inp)
+
+        emitted = mod.derive_plan(events).rerun_input()
+        assert emitted["sns_topic_arn"] == "arn:aws:sns:us-east-1:1:topic"
+        assert emitted["ec2_instance_id"] == "i-abc123"
 
     def test_degraded_tail_is_rerun_not_skipped(self, mod):
         """alpha-engine-config-I6055: a stage that DEGRADED (ran, failed,


### PR DESCRIPTION
fix(weekly-sf-rerun): stop inheriting skip_* flags from the source execution (config-I7259)

`RerunPlan.rerun_input()` did `dict(self.original_input)` and then overlaid the
derived skips. Derived flags are additive — they only ever set True — so an
inherited flag could never be cleared, and each rerun starts from the previous
rerun's input, so one such flag survives every subsequent recovery
indefinitely.

Observed 2026-08-13: `watch-rerun-2026-08-13-3`'s input carried
`skip_pit_parity_compare: true`, which the derivation did NOT produce —
`pit_parity_compare` appears in neither the completed nor the degraded set. It
rode into the next rerun's input anyway. The printed plan said the three parity
passes would re-run and said nothing about the compare stage that consumes
them being disabled, because the `derived skips` line only lists derived flags.

The existing reachability guard could not catch it: `pit_parity_compare` was
neither failed nor degraded, so it was never in `must_rerun`.

Now every `skip_*` key is dropped and reported on its own `dropped skips` line;
non-`skip_*` passthrough (`sns_topic_arn`, `ec2_instance_id`) is unchanged. The
reachability simulation is fed the EMITTED flag set rather than the source
input, so it checks the input that actually gets started.

`test_refuses_to_skip_a_failed_stage` became
`test_inherited_skip_of_a_failed_stage_is_dropped_not_carried`: the condition
it detected is now removed rather than refused — dropping a skip can only cause
MORE stages to run, so it can never strand a must-rerun stage. The guard is
retained for derived skips, where an overshadowing route is still possible.

Verified: 5618 passed, 9 skipped, 10 xfailed (full suite), and live against
`watch-rerun-2026-08-13-3` — the dry-run now prints
`dropped skips: skip_pit_parity_compare`.

Related: nousergon/alpha-engine-config#7259 (same 2026-08-13 execution), #7267

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

**Test plan (run before opening):** `pytest tests/` → **5618 passed, 9 skipped, 10 xfailed, 0 failed**. Also verified live: `scripts/weekly_sf_rerun.py --dry-run` against `watch-rerun-2026-08-13-3` now prints `dropped skips: skip_pit_parity_compare [...]` and omits it from the emitted input.

**Deployability:** no post-merge step — the script is invoked from the checkout.

Rehearsal-path: tests/test_weekly_sf_rerun.py

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)