### PR TITLE
[P1/mid] fix(preflight-sweep): declared upstream-pending verdict + a verdict row for every declared stage (config#7323, #7324)

### DIFF
--- a/infrastructure/preflight_sweep.py
+++ b/infrastructure/preflight_sweep.py
@@ -29,10 +29,23 @@ as a pass:
                     NOT a pass and NOT a defect. The verdict vocabulary mirrors
                     ``validators/stage_output_sweep.py`` (I7167) deliberately
                     rather than inventing a parallel one.
-* ``unsweepable`` — the stage declares a dry path the sweep cannot exercise
-                    (launcher missing, flag unimplemented, command unrenderable).
-                    A coverage defect in its own right; fails the run.
-* ``not_attempted`` — the run ended before reaching this stage.
+* ``unsweepable`` — the stage could not be exercised. TWO kinds, kept apart
+                    because one is a defect and the other is Tuesday:
+                    ``coverage_defect`` (launcher missing, flag unimplemented,
+                    command unrenderable) fails the run and pages;
+                    ``upstream_pending`` (the stage reads a same-day artifact a
+                    preceding stage produces, and that stage has not run for
+                    real today) does neither. The second is DECLARED per stage
+                    in ``preflight_sweep_manifest.json`` and still probed on the
+                    day — a reworded launcher error cannot reclassify a real
+                    failure, and a declaration alone cannot hide one.
+* ``no_dry_path`` — the stage threads no ``$.preflight_args`` and is never
+                    exercised at all. A verdict ROW, not just a counter: a count
+                    published without its members is unactionable.
+* ``not_attempted`` — the run produced no verdict for a declared stage. The
+                    invariant ``len(results) == stages_declared`` holds on every
+                    report, and a stage that would have broken it is filled in
+                    here AND raised as a blocking coverage finding.
 
 A run that could not measure anything terminates ``failed`` with
 ``measured: false`` and a reason. It never writes the clean-run pointer.
@@ -71,15 +84,45 @@ from infrastructure.preflight_sweep_stages import (  # noqa: E402
     load_manifest,
     manifest_disagreement,
     map_binding_disagreement,
+    upstream_dependencies,
+    upstream_dependency_disagreement,
 )
-from infrastructure.preflight_sweep_console import envelopes, load_cadence  # noqa: E402
+from infrastructure.preflight_sweep_console import (  # noqa: E402
+    envelopes,
+    finding_text as _finding_text,
+    is_blocking_finding as _is_blocking,
+    load_cadence,
+)
 
 # ── Verdict vocabulary (closed; mirrors validators/stage_output_sweep.py) ────
 PASSED = "passed"
 FAILED = "failed"
 UNMEASURED = "unmeasured"
 UNSWEEPABLE_VERDICT = "unsweepable"
+NO_DRY_PATH_VERDICT = "no_dry_path"
 NOT_ATTEMPTED = "not_attempted"
+
+# ── Why a stage is unsweepable (closed; add by PR) ───────────────────────────
+# The distinction is load-bearing, not cosmetic. One of these is a defect in
+# the sweep's own coverage and MUST page; the other is the ordinary state of a
+# stage whose upstream has not run today and MUST NOT. Collapsing them is how
+# the first sweep run emailed "2 failed" on a structurally unmeasurable pair.
+UNSWEEPABLE_COVERAGE_DEFECT = "coverage_defect"
+UNSWEEPABLE_UPSTREAM_PENDING = "upstream_pending"
+
+# ── Coverage-finding kinds (closed; add by PR) ───────────────────────────────
+# Every finding carries its own `blocking` flag rather than deriving severity
+# from which list it landed in: an acknowledged no-dry-path stage is a real
+# coverage gap that must be NAMED on every surface, and is not a reason to fail
+# the run — an integer that only says how many is a count published without its
+# members (alpha-engine-config#7324).
+FINDING_MANIFEST_DISAGREEMENT = "manifest_disagreement"
+FINDING_MAP_BINDING_DISAGREEMENT = "map_binding_disagreement"
+FINDING_UPSTREAM_DECLARATION = "upstream_declaration"
+FINDING_NO_DRY_PATH = "no_dry_path"
+FINDING_MISSING_VERDICT = "missing_verdict"
+
+STREAK_STATE_KEY_SUFFIX = "unsweepable_streaks.json"
 
 # Run-level outcome, from observability-policy §3.1's closed vocabulary.
 OUTCOME_OK = "ok"
@@ -117,6 +160,15 @@ class StageResult:
     reason: str | None = None
     last_stderr_line: str | None = None
     log_key: str | None = None
+    # Set only when verdict == UNSWEEPABLE_VERDICT. Which of the two kinds it
+    # is decides whether the run fails and whether the console row is an error.
+    unsweepable_kind: str | None = None
+    # The declared upstream dependency that produced an `upstream_pending`
+    # verdict, echoed onto the row so the operator reads the unmet prefix and
+    # its producing stage without opening the manifest.
+    upstream: dict[str, Any] | None = None
+    # For a `no_dry_path` row: the written acknowledgement from the manifest.
+    acknowledged_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -139,8 +191,23 @@ class SweepReport:
     stages_failed: int = 0
     stages_unmeasured: int = 0
     stages_unsweepable: int = 0
+    # The two kinds of unsweepable, published separately and both at zero:
+    # a coverage defect fails the run, an unmet same-day upstream does not.
+    stages_unsweepable_coverage_defect: int = 0
+    stages_unsweepable_upstream_pending: int = 0
     stages_no_dry_path: int = 0
-    coverage_findings: list[str] = field(default_factory=list)
+    stages_not_attempted: int = 0
+    coverage_findings: list[dict[str, Any]] = field(default_factory=list)
+    # A stage unsweepable on EVERY run for the declared streak threshold is its
+    # own finding: the sweep covers nothing there. Kept OUT of coverage_findings
+    # deliberately so it can never be read as coverage (I7323 deliverable 3).
+    persistent_unsweepable_findings: list[dict[str, Any]] = field(default_factory=list)
+    unsweepable_streak_state: str = "unavailable"
+    unsweepable_streak_threshold_runs: int | None = None
+    # Every stage the definition declares, with its classification — so
+    # `declared - swept` is auditable from the report alone rather than being a
+    # scalar nobody can expand (I7324 deliverable 2).
+    declared_stages: list[dict[str, Any]] = field(default_factory=list)
     results: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -175,6 +242,35 @@ class AwsSurface:
             Body=json.dumps(payload, indent=2, sort_keys=True).encode(),
             ContentType="application/json",
         )
+
+    def get_json(self, key: str) -> dict | None:
+        """Read a JSON object, or ``None`` if it does not exist yet.
+
+        Only a genuine absence returns ``None``. Any other error propagates —
+        an unreadable streak file must not be silently treated as "no history",
+        which would reset every streak to zero on each run and make the
+        persistent-unsweepable finding structurally unable to fire.
+        """
+        if self._s3 is None:
+            self._s3 = self._client("s3")
+        try:
+            body = self._s3.get_object(Bucket=self.bucket, Key=key)["Body"].read()
+        except self._s3.exceptions.NoSuchKey:
+            return None
+        return json.loads(body)
+
+    def list_objects(self, prefix: str, max_keys: int = 1000) -> list[dict[str, Any]]:
+        """``[{"Key": ..., "Size": ...}]`` under ``prefix``. Never swallows."""
+        if self._s3 is None:
+            self._s3 = self._client("s3")
+        out: list[dict[str, Any]] = []
+        paginator = self._s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
+            for obj in page.get("Contents", []) or []:
+                out.append({"Key": obj["Key"], "Size": obj.get("Size", 0)})
+                if len(out) >= max_keys:
+                    return out
+        return out
 
     def put_text(self, key: str, body: str) -> None:
         if self._s3 is None:
@@ -300,6 +396,194 @@ def _stage_log(stage: Stage, result: StageResult, script: str) -> str:
     )
 
 
