### PR TITLE
fix(weekly-sf): degraded-gate alerts name the measured cause, not a guessed one (config-I7302)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -213,8 +213,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer SILENT, and no longer skipping the sibling gate: route through the degraded-flag Pass + SNS alert, then into PipelineContractCheck (the old direct CheckMutexRole jump silently skipped gate 2 as well).",
-          "Next": "LibPinGateDegraded",
+          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer SILENT, and no longer skipping the sibling gate: route through the degraded-flag Pass + SNS alert, then into PipelineContractCheck (the old direct CheckMutexRole jump silently skipped gate 2 as well). alpha-engine-config-I7302: routes via LibPinGateDegradedFromError so the alert can name the Lambda-failure cause specifically instead of asserting a cause set that does not include the arm that actually fires.",
+          "Next": "LibPinGateDegradedFromError",
           "ResultPath": "$.libpin_drift_error"
         }
       ],
@@ -244,8 +244,8 @@
             "Variable": "$.libpin_drift_result.Payload.has_drift",
             "IsPresent": true
           },
-          "Comment": "config#2278: a gate payload WITHOUT has_drift means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
-          "Next": "LibPinGateDegraded"
+          "Comment": "config#2278: a gate payload WITHOUT has_drift means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'. alpha-engine-config-I7302: routes via LibPinGateDegradedFromProbe (which records WHICH cause degraded the gate) rather than straight to LibPinGateDegraded; the degraded Pass itself is unchanged and still the single $.gate_degraded writer.",
+          "Next": "LibPinGateDegradedFromProbe"
         }
       ],
       "Default": "PipelineContractCheck"
@@ -263,7 +263,7 @@
     },
     "PipelineContractCheck": {
       "Type": "Task",
-      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Sibling to LibPinDriftCheck: runs immediately after it, BEFORE any spot launch, and asserts PIPELINE_CONTRACT.yaml is internally self-consistent AND every artifact_id it references exists in ARTIFACT_REGISTRY.yaml. A CI validator (validate_pipeline_contract.py) already catches this at PR time, but a config/SF-definition change made outside that CI could still spend a Saturday spot before failing; this probe re-runs the same invariants at SF start so a contract break halts in seconds. FAIL-OPEN: a GitHub-fetch/parse miss sets has_violation=false (the probe's own degraded mode, reason=fetch_failed), and the Catch routes any Lambda failure straight to the pipeline \u2014 so the checker NEVER false-halts the weekly run, mirroring LibPinDriftCheck's fail-open semantics exactly.",
+      "Comment": "Preventive pre-spend PIPELINE_CONTRACT.yaml preflight gate (L4595 / config#693). Sibling to LibPinDriftCheck: runs immediately after it, BEFORE any spot launch, and asserts PIPELINE_CONTRACT.yaml is internally self-consistent AND every artifact_id it references exists in ARTIFACT_REGISTRY.yaml. A CI validator (validate_pipeline_contract.py) already catches this at PR time, but a config/SF-definition change made outside that CI could still spend a Saturday spot before failing; this probe re-runs the same invariants at SF start so a contract break halts in seconds. FAIL-OPEN: a GitHub-fetch/parse miss OMITS has_violation entirely (the probe's own degraded mode, reason=fetch_failed) \u2014 alpha-engine-config-I7048 changed it from has_violation=false precisely so 'could not measure' stops rendering as 'measured clean'; this comment asserted the pre-I7048 behaviour until alpha-engine-config-I7302, and the Catch routes any Lambda failure straight to the pipeline \u2014 so the checker NEVER false-halts the weekly run, mirroring LibPinDriftCheck's fail-open semantics exactly.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
@@ -298,8 +298,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer silent: route through the degraded-flag Pass + SNS alert before proceeding to CheckMutexRole.",
-          "Next": "PipelineContractGateDegraded",
+          "Comment": "config#2278: still fail-open \u2014 the probe's own failure must not halt the weekly run \u2014 but no longer silent: route through the degraded-flag Pass + SNS alert before proceeding to CheckMutexRole. alpha-engine-config-I7302: routes via PipelineContractGateDegradedFromError so the alert can name the Lambda-failure cause specifically instead of asserting a cause set that does not include the arm that actually fires.",
+          "Next": "PipelineContractGateDegradedFromError",
           "ResultPath": "$.pipeline_contract_error"
         }
       ],
@@ -329,8 +329,8 @@
             "Variable": "$.pipeline_contract_result.Payload.has_violation",
             "IsPresent": true
           },
-          "Comment": "config#2278: a gate payload WITHOUT has_violation means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'.",
-          "Next": "PipelineContractGateDegraded"
+          "Comment": "config#2278: a gate payload WITHOUT has_violation means the gate could not check \u2014 fail open VISIBLY (degraded flag + SNS alert) instead of silently converting 'checked and clean' into 'never checked'. alpha-engine-config-I7302: routes via PipelineContractGateDegradedFromProbe (which records WHICH cause degraded the gate) rather than straight to PipelineContractGateDegraded; the degraded Pass itself is unchanged and still the single $.gate_degraded writer.",
+          "Next": "PipelineContractGateDegradedFromProbe"
         }
       ],
       "Default": "EvaluatorDeployDriftCheck"
