### PR TITLE
fix(pause): grade the alarm register for completeness, not just correctness (config-I7023)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -146,6 +146,79 @@
         "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc"
       ]
+    },
+    "alpha-engine-watch-plane-overseer-liveness-probe-errors": {
+      "reason": "overseer liveness-probe Errors. Period=28800 with treat_missing_data=breaching, so an 8h window with no invocation latches ALARM - and the probe's only two triggers are paused. Added 2026-08-14 (alpha-engine-config-I7023): this alarm and its two siblings were the four still paging Brian after the I7174 reconciler silenced the rest, because the I7174 entry list was built from the alarms observed in ALARM on 2026-08-13 and these read OK at that moment - the backstop responder was re-invoking the probe on every firing (alpha-engine-config-I7330), manufacturing the datapoint that cleared them.",
+      "watches": [
+        "alpha-engine-overseer-liveness-0650-daily",
+        "alpha-engine-overseer-liveness-1450-daily"
+      ]
+    },
+    "alpha-engine-watch-plane-overseer-liveness-probe-throttles": {
+      "reason": "overseer liveness-probe Throttles; same shape, same window and same paused triggers as the Errors sibling above. Added 2026-08-14 (alpha-engine-config-I7023).",
+      "watches": [
+        "alpha-engine-overseer-liveness-0650-daily",
+        "alpha-engine-overseer-liveness-1450-daily"
+      ]
+    },
+    "alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor": {
+      "reason": "invocations-floor on the overseer liveness probe. This is the alarm whose ENTIRE job is detecting a probe that stopped running, so while the probe is deliberately stopped it can only report the pause back to us. Added 2026-08-14 (alpha-engine-config-I7023).",
+      "watches": [
+        "alpha-engine-overseer-liveness-0650-daily",
+        "alpha-engine-overseer-liveness-1450-daily"
+      ]
+    },
+    "alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor": {
+      "reason": "invocations-floor on the sf-watch liveness probe. Its -errors and -throttles siblings were declared under I7174 and this one was not, so it stayed armed on the same paused triggers - the family-completeness check added with this entry is what makes that shape impossible to repeat. Silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984); re-exam 2026-09-09, same predicate as the sf-watch entries it watches.",
+      "watches": [
+        "alpha-engine-sf-watch-liveness-0645-daily",
+        "alpha-engine-sf-watch-liveness-1445-daily"
+      ]
+    }
+  },
+  "armed_alarms": {
+    "_why": "alpha-engine-config-I7023. The counterpart to `paused_alarms`, and the reason that block can be graded for COMPLETENESS rather than only for correctness. Every live CloudWatch alarm with treat_missing_data=breaching can latch ALARM purely from silence, so every one of them must be classified: either it is silent because a trigger is paused (`paused_alarms`) or it is watching something that is genuinely running and must stay armed (here). `--check` reports any breaching alarm in neither block as `alarm-undeclared`, so a new one cannot be born unclassified, and reports an entry here whose actions are live-disabled as `armed-but-silenced`, so a detector cannot be muted by hand without a declaration saying why. I7174 built `paused_alarms` from the alarms OBSERVED in ALARM on 2026-08-13; four of the class read OK at that moment and were therefore never listed, which is what kept paging Brian on 2026-08-14. A register built from symptoms is an incident log, not an audit - this block is what makes it an audit. Entries need only a reason; there is nothing to reconcile, because armed is the default state and `--enforce` never disables an alarm that is not justified by `paused_alarms`.",
+    "alpha-engine-backtester-no-heartbeat": {
+      "reason": "weekly heartbeat floor for the backtester; the component is running and this is its only silence detector."
+    },
+    "alpha-engine-evaluator-no-heartbeat": {
+      "reason": "weekly heartbeat floor for the evaluator; running."
+    },
+    "alpha-engine-predictor-training-no-heartbeat": {
+      "reason": "weekly heartbeat floor for predictor training; running."
+    },
+    "alpha-engine-rag-ingestion-no-heartbeat": {
+      "reason": "weekly heartbeat floor for RAG ingestion; running."
+    },
+    "alpha-engine-research-runner-no-invocations": {
+      "reason": "weekly Invocations floor on alpha-engine-research-runner; running."
+    },
+    "alpha-engine-pipeline-deadman-preopen-trading": {
+      "reason": "ExecutionsSucceeded deadman on ne-preopen-trading-pipeline - one of the three pipelines the 2026-08-07 ruling explicitly KEPT. Silencing this would silence a kept pipeline."
+    },
+    "alpha-engine-pipeline-deadman-postclose-trading": {
+      "reason": "ExecutionsSucceeded deadman on ne-postclose-trading-pipeline - kept by the same ruling."
+    },
+    "alpha-engine-preflight-sweep-no-run": {
+      "reason": "daily run-completed floor for the preflight sweep; running."
+    },
+    "alpha-engine-dashboard-box-disk-critical": {
+      "reason": "disk on the 24/7 dashboard box (i-09b539c844515d549), explicitly kept by the 2026-08-07 ruling. Missing data means the box stopped reporting, which is itself the finding."
+    },
+    "alpha-engine-console-exposure-probe-dead": {
+      "reason": "15-min heartbeat for the console exposure probe; running."
+    },
+    "alpha-engine-console-exposure-probe-violation": {
+      "reason": "console exposure violations; the probe feeding it is running."
+    },
+    "alpha-engine-router-exposure-probe-dead": {
+      "reason": "15-min heartbeat for the router exposure probe; running."
+    },
+    "alpha-engine-router-exposure-probe-violation": {
+      "reason": "router exposure violations; the probe feeding it is running."
+    },
+    "router-degraded-mode-drill-stale": {
+      "reason": "daily freshness of the router degraded-mode drill heartbeat; running."
     }
   }
 }