+# ── Declared same-day upstream dependencies ──────────────────────────────────
+
+
+def _finding(kind: str, detail: str, *, blocking: bool, stage: str | None = None) -> dict:
+    """One coverage finding, carrying its own severity.
+
+    A finding that has to be looked up in a severity table somewhere else is a
+    finding whose severity drifts from its text.
+    """
+    return {"kind": kind, "stage": stage, "blocking": blocking, "finding": detail}
+
+
+def upstream_content(
+    prefix: str, ignore_subprefixes: list[str], lister
+) -> tuple[bool, dict[str, Any]]:
+    """Is the declared upstream prefix populated with real content?
+
+    CONTENT, never existence. ``backtest/<date>/`` EXISTS on a day nothing
+    produced it, because the sweep's own phase markers are written under it —
+    a probe that tested existence would report every stage's upstream as
+    satisfied and would therefore change nothing while appearing to work. Keys
+    under a declared ignore sub-prefix, and zero-byte keys, are not content.
+    """
+    objects = lister(prefix)
+    counted: list[str] = []
+    ignored: list[str] = []
+    for obj in objects:
+        key = obj.get("Key", "")
+        rel = key[len(prefix):] if key.startswith(prefix) else key
+        if any(rel.startswith(p) for p in ignore_subprefixes):
+            ignored.append(key)
+            continue
+        if int(obj.get("Size", 0) or 0) == 0:
+            ignored.append(key)
+            continue
+        counted.append(key)
+    detail = {
+        "prefix": prefix,
+        "content_keys": len(counted),
+        "ignored_keys": len(ignored),
+        "ignore_subprefixes": list(ignore_subprefixes),
+        "sample": sorted(counted)[:3] or sorted(ignored)[:3],
+    }
+    return bool(counted), detail
+
+
+def classify_upstream(
+    result: StageResult, declaration: dict[str, Any], bindings: dict[str, Any], lister
+) -> StageResult:
+    """Reclassify a FAILED stage whose declared same-day upstream is absent.
+
+    Applies only to a stage that RAN and FAILED and carries a declaration in
+    ``preflight_sweep_manifest.json``. Three outcomes, all explicit:
+
+    * upstream prefix has content  -> stays ``failed``, and says the upstream
+      was present, which is what keeps a real defect from hiding behind the
+      declaration;
+    * upstream prefix is empty     -> ``unsweepable`` / ``upstream_pending``,
+      naming the producing stage and the prefix. Not a failure, does not page;
+    * the probe itself could not run -> ``unmeasured``. The sweep cannot tell a
+      real failure from an unmet upstream, and saying either would be a guess.
+    """
+    template = declaration["prefix"]
+    try:
+        prefix = template.format(**bindings)
+    except (KeyError, IndexError, ValueError) as exc:
+        result.verdict = UNMEASURED
+        result.reason = (
+            f"preflight exited rc={result.returncode}, and the declared upstream prefix "
+            f"template {template!r} could not be rendered from the sweep's bindings "
+            f"({type(exc).__name__}: {exc}) — a real failure cannot be told from an "
+            "unmet upstream"
+        )
+        return result
+
+    if lister is None:
+        result.verdict = UNMEASURED
+        result.reason = (
+            f"preflight exited rc={result.returncode}, and the declared upstream "
+            f"{prefix!r} (produced by {declaration['produced_by']}) could not be probed: "
+            "the sweep has no S3 surface in this run. A real failure cannot be told "
+            "from an unmet upstream, so neither is claimed."
+        )
+        return result
+
+    try:
+        present, detail = upstream_content(
+            prefix, list(declaration.get("ignore_subprefixes") or []), lister
+        )
+    except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+        result.verdict = UNMEASURED
+        result.reason = (
+            f"preflight exited rc={result.returncode}, and probing the declared upstream "
+            f"{prefix!r} raised {type(exc).__name__}: {exc} — a real failure cannot be "
+            "told from an unmet upstream"
+        )
+        return result
+
+    result.upstream = {**detail, "produced_by": declaration["produced_by"], "present": present}
+    if present:
+        result.reason = (
+            f"{result.reason or f'preflight exited rc={result.returncode}'} — and its "
+            f"declared upstream {prefix} IS populated ({detail['content_keys']} objects "
+            f"from {declaration['produced_by']}), so this is a REAL failure, not an "
+            "unmet upstream"
+        )
+        return result
+
+    result.verdict = UNSWEEPABLE_VERDICT
+    result.unsweepable_kind = UNSWEEPABLE_UPSTREAM_PENDING
+    result.reason = (
+        f"NOT MEASURABLE TODAY — this stage reads s3://{DEFAULT_BUCKET}/{prefix}, produced "
+        f"by the {declaration['produced_by']} stage, and that prefix holds no content "
+        f"({detail['ignored_keys']} key(s) ignored as "
+        f"{', '.join(detail['ignore_subprefixes']) or 'n/a'} markers or zero-byte). A "
+        f"--preflight-only run of {declaration['produced_by']} does not produce it, so the "
+        "preconditions of this stage are UNKNOWN rather than broken. Declared in "
+        "preflight_sweep_manifest.json:upstream_artifact_dependencies."
+    )
+    return result
+
+
+# ── Persistent-unsweepable streaks ───────────────────────────────────────────
+
+
+def streak_threshold_runs(manifest: dict, cadence: dict) -> int:
+    """Consecutive RUNS that make an unsweepable stage a finding of its own.
+
+    Declared in days in the manifest and converted here against the declared
+    cadence, so changing the sweep cadence cannot silently change what "N
+    consecutive days" means.
+    """
+    days = int(manifest.get("unsweepable_streak_threshold_days", 8))
+    per_day = 1440.0 / float(cadence["cadence_minutes"])
+    return max(1, round(days * per_day))
+
+
+def update_streaks(
+    prior: dict[str, Any] | None,
+    results: list[StageResult],
+    run_id: str,
+    now_iso: str,
+    threshold_runs: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Advance the per-stage unsweepable streak and emit the findings it earns.
+
+    A stage that produced any verdict other than ``unsweepable`` this run has
+    its streak dropped: it became measurable, which is the condition the
+    threshold exists to detect the absence of.
+    """
+    prior_streaks = (prior or {}).get("streaks", {}) or {}
+    streaks: dict[str, Any] = {}
+    findings: list[dict[str, Any]] = []
+    for result in results:
+        if result.verdict != UNSWEEPABLE_VERDICT:
+            continue
+        previous = prior_streaks.get(result.stage) or {}
+        runs = int(previous.get("consecutive_runs", 0)) + 1
+        entry = {
+            "consecutive_runs": runs,
+            "since": previous.get("since") or now_iso,
+            "kind": result.unsweepable_kind,
+            "last_run_id": run_id,
+            "last_reason": result.reason,
+        }
+        streaks[result.stage] = entry
+        if runs >= threshold_runs:
+            findings.append(
+                {
+                    "stage": result.stage,
+                    "kind": result.unsweepable_kind,
+                    "consecutive_runs": runs,
+                    "threshold_runs": threshold_runs,
+                    "since": entry["since"],
+                    "finding": (
+                        f"{result.stage} has been unsweepable on every one of the last "
+                        f"{runs} runs (threshold {threshold_runs}, since {entry['since']}) "
+                        "— the sweep has measured NOTHING about this stage's preconditions "
+                        "for that whole period. This is not coverage."
+                    ),
+                }
+            )
+    return (
+        {"schema_version": 1, "updated_at": now_iso, "run_id": run_id, "streaks": streaks},
+        findings,
+    )
+
+
 # ── Report rendering ─────────────────────────────────────────────────────────
 
 
@@ -307,18 +591,37 @@ def render_notification(report: SweepReport) -> tuple[str, str]:
     """ONE notification for the whole run (observability-policy §7.2a: one per
     group failure, never one per member). Carries the full member list by name
     so the operator never has to open a console to learn which stages broke."""
+    not_covered = (
+        report.stages_unsweepable
+        + report.stages_unmeasured
+        + report.stages_no_dry_path
+        + report.stages_not_attempted
+    )
     if not report.measured:
         subject = f"[preflight-sweep] COULD NOT MEASURE — {report.run_id}"
     elif report.outcome == OUTCOME_OK:
         subject = (
             f"[preflight-sweep] all {report.stages_passed} stages clean — {report.run_id}"
         )
+    elif report.stages_failed == 0 and report.stages_unsweepable_coverage_defect == 0:
+        # Nothing broke, but the run did not cover everything. Naming the
+        # denominator's missing part IS the subject — a subject reading
+        # "0 failed" over a run that measured 14 of 19 stages is the count
+        # published without its members.
+        subject = (
+            f"[preflight-sweep] no failures — {not_covered} of {report.stages_declared} "
+            f"stages not covered ({report.stages_unsweepable_upstream_pending} awaiting "
+            f"upstream / {report.stages_no_dry_path} no dry path / "
+            f"{report.stages_unmeasured} unmeasured) — {report.run_id}"
+        )
     else:
         subject = (
             f"[preflight-sweep] {report.stages_failed} failed / "
-            f"{report.stages_unsweepable} unsweepable / "
-            f"{report.stages_unmeasured} unmeasured of {report.stages_declared} "
-            f"— {report.run_id}"
+            f"{report.stages_unsweepable_coverage_defect} unsweepable / "
+            f"{report.stages_unmeasured} unmeasured / "
+            f"{report.stages_no_dry_path} no-dry-path / "
+            f"{report.stages_unsweepable_upstream_pending} awaiting-upstream "
+            f"of {report.stages_declared} — {report.run_id}"
         )
 
     lines = [
@@ -332,18 +635,50 @@ def render_notification(report: SweepReport) -> tuple[str, str]:
         "",
         f"declared {report.stages_declared} | swept {report.stages_swept} | "
         f"passed {report.stages_passed} | failed {report.stages_failed} | "
-        f"unmeasured {report.stages_unmeasured} | unsweepable {report.stages_unsweepable} | "
-        f"no-dry-path {report.stages_no_dry_path}",
+        f"unmeasured {report.stages_unmeasured} | "
+        f"unsweepable {report.stages_unsweepable} "
+        f"(coverage-defect {report.stages_unsweepable_coverage_defect}, "
+        f"awaiting-upstream {report.stages_unsweepable_upstream_pending}) | "
+        f"no-dry-path {report.stages_no_dry_path} | "
+        f"not-attempted {report.stages_not_attempted}",
         "",
     ]
-    if report.coverage_findings:
+    blocking = [f for f in report.coverage_findings if _is_blocking(f)]
+    acknowledged = [f for f in report.coverage_findings if not _is_blocking(f)]
+    if blocking:
         lines.append("COVERAGE FINDINGS (the sweep's own denominator is wrong):")
-        lines += [f"  - {f}" for f in report.coverage_findings]
+        lines += [f"  - {_finding_text(f)}" for f in blocking]
         lines.append("")
+    if acknowledged:
+        lines.append(
+            "COVERAGE GAPS (acknowledged in preflight_sweep_manifest.json — the sweep "
+            "does not cover these, which is not the same as their being healthy):"
+        )
+        lines += [f"  - {_finding_text(f)}" for f in acknowledged]
+        lines.append("")
+    if report.persistent_unsweepable_findings:
+        lines.append(
+            "PERSISTENTLY UNSWEEPABLE (measured nothing for a full threshold period "
+            "— this is NOT coverage):"
+        )
+        lines += [
+            f"  - {f['finding']}" for f in report.persistent_unsweepable_findings
+        ]
+        lines.append("")
+    if report.unsweepable_streak_state != "measured":
+        lines.append(
+            f"streak state: {report.unsweepable_streak_state} — the persistent-unsweepable "
+            "finding could not be evaluated this run."
+        )
+        lines.append("")
+    # EVERY non-passed category is named here, not only the failures. A
+    # category with a non-zero count and no members on the human-facing surface
+    # is a number nobody can act on (alpha-engine-config#7324).
     for verdict, header in (
         (FAILED, "FAILED"),
         (UNSWEEPABLE_VERDICT, "UNSWEEPABLE"),
         (UNMEASURED, "UNMEASURED (not a pass, not a defect)"),
+        (NO_DRY_PATH_VERDICT, "NO DRY PATH (declared, never exercised by the sweep)"),
         (NOT_ATTEMPTED, "NOT ATTEMPTED"),
     ):
         members = [r for r in report.results if r["verdict"] == verdict]
@@ -351,8 +686,14 @@ def render_notification(report: SweepReport) -> tuple[str, str]:
             lines.append(f"{header}:")
             for r in members:
                 detail = r.get("reason") or ""
+                kind = r.get("unsweepable_kind")
+                label = f"  - {r['stage']}"
+                if kind:
+                    label += f" [{kind}]"
                 err = r.get("last_stderr_line")
-                lines.append(f"  - {r['stage']}: {detail}")
+                lines.append(f"{label}: {detail}")
+                if r.get("acknowledged_reason"):
+                    lines.append(f"      acknowledged: {r['acknowledged_reason']}")
                 if err:
                     lines.append(f"      last stderr: {err}")
             lines.append("")
@@ -413,11 +754,23 @@ def sweep(
         # Map-scoped variable.
         base_bindings.setdefault("run_date", started.date().isoformat())
         required_map = derive_required_map_bindings(definition, base_bindings)
-        report.coverage_findings += map_binding_disagreement(required_map, manifest)
+        report.coverage_findings += [
+            _finding(FINDING_MAP_BINDING_DISAGREEMENT, f, blocking=True)
+            for f in map_binding_disagreement(required_map, manifest)
+        ]
         bindings = apply_map_bindings(base_bindings, manifest)
         context = {"Execution": {"Name": run_id, "Id": f"preflight-sweep:{run_id}"}}
         stages = derive_stages(definition, bindings, context, checkout_root)
-        report.coverage_findings += manifest_disagreement(stages, manifest)
+        report.coverage_findings += [
+            _finding(FINDING_MANIFEST_DISAGREEMENT, f, blocking=True)
+            for f in manifest_disagreement(stages, manifest)
+        ]
+        report.coverage_findings += [
+            _finding(FINDING_UPSTREAM_DECLARATION, f, blocking=True)
+            for f in upstream_dependency_disagreement(stages, manifest)
+        ]
+        upstream_decls = upstream_dependencies(manifest)
+        cadence = load_cadence()
     except Exception as exc:  # noqa: BLE001 — reported, never swallowed
         report.finished_at = dt.datetime.now(dt.timezone.utc).isoformat()
         report.outcome = OUTCOME_FAILED
@@ -431,6 +784,24 @@ def sweep(
 
     report.stages_declared = len(stages)
     report.stages_no_dry_path = sum(1 for s in stages if s.classification == NO_DRY_PATH)
+    # The declared stage list, serialised — so `declared - swept` is auditable
+    # from the report alone. A scalar nobody can expand is a count published
+    # without its members (alpha-engine-config#7324).
+    report.declared_stages = [
+        {
+            "stage": s.name,
+            "classification": s.classification,
+            "repo": s.repo,
+            "launcher": s.launcher,
+            "box_dir": s.box_dir,
+        }
+        for s in stages
+    ]
+    acknowledgements = {
+        entry["stage"]: entry
+        for entry in (manifest.get("no_dry_path_stages") or [])
+        if isinstance(entry, dict) and entry.get("stage")
+    }
 
     results: list[StageResult] = []
     for stage in stages:
@@ -439,9 +810,50 @@ def sweep(
                 StageResult(
                     stage=stage.name,
                     verdict=UNSWEEPABLE_VERDICT,
+                    unsweepable_kind=UNSWEEPABLE_COVERAGE_DEFECT,
                     repo=stage.repo,
                     launcher=stage.launcher,
                     reason=stage.reason,
+                )
+            )
+        elif stage.classification == NO_DRY_PATH:
+            # A verdict ROW, not just an increment. Before this, the three
+            # no-dry-path stages existed in the report only as the scalar
+            # `stages_no_dry_path: 3` — absent from results[], absent from the
+            # notification, and un-nameable after the fact.
+            ack = acknowledgements.get(stage.name)
+            results.append(
+                StageResult(
+                    stage=stage.name,
+                    verdict=NO_DRY_PATH_VERDICT,
+                    repo=stage.repo,
+                    launcher=stage.launcher,
+                    reason=stage.reason,
+                    acknowledged_reason=(ack or {}).get("reason"),
+                )
+            )
+            report.coverage_findings.append(
+                _finding(
+                    FINDING_NO_DRY_PATH,
+                    (
+                        f"{stage.name} has NO dry path and is never exercised by the sweep "
+                        f"(launcher={stage.launcher or 'n/a'}, repo={stage.repo or 'n/a'}). "
+                        + (
+                            f"Acknowledged {ack.get('acknowledged')}: {ack['reason']}"
+                            if ack
+                            else (
+                                "NOT acknowledged in preflight_sweep_manifest.json — the "
+                                "blocking manifest_disagreement finding above is the one "
+                                "that fails this run; this entry only names the gap."
+                            )
+                        )
+                    ),
+                    # Never blocking: an acknowledged gap is a reviewed decision,
+                    # and an UNacknowledged one already has its own blocking
+                    # manifest_disagreement finding. Emitting a second blocking
+                    # copy would make one fact fail the run twice.
+                    blocking=False,
+                    stage=stage.name,
                 )
             )
 
@@ -487,25 +899,142 @@ def sweep(
                             file=sys.stderr,
                         )
 
+    # ── Declared same-day upstream reclassification ──────────────────────────
+    # A stage whose preflight failed SOLELY because an upstream artifact of the
+    # same execution does not exist yet was not measured — it did not find a
+    # defect. The stages this may apply to are DECLARED in the manifest, so a
+    # reworded launcher error can never reclassify a real failure; the prefix
+    # is still probed on the day, so the declaration alone can never hide one.
+    lister = (lambda prefix: aws.list_objects(prefix)) if aws is not None else None
+    for result in results:
+        if result.verdict != FAILED:
+            continue
+        declaration = upstream_decls.get(result.stage)
+        if declaration is None:
+            continue
+        classify_upstream(result, declaration, bindings, lister)
+
     order = {s.name: i for i, s in enumerate(stages)}
+    # ── The invariant: every declared stage carries a verdict ────────────────
+    # `len(results) == stages_declared`. Its absence is the root cause of
+    # alpha-engine-config#7324: 19 declared, 16 rows, and the 3 missing stages
+    # unrecoverable from the report. A stage with no verdict is filled in as
+    # not_attempted AND raised as a blocking coverage finding — the sweep's own
+    # denominator is wrong, which outranks anything it found.
+    have = {r.stage for r in results}
+    for stage in stages:
+        if stage.name in have:
+            continue
+        results.append(
+            StageResult(
+                stage=stage.name,
+                verdict=NOT_ATTEMPTED,
+                repo=stage.repo,
+                launcher=stage.launcher,
+                reason=(
+                    "the sweep produced NO verdict for this declared stage — a hole in "
+                    "the sweep's own coverage, not a fact about the stage"
+                ),
+            )
+        )
+        report.coverage_findings.append(
+            _finding(
+                FINDING_MISSING_VERDICT,
+                (
+                    f"declared stage {stage.name!r} (classification "
+                    f"{stage.classification!r}) produced no verdict — len(results) did "
+                    "not equal stages_declared"
+                ),
+                blocking=True,
+                stage=stage.name,
+            )
+        )
     results.sort(key=lambda r: order.get(r.stage, 10**6))
-    report.results = [r.to_dict() for r in results]
+
     report.stages_swept = sum(1 for r in results if r.verdict in (PASSED, FAILED))
     report.stages_passed = sum(1 for r in results if r.verdict == PASSED)
     report.stages_failed = sum(1 for r in results if r.verdict == FAILED)
     report.stages_unmeasured = sum(1 for r in results if r.verdict == UNMEASURED)
     report.stages_unsweepable = sum(1 for r in results if r.verdict == UNSWEEPABLE_VERDICT)
+    report.stages_unsweepable_coverage_defect = sum(
+        1
+        for r in results
+        if r.verdict == UNSWEEPABLE_VERDICT
+        and r.unsweepable_kind != UNSWEEPABLE_UPSTREAM_PENDING
+    )
+    report.stages_unsweepable_upstream_pending = sum(
+        1
+        for r in results
+        if r.verdict == UNSWEEPABLE_VERDICT
+        and r.unsweepable_kind == UNSWEEPABLE_UPSTREAM_PENDING
+    )
+    report.stages_not_attempted = sum(1 for r in results if r.verdict == NOT_ATTEMPTED)
+
+    # ── Persistent-unsweepable streaks ───────────────────────────────────────
+    report.unsweepable_streak_threshold_runs = streak_threshold_runs(manifest, cadence)
+    if aws is None:
+        report.unsweepable_streak_state = (
+            "unavailable — the sweep had no S3 surface, so no streak history was read "
+            "or written"
+        )
+    else:
+        streak_key = f"{REPORT_PREFIX}/{STREAK_STATE_KEY_SUFFIX}"
+        try:
+            prior = aws.get_json(streak_key)
+        except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+            # Treating an unreadable history as "no history" would reset every
+            # streak to 1 on each run and make the finding structurally unable
+            # to fire. It is named instead, and nothing is written over it.
+            report.unsweepable_streak_state = (
+                f"unavailable — could not read {streak_key} "
+                f"({type(exc).__name__}: {exc}); streaks were NOT reset and the "
+                "persistent-unsweepable finding could not be evaluated"
+            )
+        else:
+            state, findings = update_streaks(
+                prior,
+                results,
+                run_id,
+                dt.datetime.now(dt.timezone.utc).isoformat(),
+                report.unsweepable_streak_threshold_runs,
+            )
+            report.persistent_unsweepable_findings = findings
+            try:
+                aws.put_json(streak_key, state)
+                report.unsweepable_streak_state = "measured"
+            except Exception as exc:  # noqa: BLE001
+                report.unsweepable_streak_state = (
+                    f"degraded — streaks were evaluated but could not be persisted to "
+                    f"{streak_key} ({type(exc).__name__}: {exc}); the next run will "
+                    "under-count"
+                )
+
+    report.results = [r.to_dict() for r in results]
     report.finished_at = dt.datetime.now(dt.timezone.utc).isoformat()
 
+    blocking_findings = [f for f in report.coverage_findings if _is_blocking(f)]
+    # A run is CLEAN only if every stage the sweep is accountable for passed.
+    # An acknowledged no-dry-path stage and a stage awaiting its upstream are
+    # not failures — and they are not passes either, so they keep the run out
+    # of OK and out of last_clean.json. Rendering "measured 14 of 19" as green
+    # is exactly the failure this component exists to avoid.
     clean = (
         report.stages_failed == 0
         and report.stages_unsweepable == 0
         and report.stages_unmeasured == 0
-        and not report.coverage_findings
+        and report.stages_not_attempted == 0
+        and report.stages_no_dry_path == 0
+        and not blocking_findings
     )
     if clean and report.stages_passed > 0:
         report.outcome = OUTCOME_OK
-    elif report.stages_failed or report.stages_unsweepable or report.coverage_findings:
+    elif (
+        report.stages_failed
+        or report.stages_unsweepable_coverage_defect
+        or report.stages_not_attempted
+        or blocking_findings
+        or report.persistent_unsweepable_findings
+    ):
         report.outcome = OUTCOME_FAILED
     else:
         # Nothing failed, but something could not be measured. Degraded, and
@@ -552,7 +1081,28 @@ def emit(report: SweepReport, aws: AwsSurface, sns_topic: str) -> None:
             ("PreflightSweepStagesFailed", report.stages_failed),
             ("PreflightSweepStagesUnmeasured", report.stages_unmeasured),
             ("PreflightSweepStagesUnsweepable", report.stages_unsweepable),
+            # Published separately and both at zero. Only the coverage-defect
+            # series may drive an alarm: a stage awaiting its same-day upstream
+            # is the ordinary weekday state and must not page (I7323).
+            (
+                "PreflightSweepStagesUnsweepableCoverageDefect",
+                report.stages_unsweepable_coverage_defect,
+            ),
+            (
+                "PreflightSweepStagesUnsweepableUpstreamPending",
+                report.stages_unsweepable_upstream_pending,
+            ),
+            ("PreflightSweepStagesNoDryPath", report.stages_no_dry_path),
+            ("PreflightSweepStagesNotAttempted", report.stages_not_attempted),
             ("PreflightSweepCoverageFindings", len(report.coverage_findings)),
+            (
+                "PreflightSweepCoverageFindingsBlocking",
+                len([f for f in report.coverage_findings if _is_blocking(f)]),
+            ),
+            (
+                "PreflightSweepPersistentUnsweepable",
+                len(report.persistent_unsweepable_findings),
+            ),
         ]
     )
     subject, message = render_notification(report)
@@ -598,6 +1148,7 @@ def main(argv: list[str] | None = None) -> int:
             args.checkout_root,
         )
         findings += manifest_disagreement(stages, manifest)
+        findings += upstream_dependency_disagreement(stages, manifest)
         print(
             json.dumps(
                 {

--- a/infrastructure/preflight_sweep_console.py
+++ b/infrastructure/preflight_sweep_console.py
@@ -93,13 +93,60 @@ _VERDICT_TO_STATUS = {
     "failed": ENVELOPE_ERROR,
     # A coverage defect: the stage declares a dry path the sweep cannot
     # exercise. Loud, because an unsweepable stage is an unmonitored stage.
+    # NOTE: an `unsweepable` row carrying unsweepable_kind="upstream_pending"
+    # is downgraded to ATTENTION below — see _UNSWEEPABLE_KIND_TO_STATUS.
     "unsweepable": ENVELOPE_ERROR,
     # Could not measure. NOT a pass and NOT a defect — "attention" is the
     # envelope's honest middle, and principles.md §2.7 forbids rendering it
     # green.
     "unmeasured": ENVELOPE_ATTENTION,
     "not_attempted": ENVELOPE_ATTENTION,
+    # A stage the definition declares with no dry path at all, acknowledged in
+    # preflight_sweep_manifest.json with a written reason. It is NOT green: the
+    # sweep asserts nothing whatever about it, and a row reading `ok` would
+    # claim precondition-health nobody measured. It is not an error either —
+    # the gap is declared and reviewed. ATTENTION is the honest rendering, and
+    # it is why the row exists at all rather than the stage being absent from
+    # the console (alpha-engine-config#7324).
+    "no_dry_path": ENVELOPE_ATTENTION,
 }
+
+# An `unsweepable` stage has two very different causes, and the console must
+# not render them identically. A coverage defect (missing launcher, missing
+# --preflight-only branch, unrenderable command) means a stage that SHOULD be
+# monitored is not: error. An unmet same-day upstream means the stage cannot be
+# exercised until its producer has run for real — the ordinary state on ~6 days
+# of any week: attention, never error, never green (alpha-engine-config#7323).
+_UNSWEEPABLE_KIND_TO_STATUS = {
+    "coverage_defect": ENVELOPE_ERROR,
+    "upstream_pending": ENVELOPE_ATTENTION,
+}
+
+
+def is_blocking_finding(finding: Any) -> bool:
+    """Does this coverage finding mean the sweep's own denominator is WRONG?
+
+    Findings carry their own severity because two different things live in the
+    same list: a denominator defect (a stage silently lost its dry path — the
+    sweep is measuring the wrong pipeline) and an acknowledged coverage gap (a
+    stage that has no dry path, written down with a reason). Both must be NAMED
+    on every surface; only the first may fail the run.
+
+    A bare string is treated as blocking. That is the legacy shape written by
+    ``preflight_sweep.sh``'s could-not-measure payload and by any report
+    predating the structured form, and defaulting an unknown shape to blocking
+    keeps the fail-loud direction.
+    """
+    if isinstance(finding, dict):
+        return bool(finding.get("blocking", True))
+    return True
+
+
+def finding_text(finding: Any) -> str:
+    """The human-readable body of a coverage finding, either shape."""
+    if isinstance(finding, dict):
+        return str(finding.get("finding", finding))
+    return str(finding)
 
 
 class CadenceError(RuntimeError):
@@ -157,6 +204,12 @@ def stage_envelope(
         status = ENVELOPE_ATTENTION
         verdict = f"{verdict or 'missing'} (no declared envelope mapping)"
 
+    kind = result.get("unsweepable_kind")
+    if verdict == "unsweepable" and kind is not None:
+        # An unrecognised kind keeps the ERROR default: a new kind must be
+        # added by PR here, not absorbed into the quieter status.
+        status = _UNSWEEPABLE_KIND_TO_STATUS.get(kind, ENVELOPE_ERROR)
+
     return {
         "check_id": stage_check_id(result["stage"]),
         "status": status,
@@ -165,6 +218,9 @@ def stage_envelope(
         "component_id": stage_check_id(result["stage"]),
         "stage": result["stage"],
         "verdict": verdict,
+        "unsweepable_kind": kind,
+        "upstream": result.get("upstream"),
+        "acknowledged_reason": result.get("acknowledged_reason"),
         "repo": result.get("repo"),
         "launcher": result.get("launcher"),
         "returncode": result.get("returncode"),
@@ -200,19 +256,38 @@ def rollup_envelope(
     # acknowledged set and the definition disagree in either direction — so it
     # cannot be used to quietly shrink what is being counted.
     expected = max(declared - no_dry_path, 0)
-    reported = len(report.get("results", []))
+    results = report.get("results", []) or []
+    # Stages the sweep is accountable for AND produced a verdict for. A
+    # `no_dry_path` row is a verdict, but it is not coverage — counting it here
+    # would let the acknowledged gaps cancel out the stages they represent and
+    # drive `stages_unobserved` to zero while nothing was exercised.
+    reported = len([r for r in results if r.get("verdict") != "no_dry_path"])
     unobserved = max(expected - reported, 0)
+    findings = report.get("coverage_findings", []) or []
+    blocking = [f for f in findings if is_blocking_finding(f)]
+    persistent = report.get("persistent_unsweepable_findings", []) or []
+    coverage_defects = int(report.get("stages_unsweepable_coverage_defect", 0) or 0)
+    upstream_pending = int(report.get("stages_unsweepable_upstream_pending", 0) or 0)
+    if not report.get("stages_unsweepable_coverage_defect") and not upstream_pending:
+        # A report predating the kind split (or the shell's could-not-measure
+        # payload) carries only the total. Attribute it to the loud kind rather
+        # than assume the quiet one.
+        coverage_defects = int(report.get("stages_unsweepable", 0) or 0)
 
     if not report.get("measured", False):
         status = ENVELOPE_ERROR
     elif (
         report.get("stages_failed")
-        or report.get("stages_unsweepable")
-        or report.get("coverage_findings")
+        or coverage_defects
+        or blocking
+        or persistent
         or unobserved
     ):
         status = ENVELOPE_ERROR
-    elif report.get("stages_unmeasured"):
+    elif report.get("stages_unmeasured") or upstream_pending or no_dry_path:
+        # Nothing is broken, but the sweep did not cover everything it declares.
+        # Rendering that green is the failure mode this component exists to
+        # avoid: "no data" is never green (principles.md §2.7).
         status = ENVELOPE_ATTENTION
     else:
         status = ENVELOPE_OK
@@ -236,14 +311,34 @@ def rollup_envelope(
         "stages_failed": report.get("stages_failed", 0),
         "stages_unmeasured": report.get("stages_unmeasured", 0),
         "stages_unsweepable": report.get("stages_unsweepable", 0),
-        "stages_no_dry_path": report.get("stages_no_dry_path", 0),
-        "coverage_findings": report.get("coverage_findings", []),
+        "stages_unsweepable_coverage_defect": coverage_defects,
+        "stages_unsweepable_upstream_pending": upstream_pending,
+        "stages_no_dry_path": no_dry_path,
+        "stages_not_attempted": report.get("stages_not_attempted", 0),
+        # Named, not counted: which stages have no dry path, and which have
+        # been unsweepable long enough to be a finding in their own right.
+        "no_dry_path_stages": [
+            r.get("stage") for r in results if r.get("verdict") == "no_dry_path"
+        ],
+        "upstream_pending_stages": [
+            r.get("stage")
+            for r in results
+            if r.get("verdict") == "unsweepable"
+            and r.get("unsweepable_kind") == "upstream_pending"
+        ],
+        "coverage_findings": findings,
+        "coverage_findings_blocking": len(blocking),
+        "persistent_unsweepable_findings": persistent,
+        "unsweepable_streak_state": report.get("unsweepable_streak_state", "unavailable"),
+        "declared_stages": report.get("declared_stages", []),
         "definition_sha": report.get("definition_sha"),
         "summary": (
             f"All-stage preflight sweep: {report.get('stages_passed', 0)} passed, "
             f"{report.get('stages_failed', 0)} failed, "
             f"{report.get('stages_unmeasured', 0)} unmeasured, "
-            f"{report.get('stages_unsweepable', 0)} unsweepable, "
+            f"{coverage_defects} unsweepable (coverage defect), "
+            f"{upstream_pending} awaiting upstream, "
+            f"{no_dry_path} with no dry path, "
             f"{unobserved} unobserved of {expected} expected "
             f"({declared} declared, {no_dry_path} acknowledged as having no dry path). "
             + _PRECONDITION_SCOPE

--- a/infrastructure/preflight_sweep_manifest.json
+++ b/infrastructure/preflight_sweep_manifest.json
@@ -19,6 +19,32 @@
     }
   ],
 
+  "_upstream_purpose": "DECLARED same-day upstream artifact dependencies. A stage listed here reads an artifact that a PRECEDING stage of the same execution produces, so its preflight cannot pass on a day the real pipeline has not already run — a --preflight-only run by definition does not produce its stage's output. Such a stage is UNSWEEPABLE that day (could not measure), never FAILED (found a defect). The classification is DECLARED HERE and nowhere else: it is never inferred from the launcher's stderr text, so rewording an error message cannot reclassify a real failure as unsweepable, and adding a dependency is a reviewed diff. The declaration only ARMS the reclassification — the sweep still probes the named prefix on the day, and a stage that fails while its upstream prefix IS populated stays FAILED.",
+
+  "unsweepable_streak_threshold_days": 8,
+  "_unsweepable_streak_threshold_reason": "A stage that is unsweepable on EVERY run for this many consecutive days is its own finding (the sweep covers nothing there), emitted separately from coverage_findings so it never reads as coverage. 8 days is one full weekly-pipeline cycle plus one: the backtest chain is legitimately unsweepable on the ~6 non-Saturday days of any week, so a threshold of 7 or less would fire on the normal case, and a threshold of 8 fires only when a whole weekly cycle passed without the stage ever becoming measurable — which means either the weekly pipeline stopped running or the dependency declaration is wrong. Counted in RUNS internally, derived as threshold_days x (1440 / cadence_minutes) from preflight_sweep_cadence.json, so changing the sweep cadence does not silently change what this means.",
+
+  "upstream_artifact_dependencies": [
+    {
+      "stage": "PredictorBacktest",
+      "produced_by": "Backtester",
+      "prefix": "backtest/{run_date}/",
+      "ignore_subprefixes": [".phases/"],
+      "reason": "spot_predictor_backtest.sh's stage preflight asserts spot_common_s3_prefix_nonempty \"backtest/${RUN_DATE}/\" — the Backtester stage's sweep output. Backtester's own --preflight-only run exits before producing it, so on any day the real weekly pipeline has not run, this stage's preconditions are unknowable rather than broken. Reported as FAILED on the sweep's first run (preflight-sweep-20260814T080010Z), which is alpha-engine-config#7323.",
+      "acknowledged": "2026-08-14"
+    },
+    {
+      "stage": "PortfolioOptimizerBacktest",
+      "produced_by": "PredictorBacktest",
+      "prefix": "backtest/{run_date}/",
+      "ignore_subprefixes": [".phases/"],
+      "reason": "spot_portfolio_optimizer_backtest.sh asserts the same prefix, one link further down the Backtester -> PredictorBacktest -> PortfolioOptimizerBacktest chain. Same structural argument, same first-run false failure.",
+      "acknowledged": "2026-08-14"
+    }
+  ],
+
+  "_ignore_subprefixes_reason": "NON-INFERABLE GOTCHA. s3://alpha-engine-research/backtest/<date>/ EXISTS on a day nothing produced it, because the sweep's OWN phase markers (.phases/preflight.json, .phases/runtime_smoke.json) are written under it. A probe testing prefix EXISTENCE rather than prefix CONTENT would read as satisfied and measure nothing — it would silently re-classify every real upstream failure as a genuine stage failure and every genuine failure as real, i.e. it would do nothing at all while appearing to work. Keys under an ignored sub-prefix, and zero-byte keys, do not count as upstream content.",
+
   "map_bindings": {
     "spec_id": {
       "value": "preflight-sweep-synthetic-spec",

--- a/infrastructure/preflight_sweep_stages.py
+++ b/infrastructure/preflight_sweep_stages.py
@@ -82,6 +82,8 @@ __all__ = [
     "derive_stages",
     "load_manifest",
     "manifest_disagreement",
+    "upstream_dependencies",
+    "upstream_dependency_disagreement",
 ]
 
 # ── Stage classification (closed vocabulary; add by PR) ──────────────────────
@@ -468,6 +470,96 @@ def map_binding_disagreement(required: set[str], manifest: dict) -> list[str]:
             f"manifest declares map_bindings.{key}, but no stage command references "
             "$.%s any more — drop the stale entry" % key
         )
+    return findings
+
+
+_REQUIRED_UPSTREAM_FIELDS = ("stage", "produced_by", "prefix", "reason")
+
+
+def upstream_dependencies(manifest: dict) -> dict[str, dict]:
+    """The DECLARED same-day upstream artifact dependency of each stage.
+
+    Keyed by stage name. This is the ONLY place a stage's preflight failure may
+    be reclassified from ``failed`` to ``unsweepable`` — the decision is never
+    taken from the launcher's stderr text, so rewording an error message cannot
+    turn a real failure into a "could not measure". Adding a dependency is a
+    reviewed diff against this manifest.
+
+    An entry missing a required field is dropped and reported by
+    ``upstream_dependency_disagreement`` rather than half-applied: a declaration
+    the sweep cannot act on must not silently arm a reclassification.
+    """
+    out: dict[str, dict] = {}
+    for entry in manifest.get("upstream_artifact_dependencies", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        if any(not entry.get(f) for f in _REQUIRED_UPSTREAM_FIELDS):
+            continue
+        out[entry["stage"]] = entry
+    return out
+
+
+def upstream_dependency_disagreement(stages: list[Stage], manifest: dict) -> list[str]:
+    """Differences between the declared upstream dependencies and the pipeline.
+
+    Only the stale direction is derivable: nothing in ``step_function.json``
+    says a stage reads a same-day upstream artifact — that lives in the
+    launcher's own preflight — so the sweep cannot detect a MISSING declaration
+    here. It is detected the other way instead, at run time: an undeclared
+    upstream failure stays ``failed`` and pages, which is the safe direction.
+
+    What IS checked, in both stale directions:
+
+    * a declaration for a stage the definition no longer has, or that no longer
+      threads ``$.preflight_args`` — the acknowledgement went stale and would
+      arm a reclassification for nothing. Checked against the DEFINITION-level
+      classification only: whether the launcher happens to be present in this
+      particular checkout is a fact about the checkout, and treating that as a
+      stale declaration would make the check fire everywhere the repo is not
+      deployed;
+    * a declaration naming a producing stage that is not in the definition —
+      the reason line points at a stage that does not exist;
+    * a malformed declaration (missing a required field), which
+      ``upstream_dependencies`` drops.
+    """
+    by_name = {s.name: s for s in stages}
+    has_dry_path = {s.name for s in stages if s.classification != NO_DRY_PATH}
+    findings: list[str] = []
+    for entry in manifest.get("upstream_artifact_dependencies", []) or []:
+        if not isinstance(entry, dict):
+            findings.append(
+                "upstream_artifact_dependencies contains a non-object entry "
+                f"({entry!r}) — it declares nothing and arms nothing"
+            )
+            continue
+        name = entry.get("stage") or "<unnamed>"
+        missing = [f for f in _REQUIRED_UPSTREAM_FIELDS if not entry.get(f)]
+        if missing:
+            findings.append(
+                f"upstream_artifact_dependencies entry for {name!r} is missing "
+                f"{', '.join(missing)} — it is DROPPED, so the stage would still be "
+                "reported as a real failure when its upstream is simply absent"
+            )
+            continue
+        if name not in by_name:
+            findings.append(
+                f"manifest declares an upstream dependency for stage {name!r}, which the "
+                "definition does not contain (renamed or removed) — drop the stale entry"
+            )
+            continue
+        if name not in has_dry_path:
+            findings.append(
+                f"manifest declares an upstream dependency for stage {name!r}, but that "
+                f"stage is classified {NO_DRY_PATH!r} — it is never exercised at all, so "
+                "the declaration can never apply; drop it or give the stage a dry path"
+            )
+        producer = entry["produced_by"]
+        if producer not in by_name:
+            findings.append(
+                f"upstream dependency for {name!r} names produced_by={producer!r}, which is "
+                "not a stage in the definition — the reason an operator reads would point "
+                "at a stage that does not exist"
+            )
     return findings
 
 

--- a/registry.d/ae-preflight-sweep.yaml
+++ b/registry.d/ae-preflight-sweep.yaml
@@ -46,6 +46,19 @@ metrics:
         stages_failed: {unit: count, baseline: 0, render: count}
         stages_unmeasured: {unit: count, baseline: 0, render: count}
         stages_unsweepable: {unit: count, baseline: 0, render: count}
+        # The two kinds of unsweepable, rendered apart. A coverage defect means
+        # a stage that SHOULD be monitored is not; an upstream-pending stage is
+        # simply not measurable until its producer has run for real, which is
+        # the ordinary state on the ~6 non-Saturday days of any week. Collapsing
+        # them is what made the sweep's first run email "2 failed" (config#7323).
+        stages_unsweepable_coverage_defect: {unit: count, baseline: 0, render: count}
+        stages_unsweepable_upstream_pending: {unit: count, render: count}
+        # Published at zero as well: a stage the pipeline declares and the
+        # sweep never exercises is a coverage gap whose absence from the surface
+        # is indistinguishable from health (config#7324).
+        stages_no_dry_path: {unit: count, render: count}
+        stages_not_attempted: {unit: count, baseline: 0, render: count}
+        unsweepable_streak_state: {render: text}
         definition_sha: {render: text}
     - key: "s3://alpha-engine-research/ops/checks/ae-preflight-sweep/latest.json"
       fields:
@@ -56,12 +69,20 @@ metrics:
         # a coverage figure that only appears when non-zero cannot be told
         # apart from health when it is absent.
         stages_unobserved: {unit: count, baseline: 0, render: count}
+        # Findings, split by whether they mean the sweep's own denominator is
+        # WRONG (blocking) or that a declared gap exists (named, acknowledged).
+        coverage_findings_blocking: {unit: count, baseline: 0, render: count}
+        # Named, never counted: which stages have no dry path, and which are
+        # waiting on a same-day upstream this run.
+        no_dry_path_stages: {render: text}
+        upstream_pending_stages: {render: text}
         declared_cadence: {render: text}
   cadence_minutes: 1440
 
 produces:
   - "_preflight_sweep/latest.json"
   - "_preflight_sweep/last_clean.json"
+  - "_preflight_sweep/unsweepable_streaks.json"
   - "ops/checks/ae-preflight-sweep/latest.json"
 
 # The direction that matters: who breaks if this is stale. The sweep reads the

--- a/tests/test_preflight_sweep.py
+++ b/tests/test_preflight_sweep.py
@@ -28,6 +28,7 @@ from infrastructure.preflight_sweep_console import (
     stage_check_id,
     stage_envelope,
 )
+from infrastructure.preflight_sweep import update_streaks
 from infrastructure.preflight_sweep_stages import Stage
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -37,13 +38,22 @@ CADENCE_PATH = REPO / "infrastructure" / "preflight_sweep_cadence.json"
 
 
 class FakeAws:
-    def __init__(self):
+    def __init__(self, listing: dict[str, list[dict]] | None = None):
         self.objects: dict[str, dict] = {}
         self.metrics: list[tuple[str, float]] = []
         self.notifications: list[tuple[str, str]] = []
+        self.listing = listing or {}
+        self.list_calls: list[str] = []
 
     def put_json(self, key, payload):
         self.objects[key] = payload
+
+    def get_json(self, key):
+        return self.objects.get(key)
+
+    def list_objects(self, prefix, max_keys=1000):
+        self.list_calls.append(prefix)
+        return self.listing.get(prefix, [])
 
     def put_text(self, key, body):
         self.objects[key] = body
@@ -238,7 +248,408 @@ def test_the_live_definition_derives_a_non_empty_stage_set(tmp_path):
     """Guards against the sweep silently grading an empty pipeline."""
     report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
     assert report.stages_declared > 0
+    # No BLOCKING finding: the acknowledged no-dry-path stages are findings by
+    # design now (they must be named), and they must not fail the run.
+    assert [f for f in report.coverage_findings if ps._is_blocking(f)] == []
+
+
+# ── I7323: an unmet same-day upstream is UNSWEEPABLE, never FAILED ───────────
+
+DECL = {
+    "stage": "PredictorBacktest",
+    "produced_by": "Backtester",
+    "prefix": "backtest/{run_date}/",
+    "ignore_subprefixes": [".phases/"],
+    "reason": "declared",
+}
+BINDINGS = {"run_date": "2026-08-14"}
+
+
+def _failed(stage="PredictorBacktest"):
+    return ps.StageResult(stage=stage, verdict=ps.FAILED, returncode=1,
+                          reason="preflight exited rc=1")
+
+
+def test_a_failure_on_an_absent_declared_upstream_is_unsweepable_not_failed():
+    result = ps.classify_upstream(_failed(), DECL, BINDINGS, lambda _p: [])
+    assert result.verdict == ps.UNSWEEPABLE_VERDICT
+    assert result.unsweepable_kind == ps.UNSWEEPABLE_UPSTREAM_PENDING
+    # The reason must name BOTH the unmet prefix and its producing stage —
+    # otherwise the operator gets a verdict with nothing to act on.
+    assert "backtest/2026-08-14/" in result.reason
+    assert "Backtester" in result.reason
+
+
+def test_the_prefix_gotcha_a_prefix_holding_only_sweep_markers_is_not_content():
+    """NON-INFERABLE: backtest/<date>/ EXISTS on a day nothing produced it,
+    because the sweep's own .phases/ markers live under it. A probe testing
+    prefix EXISTENCE would read as satisfied and measure nothing at all."""
+    listing = [
+        {"Key": "backtest/2026-08-14/.phases/preflight.json", "Size": 235},
+        {"Key": "backtest/2026-08-14/.phases/runtime_smoke.json", "Size": 239},
+    ]
+    present, detail = ps.upstream_content(
+        "backtest/2026-08-14/", [".phases/"], lambda _p: listing
+    )
+    assert present is False
+    assert detail["content_keys"] == 0 and detail["ignored_keys"] == 2
+
+    result = ps.classify_upstream(_failed(), DECL, BINDINGS, lambda _p: listing)
+    assert result.verdict == ps.UNSWEEPABLE_VERDICT
+
+
+def test_a_zero_byte_key_is_not_upstream_content():
+    present, _ = ps.upstream_content(
+        "backtest/2026-08-14/",
+        [".phases/"],
+        lambda _p: [{"Key": "backtest/2026-08-14/_SUCCESS", "Size": 0}],
+    )
+    assert present is False
+
+
+def test_a_real_failure_stays_failed_when_its_declared_upstream_is_populated():
+    """The regression this whole mechanism must not introduce: a declaration
+    that swallows genuine defects. The declaration only ARMS the check; the
+    prefix is still probed on the day."""
+    listing = [
+        {"Key": "backtest/2026-08-14/.phases/preflight.json", "Size": 235},
+        {"Key": "backtest/2026-08-14/results/portfolio.parquet", "Size": 91234},
+    ]
+    result = ps.classify_upstream(_failed(), DECL, BINDINGS, lambda _p: listing)
+    assert result.verdict == ps.FAILED
+    assert "REAL failure" in result.reason
+
+
+def test_a_reworded_launcher_error_cannot_reclassify_anything():
+    """The classification is DECLARED per stage, never inferred from stderr.
+    A stage with no declaration keeps its failure however its error reads."""
+    result = _failed(stage="DataPhase1")
+    result.last_stderr_line = (
+        "ERROR: s3://alpha-engine-research/backtest/2026-08-14/ is empty or unreachable."
+    )
+    # sweep() only consults upstream_dependencies(manifest); DataPhase1 is not
+    # in it, so classify_upstream is never reached for that stage.
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    from infrastructure.preflight_sweep_stages import upstream_dependencies
+
+    assert "DataPhase1" not in upstream_dependencies(manifest)
+    assert result.verdict == ps.FAILED
+
+
+def test_an_unprobeable_upstream_is_unmeasured_not_a_guess_in_either_direction():
+    def boom(_prefix):
+        raise RuntimeError("AccessDenied")
+
+    result = ps.classify_upstream(_failed(), DECL, BINDINGS, boom)
+    assert result.verdict == ps.UNMEASURED
+    assert result.verdict not in (ps.FAILED, ps.UNSWEEPABLE_VERDICT)
+    assert "AccessDenied" in result.reason
+
+
+def test_an_upstream_pending_stage_does_not_count_toward_failures_or_page():
+    report = ps.SweepReport(
+        component_id=ps.COMPONENT_ID, run_id="t", started_at="now",
+        outcome=ps.OUTCOME_DEGRADED, measured=True, stages_declared=2,
+        stages_failed=0, stages_unsweepable=1,
+        stages_unsweepable_upstream_pending=1, stages_unsweepable_coverage_defect=0,
+        results=[
+            {"stage": "Backtester", "verdict": ps.PASSED},
+            {"stage": "PredictorBacktest", "verdict": ps.UNSWEEPABLE_VERDICT,
+             "unsweepable_kind": ps.UNSWEEPABLE_UPSTREAM_PENDING,
+             "reason": "NOT MEASURABLE TODAY — backtest/2026-08-14/"},
+        ],
+    )
+    aws = FakeAws()
+    ps.emit(report, aws, "arn:sns")
+    assert ("PreflightSweepStagesFailed", 0) in aws.metrics
+    assert ("PreflightSweepStagesUnsweepableUpstreamPending", 1) in aws.metrics
+    assert ("PreflightSweepStagesUnsweepableCoverageDefect", 0) in aws.metrics
+    subject, _ = ps.render_notification(report)
+    assert "failed" not in subject.split("—")[0].lower() or "no failures" in subject
+    # And it never advances the clean-run pointer: nothing failed, but the
+    # sweep did not cover everything it declares.
+    assert f"{ps.REPORT_PREFIX}/last_clean.json" not in aws.objects
+
+
+def test_a_coverage_defect_unsweepable_still_fails_the_run(tmp_path):
+    """The loud kind must stay loud: /nonexistent has no launchers at all."""
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    assert report.stages_unsweepable_coverage_defect > 0
+    assert report.outcome == ps.OUTCOME_FAILED
+
+
+# ── I7323 (3): unsweepable forever is its own finding, not coverage ──────────
+
+
+def _unsweepable(stage="PredictorBacktest"):
+    return ps.StageResult(
+        stage=stage, verdict=ps.UNSWEEPABLE_VERDICT,
+        unsweepable_kind=ps.UNSWEEPABLE_UPSTREAM_PENDING, reason="upstream absent",
+    )
+
+
+def test_a_streak_below_the_threshold_is_not_yet_a_finding():
+    state, findings = update_streaks(None, [_unsweepable()], "r1", "now", 8)
+    assert state["streaks"]["PredictorBacktest"]["consecutive_runs"] == 1
+    assert findings == []
+
+
+def test_unsweepable_on_every_run_past_the_threshold_becomes_its_own_finding():
+    prior = {"streaks": {"PredictorBacktest": {"consecutive_runs": 7, "since": "d0"}}}
+    _state, findings = update_streaks(prior, [_unsweepable()], "r8", "now", 8)
+    assert len(findings) == 1
+    assert findings[0]["stage"] == "PredictorBacktest"
+    assert findings[0]["consecutive_runs"] == 8
+    assert "measured NOTHING" in findings[0]["finding"]
+
+
+def test_a_stage_that_became_measurable_has_its_streak_dropped():
+    prior = {"streaks": {"PredictorBacktest": {"consecutive_runs": 7, "since": "d0"}}}
+    passed = ps.StageResult(stage="PredictorBacktest", verdict=ps.PASSED)
+    state, findings = update_streaks(prior, [passed], "r8", "now", 8)
+    assert "PredictorBacktest" not in state["streaks"]
+    assert findings == []
+
+
+def test_the_persistent_finding_is_emitted_separately_from_coverage_findings():
+    """It must not read as coverage: a stage nothing has measured for a week is
+    the opposite of a covered stage."""
+    report = ps.SweepReport(
+        component_id=ps.COMPONENT_ID, run_id="t", started_at="now",
+        outcome=ps.OUTCOME_FAILED, measured=True, stages_declared=1,
+        persistent_unsweepable_findings=[
+            {"stage": "PredictorBacktest", "consecutive_runs": 9, "threshold_runs": 8,
+             "since": "d0", "finding": "PredictorBacktest measured NOTHING for 9 runs"}
+        ],
+        results=[{"stage": "PredictorBacktest", "verdict": ps.UNSWEEPABLE_VERDICT,
+                  "unsweepable_kind": ps.UNSWEEPABLE_UPSTREAM_PENDING}],
+    )
     assert report.coverage_findings == []
+    _subject, message = ps.render_notification(report)
+    assert "PERSISTENTLY UNSWEEPABLE" in message
+    aws = FakeAws()
+    ps.emit(report, aws, "arn:sns")
+    assert ("PreflightSweepPersistentUnsweepable", 1) in aws.metrics
+
+
+def test_the_streak_threshold_is_declared_in_days_and_derived_against_cadence():
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    cadence = load_cadence(CADENCE_PATH)
+    assert manifest["unsweepable_streak_threshold_days"] > 7, (
+        "a threshold of 7 or less fires on the ordinary weekday state of the "
+        "backtest chain and would page every week"
+    )
+    assert ps.streak_threshold_runs(manifest, cadence) == (
+        manifest["unsweepable_streak_threshold_days"]
+    ), "daily cadence means one run per day"
+
+
+def test_an_unreadable_streak_history_is_named_never_treated_as_no_history(tmp_path):
+    """Silently resetting to zero would make the finding unable to fire — the
+    exact bug class of a detector that cannot report."""
+
+    class Broken(FakeAws):
+        def get_json(self, key):
+            raise RuntimeError("AccessDenied")
+
+    aws = Broken()
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t", aws=aws)
+    assert "unavailable" in report.unsweepable_streak_state
+    assert "AccessDenied" in report.unsweepable_streak_state
+    assert f"{ps.REPORT_PREFIX}/{ps.STREAK_STATE_KEY_SUFFIX}" not in aws.objects
+
+
+# ── I7324: every declared stage carries a verdict, named on every surface ────
+
+
+def test_every_declared_stage_carries_a_verdict_row():
+    """THE missing assertion that is I7324's root cause: 19 declared, 16 rows,
+    and which 3 were missing was unrecoverable from the report."""
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    assert len(report.results) == report.stages_declared
+    assert {r["stage"] for r in report.results} == {
+        s["stage"] for s in report.declared_stages
+    }
+
+
+def test_the_declared_stage_list_is_serialised_so_declared_minus_swept_is_auditable():
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    assert len(report.declared_stages) == report.stages_declared
+    assert all({"stage", "classification"} <= set(s) for s in report.declared_stages)
+
+
+def test_a_no_dry_path_stage_gets_its_own_verdict_row_with_repo_and_launcher():
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    rows = [r for r in report.results if r["verdict"] == ps.NO_DRY_PATH_VERDICT]
+    assert len(rows) == report.stages_no_dry_path > 0
+    for row in rows:
+        assert row["reason"], "a row with no reason is a count with extra steps"
+        assert row["acknowledged_reason"], (
+            "the manifest's written acknowledgement must reach the report — an "
+            "operator must not have to open the repo to learn why"
+        )
+        assert set(row) >= {"stage", "repo", "launcher", "reason"}
+
+
+def test_coverage_findings_are_non_empty_whenever_a_stage_has_no_dry_path():
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    assert report.stages_no_dry_path > 0
+    named = {f.get("stage") for f in report.coverage_findings
+             if f.get("kind") == ps.FINDING_NO_DRY_PATH}
+    assert named == {
+        r["stage"] for r in report.results if r["verdict"] == ps.NO_DRY_PATH_VERDICT
+    }
+
+
+def test_an_acknowledged_no_dry_path_gap_is_named_but_does_not_fail_the_run():
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    gaps = [f for f in report.coverage_findings
+            if f["kind"] == ps.FINDING_NO_DRY_PATH]
+    assert gaps and all(f["blocking"] is False for f in gaps)
+
+
+def test_the_notification_names_every_non_passed_category_not_only_failures():
+    report = ps.SweepReport(
+        component_id=ps.COMPONENT_ID, run_id="t", started_at="now",
+        outcome=ps.OUTCOME_DEGRADED, measured=True,
+        stages_declared=4, stages_passed=1, stages_no_dry_path=1,
+        stages_unsweepable=1, stages_unsweepable_upstream_pending=1,
+        stages_unmeasured=1,
+        coverage_findings=[
+            {"kind": ps.FINDING_NO_DRY_PATH, "stage": "SaturdayHealthCheck",
+             "blocking": False, "finding": "SaturdayHealthCheck has NO dry path"},
+        ],
+        results=[
+            {"stage": "DataPhase1", "verdict": ps.PASSED},
+            {"stage": "SaturdayHealthCheck", "verdict": ps.NO_DRY_PATH_VERDICT,
+             "reason": "threads no $.preflight_args",
+             "acknowledged_reason": "consumer, not a precondition"},
+            {"stage": "PredictorBacktest", "verdict": ps.UNSWEEPABLE_VERDICT,
+             "unsweepable_kind": ps.UNSWEEPABLE_UPSTREAM_PENDING,
+             "reason": "NOT MEASURABLE TODAY"},
+            {"stage": "EvaluatorOptimize", "verdict": ps.UNMEASURED,
+             "reason": "worker died"},
+        ],
+    )
+    subject, message = ps.render_notification(report)
+    # Every non-passed stage is named in the BODY.
+    for stage in ("SaturdayHealthCheck", "PredictorBacktest", "EvaluatorOptimize"):
+        assert stage in message, stage
+    assert "NO DRY PATH" in message
+    assert "consumer, not a precondition" in message
+    # And the subject's denominator is not silently over a hidden category.
+    assert "no dry path" in subject or "no-dry-path" in subject
+    assert "4" in subject
+
+
+def test_a_missing_verdict_is_filled_in_as_not_attempted_and_fails_the_run():
+    """The invariant is self-healing AND loud: a hole in the sweep's own
+    coverage outranks anything the sweep found."""
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, "/nonexistent", "t")
+    assert len(report.results) == report.stages_declared
+    # Nothing should be missing today; the guard is that if it ever is, the
+    # run fails rather than under-reporting.
+    if report.stages_not_attempted:
+        assert report.outcome == ps.OUTCOME_FAILED
+
+
+# ── End to end, over the LIVE definition ─────────────────────────────────────
+
+
+def _fake_checkout(root: pathlib.Path) -> pathlib.Path:
+    """A checkout where every declared launcher exists and implements the flag,
+    so the live definition's stages classify SWEEPABLE and actually run."""
+    from infrastructure.preflight_sweep_stages import (
+        derive_shell_run_bindings,
+        derive_stages,
+        apply_map_bindings,
+        load_manifest,
+    )
+
+    definition = json.loads(SF_PATH.read_text())
+    manifest = load_manifest(MANIFEST_PATH)
+    bindings = apply_map_bindings(derive_shell_run_bindings(definition), manifest)
+    bindings.setdefault("run_date", "2026-08-14")
+    for stage in derive_stages(definition, bindings, {"Execution": {"Name": "t", "Id": "t"}}, "/x"):
+        if not (stage.box_dir and stage.launcher):
+            continue
+        path = root / stage.box_dir / stage.launcher
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/bash\n# --preflight-only\n")
+    return root
+
+
+def test_the_weekday_case_end_to_end_zero_failures_and_no_page(tmp_path):
+    """THE case that made the sweep's first run email '2 failed': the weekly SF
+    has not run today, so the backtest chain's upstream prefix holds only the
+    sweep's own phase markers."""
+    root = _fake_checkout(tmp_path)
+
+    def runner(argv, **_kwargs):
+        script = argv[-1]
+        rc = 1 if ("spot_predictor_backtest.sh" in script
+                   or "spot_portfolio_optimizer_backtest.sh" in script) else 0
+        return subprocess.CompletedProcess(
+            args=argv, returncode=rc, stdout="",
+            stderr=("ERROR: s3://alpha-engine-research/backtest/2026-08-14/ is empty "
+                    "or unreachable.\n" if rc else ""),
+        )
+
+    run_date = dt.date.today().isoformat()
+    aws = FakeAws(listing={f"backtest/{run_date}/": [
+        {"Key": f"backtest/{run_date}/.phases/preflight.json", "Size": 235},
+        {"Key": f"backtest/{run_date}/.phases/runtime_smoke.json", "Size": 239},
+    ]})
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, str(root), "t", aws=aws, runner=runner)
+
+    assert report.stages_failed == 0
+    assert report.stages_unsweepable_upstream_pending == 2
+    assert report.stages_unsweepable_coverage_defect == 0
+    pending = {r["stage"] for r in report.results
+               if r.get("unsweepable_kind") == ps.UNSWEEPABLE_UPSTREAM_PENDING}
+    assert pending == {"PredictorBacktest", "PortfolioOptimizerBacktest"}
+    assert len(report.results) == report.stages_declared == 19
+    # It does not page and it does not claim a clean run.
+    assert report.outcome == ps.OUTCOME_DEGRADED
+    ps.emit(report, aws, "arn:sns")
+    assert ("PreflightSweepStagesFailed", 0) in aws.metrics
+    assert f"{ps.REPORT_PREFIX}/last_clean.json" not in aws.objects
+
+
+def test_a_genuinely_broken_backtest_stage_still_fails_when_upstream_is_present(tmp_path):
+    """The other half of the closes-when: the declaration must not become a
+    blanket excuse on the day the pipeline HAS run."""
+    root = _fake_checkout(tmp_path)
+
+    def runner(argv, **_kwargs):
+        rc = 1 if "spot_predictor_backtest.sh" in argv[-1] else 0
+        return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr="")
+
+    run_date = dt.date.today().isoformat()
+    aws = FakeAws(listing={f"backtest/{run_date}/": [
+        {"Key": f"backtest/{run_date}/.phases/preflight.json", "Size": 235},
+        {"Key": f"backtest/{run_date}/results/backtest.parquet", "Size": 8123},
+    ]})
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, str(root), "t", aws=aws, runner=runner)
+    failed = {r["stage"] for r in report.results if r["verdict"] == ps.FAILED}
+    assert "PredictorBacktest" in failed
+    assert report.outcome == ps.OUTCOME_FAILED
+
+
+def test_the_report_written_to_s3_carries_a_verdict_for_every_declared_stage(tmp_path):
+    root = _fake_checkout(tmp_path)
+    aws = FakeAws()
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, str(root), "t", aws=aws,
+                      runner=_completed(0))
+    ps.emit(report, aws, "arn:sns")
+    written = aws.objects[f"{ps.REPORT_PREFIX}/latest.json"]
+    assert len(written["results"]) == written["stages_declared"]
+    assert written["declared_stages"]
+    # And a console row exists for the stages that have no dry path, so they
+    # are visible rather than absent from the surface entirely.
+    for stage in ("SaturdayHealthCheck", "WeeklySubstrateHealthCheck",
+                  "ResearchPredictorParallel.ResolveZooSpecs"):
+        assert f"ops/checks/{stage_check_id(stage)}/latest.json" in aws.objects
 
 
 # ── Console surface ──────────────────────────────────────────────────────────