@@ -355,12 +355,12 @@
     },
     "PublishLibPinGateDegraded": {
       "Type": "Task",
-      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline \u2014 never States.Format against input). Best-effort Catch: a publish failure must not halt the fail-open path this alert decorates; the caught TaskFailed still logs at ERROR and is matched by SnsPublishFailedMetricFilter.",
+      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline \u2014 never States.Format against input). Best-effort Catch: a publish failure must not halt the fail-open path this alert decorates; the caught TaskFailed still logs at ERROR and is matched by SnsPublishFailedMetricFilter. alpha-engine-config-I7302: Subject stays a constant (config#1819), but Message is now States.Format over $.libpin_gate_degraded_cause.cause/.detail \u2014 two scalars written by the normalizer Pass immediately upstream on BOTH inbound arms, so no possibly-absent path is dereferenced inside the notifier and the config#1819 States.Runtime class stays closed. The pre-fix constant named a cause set excluding the arm that fires in production; an alert asserting a cause the execution history contradicts is worse than one that says less.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Lib-Pin Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "LibPinDriftCheck could not verify cross-repo pin parity (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the co-install break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Message.$": "States.Format('LibPinDriftCheck did not verify cross-repo nousergon-lib pin parity.\n\nCause: {}\nProbe output: {}\n\nCause codes: probe_returned_no_verdict means the gate Lambda RAN and returned HTTP 200 but its payload carried no verdict field; the reason key in the probe output above names why it could not measure. lambda_failed_after_retries means the invocation itself failed through both retry tiers and never produced a payload at all.\n\nProceeding FAIL-OPEN: the spot spend for this run is NOT protected against the co-install break this gate exists to catch. The completion email will carry the gates-degraded marker.\n\nView pipeline status: https://dashboard.nousergon.ai/pipeline-status', $.libpin_gate_degraded_cause.cause, $.libpin_gate_degraded_cause.detail)"
       },
       "ResultPath": "$.libpin_gate_degraded_notify",
       "Catch": [
@@ -384,12 +384,12 @@
     },
     "PublishPipelineContractGateDegraded": {
       "Type": "Task",
-      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch mirrors PublishLibPinGateDegraded.",
+      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch mirrors PublishLibPinGateDegraded. alpha-engine-config-I7302: Subject stays a constant (config#1819), but Message is now States.Format over $.pipeline_contract_gate_degraded_cause.cause/.detail \u2014 two scalars written by the normalizer Pass immediately upstream on BOTH inbound arms, so no possibly-absent path is dereferenced inside the notifier and the config#1819 States.Runtime class stays closed. The pre-fix constant named a cause set excluding the arm that fires in production; an alert asserting a cause the execution history contradicts is worse than one that says less.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Contract Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "PipelineContractCheck could not verify PIPELINE_CONTRACT.yaml self-consistency (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the contract break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Message.$": "States.Format('PipelineContractCheck did not verify PIPELINE_CONTRACT.yaml self-consistency.\n\nCause: {}\nProbe output: {}\n\nCause codes: probe_returned_no_verdict means the gate Lambda RAN and returned HTTP 200 but its payload carried no verdict field; the reason key in the probe output above names why it could not measure. lambda_failed_after_retries means the invocation itself failed through both retry tiers and never produced a payload at all.\n\nProceeding FAIL-OPEN: the spot spend for this run is NOT protected against the contract break this gate exists to catch. The completion email will carry the gates-degraded marker.\n\nView pipeline status: https://dashboard.nousergon.ai/pipeline-status', $.pipeline_contract_gate_degraded_cause.cause, $.pipeline_contract_gate_degraded_cause.detail)"
       },
       "ResultPath": "$.pipeline_contract_gate_degraded_notify",
       "Catch": [
@@ -6650,8 +6650,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-open: the probe's own failure must not halt the weekly run, but must be VISIBLE (degraded flag + SNS alert), mirroring LibPinDriftCheck/PipelineContractCheck's Catch shape exactly.",
-          "Next": "EvaluatorGateDegraded",
+          "Comment": "Fail-open: the probe's own failure must not halt the weekly run, but must be VISIBLE (degraded flag + SNS alert), mirroring LibPinDriftCheck/PipelineContractCheck's Catch shape exactly. alpha-engine-config-I7302: routes via EvaluatorGateDegradedFromError so the alert can name the Lambda-failure cause specifically instead of asserting a cause set that does not include the arm that actually fires.",
+          "Next": "EvaluatorGateDegradedFromError",
           "ResultPath": "$.evaluator_deploy_drift_result_error"
         }
       ],
@@ -6681,8 +6681,8 @@
             "Variable": "$.evaluator_deploy_drift_result.Payload.has_drift",
             "IsPresent": true
           },
-          "Comment": "A gate payload WITHOUT has_drift means the probe could not check \u2014 fail open VISIBLY (degraded flag + SNS alert), mirrors LibPinDriftGate/PipelineContractGate's config#2278 convention.",
-          "Next": "EvaluatorGateDegraded"
+          "Comment": "A gate payload WITHOUT has_drift means the probe could not check \u2014 fail open VISIBLY (degraded flag + SNS alert), mirrors LibPinDriftGate/PipelineContractGate's config#2278 convention. alpha-engine-config-I7302: routes via EvaluatorGateDegradedFromProbe (which records WHICH cause degraded the gate) rather than straight to EvaluatorGateDegraded; the degraded Pass itself is unchanged and still the single $.gate_degraded writer.",
+          "Next": "EvaluatorGateDegradedFromProbe"
         }
       ],
       "Default": "EvaluatorDirectorDeployDriftCheck"
