### PR TITLE
fix(infra): deploy CFN template via S3 --template-url, raising the size ceiling (alpha-engine-config-I7250)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -1036,20 +1036,36 @@ Resources:
 # Outputs
 # ============================================================================
 
-  # Preflight sweep — daily all-stage --preflight-only check (config-I7249).
-  # WHY these three resources are shaped as they are (schedule here rather than
-  # in deploy.sh; deliberately NO AWS::Lambda::Permission; the deadman as the
-  # operator-gate detector; Period/EvaluationPeriods derived from the declared
-  # cadence) is documented in infrastructure/preflight_sweep_stages.py,
+  # --------------------------------------------------------------------------
+  # Preflight sweep — daily all-stage --preflight-only check (config-I7249)
+  # --------------------------------------------------------------------------
+  # WHY these three resources are shaped as they are — schedule declared HERE
+  # rather than baked into deploy.sh; deliberately NO AWS::Lambda::Permission
+  # (the dispatcher Lambda's resource-based policy is granted out-of-band by
+  # deploy.sh --bootstrap, mirroring the other scheduled dispatchers in this
+  # template); the deadman alarm as the operator-facing "did this even run"
+  # detector, distinct from the dispatcher-errors alarm below which only
+  # catches the Lambda itself erroring; Period/EvaluationPeriods on the
+  # deadman derived from the declared daily cadence rather than picked ad
+  # hoc — is documented in infrastructure/preflight_sweep_stages.py,
   # infrastructure/preflight_sweep_cadence.json and the dispatcher README.
   # tests/test_preflight_sweep_cadence.py fails if any of it drifts from the
-  # manifest. Comments are terse here ONLY because this template is within
-  # ~3KB of CloudFormation's 51200-byte inline --template-body ceiling.
+  # manifest (the single declared source per sf-pipeline-policy §2.6).
+  #
+  # These comments were trimmed to fit the old 51200-byte inline
+  # --template-body ceiling and are restored here now that
+  # deploy-infrastructure.sh uploads via --template-url instead
+  # (alpha-engine-config-I7250 — the ceiling is 460800 bytes now).
   PreflightSweepDailyTrigger:
     Type: AWS::Events::Rule
     Properties:
       Name: alpha-engine-preflight-sweep-daily
-      Description: Daily all-stage --preflight-only sweep of the weekly SF (config-I7249). Cadence declared in infrastructure/preflight_sweep_cadence.json.
+      Description: >-
+        Daily all-stage --preflight-only sweep of the weekly SF (config-I7249).
+        Cadence declared in infrastructure/preflight_sweep_cadence.json — this
+        rule's ScheduleExpression is asserted against that manifest by
+        tests/test_preflight_sweep_cadence.py, so the two cannot drift apart
+        silently.
       ScheduleExpression: 'cron(0 8 ? * * *)'
       State: ENABLED
       Targets:
@@ -1061,7 +1077,15 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: alpha-engine-preflight-sweep-no-run
-      AlarmDescription: Daily all-stage preflight sweep did not report at all (config-I7249). Subject is emitted on every terminal path incl. could-not-measure, so this fires only on total silence. Also stays red until deploy.sh --bootstrap creates the dispatcher Lambda.
+      AlarmDescription: >-
+        Daily all-stage preflight sweep did not report AT ALL (config-I7249).
+        PreflightSweepRunCompleted is emitted on every terminal path,
+        including could-not-measure, so this fires ONLY on total silence —
+        distinct from a sweep that ran and reported a bad result, which is a
+        separate, non-deadman alarm. Also stays red (TreatMissingData:
+        breaching) until deploy.sh --bootstrap creates the dispatcher Lambda,
+        which is the intended fail-closed posture for a component that has
+        not yet been onboarded rather than a false green.
       Namespace: AlphaEngine
       MetricName: PreflightSweepRunCompleted
       Dimensions:
@@ -1083,7 +1107,14 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: alpha-engine-preflight-sweep-dispatcher-errors
-      AlarmDescription: preflight-sweep dispatcher Lambda errored — launcher box or SSM command never happened (config-I7249)
+      AlarmDescription: >-
+        preflight-sweep dispatcher Lambda errored — the launcher box or the
+        SSM command it issues never happened (config-I7249). Complements
+        PreflightSweepDeadman above: this fires FAST on a Lambda-level
+        exception (Period 3600s vs the deadman's 86400s), while the deadman
+        is the backstop that still catches a silent failure this alarm's
+        Lambda-Errors metric cannot see (e.g. the Lambda invokes cleanly but
+        the downstream SSM command never runs).
       Namespace: AWS/Lambda
       MetricName: Errors
       Dimensions:

--- a/infrastructure/deploy-infrastructure.sh
+++ b/infrastructure/deploy-infrastructure.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # infrastructure/deploy-infrastructure.sh — Deploy Alpha Engine orchestration infrastructure.
 #
-# Uploads Step Function definitions to S3, then deploys/updates the CloudFormation
-# stack. Also updates the state machines directly (CloudFormation can't update
-# Step Function definitions from S3 on stack update — it only reads on create).
+# Uploads the CFN template AND the Step Function definitions to S3, then
+# deploys/updates the CloudFormation stack via --template-url (not inline
+# --template-body — see alpha-engine-config-I7250). Also updates the state
+# machines directly (CloudFormation can't update Step Function definitions
+# from S3 on stack update — it only reads on create).
 #
 # Usage:
 #   bash infrastructure/deploy-infrastructure.sh              # deploy/update
@@ -20,8 +22,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUCKET="alpha-engine-research"
 STACK_NAME="alpha-engine-orchestration"
 TEMPLATE="$SCRIPT_DIR/cloudformation/alpha-engine-orchestration.yaml"
+# alpha-engine-config-I7250: the template is uploaded to S3 and deployed via
+# --template-url rather than passed inline. Inline --template-body is capped
+# at CloudFormation's 51200-byte ceiling; an S3-sourced template raises that
+# to 460800 bytes. Same bucket/prefix InfraDeployS3 already grants
+# (arn:aws:s3:::alpha-engine-research/infrastructure/*) — no new IAM needed.
+TEMPLATE_S3_KEY="infrastructure/alpha-engine-orchestration.yaml"
 REGION="us-east-1"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+TEMPLATE_URL="https://${BUCKET}.s3.${REGION}.amazonaws.com/${TEMPLATE_S3_KEY}"
 
 # Git SHA stamp — baked into the SF Comment field and the CF stack tags so
 # the deploy-drift preflight can detect when main has moved past the deployed
@@ -45,9 +54,17 @@ echo "  Account:  $ACCOUNT_ID"
 echo "  Dry run:  $DRY_RUN"
 echo ""
 
-# ── 1. Validate CloudFormation template ──────────────────────────────────────
+# ── 1. Upload the CFN template to S3, then validate via --template-url ───────
+# Uploaded BEFORE validation (not just before create/update-stack) so
+# validate-template exercises the exact artifact create-stack/update-stack
+# will read below — an S3-sourced template that fails to upload fails here,
+# not three steps later against a stale copy.
+echo "==> Uploading CloudFormation template to S3..."
+aws s3 cp "$TEMPLATE" "s3://$BUCKET/$TEMPLATE_S3_KEY" --quiet
+echo "  Uploaded to s3://$BUCKET/$TEMPLATE_S3_KEY"
+
 echo "==> Validating CloudFormation template..."
-aws cloudformation validate-template --template-body "file://$TEMPLATE" --query "Description" --output text
+aws cloudformation validate-template --template-url "$TEMPLATE_URL" --query "Description" --output text
 echo "  Template valid."
 
 if $DRY_RUN; then
@@ -426,7 +443,7 @@ if [ "$STACK_STATUS" = "DOES_NOT_EXIST" ]; then
     echo "  Creating new stack..."
     aws cloudformation create-stack \
         --stack-name "$STACK_NAME" \
-        --template-body "file://$TEMPLATE" \
+        --template-url "$TEMPLATE_URL" \
         --capabilities CAPABILITY_NAMED_IAM \
         --tags "Key=git-sha,Value=$GIT_SHA" \
         --query "StackId" --output text
@@ -439,7 +456,7 @@ else
     set +e
     aws cloudformation update-stack \
         --stack-name "$STACK_NAME" \
-        --template-body "file://$TEMPLATE" \
+        --template-url "$TEMPLATE_URL" \
         --capabilities CAPABILITY_NAMED_IAM \
         --tags "Key=git-sha,Value=$GIT_SHA" \
         --query "StackId" --output text > "$UPDATE_OUT" 2>&1

--- a/tests/test_preflight_sweep_cadence.py
+++ b/tests/test_preflight_sweep_cadence.py
@@ -141,28 +141,36 @@ def test_the_descriptor_names_the_component_id_every_surface_uses(cadence):
 
 # ── The template must stay deployable ────────────────────────────────────────
 
-# CloudFormation's inline --template-body ceiling. infrastructure/
-# deploy-infrastructure.sh passes `--template-body file://` for BOTH
-# validate-template and create/update-stack, and that workflow runs on EVERY
-# push to main with no path filter — so a template that crosses this ceiling
-# does not fail the PR that did it, it fails every subsequent merge's infra
-# deploy, for changes whose authors have no idea why.
+# CloudFormation's S3-sourced --template-url ceiling (alpha-engine-config-I7250).
+# deploy-infrastructure.sh used to pass `--template-body file://` for BOTH
+# validate-template and create/update-stack, capped at the 51200-byte inline
+# ceiling. Measured 2026-08-13 while adding the preflight-sweep resources:
+# main was already at 48015 of 51200 bytes, under 7% headroom, with nothing
+# anywhere reporting that — and that workflow runs on EVERY push to main with
+# no path filter, so crossing the ceiling doesn't fail the PR that did it, it
+# fails every subsequent merge's infra deploy for authors who never touched
+# infrastructure/.
 #
-# Measured 2026-08-13 while adding the preflight-sweep resources: main was
-# already at 48015 of 51200 bytes, under 7% headroom, with nothing anywhere
-# reporting that. The structural fix is to upload the template to S3 and use
-# --template-url (1MB ceiling) — filed separately; this test is the guard that
-# turns a silent deploy break into a merge-time failure in the meantime.
-CFN_INLINE_BODY_LIMIT = 51200
+# I7250 moved the deploy to `aws s3 cp` + `--template-url`, which raises the
+# real ceiling to 460800 bytes (CloudFormation's S3-template limit). This
+# guard is retargeted at that higher ceiling, MINUS a margin — asserting
+# against the raw 460800-byte hard limit would recreate the exact defect one
+# order of magnitude later: a template that silently grows to within a few
+# hundred bytes of a wall nothing warns about until it's crossed. The margin
+# below (60800 bytes, ~13%) is deliberately generous relative to the 459-byte
+# headroom that triggered this issue.
+CFN_TEMPLATE_URL_HARD_LIMIT = 460800
+CFN_TEMPLATE_URL_MARGIN = 60800
+CFN_TEMPLATE_URL_GUARD_CEILING = CFN_TEMPLATE_URL_HARD_LIMIT - CFN_TEMPLATE_URL_MARGIN
 
 
 def test_the_orchestration_template_still_fits_the_inline_deploy_limit():
     size = len(CFN_PATH.read_bytes())
-    assert size <= CFN_INLINE_BODY_LIMIT, (
-        f"{CFN_PATH.name} is {size} bytes, over CloudFormation's "
-        f"{CFN_INLINE_BODY_LIMIT}-byte inline --template-body ceiling. "
-        "deploy-infrastructure.sh passes the template inline on EVERY push to "
-        "main, so this breaks the infra deploy for every subsequent merge, not "
-        "just this change. Either trim, or switch deploy-infrastructure.sh to "
-        "an S3 --template-url upload (1MB ceiling)."
+    assert size <= CFN_TEMPLATE_URL_GUARD_CEILING, (
+        f"{CFN_PATH.name} is {size} bytes, within {CFN_TEMPLATE_URL_MARGIN} "
+        f"bytes of CloudFormation's {CFN_TEMPLATE_URL_HARD_LIMIT}-byte "
+        "--template-url ceiling (deploy-infrastructure.sh uploads the "
+        "template to S3 and deploys via --template-url — I7250). Trim the "
+        "template, or raise CFN_TEMPLATE_URL_MARGIN here with a written "
+        "rationale — never delete this guard."
     )


### PR DESCRIPTION
## What & why

`infrastructure/cloudformation/alpha-engine-orchestration.yaml` was 459 bytes from CloudFormation's 51200-byte inline `--template-body` ceiling (measured 2026-08-13, `alpha-engine-config-I7250`). `infrastructure/deploy-infrastructure.sh` passes the template inline for both `validate-template` and `create-stack`/`update-stack`, and `.github/workflows/deploy-infrastructure.yml` runs on **every** push to main with no path filter — so crossing the ceiling doesn't fail the PR that crosses it, it fails every subsequent merge's infra deploy, for authors who never touched `infrastructure/`.

An interim merge-time size guard already landed in `nousergon-data-PR1364` (`tests/test_preflight_sweep_cadence.py::test_the_orchestration_template_still_fits_the_inline_deploy_limit`). This PR is the structural fix that issue named.

## What changed

- `deploy-infrastructure.sh` now uploads the template to `s3://alpha-engine-research/infrastructure/alpha-engine-orchestration.yaml` (same bucket/prefix `InfraDeployS3` already grants — `arn:aws:s3:::alpha-engine-research/infrastructure/*` — no new IAM needed) and deploys via `--template-url` for `validate-template`, `create-stack` and `update-stack`. Raises the real ceiling from 51200 bytes to CloudFormation's S3-template limit of 460800 bytes.
- The size guard is retargeted at `460800 - 60800 = 400000` bytes (a deliberate margin, not the raw hard limit — asserting against 460800 itself would recreate the same defect one order of magnitude later).
- Restored the comment density trimmed from the `PreflightSweepDailyTrigger`/`PreflightSweepDeadman`/`PreflightSweepDispatcherErrors` CFN block — those comments were cut only to fit the old ceiling and the template said so inline; headroom is no longer scarce (current size: 52553 bytes, well under the new 400000-byte guard ceiling).

## Deploy-mechanism

Fully automated on merge — `deploy-infrastructure.yml` runs `deploy-infrastructure.sh` on every push to main, no operator step. Deployable by the merge button alone.

## Verification

- `aws cloudformation validate-template --template-url <uploaded-object>` succeeded against the live account.
- `aws cloudformation create-change-set --template-url <uploaded-object>` against the live `alpha-engine-orchestration` stack parsed cleanly and returned "no changes" (expected — only the deploy mechanism changed, not stack content). Change set deleted, test S3 object removed after verification; the real deploy re-uploads on merge.
- The size guard was verified to FAIL against a deliberately oversized template (appended ~401KB of padding, observed `AssertionError: ... 453566 bytes ... assert 453566 <= 400000`), then the oversized file was discarded (`git checkout --`).
- Full test suite green both before and after: baseline (origin/main, fresh Python 3.12 venv from `requirements.txt`) 5616 passed/9 skipped/10 xfailed; this branch (post-rebase) 5618 passed/9 skipped/10 xfailed (the +2 came in via the rebase, unrelated to this change).
- `bash -n` and `shellcheck` clean on `deploy-infrastructure.sh` (pre-existing SC2064 warnings on unrelated `trap` lines, not introduced here).

Closes-when (per the issue): `deploy-infrastructure.sh` deploys via `--template-url`, a merge to main is observed applying the stack successfully with a template over 51200 bytes, and the size test asserts the raised ceiling. This PR satisfies the first and third; the second is observed on the first post-merge CI run.

Refs: `alpha-engine-config-I7250`

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)