### PR TITLE
fix(backstop): decline to restart paused automation; report dispatch state honestly (config-I7330)

### DIFF
--- a/.github/workflows/deploy-overseer-backstop-responder.yml
+++ b/.github/workflows/deploy-overseer-backstop-responder.yml
@@ -10,6 +10,13 @@ name: Deploy overseer-backstop-responder
 # the zip at deploy — a registry edit therefore deploys through THIS workflow's
 # code path (the path filter includes the registry).
 #
+# The automation pause manifest (infrastructure/automation_pause.json) is
+# bundled the same way and for the same reason (alpha-engine-config-I7330), so
+# it is in the path filter too. Without that line a pause edit would merge
+# green and change nothing in the deployed package: the responder would keep
+# deciding from a stale copy, with no check anywhere going red. Any file added
+# to the zip by deploy.sh must be added here in the SAME change.
+#
 # Designed per alpha-engine-config-I4480 (G9 of the 2026-07-27 conformance audit).
 # The backstop-responder subscribes directly to the alarm-backstop SNS topic and
 # performs bounded non-agentic recovery per cooldown window.
@@ -23,6 +30,7 @@ on:
     paths:
       - 'infrastructure/lambdas/overseer-backstop-responder/**'
       - 'infrastructure/overseer/playbooks.yaml'
+      - 'infrastructure/automation_pause.json'
       - '.github/workflows/deploy-overseer-backstop-responder.yml'
   workflow_dispatch:
 

--- a/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
+++ b/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
@@ -97,6 +97,23 @@ else
   echo "Continuing; deploy.sh --smoke will catch this."
 fi
 
+# Bundle the automation pause manifest (alpha-engine-config-I7330). It is the
+# fleet's record of which triggers an operator has deliberately disabled, and
+# the responder consults it before acting so a recovery cannot restart paused
+# automation. Bundled rather than fetched for the same reason playbooks.yaml is:
+# this Lambda must not acquire a runtime dependency on the plane it rescues.
+# A MISSING manifest is not fatal — index.py treats an unreadable manifest as
+# UNKNOWN, acts, and says so in the page. Failing the deploy here would make a
+# file-copy problem take out the backstop itself.
+PAUSE_SRC="${SCRIPT_DIR}/../../automation_pause.json"
+if [[ -f "${PAUSE_SRC}" ]]; then
+  cp "${PAUSE_SRC}" "${PKG}/automation_pause.json"
+  echo "Bundled automation_pause.json from ${PAUSE_SRC}"
+else
+  echo "WARNING: automation_pause.json not found at ${PAUSE_SRC} — the pause"
+  echo "         check will report UNKNOWN and actions will proceed unguarded."
+fi
+
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"

--- a/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
+++ b/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
@@ -105,7 +105,7 @@ fi
 # A MISSING manifest is not fatal — index.py treats an unreadable manifest as
 # UNKNOWN, acts, and says so in the page. Failing the deploy here would make a
 # file-copy problem take out the backstop itself.
-PAUSE_SRC="${SCRIPT_DIR}/../../automation_pause.json"
+PAUSE_SRC="${REPO_ROOT}/infrastructure/automation_pause.json"
 if [[ -f "${PAUSE_SRC}" ]]; then
   cp "${PAUSE_SRC}" "${PKG}/automation_pause.json"
   echo "Bundled automation_pause.json from ${PAUSE_SRC}"

--- a/infrastructure/lambdas/overseer-backstop-responder/index.py
+++ b/infrastructure/lambdas/overseer-backstop-responder/index.py
@@ -22,7 +22,10 @@ bounded things:
   2. **Attempts ONE recovery**, once per alarm per cooldown window, from a
      hardcoded reviewed allowlist: re-invoke the liveness probe, or re-dispatch
      one playbook through the router. Nothing else exists in the map, and an
-     unmapped alarm reports without acting.
+     unmapped alarm reports without acting. It also declines to act when the
+     target component's triggers are ALL paused in `automation_pause.json` —
+     restarting automation an operator deliberately turned off is not recovery
+     (alpha-engine-config-I7330).
   3. **Escalates on the second firing** inside the window — the attempt did not
      work, a human is needed now, and retrying would be a loop.
 