@@ -6707,12 +6707,12 @@
     },
     "PublishEvaluatorGateDegraded": {
       "Type": "Task",
-      "Comment": "Fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch. Proceeds to EvaluatorDirectorDeployDriftCheck (NOT straight to CheckMutexRole) \u2014 mirrors PublishLibPinGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too.",
+      "Comment": "Fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch. Proceeds to EvaluatorDirectorDeployDriftCheck (NOT straight to CheckMutexRole) \u2014 mirrors PublishLibPinGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too. alpha-engine-config-I7302: Subject stays a constant (config#1819), but Message is now States.Format over $.evaluator_gate_degraded_cause.cause/.detail \u2014 two scalars written by the normalizer Pass immediately upstream on BOTH inbound arms, so no possibly-absent path is dereferenced inside the notifier and the config#1819 States.Runtime class stays closed. The pre-fix constant named a cause set excluding the arm that fires in production; an alert asserting a cause the execution history contradicts is worse than one that says less.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Evaluator Deploy-Drift Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "The evaluator Lambda-SHA drift probe could not verify alpha-engine-evaluator and/or alpha-engine-evaluator-director against origin/main (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run is NOT protected against a stale :live alias this gate exists to catch. The completion email will carry the gates-degraded marker. config#2348."
+        "Message.$": "States.Format('The evaluator Lambda-SHA drift probe did not verify alpha-engine-evaluator against origin/main.\n\nCause: {}\nProbe output: {}\n\nCause codes: probe_returned_no_verdict means the gate Lambda RAN and returned HTTP 200 but its payload carried no verdict field; the reason key in the probe output above names why it could not measure. lambda_failed_after_retries means the invocation itself failed through both retry tiers and never produced a payload at all.\n\nProceeding FAIL-OPEN: this run is NOT protected against the stale live-alias drift this gate exists to catch. The completion email will carry the gates-degraded marker.\n\nView pipeline status: https://dashboard.nousergon.ai/pipeline-status', $.evaluator_gate_degraded_cause.cause, $.evaluator_gate_degraded_cause.detail)"
       },
       "ResultPath": "$.evaluator_gate_degraded_notify",
       "Catch": [
@@ -6764,8 +6764,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Comment": "Fail-open: the probe's own failure must not halt the weekly run, but must be VISIBLE (degraded flag + SNS alert), mirroring LibPinDriftCheck/PipelineContractCheck's Catch shape exactly.",
-          "Next": "EvaluatorDirectorGateDegraded",
+          "Comment": "Fail-open: the probe's own failure must not halt the weekly run, but must be VISIBLE (degraded flag + SNS alert), mirroring LibPinDriftCheck/PipelineContractCheck's Catch shape exactly. alpha-engine-config-I7302: routes via EvaluatorDirectorGateDegradedFromError so the alert can name the Lambda-failure cause specifically instead of asserting a cause set that does not include the arm that actually fires.",
+          "Next": "EvaluatorDirectorGateDegradedFromError",
           "ResultPath": "$.evaluator_director_deploy_drift_result_error"
         }
       ],
@@ -6795,8 +6795,8 @@
             "Variable": "$.evaluator_director_deploy_drift_result.Payload.has_drift",
             "IsPresent": true
           },
-          "Comment": "Fail open VISIBLY on a malformed/missing payload, mirrors EvaluatorDeployDriftGate.",
-          "Next": "EvaluatorDirectorGateDegraded"
+          "Comment": "Fail open VISIBLY on a malformed/missing payload, mirrors EvaluatorDeployDriftGate. alpha-engine-config-I7302: routes via EvaluatorDirectorGateDegradedFromProbe (which records WHICH cause degraded the gate) rather than straight to EvaluatorDirectorGateDegraded; the degraded Pass itself is unchanged and still the single $.gate_degraded writer.",
+          "Next": "EvaluatorDirectorGateDegradedFromProbe"
         }
       ],
       "Default": "WeeklyPreflight"
