### PR TITLE
fix(weekly-sf): degraded gate alerts stop asserting a cause they never measured (config-I7301)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -348,7 +348,7 @@
     },
     "LibPinGateDegraded": {
       "Type": "Pass",
-      "Comment": "config#2278: the lib-pin gate could not CHECK (Lambda failure after both retry tiers, or a payload without has_drift). Still fail-open \u2014 availability over gating for a weekly pipeline \u2014 but VISIBLE and rarer: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishLibPinGateDegraded alerts NOW (mirroring WeeklyRunDayGateFailed's fail-open+alert shape). Proceeds into PipelineContractCheck so a lib-pin-gate infra flake no longer silently skips the SIBLING gate too.",
+      "Comment": "config#2278: the lib-pin gate could not CHECK (Lambda failure after both retry tiers, or a payload without has_drift). Still fail-open \u2014 availability over gating for a weekly pipeline \u2014 but VISIBLE and rarer: gate_degraded=true threads into the completion email via CheckGateDegradedNotify, and PublishLibPinGateDegraded alerts NOW (mirroring WeeklyRunDayGateFailed's fail-open+alert shape). Proceeds into PipelineContractCheck so a lib-pin-gate infra flake no longer silently skips the SIBLING gate too. | alpha-engine-config-I7301 (2026-08-13): this state's population NARROWED and its alert text stopped guessing. The probe now HALTS (has_drift=true, offenders named) when a co-install-pair member's pin was read successfully but is permanently uncomparable \u2014 sha_pinned / unrecognised_pin \u2014 because that is a measured defect, not a failed measurement. Only genuine could-not-measure reaches here now: a Lambda failure, an unreachable GitHub, or a permanent problem on a FLOOR-ONLY repo. The old Message asserted 'gate Lambda failed after retries, or returned a malformed payload' as the cause on EVERY arrival; from 2026-07-31 to 2026-08-13 the real cause was a well-formed payload from a healthy Lambda declining to verdict on a SHA-pinned predictor, and the text sent readers to investigate Lambda health instead. An alert may name only what it measured \u2014 the cause now lives on the execution record and the Message points at the field.",
       "Result": true,
       "ResultPath": "$.gate_degraded",
       "Next": "SetLibPinGateDegradedSummary"
@@ -360,7 +360,7 @@
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Lib-Pin Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "LibPinDriftCheck could not verify cross-repo pin parity (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the co-install break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Message": "LibPinDriftCheck could not verify cross-repo lib-pin parity on this run. Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the co-install break this gate exists to catch. THIS ALERT IS NOT A REPORTED DEFECT and it does not mean the gate Lambda is broken. A confirmed parity break, and an unverifiable pin on either half of the co-install pair, both HALT the run through HandleFailure with the offenders named (alpha-engine-config-I7301) \u2014 neither arrives here. What reaches this alert is a genuine could-not-measure, and the cause is on the execution record, never guessed by this text: $.libpin_drift_result.Payload.reason names it (fetch_failed = GitHub was unreachable, the one transient cause; sha_pinned / unrecognised_pin = a FLOOR-ONLY repo's pin is not comparable to the floor), with $.libpin_drift_result.Payload.unresolved carrying the per-repo detail. If the gate Lambda itself failed after both retry tiers, $.libpin_drift_error holds the exception and the payload path is absent. The completion email will carry the gates-degraded marker. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.libpin_gate_degraded_notify",
       "Catch": [
@@ -384,12 +384,12 @@
     },
     "PublishPipelineContractGateDegraded": {
       "Type": "Task",
-      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch mirrors PublishLibPinGateDegraded.",
+      "Comment": "config#2278: fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch mirrors PublishLibPinGateDegraded. | alpha-engine-config-I7301: Message no longer asserts 'gate Lambda failed after retries, or returned a malformed payload' as the cause. That parenthetical was a guess baked into a config#1819 constant and fired on every arrival; on the lib-pin sibling it was false on both halves for 13 days and sent readers to investigate a healthy Lambda. A constant cannot name this run's cause, so it must not pretend to \u2014 it states the class and points at the execution-record field. Pinned by tests/test_sf_degraded_alert_names_only_what_it_measured.py.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Contract Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "PipelineContractCheck could not verify PIPELINE_CONTRACT.yaml self-consistency (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the contract break this gate exists to catch. The completion email will carry the gates-degraded marker. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Message": "PipelineContractCheck could not verify PIPELINE_CONTRACT.yaml self-consistency on this run. Proceeding FAIL-OPEN: this run's spot spend is NOT protected against the contract break this gate exists to catch. THIS ALERT IS NOT A REPORTED DEFECT and it does not mean the gate Lambda is broken \u2014 a confirmed contract violation HALTS the run through HandleFailure with the violations named, and never arrives here. What reaches this alert is a genuine could-not-measure, and the cause is on the execution record rather than guessed by this text: $.pipeline_contract_result.Payload.reason names it, and $.pipeline_contract_error holds the exception if the gate Lambda itself failed after both retry tiers (in which case the payload path is absent). The completion email will carry the gates-degraded marker. alpha-engine-config-I7301. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.pipeline_contract_gate_degraded_notify",
       "Catch": [
@@ -6707,12 +6707,12 @@
     },
     "PublishEvaluatorGateDegraded": {
       "Type": "Task",
-      "Comment": "Fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch. Proceeds to EvaluatorDirectorDeployDriftCheck (NOT straight to CheckMutexRole) \u2014 mirrors PublishLibPinGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too.",
+      "Comment": "Fail-open + alert. Subject/Message are hardcoded constants (config#1819 discipline). Best-effort Catch. Proceeds to EvaluatorDirectorDeployDriftCheck (NOT straight to CheckMutexRole) \u2014 mirrors PublishLibPinGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too. | alpha-engine-config-I7301: Message no longer asserts 'gate Lambda failed after retries, or returned a malformed payload' as the cause. That parenthetical was a guess baked into a config#1819 constant and fired on every arrival; on the lib-pin sibling it was false on both halves for 13 days and sent readers to investigate a healthy Lambda. A constant cannot name this run's cause, so it must not pretend to \u2014 it states the class and points at the execution-record field. Pinned by tests/test_sf_degraded_alert_names_only_what_it_measured.py.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Evaluator Deploy-Drift Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "The evaluator Lambda-SHA drift probe could not verify alpha-engine-evaluator and/or alpha-engine-evaluator-director against origin/main (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN: this run is NOT protected against a stale :live alias this gate exists to catch. The completion email will carry the gates-degraded marker. config#2348."
+        "Message": "The evaluator Lambda-SHA drift probe could not verify alpha-engine-evaluator and/or alpha-engine-evaluator-director against origin/main on this run. Proceeding FAIL-OPEN: this run is NOT protected against a stale :live alias this gate exists to catch. THIS ALERT IS NOT A REPORTED DEFECT and it does not mean the gate Lambda is broken \u2014 confirmed SHA drift HALTS the run through HandleFailure with the offenders named, and never arrives here. What reaches this alert is a genuine could-not-measure, and the cause is on the execution record rather than guessed by this text: $.evaluator_deploy_drift_result.Payload.reason names it, and $.evaluator_deploy_drift_result_error holds the exception if the gate Lambda itself failed after both retry tiers (in which case the payload path is absent). The completion email will carry the gates-degraded marker. config#2348, alpha-engine-config-I7301."
       },
       "ResultPath": "$.evaluator_gate_degraded_notify",
       "Catch": [
@@ -6821,12 +6821,12 @@
     },
     "PublishEvaluatorDirectorGateDegraded": {
       "Type": "Task",
-      "Comment": "Fail-open + alert, mirrors PublishEvaluatorGateDegraded. Proceeds to WeeklyPreflight (NOT straight to CheckMutexRole) -- mirrors PublishPipelineContractGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too.",
+      "Comment": "Fail-open + alert, mirrors PublishEvaluatorGateDegraded. Proceeds to WeeklyPreflight (NOT straight to CheckMutexRole) -- mirrors PublishPipelineContractGateDegraded's config#2278 fix: the degraded chain must not silently skip the sibling gate too. | alpha-engine-config-I7301: Message no longer asserts 'gate Lambda failed after retries, or returned a malformed payload' as the cause. That parenthetical was a guess baked into a config#1819 constant and fired on every arrival; on the lib-pin sibling it was false on both halves for 13 days and sent readers to investigate a healthy Lambda. A constant cannot name this run's cause, so it must not pretend to \u2014 it states the class and points at the execution-record field. Pinned by tests/test_sf_degraded_alert_names_only_what_it_measured.py.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Weekly Pipeline \u2014 Evaluator-Director Deploy-Drift Gate DEGRADED (Proceeding Unchecked)",
-        "Message": "The evaluator-director Lambda-SHA drift probe could not verify alpha-engine-evaluator-director against origin/main (gate Lambda failed after retries, or returned a malformed payload). Proceeding FAIL-OPEN. The completion email will carry the gates-degraded marker. config#2348."
+        "Message": "The evaluator-director Lambda-SHA drift probe could not verify alpha-engine-evaluator-director against origin/main on this run. Proceeding FAIL-OPEN. THIS ALERT IS NOT A REPORTED DEFECT and it does not mean the gate Lambda is broken \u2014 confirmed SHA drift HALTS the run through HandleFailure with the offenders named, and never arrives here. What reaches this alert is a genuine could-not-measure, and the cause is on the execution record rather than guessed by this text: $.evaluator_director_deploy_drift_result.Payload.reason names it, and $.evaluator_director_deploy_drift_result_error holds the exception if the gate Lambda itself failed after both retry tiers (in which case the payload path is absent). The completion email will carry the gates-degraded marker. config#2348, alpha-engine-config-I7301."
       },
       "ResultPath": "$.evaluator_director_gate_degraded_notify",
       "Catch": [

--- a/tests/test_sf_degraded_alert_names_only_what_it_measured.py
+++ b/tests/test_sf_degraded_alert_names_only_what_it_measured.py
@@ -1,0 +1,102 @@
+"""alpha-engine-config-I7301 — a fail-open alert may not assert a cause it did
+not measure.
+
+The 2026-08-13 finding. `PublishLibPinGateDegraded`'s Message read:
+
+    "LibPinDriftCheck could not verify cross-repo pin parity (gate Lambda
+     failed after retries, or returned a malformed payload)."
+
+Both halves were false on every firing from 2026-07-31 onward. The gate Lambda
+returned HTTP 200 in ~3s with a well-formed payload; it deliberately omitted
+`has_drift` because `crucible-predictor` pinned nousergon-lib by commit SHA and
+the parity comparison could not be made. The alert's parenthetical was not a
+measurement, it was a guess baked into a constant — and because it named the
+Lambda, it sent readers to investigate Lambda health while the real defect
+(backtester v0.124.5 against a predictor SHA sitting ~v0.124.16 — a live
+co-install parity break) sat unexamined for 13 days.
+
+config#1819 requires these Subject/Message values to be hardcoded constants,
+never `States.Format` against input. That constraint is correct and is not
+relaxed here. It does mean a constant CANNOT name the run's actual cause — so
+the obligation is the opposite one: a constant must not PRETEND to. It states
+the class, and points at the execution-record field where the measured cause
+lives.
+
+This is the same bug class as I7048/I7277/I7171 one layer out: those were
+payloads that could not distinguish "could not measure" from "measured
+nothing"; this is an alert that could not distinguish them either, and
+resolved the ambiguity by inventing the more alarming reading.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+import pytest
+
+_WEEKLY = pathlib.Path(__file__).parent.parent / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_WEEKLY.read_text())["States"]
+
+
+def test_libpin_degraded_alert_does_not_assert_the_lambda_failed(states):
+    msg = states["PublishLibPinGateDegraded"]["Parameters"]["Message"]
+    # The exact fabrication removed by I7301. Named as a literal so a future
+    # edit that reintroduces the guess fails here rather than in an operator's
+    # inbox 13 days later.
+    assert "gate Lambda failed after retries" not in msg
+    assert "returned a malformed payload" not in msg
+
+
+def test_libpin_degraded_alert_points_at_the_field_carrying_the_real_cause(states):
+    msg = states["PublishLibPinGateDegraded"]["Parameters"]["Message"]
+    # A constant cannot carry the run's cause (config#1819). It must therefore
+    # tell the reader where the cause IS, or the reader guesses — which is the
+    # failure this test exists to prevent, one step downstream.
+    assert "$.libpin_drift_result.Payload.reason" in msg
+    assert "$.libpin_drift_error" in msg
+
+
+def test_libpin_degraded_alert_says_it_is_not_a_reported_defect(states):
+    # The operative distinction: a real drift, and an unverifiable pin on the
+    # co-install pair, both HALT via HandleFailure. Anything arriving at this
+    # alert is a could-not-measure. Saying so is what stops the alert being
+    # read as a finding.
+    msg = states["PublishLibPinGateDegraded"]["Parameters"]["Message"]
+    assert "NOT A REPORTED DEFECT" in msg.upper()
+
+
+# The four pre-spend gate degraded alerts share one shape. None of them may
+# assert a cause; the lib-pin one is simply the instance that was caught.
+_DEGRADED_PUBLISHERS = [
+    "PublishLibPinGateDegraded",
+    "PublishPipelineContractGateDegraded",
+    "PublishEvaluatorGateDegraded",
+    "PublishEvaluatorDirectorGateDegraded",
+]
+
+# Phrasings that assert a specific mechanism as THE cause of this firing.
+# "or" does not launder a guess: enumerating two mechanisms still excludes
+# every other one, which is how the lib-pin text managed to be wrong about
+# both halves at once.
+_ASSERTS_A_CAUSE = re.compile(
+    r"\((?:[^)]*\b(?:Lambda failed|failed after retries|malformed payload)\b[^)]*)\)",
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.parametrize("publisher", _DEGRADED_PUBLISHERS)
+def test_no_prespend_degraded_alert_asserts_a_mechanism_as_the_cause(states, publisher):
+    msg = states[publisher]["Parameters"]["Message"]
+    match = _ASSERTS_A_CAUSE.search(msg)
+    assert match is None, (
+        f"{publisher}'s Message asserts a cause it cannot have measured: "
+        f"{match.group(0)!r}. This Message is a hardcoded constant "
+        f"(config#1819) fired on every arrival at the degraded chain, so any "
+        f"cause named in it is a guess. State the class and point at the "
+        f"execution-record field instead (alpha-engine-config-I7301)."
+    )


### PR DESCRIPTION
## What

All four pre-spend gate fail-open alerts carried the same parenthetical:

> `(gate Lambda failed after retries, or returned a malformed payload)`

These `Message` values are hardcoded constants fired on every arrival at the degraded chain (config#1819 — never `States.Format` against input). A constant therefore cannot know this run's cause, so any cause it names is a guess.

On `PublishLibPinGateDegraded` that guess was false on **both halves**, on every firing from 2026-07-31 to 2026-08-13. Measured on `watch-rerun-2026-08-13-5`, event 13: the gate Lambda returned HTTP 200 from `alpha-engine-predictor-inference:live` v474 in 3.4s with a well-formed payload. It omitted `has_drift` deliberately, because `crucible-predictor` pins `nousergon-lib` by commit SHA and the co-install parity comparison could not be made. No `Catch` was taken; nothing failed.

Because the text named the Lambda, it pointed every reader at healthy infrastructure. Underneath it sat a live parity break — `crucible-backtester` `v0.124.5` against a predictor SHA at `~v0.124.16` — unexamined for 13 days.

## Change

Each of the four Messages now:

- states the class (**could not measure**) instead of asserting a mechanism;
- says explicitly that it is **not a reported defect** — a confirmed drift/violation halts through `HandleFailure` with offenders named and never arrives at this alert;
- points at the execution-record field carrying the measured reason (`$.<gate>_result.Payload.reason`, and `$.<gate>_error` when the Lambda itself failed).

config#1819 is **not** relaxed. The constraint stands, and it is the reason a constant must not pretend to name a cause.

`tests/test_sf_degraded_alert_names_only_what_it_measured.py` pins the class. It found the other three instances after the lib-pin one was fixed, and fails on any future Message naming a mechanism as the cause.

## Testing

Full suite on Python 3.12: **5659 passed, 9 skipped**. No behavioral change — `Message` text and `Comment` only; the routing, flags, retries and notifier selection are untouched, and the existing wiring tests (`test_sf_prespend_gate_alerting.py`, `test_sf_lib_pin_drift_wiring.py`, `test_sf_structural_contract.py`, `test_sf_choice_guards.py`) pass unchanged.

## Related

- `alpha-engine-config-I7301` — the umbrella finding.
- `crucible-predictor-PR492` (companion, DRAFT): makes an unverifiable co-install pin halt rather than degrade. Independent of this PR — merge order does not matter between the two.
- The underlying pin repin (`crucible-predictor` off the SHA) is deliverable 1 of I7301 and is **not** in either PR.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_degraded_alert_names_only_what_it_measured.py