--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -52,6 +52,22 @@ configuration survive for later reconstruction. Re-enabling an alarm is NOT
 the trigger-reenable asymmetry below — it only resumes paging, it starts no
 scheduled work, so it is safe for ``enforce()`` to do unattended.
 
+``paused_alarms`` is graded for CORRECTNESS by the above: every entry in it must
+still be justified and must match live state. It is graded for COMPLETENESS by
+``armed_alarms`` (alpha-engine-config-I7023). Every live alarm with
+``TreatMissingData=breaching`` can latch ALARM from silence alone, so each one
+must be classified into exactly one of the two blocks — silenced because a
+trigger is paused, or armed because it watches something genuinely running. An
+alarm in NEITHER block is an ``alarm-undeclared`` finding, so a new one cannot be
+born unclassified; an ``armed_alarms`` entry whose live actions are disabled is
+``armed-but-silenced``, so a detector cannot be muted by hand with no
+declaration saying why. This exists because the original ``paused_alarms`` list
+was built from the alarms OBSERVED in ALARM on one morning: four members of the
+class read OK at that moment — one of them because another component was
+re-invoking their paused probe — and were therefore never listed, and kept
+paging. A register built from symptoms is an incident log; ``armed_alarms`` is
+what makes this one an audit.
+
 Usage:
   ./infrastructure/automation_pause.py --check     # verify; exit 1 on any finding
   ./infrastructure/automation_pause.py --enforce   # re-disable anything that came back,
@@ -162,6 +178,19 @@ def alarm_entries(manifest: dict | None = None) -> list[dict]:
     return out
 
 