@@ -6821,12 +6821,12 @@
     },
     "PublishEvaluatorDirectorGateDegraded": {
       "Type": "Task",
-      "Comment": "Fail-open + alert, mirrors PublishEvaluatorGateDegraded. Proceeds to WeeklyPreflight (NOT straight to CheckMutexRole) -- mirrors PublishPipelineContractGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too.",
+      "Comment": "Fail-open + alert, mirrors PublishEvaluatorGateDegraded. Proceeds to WeeklyPreflight (NOT straight to CheckMutexRole) -- mirrors PublishPipelineContractGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too. alpha-engine-config-I7302: Subject stays a constant (config#1819), but Message is now States.Format over $.evaluator_director_gate_degraded_cause.cause/.detail \u2014 two scalars written by the normalizer Pass immediately upstream on BOTH inbound arms, so no possibly-absent path is dereferenced inside the notifier and the config#1819 States.Runtime class stays closed. The pre-fix constant named a cause set excluding the arm that fires in production; an alert asserting a cause the execution history contradicts is worse than one that says less.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Evaluator-Director Deploy-Drift Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "The evaluator-director Lambda-SHA drift probe could not verify alpha-engine-evaluator-director against origin/main (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN. The completion email will carry the gates-degraded marker. config#2348."
+        "Message.$": "States.Format('The evaluator-director Lambda-SHA drift probe did not verify alpha-engine-evaluator-director against origin/main.\n\nCause: {}\nProbe output: {}\n\nCause codes: probe_returned_no_verdict means the gate Lambda RAN and returned HTTP 200 but its payload carried no verdict field; the reason key in the probe output above names why it could not measure. lambda_failed_after_retries means the invocation itself failed through both retry tiers and never produced a payload at all.\n\nProceeding FAIL-OPEN: this run is NOT protected against the stale live-alias drift this gate exists to catch. The completion email will carry the gates-degraded marker.\n\nView pipeline status: https://dashboard.nousergon.ai/pipeline-status', $.evaluator_director_gate_degraded_cause.cause, $.evaluator_director_gate_degraded_cause.detail)"
       },
       "ResultPath": "$.evaluator_director_gate_degraded_notify",
       "Catch": [
@@ -7981,6 +7981,86 @@
       },
       "ResultPath": "$.error",
       "Next": "NormalizeFailureContext"
+    },
+    "LibPinGateDegradedFromProbe": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: normalizes the gate's OWN reported cause onto a single guaranteed-present path so PublishLibPinGateDegraded can interpolate it. Entered from LibPinDriftGate's absence arm, which fires when the probe Lambda SUCCEEDED and returned a payload carrying no verdict field. Measured 2026-08-13 on ne-weekly-freshness-pipeline/watch-rerun-2026-08-13-5: this is the arm that fires in production, and the pre-fix constant Message asserted the opposite ('gate Lambda failed after retries') \u2014 a cause the execution history contradicted, sending the reader to CloudWatch to recover a string the payload already contained. Dereferences only $.libpin_drift_result.Payload, guaranteed present because LibPinDriftGate already evaluated IsPresent against a child of it, so this normalizer cannot itself raise a missing-field States.Runtime; States.JsonToString carries the WHOLE payload rather than a named field, so a probe that omits 'reason' too still renders.",
+      "Parameters": {
+        "cause": "probe_returned_no_verdict",
+        "detail.$": "States.JsonToString($.libpin_drift_result.Payload)"
+      },
+      "ResultPath": "$.libpin_gate_degraded_cause",
+      "Next": "LibPinGateDegraded"
+    },
+    "LibPinGateDegradedFromError": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: sibling of LibPinGateDegradedFromProbe for the OTHER degraded cause \u2014 LibPinDriftCheck's Catch(States.ALL), i.e. the invocation failed through both retry tiers and produced no payload at all. Writes the same ResultPath so PublishLibPinGateDegraded interpolates one path regardless of which cause fired. Dereferences only $.libpin_drift_error, guaranteed present because the Catch that routes here sets it as its ResultPath.",
+      "Parameters": {
+        "cause": "lambda_failed_after_retries",
+        "detail.$": "States.JsonToString($.libpin_drift_error)"
+      },
+      "ResultPath": "$.libpin_gate_degraded_cause",
+      "Next": "LibPinGateDegraded"
+    },
+    "PipelineContractGateDegradedFromProbe": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: normalizes the gate's OWN reported cause onto a single guaranteed-present path so PublishPipelineContractGateDegraded can interpolate it. Entered from PipelineContractGate's absence arm, which fires when the probe Lambda SUCCEEDED and returned a payload carrying no verdict field. Measured 2026-08-13 on ne-weekly-freshness-pipeline/watch-rerun-2026-08-13-5: this is the arm that fires in production, and the pre-fix constant Message asserted the opposite ('gate Lambda failed after retries') \u2014 a cause the execution history contradicted, sending the reader to CloudWatch to recover a string the payload already contained. Dereferences only $.pipeline_contract_result.Payload, guaranteed present because PipelineContractGate already evaluated IsPresent against a child of it, so this normalizer cannot itself raise a missing-field States.Runtime; States.JsonToString carries the WHOLE payload rather than a named field, so a probe that omits 'reason' too still renders.",
+      "Parameters": {
+        "cause": "probe_returned_no_verdict",
+        "detail.$": "States.JsonToString($.pipeline_contract_result.Payload)"
+      },
+      "ResultPath": "$.pipeline_contract_gate_degraded_cause",
+      "Next": "PipelineContractGateDegraded"
+    },
+    "PipelineContractGateDegradedFromError": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: sibling of PipelineContractGateDegradedFromProbe for the OTHER degraded cause \u2014 PipelineContractCheck's Catch(States.ALL), i.e. the invocation failed through both retry tiers and produced no payload at all. Writes the same ResultPath so PublishPipelineContractGateDegraded interpolates one path regardless of which cause fired. Dereferences only $.pipeline_contract_error, guaranteed present because the Catch that routes here sets it as its ResultPath.",
+      "Parameters": {
+        "cause": "lambda_failed_after_retries",
+        "detail.$": "States.JsonToString($.pipeline_contract_error)"
+      },
+      "ResultPath": "$.pipeline_contract_gate_degraded_cause",
+      "Next": "PipelineContractGateDegraded"
+    },
+    "EvaluatorGateDegradedFromProbe": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: normalizes the gate's OWN reported cause onto a single guaranteed-present path so PublishEvaluatorGateDegraded can interpolate it. Entered from EvaluatorDeployDriftGate's absence arm, which fires when the probe Lambda SUCCEEDED and returned a payload carrying no verdict field. Measured 2026-08-13 on ne-weekly-freshness-pipeline/watch-rerun-2026-08-13-5: this is the arm that fires in production, and the pre-fix constant Message asserted the opposite ('gate Lambda failed after retries') \u2014 a cause the execution history contradicted, sending the reader to CloudWatch to recover a string the payload already contained. Dereferences only $.evaluator_deploy_drift_result.Payload, guaranteed present because EvaluatorDeployDriftGate already evaluated IsPresent against a child of it, so this normalizer cannot itself raise a missing-field States.Runtime; States.JsonToString carries the WHOLE payload rather than a named field, so a probe that omits 'reason' too still renders.",
+      "Parameters": {
+        "cause": "probe_returned_no_verdict",
+        "detail.$": "States.JsonToString($.evaluator_deploy_drift_result.Payload)"
+      },
+      "ResultPath": "$.evaluator_gate_degraded_cause",
+      "Next": "EvaluatorGateDegraded"
+    },
+    "EvaluatorGateDegradedFromError": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: sibling of EvaluatorGateDegradedFromProbe for the OTHER degraded cause \u2014 EvaluatorDeployDriftCheck's Catch(States.ALL), i.e. the invocation failed through both retry tiers and produced no payload at all. Writes the same ResultPath so PublishEvaluatorGateDegraded interpolates one path regardless of which cause fired. Dereferences only $.evaluator_deploy_drift_result_error, guaranteed present because the Catch that routes here sets it as its ResultPath.",
+      "Parameters": {
+        "cause": "lambda_failed_after_retries",
+        "detail.$": "States.JsonToString($.evaluator_deploy_drift_result_error)"
+      },
+      "ResultPath": "$.evaluator_gate_degraded_cause",
+      "Next": "EvaluatorGateDegraded"
+    },
+    "EvaluatorDirectorGateDegradedFromProbe": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: normalizes the gate's OWN reported cause onto a single guaranteed-present path so PublishEvaluatorDirectorGateDegraded can interpolate it. Entered from EvaluatorDirectorDeployDriftGate's absence arm, which fires when the probe Lambda SUCCEEDED and returned a payload carrying no verdict field. Measured 2026-08-13 on ne-weekly-freshness-pipeline/watch-rerun-2026-08-13-5: this is the arm that fires in production, and the pre-fix constant Message asserted the opposite ('gate Lambda failed after retries') \u2014 a cause the execution history contradicted, sending the reader to CloudWatch to recover a string the payload already contained. Dereferences only $.evaluator_director_deploy_drift_result.Payload, guaranteed present because EvaluatorDirectorDeployDriftGate already evaluated IsPresent against a child of it, so this normalizer cannot itself raise a missing-field States.Runtime; States.JsonToString carries the WHOLE payload rather than a named field, so a probe that omits 'reason' too still renders.",
+      "Parameters": {
+        "cause": "probe_returned_no_verdict",
+        "detail.$": "States.JsonToString($.evaluator_director_deploy_drift_result.Payload)"
+      },
+      "ResultPath": "$.evaluator_director_gate_degraded_cause",
+      "Next": "EvaluatorDirectorGateDegraded"
+    },
+    "EvaluatorDirectorGateDegradedFromError": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7302: sibling of EvaluatorDirectorGateDegradedFromProbe for the OTHER degraded cause \u2014 EvaluatorDirectorDeployDriftCheck's Catch(States.ALL), i.e. the invocation failed through both retry tiers and produced no payload at all. Writes the same ResultPath so PublishEvaluatorDirectorGateDegraded interpolates one path regardless of which cause fired. Dereferences only $.evaluator_director_deploy_drift_result_error, guaranteed present because the Catch that routes here sets it as its ResultPath.",
+      "Parameters": {
+        "cause": "lambda_failed_after_retries",
+        "detail.$": "States.JsonToString($.evaluator_director_deploy_drift_result_error)"
+      },
+      "ResultPath": "$.evaluator_director_gate_degraded_cause",
+      "Next": "EvaluatorDirectorGateDegraded"
     }
   }
 }

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -208,12 +208,23 @@ STAGES: tuple[Stage, ...] = (
         # these Pass+Publish pairs — no skip flag is emitted either way
         # (emit_skip=False), but the summary must say "degraded", not
         # "completed", when one was hit.
+        # alpha-engine-config-I7302 added the *GateDegradedFromProbe /
+        # *GateDegradedFromError entry pair per gate: the cause-recording
+        # normalizers the Choice absence arm and the Task Catch now route
+        # through on their way to the unchanged *GateDegraded Pass. They are
+        # part of the same degraded route, so they belong in the same witness
+        # set — a run that stopped ON one of them is a degraded gate, not a
+        # completed one.
         degraded_witness=frozenset({
+            "LibPinGateDegradedFromProbe", "LibPinGateDegradedFromError",
             "LibPinGateDegraded", "SetLibPinGateDegradedSummary", "PublishLibPinGateDegraded",
+            "PipelineContractGateDegradedFromProbe", "PipelineContractGateDegradedFromError",
             "PipelineContractGateDegraded", "SetPipelineContractGateDegradedSummary",
             "PublishPipelineContractGateDegraded",
+            "EvaluatorGateDegradedFromProbe", "EvaluatorGateDegradedFromError",
             "EvaluatorGateDegraded", "SetEvaluatorGateDegradedSummary",
             "PublishEvaluatorGateDegraded",
+            "EvaluatorDirectorGateDegradedFromProbe", "EvaluatorDirectorGateDegradedFromError",
             "EvaluatorDirectorGateDegraded", "SetEvaluatorDirectorGateDegradedSummary",
             "PublishEvaluatorDirectorGateDegraded",
             # alpha-engine-config#6722: AcquireMutex's mutex-acquire

--- a/tests/test_sf_choice_guards.py
+++ b/tests/test_sf_choice_guards.py
@@ -299,10 +299,14 @@ def _choice_target(definition: dict, choice_name: str, data) -> str:
         # Branch A's producer.
         ("WeeklyRunDayGateChoice", {"weekly_run_day_gate": {"Payload": {}}},
          "WeeklyRunDayGateMalformed"),
+        # fail-open, VISIBLY (config#2278) — and since I7302, through the
+        # normalizer that records WHICH cause degraded the gate. This arm is
+        # the "probe ran, returned no verdict" cause, so it lands on
+        # *GateDegradedFromProbe (which then reaches *GateDegraded unchanged).
         ("LibPinDriftGate", {"libpin_drift_result": {"Payload": {}}},
-         "LibPinGateDegraded"),  # fail-open, VISIBLY (config#2278)
+         "LibPinGateDegradedFromProbe"),
         ("PipelineContractGate", {"pipeline_contract_result": {"Payload": {}}},
-         "PipelineContractGateDegraded"),  # fail-open, VISIBLY (config#2278)
+         "PipelineContractGateDegradedFromProbe"),
         ("EvalJudgePollChoice", {"eval_judge_submit": {"Payload": {}}},
          "EvalRollingMean"),  # eval is observability — fail-soft
         ("EvalJudgePollDecision", {"eval_judge_poll": {"Payload": {}}},

--- a/tests/test_sf_lib_pin_drift_wiring.py
+++ b/tests/test_sf_lib_pin_drift_wiring.py
@@ -83,7 +83,13 @@ def test_check_fails_open_via_catch(states):
     # through the visible degraded chain (flag + SNS alert), re-entering the
     # SIBLING contract gate instead of skipping it (the old direct
     # CheckMutexRole jump); full topology in test_sf_prespend_gate_alerting.
-    assert catch["Next"] == "LibPinGateDegraded"
+    # alpha-engine-config-I7302: the Catch now enters the chain at the
+    # cause normalizer, which records lambda_failed_after_retries and
+    # hands off to LibPinGateDegraded unchanged. Pre-fix, this arm and the
+    # Choice absence arm were indistinguishable downstream, so the SNS
+    # alert asserted the Lambda-failure cause on BOTH.
+    assert catch["Next"] == "LibPinGateDegradedFromError"
+    assert states["LibPinGateDegradedFromError"]["Next"] == "LibPinGateDegraded"
 
 
 def test_gate_halts_only_on_confirmed_drift(states):

--- a/tests/test_sf_pipeline_contract_wiring.py
+++ b/tests/test_sf_pipeline_contract_wiring.py
@@ -68,7 +68,13 @@ def test_check_fails_open_via_catch(states):
     # config#2278: still fail-open (the pipeline, not HandleFailure) — but
     # through the visible degraded chain (flag + SNS alert); full topology
     # in test_sf_prespend_gate_alerting.
-    assert catch["Next"] == "PipelineContractGateDegraded"
+    # alpha-engine-config-I7302: the Catch now enters the chain at the
+    # cause normalizer, which records lambda_failed_after_retries and
+    # hands off to PipelineContractGateDegraded unchanged. Pre-fix, this arm and the
+    # Choice absence arm were indistinguishable downstream, so the SNS
+    # alert asserted the Lambda-failure cause on BOTH.
+    assert catch["Next"] == "PipelineContractGateDegradedFromError"
+    assert states["PipelineContractGateDegradedFromError"]["Next"] == "PipelineContractGateDegraded"
 
 
 def test_gate_halts_only_on_confirmed_violation(states):

--- a/tests/test_sf_prespend_gate_alerting.py
+++ b/tests/test_sf_prespend_gate_alerting.py
@@ -44,12 +44,14 @@ def states() -> dict:
 
 
 GATES = [
-    # (check state, result field, degraded pass, publish state, proceed-to)
+    # (check state, result field, degraded pass, publish state, proceed-to,
+    #  cause path)
     ("LibPinDriftCheck", "$.libpin_drift_result.Payload.has_drift",
-     "LibPinGateDegraded", "PublishLibPinGateDegraded", "PipelineContractCheck"),
+     "LibPinGateDegraded", "PublishLibPinGateDegraded", "PipelineContractCheck",
+     "$.libpin_gate_degraded_cause"),
     ("PipelineContractCheck", "$.pipeline_contract_result.Payload.has_violation",
      "PipelineContractGateDegraded", "PublishPipelineContractGateDegraded",
-     "EvaluatorDeployDriftCheck"),
+     "EvaluatorDeployDriftCheck", "$.pipeline_contract_gate_degraded_cause"),
     # config#2348: third pre-spend sibling gate — evaluator's 2 Lambdas,
     # checked in sequence (grading, then director). Each has its own
     # Check/Gate/Degraded/Publish quartet; both mirror the shape above.
@@ -58,16 +60,20 @@ GATES = [
     # gate" fix config#2278 applied to LibPinGateDegraded.
     ("EvaluatorDeployDriftCheck", "$.evaluator_deploy_drift_result.Payload.has_drift",
      "EvaluatorGateDegraded", "PublishEvaluatorGateDegraded",
-     "EvaluatorDirectorDeployDriftCheck"),
+     "EvaluatorDirectorDeployDriftCheck", "$.evaluator_gate_degraded_cause"),
     ("EvaluatorDirectorDeployDriftCheck", "$.evaluator_director_deploy_drift_result.Payload.has_drift",
      "EvaluatorDirectorGateDegraded", "PublishEvaluatorDirectorGateDegraded",
-     "WeeklyPreflight"),
+     "WeeklyPreflight", "$.evaluator_director_gate_degraded_cause"),
 ]
 