@@ -67,6 +70,7 @@ import os
 import urllib.parse
 import urllib.request
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import boto3
 
@@ -105,32 +109,81 @@ TELEGRAM_CHAT_PARAM = os.environ.get(
 # `redispatch` payloads mirror what the scheduler sends, minus the run id (the
 # executor mints its own). `is_drill` is always false: a drill would prove the
 # pipe works while leaving the real backlog untouched.
+#
+# `triggers` names every schedule/rule the action's TARGET component runs on. It
+# is what makes the pause check below possible: recovering a component whose own
+# triggers an operator deliberately disabled is not recovery, it is restarting
+# paused automation (alpha-engine-config-I7330). Names are pinned against
+# automation_pause.json by test_handler.py — a typo here would silently disable
+# the gate rather than fail it.
 ALARM_ACTIONS: dict[str, dict] = {
     "alpha-engine-watch-plane-overseer-intake-age": {
         "action": "redispatch",
         "playbook": "alert-drain",
         "payload": {"trigger": "backstop-recovery", "is_drill": "false"},
         "rationale": "queue ageing means the drain is not draining — one dispatch",
+        "component": "alert-drain",
+        "triggers": [
+            "alpha-engine-alert-drain-0400utc",
+            "alpha-engine-alert-drain-1000utc",
+            "alpha-engine-alert-drain-1600utc",
+            "alpha-engine-alert-drain-2200utc",
+        ],
     },
     "alpha-engine-watch-plane-overseer-intake-depth": {
         "action": "redispatch",
         "playbook": "alert-drain",
         "payload": {"trigger": "backstop-recovery", "is_drill": "false"},
         "rationale": "queue depth means the drain is not draining — one dispatch",
+        "component": "alert-drain",
+        "triggers": [
+            "alpha-engine-alert-drain-0400utc",
+            "alpha-engine-alert-drain-1000utc",
+            "alpha-engine-alert-drain-1600utc",
+            "alpha-engine-alert-drain-2200utc",
+        ],
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-errors": {
         "action": "invoke_probe",
         "rationale": "a probe erroring every invocation blinds the whole plane",
+        "component": "overseer-liveness-probe",
+        "triggers": [
+            "alpha-engine-overseer-liveness-0650-daily",
+            "alpha-engine-overseer-liveness-1450-daily",
+        ],
     },
 }
 
-# Kill switches to report. Component -> (function name, env var).
-KILL_SWITCHES = [
+# Per-component dispatch flags to report. Component -> (function, variable).
+#
+# NOTE THE POLARITY. Every variable here is named `*_DISPATCH_ENABLED`, so
+# `true` means the component WILL dispatch — it is an enable flag, not a kill
+# switch, and the two read as exact opposites. This block was previously
+# rendered under the heading "kill switches", which made `router: true` read as
+# "the router is stopped" when it means "the router is running". On 2026-08-14
+# that line was taken as proof the overseer plane was off and a P1 was filed
+# against the wrong component (alpha-engine-config-I7330). `_dispatch_state()`
+# now renders the semantic state and carries the raw variable alongside it, so
+# the value can never disagree with its label again.
+DISPATCH_FLAGS = [
     ("router", ROUTER_FUNCTION, "OVERSEER_DISPATCH_ENABLED"),
     ("alert-drain", "alpha-engine-alert-drain-dispatcher", "ALERT_DRAIN_DISPATCH_ENABLED"),
     ("ci-watch", "alpha-engine-ci-watch-dispatcher", "CI_WATCH_DISPATCH_ENABLED"),
     ("sf-watch", "alpha-engine-sf-watch-spot-dispatcher", "SF_WATCH_DISPATCH_ENABLED"),
 ]
+
+# The automation pause manifest, bundled into the deploy package by deploy.sh.
+#
+# Read from disk, never from the network: this Lambda must not acquire a runtime
+# dependency on the plane it rescues (see WHAT IT DELIBERATELY IS NOT, above).
+# It mirrors overseer-liveness-probe/deploy.sh, which bundles playbooks.yaml for
+# the same reason — a registry edit ships through the normal code path.
+#
+# Staleness is already covered: infrastructure/automation_pause.py --check runs
+# in the daily drift sweep and fails in BOTH directions when the manifest and
+# live AWS disagree, so a bundled copy that has drifted is a red check rather
+# than a silent wrong answer here.
+PAUSE_MANIFEST = Path(__file__).parent / "automation_pause.json"
 
 # Playbook -> S3 prefix whose newest object proves the playbook last completed.
 LEDGER_PREFIXES = {
@@ -146,18 +199,72 @@ def _utcnow() -> datetime:
 # ── Evidence gathering — every step degrades to a string, never raises ───────
 
 
-def _kill_switch_state() -> dict[str, str]:
+def _dispatch_state() -> dict[str, str]:
+    """Per-component dispatch state, rendered so the value agrees with the label.
+
+    Returns e.g. ``{"router": "ENABLED (OVERSEER_DISPATCH_ENABLED=true)"}``. The
+    raw variable stays in the string because it names the thing an operator would
+    actually flip; the leading word is what the reader acts on. See the polarity
+    note on DISPATCH_FLAGS for why this is not a raw boolean.
+    """
     out: dict[str, str] = {}
     lam = boto3.client("lambda", region_name=REGION)
-    for label, function, var in KILL_SWITCHES:
+    for label, function, var in DISPATCH_FLAGS:
         try:
             cfg = lam.get_function_configuration(FunctionName=function)
-            out[label] = cfg.get("Environment", {}).get("Variables", {}).get(
-                var, "(unset — defaults to enabled)"
-            )
+            raw = cfg.get("Environment", {}).get("Variables", {}).get(var)
+            if raw is None:
+                out[label] = f"ENABLED ({var} unset — defaults to enabled)"
+            elif str(raw).strip().lower() == "true":
+                out[label] = f"ENABLED ({var}={raw})"
+            else:
+                out[label] = f"STOPPED ({var}={raw})"
         except Exception as exc:  # noqa: BLE001 — see FAILURE POSTURE
             out[label] = f"UNREADABLE: {type(exc).__name__}"
     return out
+
+
+def _paused_trigger_names() -> set[str] | None:
+    """Every trigger name the pause manifest says is deliberately off.
+
+    Returns None when the manifest cannot be read or parsed. None means UNKNOWN,
+    not "nothing is paused" — the caller acts and says so in the page, because a
+    backstop that silently stops acting because it could not read a file is the
+    failure mode this Lambda exists to survive. Both blocks count: ``paused`` is
+    what is off now, ``pending`` is what must be born off.
+    """
+    try:
+        manifest = json.loads(PAUSE_MANIFEST.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 — see FAILURE POSTURE
+        print(f"WARN: pause manifest unreadable ({type(exc).__name__}) — the "
+              f"pause check cannot run; actions proceed and the page says so")
+        return None
+    names: set[str] = set()
+    for surface in ("events_rules", "scheduler_schedules"):
+        names |= set(manifest.get("paused", {}).get(surface, {}))
+    names |= {k for k in manifest.get("pending", {}) if not k.startswith("_")}
+    return names
+
+
+def _pause_verdict(spec: dict) -> str | None:
+    """Return a skip reason when the action's target component is fully paused.
+
+    ALL of the component's triggers must be paused. A component with even one
+    live trigger is still running on its own cadence, so a recovery dispatch is
+    still the right response to its alarm — it is only when an operator has
+    turned every trigger off that acting means restarting paused automation.
+    """
+    triggers = spec.get("triggers") or []
+    if not triggers:
+        return None
+    paused = _paused_trigger_names()
+    if paused is None:
+        return None
+    if all(t in paused for t in triggers):
+        component = spec.get("component") or spec["action"]
+        return (f"{component} is paused in automation_pause.json "
+                f"({len(triggers)} trigger(s), all disabled) — reporting only")
+    return None
 
 
 def _queue_age_seconds(queue_name: str) -> int | None:
@@ -443,8 +550,8 @@ def _render(alarm: str, reason: str, evidence: dict, outcome: dict) -> str:
     lines.append("  last ledger:")
     for k, v in evidence["ledgers"].items():
         lines.append(f"    {k}: {v}")
-    lines.append("  kill switches:")
-    for k, v in evidence["kill_switches"].items():
+    lines.append("  dispatch flags:")
+    for k, v in evidence["dispatch"].items():
         lines.append(f"    {k}: {v}")
     lines += ["", "RECOVERY"]
     if outcome.get("escalated"):
@@ -478,19 +585,25 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         reason = f"(could not parse SNS message: {type(exc).__name__})"
 
     evidence = {
-        "kill_switches": _kill_switch_state(),
+        "dispatch": _dispatch_state(),
         "queues": _queue_state(),
         "ledgers": _last_ledger_ages(),
         "probe": _probe_health(),
     }
 
     spec = ALARM_ACTIONS.get(alarm)
+    pause_skip = _pause_verdict(spec) if spec else None
     if spec is None:
         outcome = {"skipped": "alarm has no entry in the reviewed action "
                               "allowlist — reporting only"}
     elif not RECOVERY_ENABLED:
         outcome = {"skipped": "BACKSTOP_RECOVERY_ENABLED=false (operator "
                               "kill switch) — reporting only"}
+    elif pause_skip is not None:
+        # Checked BEFORE _claim_attempt: a paused component must not consume its
+        # own cooldown window, or the first firing after the pause lifts would
+        # escalate as a "second firing" without a first attempt ever happening.
+        outcome = {"skipped": pause_skip}
     else:
         first, prior = _claim_attempt(alarm, now)
         if not first:

--- a/infrastructure/lambdas/overseer-backstop-responder/test_handler.py
+++ b/infrastructure/lambdas/overseer-backstop-responder/test_handler.py
@@ -124,6 +124,11 @@ def wired(monkeypatch):
     monkeypatch.setattr(index, "_telegram",
                         lambda text: (state["pages"].append(text), True)[1])
     monkeypatch.setattr(index, "RECOVERY_ENABLED", True)
+    # Nothing paused, stated explicitly. In the source tree the bundled manifest
+    # does not sit next to index.py (deploy.sh copies it in), so without this the
+    # every-action test would pass because the manifest was UNREADABLE rather
+    # than because nothing was paused — a green that proves the wrong thing.
+    monkeypatch.setattr(index, "_paused_trigger_names", lambda: set())
     return state
 
 
@@ -177,8 +182,141 @@ def test_every_allowlist_entry_is_a_known_action():
     for alarm, spec in index.ALARM_ACTIONS.items():
         assert spec["action"] in ("redispatch", "invoke_probe"), alarm
         assert spec.get("rationale"), f"{alarm} must carry a rationale"
+        assert spec.get("component"), f"{alarm} must name its target component"
+        assert spec.get("triggers"), f"{alarm} must name its component's triggers"
         if spec["action"] == "redispatch":
             assert spec.get("playbook") and isinstance(spec.get("payload"), dict)
+
+
+# ── Property 5: never restart automation the operator paused (I7330) ────────
+
+
+REPO_MANIFEST = (
+    Path(__file__).resolve().parents[2] / "automation_pause.json"
+)
+
+
+def _manifest_names() -> set[str]:
+    m = json.loads(REPO_MANIFEST.read_text(encoding="utf-8"))
+    names = set()
+    for surface in ("events_rules", "scheduler_schedules"):
+        names |= set(m["paused"][surface])
+    names |= {k for k in m.get("pending", {}) if not k.startswith("_")}
+    return names
+
+
+def test_declared_triggers_all_exist_in_the_repo_manifest():
+    """A typo in `triggers` would silently disable the gate, not fail it.
+
+    `_pause_verdict` asks whether every declared name is IN the paused set. A
+    misspelled name can never be in it, so the component reads as live forever
+    and the guard is gone with nothing red. This test is the only thing that
+    notices — it compares against the real repo manifest, not a fixture.
+    """
+    known = _manifest_names()
+    assert known, "the repo manifest parsed to zero paused triggers"
+    for alarm, spec in index.ALARM_ACTIONS.items():
+        for trigger in spec["triggers"]:
+            assert trigger in known, (
+                f"{alarm}: declared trigger {trigger!r} appears nowhere in "
+                f"automation_pause.json. Either it was renamed there, or it is "
+                f"a typo — both make the pause gate a permanent no-op."
+            )
+
+
+def test_action_is_skipped_when_every_trigger_of_its_component_is_paused(
+        wired, monkeypatch):
+    for alarm, spec in index.ALARM_ACTIONS.items():
+        wired["lambda"].invocations.clear()
+        monkeypatch.setattr(index, "_paused_trigger_names",
+                            lambda s=spec: set(s["triggers"]))
+        out = index.handler(_sns(alarm), None)
+        assert wired["lambda"].invocations == [], (
+            f"{alarm}: acted on a component whose every trigger is paused"
+        )
+        assert "paused in automation_pause.json" in out["outcome"]["skipped"]
+        assert wired["pages"], "reporting stays unconditional"
+
+
+def test_a_partially_paused_component_is_still_recovered(wired, monkeypatch):
+    """One live trigger means the component still runs on its own cadence, so
+    its alarm is a real failure and the bounded recovery is still correct."""
+    spec = index.ALARM_ACTIONS[INTAKE_AGE]
+    monkeypatch.setattr(index, "_paused_trigger_names",
+                        lambda: set(spec["triggers"][1:]))
+    index.handler(_sns(INTAKE_AGE), None)
+    assert len(wired["lambda"].invocations) == 1
+
+
+def test_a_paused_component_does_not_consume_its_cooldown_window(wired, monkeypatch):
+    """The skip must happen BEFORE the attempt is claimed.
+
+    Otherwise the first firing after the pause lifts would escalate as a
+    "second firing" while no attempt was ever made — the escalation path would
+    fire having never tried anything.
+    """
+    spec = index.ALARM_ACTIONS[PROBE_ERRORS]
+    monkeypatch.setattr(index, "_paused_trigger_names",
+                        lambda: set(spec["triggers"]))
+    index.handler(_sns(PROBE_ERRORS), None)
+    assert wired["s3"].puts == [], "a paused component must not claim a window"
+
+    monkeypatch.setattr(index, "_paused_trigger_names", lambda: set())
+    out = index.handler(_sns(PROBE_ERRORS), None)
+    assert len(wired["lambda"].invocations) == 1
+    assert not out["outcome"].get("escalated"), (
+        "the first real attempt must not be treated as a retry"
+    )
+
+
+def test_an_unreadable_manifest_reports_unknown_rather_than_not_paused(
+        monkeypatch, capsys):
+    """UNKNOWN is not "nothing is paused", but it must not stop the backstop.
+
+    A backstop that silently declines to act because it could not read a file is
+    the failure mode this Lambda exists to survive, so `_pause_verdict` returns
+    no skip and the read failure is printed. Deliberately does NOT use the
+    `wired` fixture, which stubs the function under test.
+    """
+    monkeypatch.setattr(index, "PAUSE_MANIFEST", Path("/nonexistent/pause.json"))
+    assert index._paused_trigger_names() is None
+    assert "pause manifest unreadable" in capsys.readouterr().out
+    assert index._pause_verdict(index.ALARM_ACTIONS[PROBE_ERRORS]) is None
+
+
+# ── The dispatch-flag block reports state whose value agrees with its label ──
+
+
+def test_dispatch_flags_never_render_a_bare_boolean(wired):
+    """`router: true` under a heading reading "kill switches" says the opposite
+    of what it means — every variable in DISPATCH_FLAGS is an *_ENABLED flag.
+    Read as "the router is stopped", it cost a P1 filed against the wrong
+    component on 2026-08-14 (alpha-engine-config-I7330).
+    """
+    out = index.handler(_sns(INTAKE_AGE), None)
+    page = wired["pages"][-1]
+    assert "kill switches:" not in page
+    assert "dispatch flags:" in page
+    for label, value in out["evidence"]["dispatch"].items():
+        assert value.split(" ")[0] in ("ENABLED", "STOPPED", "UNREADABLE:"), (
+            f"{label}: {value!r} must lead with the semantic state"
+        )
+        assert f"    {label}: true" not in page
+        assert f"    {label}: false" not in page
+
+
+def test_dispatch_flag_polarity_matches_the_variable_value(wired, monkeypatch):
+    cases = [({"OVERSEER_DISPATCH_ENABLED": "true"}, "ENABLED"),
+             ({"OVERSEER_DISPATCH_ENABLED": "false"}, "STOPPED"),
+             ({}, "ENABLED")]  # unset defaults to enabled
+    for variables, expected in cases:
+        monkeypatch.setattr(
+            wired["lambda"], "get_function_configuration",
+            lambda FunctionName, v=variables: {"Environment": {"Variables": v}},
+        )
+        assert index._dispatch_state()["router"].startswith(expected), (
+            f"{variables} should render as {expected}"
+        )
 
 
 # ── Property 2: one attempt per window, then escalate ───────────────────────
@@ -299,8 +437,13 @@ def test_no_agent_bus_or_queue_dependency_in_the_source():
         f"responder — it must have no agent or bus dependency "
         f"(overseer-policy §4 inv. 3)"
     )
-    assert imported <= {"__future__", "json", "os", "urllib", "datetime", "boto3"}, (
-        f"unexpected import(s) {sorted(imported - {'__future__', 'json', 'os', 'urllib', 'datetime', 'boto3'})} "
+    # One list, referenced twice — the assertion and its message drifted apart
+    # once already, and a message naming a stale set sends the reader looking
+    # for an import that is not the one that failed.
+    allowed = {"__future__", "json", "os", "urllib", "datetime", "pathlib",
+               "boto3"}
+    assert imported <= allowed, (
+        f"unexpected import(s) {sorted(imported - allowed)} "
         f"— the backstop's dependency set is boto3 + stdlib, by design"
     )
 

--- a/infrastructure/lambdas/overseer-backstop-responder/test_handler.py
+++ b/infrastructure/lambdas/overseer-backstop-responder/test_handler.py
@@ -284,6 +284,57 @@ def test_an_unreadable_manifest_reports_unknown_rather_than_not_paused(
     assert index._pause_verdict(index.ALARM_ACTIONS[PROBE_ERRORS]) is None
 
 
+def test_every_bundled_file_is_in_the_deploy_workflow_path_filter():
+    """A file in the zip but not in the path filter merges green and deploys nothing.
+
+    `deploy.sh` copies three files into the package. The workflow only runs when
+    a path in its filter changes, so a bundled file missing from that list means
+    edits to it never reach the deployed Lambda — the responder keeps deciding
+    from a stale copy and no check goes red. `automation_pause.json` was exactly
+    that gap when it was first bundled. This asserts the general property rather
+    than the one instance, so the next bundled file cannot repeat it.
+    """
+    import re
+
+    lambda_dir = Path(__file__).resolve().parent
+    repo_root = lambda_dir.parents[2]
+    deploy = (lambda_dir / "deploy.sh").read_text(encoding="utf-8")
+    workflow = (
+        repo_root / ".github/workflows/deploy-overseer-backstop-responder.yml"
+    ).read_text(encoding="utf-8")
+
+    # Resolve the handful of path variables deploy.sh uses as `cp` sources.
+    variables = {"SCRIPT_DIR": str(lambda_dir), "REPO_ROOT": str(repo_root)}
+    for name in ("REGISTRY_SRC", "PAUSE_SRC"):
+        m = re.search(rf'^{name}="([^"]+)"', deploy, re.M)
+        assert m, f"{name} is no longer assigned in deploy.sh — update this test"
+        variables[name] = m.group(1)
+
+    def _expand(raw: str) -> str:
+        for _ in range(3):  # variables reference each other one level deep
+            raw = re.sub(r"\$\{(\w+)\}",
+                         lambda mo: variables.get(mo.group(1), mo.group(0)), raw)
+        return raw
+
+    sources = [_expand(m) for m in
+               re.findall(r'^\s*cp "([^"]+)" "\$\{PKG\}/', deploy, re.M)]
+    assert len(sources) >= 3, f"expected 3+ bundled files, parsed {sources}"
+
+    filters = re.findall(r"^\s+- '([^']+)'$", workflow, re.M)
+    for source in sources:
+        assert "${" not in source, f"unresolved variable in {source!r}"
+        rel = Path(source).resolve().relative_to(repo_root).as_posix()
+        covered = any(
+            rel == f or (f.endswith("/**") and rel.startswith(f[:-2]))
+            for f in filters
+        )
+        assert covered, (
+            f"{rel} is bundled into the zip by deploy.sh but matches no path "
+            f"filter in deploy-overseer-backstop-responder.yml. Editing it "
+            f"would merge green and deploy nothing. Filters: {filters}"
+        )
+
+
 # ── The dispatch-flag block reports state whose value agrees with its label ──
 
 


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7330`

## Why

Brian: *"I thought overseer is disabled — why am I still getting harassed by alerts?"* Four pages
per 8-hour cycle from `alpha-engine-watch-plane-overseer-liveness-probe-{errors,throttles}`, on a
plane whose schedules were deliberately disabled on 2026-08-07. This PR fixes the half of that
which lives in the responder. The alarm half is `alpha-engine-config-I7023`, shipped separately as
`nousergon-data-PR1380`; the two are independent and can merge in either order.

## What was wrong

**1. `invoke_probe` restarted paused automation.** `alpha-engine-overseer-liveness-probe` has both
its EventBridge Scheduler schedules (`alpha-engine-overseer-liveness-0650-daily`, `-1450-daily`)
in `DISABLED` state under the pause ruling, recorded in `automation_pause.json`. The responder
invoked it anyway — it consulted `BACKSTOP_RECOVERY_ENABLED` and nothing else — and is the only
thing giving that Lambda any invocations at all.

The second-order effect is what actually reached Brian: each invocation puts an `Invocations`
datapoint into an otherwise-empty window, flipping the probe's `-errors` and `-throttles` alarms
(`TreatMissingData=breaching`, `Period=28800`) from ALARM to OK — and the OK notification pages
too. Two alarms x (ALARM + OK) = four messages per cycle, self-sustaining for the duration of the
pause.

**2. The page inverted its own most load-bearing field.** `KILL_SWITCHES` held four
`*_DISPATCH_ENABLED` variables and the page printed their raw values under the heading
`kill switches:`. `router: true` therefore read as "the router is stopped" while meaning "the
router is running". Measured live: all four are `true`, i.e. all four dispatchers are enabled.
On 2026-08-14 that line was read as proof the plane was off, and a P1 was filed against the wrong
component before the values were checked.

## What changed

| | |
|---|---|
| `ALARM_ACTIONS` | each entry declares `component` and the `triggers` its target runs on |
| `_pause_verdict()` | skips the action when **all** of a component's triggers are paused |
| `_paused_trigger_names()` | reads the bundled manifest; returns `None` (UNKNOWN) if unreadable |
| `_kill_switch_state()` → `_dispatch_state()` | values lead with `ENABLED` / `STOPPED` / `UNREADABLE`, raw variable retained |
| `_render()` | heading is `dispatch flags:`, not `kill switches:` |
| `deploy.sh` | bundles `automation_pause.json` into the zip |
| deploy workflow | `infrastructure/automation_pause.json` added to `on.push.paths` |

**All triggers, not any.** A component with even one live trigger is still running on its own
cadence, so its alarm is a real failure and the bounded recovery is still the right response. Only
when an operator has turned every trigger off does acting mean restarting paused automation.

**The check runs before `_claim_attempt`.** Otherwise a paused component burns its cooldown window
on a skip, and the first firing after the pause lifts escalates as a "second firing" having never
attempted anything.

**Bundled, not fetched.** Mirrors `overseer-liveness-probe/deploy.sh`, which already copies
`playbooks.yaml` into its package. This Lambda must not acquire a runtime dependency on the plane
it rescues (module docstring, "WHAT IT DELIBERATELY IS NOT"), so a static file is the only shape
available. Staleness is already covered in both directions by `automation_pause.py --check` in the
daily drift sweep — no new detector, and no second hand-maintained list.

**Unreadable manifest means UNKNOWN, not "nothing is paused".** The action proceeds and the read
failure is printed. A backstop that silently declines to act because it could not read a file is
precisely the failure mode this Lambda exists to survive. Same reasoning makes a missing manifest
a deploy WARNING rather than a deploy failure.

## The deploy-filter gap, found while writing this

Bundling a file into the zip is only half the change: the workflow runs on a path filter, so
`automation_pause.json` had to be added to `on.push.paths` as well. Without that line a pause edit
merges green and deploys nothing — the responder keeps deciding from a stale bundled copy, and no
check anywhere goes red. The workflow header already explains this for `playbooks.yaml`; the
filter line was simply missing for the new file.

Fixed for the instance and for the class: `test_every_bundled_file_is_in_the_deploy_workflow_path_filter`
parses the `cp ... "${PKG}/..."` lines out of `deploy.sh`, resolves their path variables, and
asserts each resolved path is covered by a filter glob. **Verified it fails with the filter line
removed and passes with it restored** — a guard that cannot fail is not a guard. The next file
bundled into this package cannot repeat the mistake silently.

## Tests

`infrastructure/lambdas/overseer-backstop-responder/test_handler.py`, 25 passing:

- skip-when-fully-paused, once **per allowlist entry**, asserting the boto3 mock's invocation list
  is empty — not just that the returned dict says "skipped";
- act-when-partially-paused;
- no cooldown claim is written while paused, and the first firing after the pause lifts attempts
  rather than escalates;
- unreadable manifest returns `None` and yields no skip;
- **declared trigger names pinned against the real repo manifest** — a typo in `triggers` could
  never be in the paused set, so the gate would become a permanent no-op with nothing red. This
  test is the only thing that would notice;
- dispatch-flag polarity for `true` / `false` / unset, and that the page renders no bare boolean;
- the bundled-file/path-filter property above.

The `wired` fixture now stubs `_paused_trigger_names` to an empty set. In the source tree the
bundled manifest does not sit next to `index.py` (deploy.sh copies it in), so without this the
act-normally tests would have passed because the manifest was UNREADABLE rather than because
nothing was paused — a green proving the wrong thing.

`pathlib` added to the import allowlist in `test_no_agent_bus_or_queue_dependency_in_the_source`
(stdlib; the forbidden-dependency set is untouched). That assertion's message duplicated the
allowed-set literal and had already drifted from it — both now reference one named constant.

## Scope note

`overseer-liveness-probe/index.py` and `sf-watch-reclaim-sweep-handler/index.py` also use the name
`kill_switches` internally. They are **not** changed here: both key the dict by the variable name
itself (`SF_WATCH_DISPATCH_ENABLED: true`), which reads correctly. The responder was the only place
that dropped the variable name and kept a bare component label under a heading meaning the
opposite.

## Deploy

Automatic on merge, via `.github/workflows/deploy-overseer-backstop-responder.yml` (code-only,
flagless `deploy.sh` run — no bootstrap, no IAM write, no new permission). Nothing to run after
merging.

## Test plan

Run BEFORE opening, not deferred to CI:

- `.venv/bin/python -m pytest infrastructure/lambdas/overseer-backstop-responder/test_handler.py -q` → **25 passed**
- `.venv/bin/python -m pytest tests/ -q -k "watch_plane or pause or overseer or backstop"` → **231 passed**
- `ruff check infrastructure/lambdas/overseer-backstop-responder/` → clean
- Negative check on the new deploy-filter guard: filter line removed → FAILS; restored → passes

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