+def armed_alarm_names(manifest: dict | None = None) -> set[str]:
+    """Alarms deliberately left ARMED — the completeness counterpart to ``paused_alarms``.
+
+    No ``watches`` field and nothing to reconcile: armed is the default state,
+    and ``enforce()`` never silences an alarm that ``paused_alarms`` does not
+    justify. The block exists so every breaching alarm is classified rather than
+    merely every silenced one. ``_``-prefixed keys are prose, same convention as
+    every other block here.
+    """
+    m = manifest if manifest is not None else load_manifest()
+    return {k for k in m.get("armed_alarms", {}) if not k.startswith("_")}
+
+
 def alarm_justified(entry: dict, manifest: dict | None = None) -> bool:
     """Is silencing ``entry`` still justified by the manifest, right now?
 
@@ -244,6 +273,38 @@ def _alarm_actions_enabled(name: str) -> bool | None:
     if out in ("None", ""):
         return None
     return out == "True"
+
+
+def _live_breaching_alarms() -> dict[str, bool]:
+    """``{alarm name: ActionsEnabled}`` for every live alarm that latches on silence.
+
+    ``TreatMissingData=breaching`` is the whole population that can go ALARM with
+    nothing wrong, so it is the population the two manifest blocks must between
+    them cover. Paginated explicitly: DescribeAlarms caps at 100 per page and a
+    truncated first page would silently shrink the very set being graded for
+    completeness.
+    """
+    alarms: dict[str, bool] = {}
+    token: str | None = None
+    while True:
+        args = [
+            "cloudwatch", "describe-alarms", "--max-items", "100",
+            "--query",
+            "{a: MetricAlarms[?TreatMissingData=='breaching'].{n: AlarmName, e: ActionsEnabled}, "
+            "t: NextToken}",
+            "--output", "json",
+        ]
+        if token:
+            args += ["--starting-token", token]
+        rc, out, err = _aws(args)
+        if rc != 0:
+            raise RuntimeError(f"aws cloudwatch describe-alarms: {err}")
+        page = json.loads(out or "{}")
+        for row in page.get("a") or []:
+            alarms[row["n"]] = bool(row["e"])
+        token = page.get("t")
+        if not token:
+            return alarms
 
 
 def _set_alarm_actions(name: str, enabled: bool) -> None:
@@ -369,6 +430,61 @@ def alarm_findings() -> list[dict]:
                     f"entry."
                 ),
             })
+
+    out.extend(alarm_coverage_findings())
+    return out
+
+
+def alarm_coverage_findings() -> list[dict]:
+    """Is every silence-latching alarm CLASSIFIED — not merely every listed one?
+
+    ``alarm_findings()`` above grades the entries that exist. This grades the
+    ones that do not: any live alarm with ``TreatMissingData=breaching`` in
+    neither ``paused_alarms`` nor ``armed_alarms``, and any ``armed_alarms``
+    entry that has been silenced or has vanished. Without this, the manifest can
+    only ever be as complete as whatever was firing on the day someone wrote it.
+    """
+    out: list[dict] = []
+    declared_paused = {e["name"] for e in alarm_entries()}
+    declared_armed = armed_alarm_names()
+    live = _live_breaching_alarms()
+
+    for name in sorted(set(live) - declared_paused - declared_armed):
+        out.append({
+            "trigger": name, "surface": "cloudwatch", "kind": "alarm-undeclared",
+            "detail": (
+                "treat_missing_data=breaching, so it can latch ALARM on silence "
+                "alone, but it appears in neither paused_alarms nor "
+                "armed_alarms. Classify it: add it to paused_alarms with the "
+                "trigger(s) it watches if it is quiet because they are paused, "
+                "or to armed_alarms with a one-line reason if it watches "
+                "something genuinely running. An unclassified alarm of this "
+                "class is exactly what paged on 2026-08-14."
+            ),
+        })
+
+    for name in sorted(declared_armed):
+        if name not in live:
+            out.append({
+                "trigger": name, "surface": "cloudwatch", "kind": "armed-missing-in-aws",
+                "detail": (
+                    "declared in armed_alarms but no live alarm of that name has "
+                    "treat_missing_data=breaching — it was deleted, renamed, or its "
+                    "missing-data treatment was changed, and whatever it detected is "
+                    "now undetected. Remove or correct the entry."
+                ),
+            })
+        elif not live[name]:
+            out.append({
+                "trigger": name, "surface": "cloudwatch", "kind": "armed-but-silenced",
+                "detail": (
+                    "declared as deliberately ARMED, but ActionsEnabled=false — a "
+                    "detector was muted by hand with no declaration saying why, and a "
+                    "muted alarm is indistinguishable from a healthy one on every "
+                    "surface. Either re-arm it, or move it to paused_alarms naming the "
+                    "trigger(s) whose pause justifies the silence."
+                ),
+            })
     return out
 
 
@@ -442,16 +558,20 @@ def main() -> int:
         print(json.dumps({"checked": len(entries),
                           "kept_checked": len(kept_names()),
                           "alarms_checked": len(alarm_entries()),
+                          "armed_alarms_checked": len(armed_alarm_names()),
                           "findings": findings}, indent=2))
     else:
         kept = kept_names()
         alarms = alarm_entries()
+        armed = armed_alarm_names()
         print(f"automation pause — {len(entries)} paused / {len(kept)} kept trigger(s), "
-              f"{len(alarms)} declared alarm(s) checked")
+              f"{len(alarms)} silenced / {len(armed)} armed alarm(s) checked")
         if not findings:
             print("  ✓ every paused trigger exists live and is DISABLED")
             print("  ✓ every kept trigger exists live and is ENABLED")
             print("  ✓ every declared alarm's ActionsEnabled matches its current justification")
+            print("  ✓ every breaching alarm live in CloudWatch is declared in one block "
+                  "or the other")
         for f in findings:
             print(f"  ✗ [{f['kind']}] {f['surface']}:{f['trigger']}")
             print(f"      {f['detail']}")

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -208,14 +208,30 @@ _effective_evals() {
 
 _effective_treat_missing() {
   local label="$1"
-  # For slow-cadence probes: a completely silent period means the probe never
-  # ran — which IS a failure (the "not running" failure mode). For event-driven
-  # Lambdas, missing data is the healthy steady state.
-  if [ -n "${_LAMBDA_CADENCE_SECONDS[$label]:-}" ]; then
-    echo "breaching"
-  else
-    echo "$DEFAULT_ALARM_TREAT_MISSING"
-  fi
+  # ALWAYS notBreaching in the Errors/Throttles loop, slow-cadence probes
+  # included. This is deliberately not a per-label decision any more; the
+  # function is kept as the seam where someone would be tempted to re-add
+  # `breaching`, so the argument against it lives where the change would be made.
+  #
+  # WHY (alpha-engine-config-I7023). These two alarms are `Sum(Errors) >= 1` and
+  # `Sum(Throttles) >= 1`. Treating an empty window as breaching makes the
+  # ABSENCE OF AN ERROR page, and it destroys the only distinction that matters
+  # when a probe goes quiet: "ran and failed" versus "did not run". Both alarms
+  # then report the same fact, neither reports it cleanly, and a deliberately
+  # paused probe latches ALARM on all three of its alarms at once — four pages
+  # per cycle on 2026-08-14, from a plane that was off on purpose.
+  #
+  # The "did not run" failure mode is NOT lost: that is exactly what the
+  # per-liveness-probe Invocations-floor alarm in section 3 detects, and it
+  # keeps `breaching`, because for THAT alarm absence is the condition being
+  # measured rather than the absence of the condition. That alarm postdates this
+  # override (I5567 after I4477) — it took the job over and the override was
+  # never narrowed.
+  #
+  # The Period/EvaluationPeriods override is untouched and still needed: a
+  # slow-cadence probe failing every invocation must not self-clear in the
+  # datapoint-sparse windows between runs (the original I4477 finding).
+  echo "$DEFAULT_ALARM_TREAT_MISSING"
 }
 
 echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.11"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+  "real_alarm_scan: opt out of the autouse CloudWatch stub in tests/test_automation_pause.py — for the one test whose subject IS the live-alarm scan",
+]
 
 [tool.coverage.run]
 source = ["."]

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -570,7 +570,13 @@ def test_reconcile_monthly_is_paused_not_pending(manifest, module):
 # check() is bidirectional (unexpectedly-enabled AND stale-disabled); and
 # enforce() can act in BOTH directions for alarms specifically, unlike triggers.
 
-ALARM_NAMES = {
+# The nine declared when the block was created (alpha-engine-config-I7174).
+# Asserted as a SUBSET below, never as equality. The original test demanded
+# equality, which meant the manifest could not gain an entry without a test
+# edit — and the four alarms it was missing were precisely the ones still paging
+# on 2026-08-14. A frozen expected-set turns "the register grew" into a failure
+# and "the register is incomplete" into a pass, which is backwards.
+ORIGINAL_ALARM_NAMES = {
     "alpha-engine-watch-plane-alert-drain-liveness-probe-invocations-floor",
     "alpha-engine-watch-plane-canary-replay-liveness-probe-invocations-floor",
     "alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor",
@@ -583,11 +589,30 @@ ALARM_NAMES = {
 }
 
 
-def test_all_nine_pause_caused_alarms_are_declared(manifest, module):
+def test_the_original_pause_caused_alarms_are_still_declared(manifest, module):
     names = {e["name"] for e in module.alarm_entries(manifest)}
-    assert names == ALARM_NAMES, (
-        f"missing: {ALARM_NAMES - names}; unexpected: {names - ALARM_NAMES}"
+    assert ORIGINAL_ALARM_NAMES <= names, (
+        f"an alarm silenced under I7174 lost its declaration: "
+        f"{ORIGINAL_ALARM_NAMES - names}"
     )
+
+
+def test_the_four_alarms_that_paged_on_2026_08_14_are_declared(manifest, module):
+    """The instance this issue was opened for (alpha-engine-config-I7023).
+
+    These four have exactly the same shape as the nine above — breaching alarms
+    on probes whose every trigger is paused — and were left out because the
+    original list was built from what was firing that morning rather than from
+    the class.
+    """
+    names = {e["name"] for e in module.alarm_entries(manifest)}
+    for name in (
+        "alpha-engine-watch-plane-overseer-liveness-probe-errors",
+        "alpha-engine-watch-plane-overseer-liveness-probe-throttles",
+        "alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor",
+    ):
+        assert name in names, f"{name} is undeclared and will page again"
 
 
 def test_the_three_deliberately_armed_alarms_are_not_declared(manifest, module):
@@ -660,17 +685,33 @@ def test_alarm_justified_requires_ALL_watched_triggers_paused(module):
     assert module.alarm_justified(entry, partial) is False
 
 
-def test_check_flags_a_justified_alarm_left_armed(module, monkeypatch):
+@pytest.fixture
+def classified_world(module, monkeypatch):
+    """A live CloudWatch in which every breaching alarm is already classified.
+
+    `check()` now scans live alarms for coverage, so without this the tests
+    below would shell out to `aws cloudwatch describe-alarms` and grade against
+    whatever the real account happens to hold. Returns the dict so a test can
+    mutate it to induce a coverage finding.
+    """
+    live = {e["name"]: False for e in module.alarm_entries()}
+    live.update({name: True for name in module.armed_alarm_names()})
+    monkeypatch.setattr(module, "_live_breaching_alarms", lambda: live)
+    return live
+
+
+def test_check_flags_a_justified_alarm_left_armed(module, monkeypatch, classified_world):
     """The bug this issue fixes, induced: paused trigger, ActionsEnabled=true."""
     monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
     monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: True)
     findings = module.check()
     kinds = {(f["trigger"], f["kind"]) for f in findings}
-    for name in ALARM_NAMES:
+    for name in ORIGINAL_ALARM_NAMES:
         assert (name, "alarm-unexpectedly-enabled") in kinds, findings
 
 
-def test_check_flags_a_stale_disabled_alarm_after_its_pause_lifts(module, monkeypatch):
+def test_check_flags_a_stale_disabled_alarm_after_its_pause_lifts(
+        module, monkeypatch, classified_world):
     """The failure this issue exists to prevent: pause lifted, alarm never re-armed."""
     lifted = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     del lifted["paused"]["scheduler_schedules"]["alpha-engine-sf-watch-liveness-0645-daily"]
@@ -686,11 +727,81 @@ def test_check_flags_a_stale_disabled_alarm_after_its_pause_lifts(module, monkey
             "alarm-stale-disabled") in kinds, findings
 
 
-def test_check_is_silent_on_alarms_whose_state_matches_justification(module, monkeypatch):
+def test_check_is_silent_on_alarms_whose_state_matches_justification(
+        module, monkeypatch, classified_world):
     monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
     monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
     findings = module.check()
     assert not [f for f in findings if f["surface"] == "cloudwatch"], findings
+
+
+# ── Completeness: every breaching alarm is classified (config-I7023) ────────
+
+
+def test_every_armed_alarm_entry_carries_a_reason(manifest, module):
+    for name in module.armed_alarm_names(manifest):
+        reason = manifest["armed_alarms"][name].get("reason", "")
+        assert reason.strip(), f"{name} is declared armed with no reason"
+
+
+def test_no_alarm_is_declared_both_paused_and_armed(manifest, module):
+    """The two blocks are a partition, not two lists that may overlap.
+
+    An alarm in both is a contradiction the reconciler would resolve silently in
+    favour of whichever block it reads first.
+    """
+    paused = {e["name"] for e in module.alarm_entries(manifest)}
+    both = paused & module.armed_alarm_names(manifest)
+    assert not both, f"declared as both silenced and armed: {sorted(both)}"
+
+
+def test_an_undeclared_breaching_alarm_is_a_finding(module, monkeypatch,
+                                                    classified_world):
+    """The defect this check exists for: a new absence-alarm nobody classified."""
+    monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
+    monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
+    classified_world["alpha-engine-brand-new-probe-dead"] = True
+    kinds = {(f["trigger"], f["kind"]) for f in module.check()}
+    assert ("alpha-engine-brand-new-probe-dead", "alarm-undeclared") in kinds
+
+
+def test_a_hand_muted_armed_alarm_is_a_finding(module, monkeypatch, classified_world):
+    """A detector muted with no declaration is indistinguishable from a healthy one."""
+    monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
+    monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
+    victim = sorted(module.armed_alarm_names())[0]
+    classified_world[victim] = False
+    kinds = {(f["trigger"], f["kind"]) for f in module.check()}
+    assert (victim, "armed-but-silenced") in kinds
+
+
+def test_an_armed_alarm_that_vanished_is_a_finding(module, monkeypatch,
+                                                   classified_world):
+    monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
+    monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
+    victim = sorted(module.armed_alarm_names())[0]
+    del classified_world[victim]
+    kinds = {(f["trigger"], f["kind"]) for f in module.check()}
+    assert (victim, "armed-missing-in-aws") in kinds
+
+
+def test_describe_alarms_pagination_is_followed(module, monkeypatch):
+    """A truncated first page would silently shrink the population being graded."""
+    pages = [
+        ('{"a": [{"n": "a1", "e": true}], "t": "tok"}', None),
+        ('{"a": [{"n": "a2", "e": false}], "t": null}', "tok"),
+    ]
+    seen: list[str | None] = []
+
+    def fake_aws(args):
+        token = args[args.index("--starting-token") + 1] if "--starting-token" in args else None
+        seen.append(token)
+        body = next(b for b, t in pages if t == token)
+        return 0, body, ""
+
+    monkeypatch.setattr(module, "_aws", fake_aws)
+    assert module._live_breaching_alarms() == {"a1": True, "a2": False}
+    assert seen == [None, "tok"], "the second page was never requested"
 
 
 def test_enforce_can_both_disable_and_enable_alarm_actions(module, monkeypatch):

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -685,18 +685,27 @@ def test_alarm_justified_requires_ALL_watched_triggers_paused(module):
     assert module.alarm_justified(entry, partial) is False
 
 
-@pytest.fixture
-def classified_world(module, monkeypatch):
+@pytest.fixture(autouse=True)
+def classified_world(module, monkeypatch, request):
     """A live CloudWatch in which every breaching alarm is already classified.
 