+_PARAMS = ("check", "_field", "degraded", "publish", "proceed", "cause_path")
+_IDS = [g[0] for g in GATES]
 
-@pytest.mark.parametrize(("check", "_field", "degraded", "publish", "proceed"),
-                         GATES, ids=[g[0] for g in GATES])
-def test_gate_has_transient_retry_tier(states, check, _field, degraded, publish, proceed):
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_gate_has_transient_retry_tier(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
     retries = states[check]["Retry"]
     by_errors = {tuple(sorted(r["ErrorEquals"])): r for r in retries}
     transient = by_errors[("States.TaskFailed", "States.Timeout")]
@@ -77,14 +83,17 @@ def test_gate_has_transient_retry_tier(states, check, _field, degraded, publish,
     assert lambda_tier["MaxAttempts"] == 2
 
 
-@pytest.mark.parametrize(("check", "_field", "degraded", "publish", "proceed"),
-                         GATES, ids=[g[0] for g in GATES])
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
 def test_gate_catch_routes_through_degraded_alert_chain(
-    states, check, _field, degraded, publish, proceed
+    states, check, _field, degraded, publish, proceed, cause_path
 ):
     (catch,) = states[check]["Catch"]
     assert catch["ErrorEquals"] == ["States.ALL"]
-    assert catch["Next"] == degraded
+    # alpha-engine-config-I7302: the Catch enters the chain one state earlier,
+    # at the normalizer that records WHICH cause degraded the gate, and that
+    # normalizer hands off to the unchanged degraded Pass.
+    assert catch["Next"] == f"{degraded}FromError"
+    assert states[f"{degraded}FromError"]["Next"] == degraded
 
     degraded_state = states[degraded]
     assert degraded_state["Type"] == "Pass"
@@ -95,11 +104,18 @@ def test_gate_catch_routes_through_degraded_alert_chain(
     publish_state = states[publish]
     assert publish_state["Resource"] == "arn:aws:states:::sns:publish"
     assert publish_state["Parameters"]["TopicArn.$"] == "$.sns_topic_arn"
-    # config#1819: constants only — a parameterized Subject/Message here
-    # would reintroduce the SNS-contract States.Runtime class.
+    # config#1819: the Subject stays a constant. alpha-engine-config-I7302
+    # deliberately parameterized the MESSAGE — the constant asserted "gate
+    # Lambda failed after retries, or returned a malformed payload", a cause
+    # set that excludes the arm which actually fires in production (measured
+    # on watch-rerun-2026-08-13-5: the Lambda returned HTTP 200 in 142 ms).
+    # config#1819's States.Runtime hazard is closed structurally instead: the
+    # only paths dereferenced are two scalars written by the normalizer Pass
+    # immediately upstream on BOTH inbound arms — see
+    # test_degraded_message_names_the_cause_from_a_guaranteed_present_path.
     assert "Subject" in publish_state["Parameters"]
     assert "Subject.$" not in publish_state["Parameters"]
-    assert "Message.$" not in publish_state["Parameters"]
+    assert "Message" not in publish_state["Parameters"]
     assert "DEGRADED" in publish_state["Parameters"]["Subject"]
     assert len(publish_state["Parameters"]["Subject"]) <= 100
     # Fail-open: alert then PROCEED — and a publish failure proceeds too.
@@ -140,7 +156,8 @@ def test_malformed_gate_payload_routes_to_degraded_chain(states, gate, field, de
         if r.get("Not", {}).get("Variable") == field
         and r["Not"].get("IsPresent") is True
     )
-    assert absence_rule["Next"] == degraded
+    assert absence_rule["Next"] == f"{degraded}FromProbe"
+    assert states[f"{degraded}FromProbe"]["Next"] == degraded
 
 
 def test_gate_degraded_threads_into_completion_email(states):
@@ -194,3 +211,130 @@ def test_only_degraded_passes_set_gate_degraded(states):
         "PipelineContractGateDegraded",
         "SetMutexAcquireDegradedFlag",
     ]
+
+
+# --------------------------------------------------------------------------
+# alpha-engine-config-I7302 — the degraded alert must name the cause the
+# execution history shows, not a cause set chosen at authoring time.
+#
+# Measured 2026-08-13, ne-weekly-freshness-pipeline/watch-rerun-2026-08-13-5:
+# PipelineContractCheck reached TaskSucceeded (HTTP 200, 142 ms, zero
+# retries) and returned {"violations": [], "boundary_count": null, "reason":
+# "fetch_failed"}. The gate degraded via the Choice absence arm — and the
+# constant SNS Message asserted "gate Lambda failed after retries, or
+# returned a malformed payload". Both halves were false, and the one field
+# that WAS true (reason) never reached the reader.
+# --------------------------------------------------------------------------
+
+_LAMBDA_FAILURE_CLAIM = "gate Lambda failed after retries"
+
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_degraded_message_names_the_cause_from_a_guaranteed_present_path(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
+    """The Message interpolates the normalizer's two scalars and nothing else.
+
+    This is what keeps config#1819's States.Runtime hazard closed while the
+    Message is parameterized: every JsonPath the notifier dereferences is
+    written by the Pass immediately upstream, on BOTH inbound arms.
+    """
+    message = states[publish]["Parameters"]["Message.$"]
+    assert message.startswith("States.Format(")
+
+    args = message[message.rindex("'") + 1:].rstrip(")")
+    referenced = [a.strip() for a in args.split(",") if a.strip()]
+    assert referenced == [f"{cause_path}.cause", f"{cause_path}.detail"], (
+        f"{publish} dereferences {referenced} — only the normalizer's own "
+        f"scalars under {cause_path} are guaranteed present on both the "
+        "Catch arm and the Choice absence arm"
+    )
+
+    template = message[message.index("'") + 1:message.rindex("'")]
+    assert template.count("{}") == len(referenced)
+
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_degraded_message_template_is_intrinsic_safe(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
+    """A States.Format argument is a SINGLE-QUOTED ASL literal.
+
+    An apostrophe in the prose, or a stray curly brace (a `{run_date}`-style
+    placeholder copied from a sibling alert), terminates or mis-parses the
+    intrinsic and the whole definition fails to deploy — a red CI is the
+    good outcome; the bad one is a notifier that raises States.Runtime on
+    the exact path it exists to report.
+    """
+    message = states[publish]["Parameters"]["Message.$"]
+    template = message[message.index("'") + 1:message.rindex("'")]
+    assert "'" not in template, f"{publish}: apostrophe in a States.Format literal"
+    assert template.count("{") == template.count("}") == template.count("{}")
+
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_degraded_message_does_not_assert_an_unverified_cause(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
+    """The regression this issue exists for.
+
+    The alert may DEFINE what the cause codes mean; it may not ASSERT that a
+    particular one happened. Only the interpolated `cause` scalar, written by
+    whichever normalizer actually ran, may do that.
+    """
+    message = states[publish]["Parameters"]["Message.$"]
+    template = message[message.index("'") + 1:message.rindex("'")]
+    claim_line = next(
+        (ln for ln in template.splitlines()
+         if _LAMBDA_FAILURE_CLAIM in ln and "Cause codes:" not in ln),
+        None,
+    )
+    assert claim_line is None, (
+        f"{publish} asserts {_LAMBDA_FAILURE_CLAIM!r} outside the cause-code "
+        f"legend: {claim_line!r}. The gate degrades far more often via the "
+        "Choice absence arm, where the Lambda succeeded."
+    )
+
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_both_degraded_causes_converge_on_one_result_path(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
+    from_probe = states[f"{degraded}FromProbe"]
+    from_error = states[f"{degraded}FromError"]
+
+    for name, st in ((f"{degraded}FromProbe", from_probe),
+                     (f"{degraded}FromError", from_error)):
+        assert st["Type"] == "Pass"
+        assert st["ResultPath"] == cause_path, name
+        assert st["Next"] == degraded, name
+        assert set(st["Parameters"]) == {"cause", "detail.$"}, name
+        assert st["Parameters"]["detail.$"].startswith("States.JsonToString("), name
+
+    assert from_probe["Parameters"]["cause"] == "probe_returned_no_verdict"
+    assert from_error["Parameters"]["cause"] == "lambda_failed_after_retries"
+
+    # Each normalizer may only read the path its OWN inbound arm guarantees.
+    result_path = states[check]["ResultPath"]
+    (catch,) = states[check]["Catch"]
+    assert from_probe["Parameters"]["detail.$"] == (
+        f"States.JsonToString({result_path}.Payload)"
+    )
+    assert from_error["Parameters"]["detail.$"] == (
+        f"States.JsonToString({catch['ResultPath']})"
+    )
+
+
+@pytest.mark.parametrize(_PARAMS, GATES, ids=_IDS)
+def test_normalizers_do_not_touch_the_gate_degraded_marker(
+    states, check, _field, degraded, publish, proceed, cause_path
+):
+    """The completion-email marker stays SF-controlled and single-writer.
+
+    `test_only_degraded_passes_set_gate_degraded` pins the writer list; these
+    eight new states must not join it, or the family-boolean accumulation
+    `CheckGateDegradedNotify` depends on changes shape.
+    """
+    for name in (f"{degraded}FromProbe", f"{degraded}FromError"):
+        assert states[name]["ResultPath"] != "$.gate_degraded"
+        assert states[name]["ResultPath"] != "$.degraded_summary"


### PR DESCRIPTION
## What and why

The alert Brian received tonight named a cause the execution history contradicts.

`ne-weekly-freshness-pipeline` / `watch-rerun-2026-08-13-5`, `PublishPipelineContractGateDegraded` sent:

> PipelineContractCheck could not verify PIPELINE_CONTRACT.yaml self-consistency (**gate Lambda failed after retries, or returned a malformed payload**).

| Claim | Measured on that execution |
|---|---|
| gate Lambda failed after retries | event 29 = `TaskSucceeded`. Zero retries. HTTP 200, 142 ms. |
| returned a malformed payload | well-formed and self-describing: `{"violations": [], "boundary_count": null, "reason": "fetch_failed"}` |

The gate degraded through the **Choice absence arm** — the probe ran fine and honestly reported it could not measure — and the hardcoded constant `Message` names a cause set that does not include that arm. The one field that told the truth, the probe's own `reason`, never reached the reader. Diagnosing the alert required pulling the SF history and CloudWatch to recover a string the payload already contained.

All **four** pre-spend gates carried the identical false constant, so all four are fixed here, not just the one that alerted.

## How

Each gate now enters its degraded chain through a cause normalizer:

```
<Gate>DriftGate  --absence arm-->  <Gate>GateDegradedFromProbe  --\
                                                                   >-- <Gate>GateDegraded (unchanged)
<Gate>Check      --Catch-------->  <Gate>GateDegradedFromError  --/
```

Both write one `ResultPath` — `$.<family>_gate_degraded_cause` — carrying `cause` and `detail` (`States.JsonToString` of the probe payload, or of the caught error). The publisher then interpolates those two scalars with `States.Format`.

**On config#1819.** That rule made these `Message`s constants to keep a possibly-absent path out of the notifier and the `States.Runtime` class closed. The `Subject` stays constant. The `Message` now dereferences *only* paths the `Pass` immediately upstream writes on **both** inbound arms — so the hazard is closed structurally rather than by the alert saying less. Two tests pin that: one asserts the notifier references nothing outside `$.<family>_gate_degraded_cause`, the other that the `States.Format` literal contains no apostrophes and no stray braces (its argument is a single-quoted ASL literal; a `{run_date}`-style placeholder copied from a sibling alert would mis-parse the whole definition).

Rendered output, from the real production payload:

```
PipelineContractCheck did not verify PIPELINE_CONTRACT.yaml self-consistency.

Cause: probe_returned_no_verdict
Probe output: {"violations":[],"boundary_count":null,"reason":"fetch_failed"}

Cause codes: probe_returned_no_verdict means the gate Lambda RAN and returned HTTP 200
but its payload carried no verdict field; the reason key in the probe output above names
why it could not measure. lambda_failed_after_retries means the invocation itself failed
through both retry tiers and never produced a payload at all.

Proceeding FAIL-OPEN: the spot spend for this run is NOT protected against the contract
break this gate exists to catch. The completion email will carry the gates-degraded marker.

View pipeline status: https://dashboard.nousergon.ai/pipeline-status
```

Also corrects `PipelineContractCheck`'s `Comment`, which still described the pre-`alpha-engine-config-I7048` behaviour (`sets has_violation=false` on a fetch miss — I7048 changed it to omit the key, which is precisely what routes to this degraded arm).

`scripts/weekly_sf_rerun.py`: the eight new states join the `lib_pin_drift_check` stage's `degraded_witness`, so a run that stopped on one is a degraded gate rather than a completed one. `tests/test_weekly_sf_rerun.py::test_every_degraded_state_is_mapped` caught that omission — the guard worked.

## Verification

- `aws stepfunctions validate-state-machine-definition` → `{"result": "OK", "diagnostics": []}`
- `aws stepfunctions test-state` against **the actual payload from `watch-rerun-2026-08-13-5`** — the `FromProbe` normalizer, the `FromError` normalizer, and the `States.Format` message all `SUCCEEDED` and render as shown above.
- Full suite: **5672 passed, 9 skipped**, on the repo venv (Python 3.12.13), including the 36 in `test_sf_prespend_gate_alerting.py`.
- Mutation-checked the intrinsic-safety test: re-introducing one apostrophe into a template fails it.

## Scope note

This makes the alert honest. It does **not** fix the underlying `fetch_failed`: `pipeline_contract_check.py::_fetch_raw` reads `raw.githubusercontent.com` unauthenticated against `nousergon/alpha-engine-config`, which is private, so it 404s — **190 of 190 invocations in the last 30 days**, i.e. the gate has never validated the contract since it shipped. That is `nousergon/alpha-engine-config#7281`, in `crucible-predictor`, and is unaffected by this PR. Related: `nousergon/alpha-engine-config#7277` (probe payload honesty), `#7171` (the sibling gate's `sha_pinned`, also degraded on this same run).

Closes nousergon/alpha-engine-config#7302

## Deploy mechanism
**Deploy-mechanism:** `deploy-infrastructure.yml` — fires on every push to `main`, restamps the SF via `update-state-machine`. No post-merge step.

Rehearsal-path: tests/test_sf_prespend_gate_alerting.py

Rehearsed two ways before opening: that structural suite (36 tests, all four gates parameterized), and `aws stepfunctions test-state` executing the two new normalizer Pass states plus the `States.Format` message against the real payload `watch-rerun-2026-08-13-5` produced — the honesty property is asserted against the exact input that triggered the false alert, so a Saturday run is confirmation, not first contact.

---

**Prepared by:** claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