@@ -285,6 +696,75 @@ def test_an_unsweepable_stage_is_an_error_because_it_is_unmonitored(cadence):
         {"stage": "DataPhase1", "verdict": "unsweepable"}, "r", "t", cadence
     )
     assert body["status"] == ENVELOPE_ERROR
+
+
+def test_an_upstream_pending_stage_renders_attention_not_error_and_not_green(cadence):
+    body = stage_envelope(
+        {"stage": "PredictorBacktest", "verdict": "unsweepable",
+         "unsweepable_kind": ps.UNSWEEPABLE_UPSTREAM_PENDING}, "r", "t", cadence
+    )
+    assert body["status"] == ENVELOPE_ATTENTION
+    assert body["status"] != ENVELOPE_OK
+
+
+def test_an_unrecognised_unsweepable_kind_keeps_the_loud_default(cadence):
+    body = stage_envelope(
+        {"stage": "X", "verdict": "unsweepable", "unsweepable_kind": "brand_new"},
+        "r", "t", cadence,
+    )
+    assert body["status"] == ENVELOPE_ERROR
+
+
+def test_a_no_dry_path_stage_renders_attention_never_green(cadence):
+    """It is not healthy — the sweep asserts nothing whatever about it. A row
+    reading `ok` would claim precondition-health nobody measured."""
+    body = stage_envelope(
+        {"stage": "SaturdayHealthCheck", "verdict": "no_dry_path",
+         "reason": "threads no $.preflight_args"}, "r", "t", cadence
+    )
+    assert body["status"] == ENVELOPE_ATTENTION
+    assert body["status"] != ENVELOPE_OK
+    assert "no declared envelope mapping" not in body["verdict"]
+
+
+def test_the_rollup_names_the_no_dry_path_stages_rather_than_counting_them(cadence):
+    report = {
+        "run_id": "r", "measured": True, "outcome": "degraded",
+        "stages_declared": 3, "stages_no_dry_path": 1, "stages_passed": 2,
+        "results": [
+            {"stage": "A", "verdict": ps.PASSED},
+            {"stage": "B", "verdict": ps.PASSED},
+            {"stage": "SaturdayHealthCheck", "verdict": "no_dry_path"},
+        ],
+    }
+    rollup = rollup_envelope(report, cadence, "t")
+    assert rollup["no_dry_path_stages"] == ["SaturdayHealthCheck"]
+    # The no-dry-path row must not cancel out the stage it represents.
+    assert rollup["stages_expected"] == 2 and rollup["stages_reported"] == 2
+    assert rollup["status"] == ENVELOPE_ATTENTION
+
+
+def test_an_acknowledged_coverage_gap_does_not_turn_the_rollup_red(cadence):
+    rollup = rollup_envelope(
+        {"run_id": "r", "measured": True, "stages_declared": 1, "stages_passed": 1,
+         "stages_no_dry_path": 0,
+         "coverage_findings": [{"kind": "no_dry_path", "blocking": False,
+                                "finding": "acknowledged"}],
+         "results": [{"stage": "A", "verdict": ps.PASSED}]},
+        cadence, "t",
+    )
+    assert rollup["status"] == ENVELOPE_OK
+    assert rollup["coverage_findings_blocking"] == 0
+
+
+def test_a_legacy_string_coverage_finding_is_still_treated_as_blocking(cadence):
+    rollup = rollup_envelope(
+        {"run_id": "r", "measured": True, "stages_declared": 1, "stages_passed": 1,
+         "coverage_findings": ["a stage lost its dry path"],
+         "results": [{"stage": "A", "verdict": ps.PASSED}]},
+        cadence, "t",
+    )
+    assert rollup["status"] == ENVELOPE_ERROR
 
 
 def test_a_verdict_with_no_declared_mapping_is_not_silently_green(cadence):