-    `check()` now scans live alarms for coverage, so without this the tests
-    below would shell out to `aws cloudwatch describe-alarms` and grade against
-    whatever the real account happens to hold. Returns the dict so a test can
+    `check()` scans live alarms for coverage, so without this a test would shell
+    out to `aws cloudwatch describe-alarms` and grade against whatever the real
+    account happens to hold — passing on a developer laptop with credentials and
+    failing in CI, which has none by design. Returns the dict so a test can
     mutate it to induce a coverage finding.
+
+    AUTOUSE deliberately. I7174 added a live alarm read to `check()` and patched
+    the three tests that noticed, one at a time; I7023 added another and the
+    same three broke again the same way. The fixture makes the whole module
+    unable to reach AWS, so the next live read added to `check()` cannot
+    reintroduce this — the failure mode is a test file that silently depends on
+    ambient credentials, not any one call.
     """
     live = {e["name"]: False for e in module.alarm_entries()}
     live.update({name: True for name in module.armed_alarm_names()})
-    monkeypatch.setattr(module, "_live_breaching_alarms", lambda: live)
+    if request.node.get_closest_marker("real_alarm_scan") is None:
+        monkeypatch.setattr(module, "_live_breaching_alarms", lambda: live)
     return live
 
 
@@ -785,8 +794,14 @@ def test_an_armed_alarm_that_vanished_is_a_finding(module, monkeypatch,
     assert (victim, "armed-missing-in-aws") in kinds
 
 
+@pytest.mark.real_alarm_scan
 def test_describe_alarms_pagination_is_followed(module, monkeypatch):
-    """A truncated first page would silently shrink the population being graded."""
+    """A truncated first page would silently shrink the population being graded.
+
+    Opts out of the autouse stub — this is the one test whose subject IS
+    `_live_breaching_alarms`. It fakes `_aws` instead, so it still never reaches
+    the network.
+    """
     pages = [
         ('{"a": [{"n": "a1", "e": true}], "t": "tok"}', None),
         ('{"a": [{"n": "a2", "e": false}], "t": null}', "tok"),

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -181,6 +181,40 @@ class TestAlarmSemantics:
             "outside this block"
         )
 
+    def test_no_label_can_make_errors_or_throttles_breaching(self, script_text):
+        """`_effective_treat_missing` returns the default for EVERY label.
+
+        Previously it returned "breaching" for any label in
+        `_LAMBDA_CADENCE_SECONDS`, which made the absence of an error page and
+        erased the only distinction that matters when a probe goes quiet: "ran
+        and failed" versus "did not run". The Invocations-floor alarm (I5567)
+        owns "did not run" and keeps breaching; these two must not duplicate it.
+        Asserted on the function body, because a per-label branch reintroduced
+        there is invisible to the loop-body scan above (alpha-engine-config-I7023).
+        """
+        start = script_text.find("_effective_treat_missing() {")
+        assert start != -1, "the seam this property lives on was renamed"
+        body = script_text[start:script_text.find("\n}", start)]
+        code = [ln.strip() for ln in body.splitlines()
+                if ln.strip() and not ln.strip().startswith("#")]
+        assert not any("breaching" in ln and "notBreaching" not in ln
+                       for ln in code), (
+            f"a label-conditional breaching value is back in "
+            f"_effective_treat_missing: {code}"
+        )
+        assert 'echo "$DEFAULT_ALARM_TREAT_MISSING"' in body
+
+    def test_the_invocations_floor_alarm_still_owns_absence(self, script_text):
+        """The counterpart to the test above: absence detection must not be lost.
+
+        Narrowing Errors/Throttles to notBreaching is only correct because this
+        alarm keeps breaching. If both were relaxed, a probe that stopped running
+        would report green on every alarm it has.
+        """
+        block = script_text[script_text.find("Invocations-floor alarms..."):]
+        assert '--metric-name "Invocations"' in block
+        assert '--treat-missing-data "breaching"' in block
+
     def test_default_period_five_minutes_single_eval(self, script_text):
         # The default alarm shape is Period=300 (5 min), EvaluationPeriods=1
         # for event-driven Lambdas. Slow-cadence probes (config#4477) can


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7023`

## Why

Brian, 2026-08-14: *"I thought overseer is disabled — why am I still getting harassed by alerts?"*
Four `OVERSEER BACKSTOP` pages per 8-hour cycle, from a plane deliberately off since 2026-08-07.

## What was already right

`alpha-engine-config-I7174` built the `paused_alarms` block and the reconciler that silences a
paused component's alarms and re-arms them when the pause lifts. It works. Its CI step
(`automation_pause.py --enforce --alarms-only` in `sf-arn-drift-check.yml`) has been green, and it
correctly silenced nine alarms on 2026-08-13. This PR does not rework any of that.

## What was wrong

The register was missing four alarms of exactly the same class:

```
alpha-engine-watch-plane-overseer-liveness-probe-errors
alpha-engine-watch-plane-overseer-liveness-probe-throttles
alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor
alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor
```

Those four are the entire reason Brian was still being paged.

**Why they were missing is the part worth fixing.** The I7174 list was built from the alarms
*observed in ALARM* on 2026-08-13. The three overseer ones read **OK** at that moment — the
backstop responder was re-invoking their paused probe on every firing (`alpha-engine-config-I7330`,
fixed in `nousergon-data-PR1379`), manufacturing the `Invocations` datapoint that cleared them. The
sf-watch floor was simply skipped while its two siblings were listed.

A register built from symptoms is an incident log, not an audit. It is complete only by luck, and
here the luck ran out in one direction while another defect hid it in the other.

## What changed

**1. The four entries**, each naming the paused triggers that justify silencing it. The reconciler
already holds them muted and will re-arm them automatically when the pause lifts — no separate AWS
command, no second edit.

**2. `armed_alarms`** — the completeness counterpart. Every live alarm with
`TreatMissingData=breaching` can latch ALARM from silence alone, so every one must be classified
into exactly one block: silenced because a trigger is paused, or armed because it watches something
genuinely running. Fourteen entries, one line of reason each. `--check` now reports:

| Finding | Catches |
|---|---|
| `alarm-undeclared` | a breaching alarm in neither block — a new absence-alarm cannot be born unclassified |
| `armed-but-silenced` | a declared-armed alarm whose actions are off — a detector muted by hand with nothing recording why, and a muted alarm is indistinguishable from a healthy one |
| `armed-missing-in-aws` | a declared-armed alarm deleted, renamed, or whose missing-data treatment changed under it |

No new IAM: `cloudwatch:DescribeAlarms` is already granted for I7188. `DescribeAlarms` is paginated
explicitly — a truncated first page would silently shrink the very population being graded for
completeness.

**3. Errors/Throttles narrowed to `notBreaching` for every label.**
`_effective_treat_missing` returned `breaching` for slow-cadence probes, so `Sum(Errors) >= 1` paged
on the *absence of an error* — and lost the only distinction that matters when a probe goes quiet:
*ran and failed* versus *did not run*. The Invocations-floor alarm (I5567) owns *did not run* and
keeps `breaching`; it postdates the I4477 cadence override and took that job over without the
override being narrowed. Three alarms reported one fact and none reported it cleanly. This removes
2/3 of the noise on its own, before the pause gate does anything. **Period and EvaluationPeriods
overrides are untouched** — a slow-cadence probe failing every invocation must still not self-clear
in the sparse windows between runs, which was the original I4477 finding.

## Tests

`128 passing` across `test_automation_pause.py`, `test_pause_reconcile.py`,
`test_watch_plane_alarms_script.py`.

**The frozen expected-set had to go.** `test_all_nine_pause_caused_alarms_are_declared` asserted
set *equality* against nine hardcoded names, so the manifest could not gain an entry without a test
edit: "the register is incomplete" passed and "the register grew" failed. It is now a subset
assertion over the original nine, plus a named test for the four that paged.

Added:
- paused and armed are a partition, never overlapping;
- every armed entry carries a reason;
- each of the three new finding kinds, induced;
- `DescribeAlarms` pagination is actually followed (asserts the second page was requested);
- no label can make Errors/Throttles breaching — asserted on the **function body**, because a
  per-label branch reintroduced there is invisible to the existing loop-body scan;
- the Invocations-floor alarm still keeps `breaching`, so narrowing its siblings cannot quietly
  cost absence detection.

The three tests that call `check()` now stub the live alarm scan. Without that they shell out to the
real account and grade against whatever it happens to hold.

**Both new pins were verified to fail when the fix is reverted and pass when restored.** A guard
that cannot fail is not a guard.

## Live verification

```
$ AWS_PROFILE=ne-admin python3 infrastructure/automation_pause.py --check
automation pause — 36 paused / 20 kept trigger(s), 13 silenced / 14 armed alarm(s) checked
  ✓ every paused trigger exists live and is DISABLED
  ✓ every kept trigger exists live and is ENABLED
  ✓ every declared alarm's ActionsEnabled matches its current justification
  ✓ every breaching alarm live in CloudWatch is declared in one block or the other
```

The four alarms were disabled in-session ahead of this PR to stop the paging immediately; this
change is what makes that state *declared* rather than an undeclared hand-mute — which the new
`armed-but-silenced` finding would otherwise have flagged, correctly.

## Test plan

Run BEFORE opening, not deferred to CI:

- `.venv/bin/python -m pytest tests/test_automation_pause.py tests/test_pause_reconcile.py tests/test_watch_plane_alarms_script.py -q` → **128 passed**
- `.venv/bin/python -m pytest tests/ -q -k "watch_plane or pause or overseer or backstop or alarm"` → **314 passed**
- `bash -n infrastructure/setup_watch_plane_alarms.sh` → clean; `ruff check` → clean
- `automation_pause.py --check` against the live account → green (above)
- Negative checks: polarity pin fails with the `breaching` branch restored; coverage check fails
  with an `armed_alarms` entry removed

## Related

`nousergon-data-PR1379` (`alpha-engine-config-I7330`) fixes the responder half — it stops
`invoke_probe` from restarting the paused probe, which is what hid three of these four alarms from
the I7174 sweep. Independent of this PR; either may merge first.

## Deploy

Nothing to run after merging; both halves are automatic.

- The `paused_alarms` entries are applied by the `--enforce --alarms-only` step in
  `sf-arn-drift-check.yml` on its next run (they already match live state, so it is a no-op).
- The `notBreaching` narrowing is applied by `deploy-watch-plane-alarms.yml`, which runs
  `setup_watch_plane_alarms.sh` on merge to main whenever that script changes — this diff touches
  it, so the workflow fires.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