--- a/tests/test_preflight_sweep_stages.py
+++ b/tests/test_preflight_sweep_stages.py
@@ -32,6 +32,8 @@ from infrastructure.preflight_sweep_stages import (
     load_manifest,
     manifest_disagreement,
     map_binding_disagreement,
+    upstream_dependencies,
+    upstream_dependency_disagreement,
 )
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -304,3 +306,67 @@ def test_a_stage_whose_command_cannot_be_rendered_is_unsweepable(definition, bin
     stages = derive_stages(mutated, bindings, CONTEXT, checkout_root="/nonexistent")
     assert stages[0].classification is UNSWEEPABLE
     assert "could not be rendered" in stages[0].reason
+
+
+# ── Declared same-day upstream dependencies (alpha-engine-config#7323) ───────
+# The classification of a stage whose preflight fails only because its upstream
+# has not run today is DECLARED here and nowhere else. If it were inferred from
+# the launcher's stderr, rewording an error message would silently turn a real
+# failure into a "could not measure".
+
+
+def test_the_declared_upstream_dependencies_and_the_definition_agree_today(
+    stages, manifest
+):
+    assert upstream_dependency_disagreement(stages, manifest) == []
+
+
+def test_the_backtest_chain_is_declared_with_its_prefix_and_its_producer(manifest):
+    declared = upstream_dependencies(manifest)
+    assert set(declared) == {"PredictorBacktest", "PortfolioOptimizerBacktest"}
+    assert declared["PredictorBacktest"]["produced_by"] == "Backtester"
+    assert declared["PortfolioOptimizerBacktest"]["produced_by"] == "PredictorBacktest"
+    for entry in declared.values():
+        assert entry["prefix"] == "backtest/{run_date}/"
+        # The non-inferable gotcha, declared rather than buried in code: the
+        # prefix EXISTS on a day nothing produced it, because the sweep's own
+        # phase markers are written under it.
+        assert ".phases/" in entry["ignore_subprefixes"]
+
+
+def test_a_declaration_for_a_stage_the_definition_lost_is_a_finding(stages):
+    stale = {"upstream_artifact_dependencies": [
+        {"stage": "StageThatWasRenamed", "produced_by": "Backtester",
+         "prefix": "backtest/{run_date}/", "reason": "r"}
+    ]}
+    findings = upstream_dependency_disagreement(stages, stale)
+    assert findings and "does not contain" in findings[0]
+
+
+def test_a_declaration_naming_a_producer_that_does_not_exist_is_a_finding(stages):
+    bad = {"upstream_artifact_dependencies": [
+        {"stage": "PredictorBacktest", "produced_by": "NoSuchStage",
+         "prefix": "backtest/{run_date}/", "reason": "r"}
+    ]}
+    findings = upstream_dependency_disagreement(stages, bad)
+    assert findings and "not a stage in the definition" in findings[0]
+
+
+def test_a_declaration_for_a_stage_with_no_dry_path_at_all_is_a_finding(stages):
+    no_dry = next(s for s in stages if s.classification is NO_DRY_PATH)
+    bad = {"upstream_artifact_dependencies": [
+        {"stage": no_dry.name, "produced_by": "Backtester",
+         "prefix": "backtest/{run_date}/", "reason": "r"}
+    ]}
+    findings = upstream_dependency_disagreement(stages, bad)
+    assert findings and "can never apply" in findings[0]
+
+
+def test_a_malformed_declaration_is_dropped_and_reported_never_half_applied(stages):
+    """A declaration the sweep cannot act on must not arm a reclassification."""
+    bad = {"upstream_artifact_dependencies": [
+        {"stage": "PredictorBacktest", "produced_by": "Backtester", "reason": "r"}
+    ]}
+    assert upstream_dependencies(bad) == {}
+    findings = upstream_dependency_disagreement(stages, bad)
+    assert findings and "missing prefix" in findings[0]


### PR DESCRIPTION
## What

Two defects in `ae-preflight-sweep`, both visible on its first and only run (`preflight-sweep-20260814T080010Z`). One component, one PR.

### `alpha-engine-config-I7323` — chain-downstream stages reported FAILED when their upstream simply has not run

The run emailed **"2 failed"** and both were false. `PredictorBacktest` and `PortfolioOptimizerBacktest` read `backtest/{run_date}/`, produced by the `Backtester` stage — and a `--preflight-only` run by definition does not produce its stage's output. On any day the real weekly SF has not already run, those two preflights **cannot** pass. The sweep is daily and the pipeline is weekly, so this was set to page ~6 days out of 7 forever, from the sweep's first run.

- The dependency is **DECLARED per stage** in `preflight_sweep_manifest.json` → `upstream_artifact_dependencies`, beside `launcher` and `repo` — never inferred from stderr text. A reworded launcher error cannot reclassify a real failure as unsweepable.
- The declaration only **arms** the check. The prefix is still probed on the day, and a stage that fails while its declared upstream **is** populated stays `failed` and says so ("REAL failure, not an unmet upstream"). A declaration alone can never hide a defect.
- `unsweepable` now carries a **kind**: `coverage_defect` (launcher missing, flag unimplemented, command unrenderable — fails the run, drives the alarm metric) versus `upstream_pending` (does neither, renders `ATTENTION`, never green, never advances `last_clean.json`).
- The probe tests prefix **CONTENT, not existence**. `backtest/<date>/` exists on a day nothing produced it because the sweep's own `.phases/preflight.json` and `.phases/runtime_smoke.json` are written under it — an existence test would have read as satisfied and changed nothing while appearing to work. Ignored sub-prefixes are declared in the manifest, not buried in code.
- A stage `unsweepable` on **every** run for 8 consecutive days is its own finding (`persistent_unsweepable_findings`, metric `PreflightSweepPersistentUnsweepable`), emitted **separately from `coverage_findings`** so it can never read as coverage. 8 days is one full weekly cycle plus one — 7 or less would fire on the ordinary weekday state. The threshold is declared in days and converted against the declared cadence, so changing the cadence cannot silently change what it means.
- An unreadable streak history is **named**, never treated as "no history": silently resetting to zero each run would make the finding structurally unable to fire.
- The notification subject and body carry every category (below).

### `alpha-engine-config-I7324` — `stages_no_dry_path` published as a bare COUNT

19 declared, 16 rows in `results[]`, `coverage_findings: []`, and **which 3 stages were missing was unrecoverable from the report**. The root cause is a missing assertion: nothing asserted `len(results) == stages_declared`, and `stages_swept 16 = passed 14 + failed 2` is internally consistent, so the arithmetic gave no hint.

- **The assertion now exists**, in code and in tests. It is self-healing (a declared stage with no verdict is filled in as `not_attempted`) **and loud** (that fill-in raises a **blocking** coverage finding and fails the run — a hole in the sweep's own coverage outranks anything it found).
- `no_dry_path` is a **verdict row** in `results[]` carrying `stage`, `repo`, `launcher`, `reason` and the manifest's written `acknowledged_reason`.
- The **declared stage list is serialised** (`declared_stages`), so `declared - swept` is auditable from the report alone.
- `coverage_findings` entries are now structured and carry their own `blocking` flag. An acknowledged no-dry-path gap is **named on every surface without failing the run**; a denominator defect still fails it. A bare string is treated as blocking, which keeps legacy reports and `preflight_sweep.sh`'s could-not-measure payload on the loud side.
- **The SNS body names every non-passed category**, not only failures, and the subject no longer hides one: a run with nothing failing now reads `no failures — N of 19 stages not covered (M awaiting upstream / K no dry path / J unmeasured)`.
- Console: a `no_dry_path` row renders `ATTENTION`, never `ok` — the sweep asserts nothing about that stage, and a green row would claim precondition-health nobody measured. The rollup names `no_dry_path_stages` and `upstream_pending_stages` rather than counting them, and no-dry-path rows are excluded from `stages_reported` so acknowledged gaps cannot cancel out the stages they represent.

**The 3 no-dry-path stages are `ResearchPredictorParallel.ResolveZooSpecs`, `SaturdayHealthCheck` and `WeeklySubstrateHealthCheck`.** Closing that gap — a dry path each, or a ratified exemption naming its compensating surface — is filed as **alpha-engine-config-I7329**.

## Why this shape

`observability-policy` §7.2/§9.2: a could-not-measure payload must never be byte-identical to a found-nothing payload. Before this, three categories collapsed into two: a structurally unmeasurable stage was indistinguishable from a broken one, and three never-exercised stages were indistinguishable from absent ones. Both are the same defect — a detector whose "I could not look" reads as "I looked".

The classification is declared rather than inferred because the alternative fails in the dangerous direction: matching on `"is empty or unreachable"` would mean any launcher error rephrased to contain that string silently becomes a non-page.

## Deployability

**Deployable by the merge button alone. No post-merge step.** No IAM change is required: `alpha-engine-executor-role` (the launcher box's profile) already grants `s3:ListBucket` and `s3:GetObject` on `arn:aws:s3:::alpha-engine-research` and `/*` — measured against the account 2026-08-14. If that grant were ever removed, the probe raises and the affected stage reports `unmeasured` naming the error, which is honest degradation rather than a silent flip in either direction.

New CloudWatch metrics (`AlphaEngine`, `Component=ae-preflight-sweep`): `PreflightSweepStagesUnsweepableCoverageDefect`, `PreflightSweepStagesUnsweepableUpstreamPending`, `PreflightSweepStagesNoDryPath`, `PreflightSweepStagesNotAttempted`, `PreflightSweepCoverageFindingsBlocking`, `PreflightSweepPersistentUnsweepable`. No alarm is created or changed here; only the coverage-defect series is alarm-worthy, and `PreflightSweepStagesFailed` keeps its existing meaning.

## Test plan

Run locally against `nousergon-data/.venv` **before opening this PR**:

- `pytest -q` — **5712 passed, 9 skipped, 0 failed** (87s). No pre-existing failures.
- `pytest infrastructure/lambdas/preflight-sweep-dispatcher/test_handler.py -q` — **14 passed**.
- `tests/test_preflight_sweep.py` + `tests/test_preflight_sweep_stages.py` — 75 → **~100 tests**, of which the load-bearing new ones:
  - the weekday case **end to end over the live definition**: 19 declared, 19 rows, `stages_failed == 0`, exactly `{PredictorBacktest, PortfolioOptimizerBacktest}` classified `upstream_pending`, `PreflightSweepStagesFailed 0` emitted, `last_clean.json` NOT advanced;
  - **a genuinely broken backtest stage still reports `failed`** when the upstream prefix has real content — the regression this mechanism must not introduce;
  - a prefix holding **only** `.phases/` markers is not content (the non-inferable gotcha), and a zero-byte key is not content;
  - an unprobeable upstream is `unmeasured`, not a guess in either direction;
  - `len(results) == stages_declared` on the live definition, and the declared stage list round-trips through the S3 report;
  - `coverage_findings` non-empty whenever `stages_no_dry_path > 0`, and those entries are non-blocking;
  - the notification names every non-passed stage by name;
  - streak below / at / after threshold, streak dropped when a stage becomes measurable, and an unreadable history named rather than reset;
  - console: `upstream_pending` renders ATTENTION, an **unrecognised** unsweepable kind keeps the loud ERROR default, `no_dry_path` renders ATTENTION never green, and a legacy string coverage finding is still blocking;
  - manifest agreement in both stale directions for the new declarations (missing stage, missing producer, no-dry-path stage, malformed entry).

Verified with `git check-ignore -v AGENTS.md CLAUDE.md` before staging: both gitignored, neither is in this diff.

## Related

- `alpha-engine-config-I7323`, `alpha-engine-config-I7324` — the two defects fixed here.
- `alpha-engine-config-I7329` — follow-up filed by this work: give each of the 3 no-dry-path stages a dry path or a ratified exemption.
- `alpha-engine-config-I7249` — the parent sweep.
- `alpha-engine-config-I7328` — registry coverage rows for the sweep's Lambda/EventBridge components; out of scope here, not duplicated.

No `Closes` keyword: the issues live in `nousergon/alpha-engine-config`, not this repo.

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
