### PR TITLE
fix(pause): the provisioner must not re-arm what the pause silenced (config-I7023)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -76,20 +76,6 @@ jobs:
           role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
           aws-region: us-east-1
 
-      # Brian ruling 2026-08-07: all scheduled automation paused except the
-      # weekly/preopen/postclose SFs and the 24/7 box. This asserts the pause
-      # still holds — the opposite direction from every other check here, and
-      # the only surface that would notice a redeploy quietly switching a
-      # paused trigger back on. Runs unconditionally on every trigger this
-      # workflow has: the invariant is about live AWS, and tests/
-      # test_automation_pause.py::test_ci_runs_the_pause_check pins that it
-      # carries no `if:` — the 2026-08-10 fix was to the workflow's TRIGGER
-      # set, never to this step's reachability.
-      # Read-only; needs nothing beyond the events:DescribeRule +
-      # scheduler:GetSchedule this role already holds.
-      - name: Scheduled-automation pause still holds (live)
-        run: python3 infrastructure/automation_pause.py --check
-
       # alpha-engine-config-I7174. A paused component's absence-alarm
       # (treat_missing_data: breaching) cannot tell "gated off by declaration"
       # from "upstream died" — nine watch-plane/liveness alarms fired
@@ -103,15 +89,33 @@ jobs:
       # disables or enables a trigger — enable-alarm-actions only resumes
       # paging, so it carries none of the risk that keeps automation_pause.py
       # from ever re-enabling a paused TRIGGER unattended.
-      # Needs cloudwatch:DescribeAlarms + EnableAlarmActions +
-      # DisableAlarmActions on this role — granted in a companion
-      # crucible-executor change (alpha-engine-config-I7188). AccessDenied
-      # here means that grant has not landed yet; `continue-on-error` is soft
-      # only until then — same form-3 pattern as the exercise-cadence step
-      # below. Remove continue-on-error in the PR that lands I7188.
+      #
+      # ORDER IS LOAD-BEARING (alpha-engine-config-I7023): repair, THEN verify.
+      # This step used to run AFTER `--check`, and `--check` has no
+      # continue-on-error — so on exactly the runs where drift existed, the
+      # check failed the job and this remediation was SKIPPED. The self-healing
+      # loop could only ever run when there was nothing to heal. Measured
+      # 2026-08-14 (run 31819251392): eleven `alarm-unexpectedly-enabled`
+      # findings, remediation never reached. Repair-then-verify also makes the
+      # verify meaningful: a `--check` failure now means remediation ran and did
+      # not hold, which is the escalation-worthy condition.
       - name: Paused-component alarm actions reconciled with the manifest (live)
         continue-on-error: true
         run: python3 infrastructure/automation_pause.py --enforce --alarms-only
+
+      # Brian ruling 2026-08-07: all scheduled automation paused except the
+      # weekly/preopen/postclose SFs and the 24/7 box. This asserts the pause
+      # still holds — the opposite direction from every other check here, and
+      # the only surface that would notice a redeploy quietly switching a
+      # paused trigger back on. Runs unconditionally on every trigger this
+      # workflow has: the invariant is about live AWS, and tests/
+      # test_automation_pause.py::test_ci_runs_the_pause_check pins that it
+      # carries no `if:` — the 2026-08-10 fix was to the workflow's TRIGGER
+      # set, never to this step's reachability.
+      # Read-only; needs nothing beyond the events:DescribeRule +
+      # scheduler:GetSchedule this role already holds.
+      - name: Scheduled-automation pause still holds (live)
+        run: python3 infrastructure/automation_pause.py --check
 
       # alpha-engine-config-I7056. The step above asks "is the pause intact".
       # This one asks the question nothing asked before it: for each of the

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -61,6 +61,46 @@ DRY_RUN=false
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 
+# --- 0. The pause overrides this script's default arming --------------------
+#
+# `put-metric-alarm` is an UPSERT of the whole alarm, and it resets
+# ActionsEnabled to true. So every run of this script re-armed every alarm the
+# automation pause had deliberately silenced — measured 2026-08-14: the merge of
+# alpha-engine-config-I7023 fired this script's deploy workflow and re-armed all
+# eleven, and Brian would have been paged again within the hour. The pause was
+# not weak; the provisioner was overwriting it, silently, and nothing said so.
+#
+# Fixed here rather than by re-muting afterwards, because a fix downstream of
+# the overwrite leaves a window in which the alarms are live, and because this
+# script is the thing that knows it is about to reset the field.
+#
+# Justification is computed from the manifest alone — no AWS calls, no second
+# list. An alarm is silenced here for exactly as long as
+# `automation_pause.alarm_justified()` says it is, which is the same predicate
+# `--check` and `--enforce --alarms-only` grade against, so the three can never
+# disagree about which alarms are paused.
+#
+# Fails loud: if the manifest or module cannot be read we do NOT fall back to
+# arming everything, because that is precisely the silent overwrite this exists
+# to stop.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SILENCED_ALARMS=" $(python3 -c "
+import sys
+sys.path.insert(0, '${SCRIPT_DIR}')
+import automation_pause as ap
+print(' '.join(e['name'] for e in ap.alarm_entries() if ap.alarm_justified(e)))
+") "
+echo "  Paused-component alarms (provisioned with actions DISABLED):"
+echo "${SILENCED_ALARMS}" | tr ' ' '\n' | grep -v '^$' | sed 's/^/    /' || echo "    (none)"
+
+# Emits the put-metric-alarm flag controlling whether this alarm may page.
+_actions_flag() {
+  case "${SILENCED_ALARMS}" in
+    *" $1 "*) echo "--no-actions-enabled" ;;
+    *) echo "--actions-enabled" ;;
+  esac
+}
+
 # Deliberately NOT alpha-engine-alerts — see header comment. Provisioned by
 # setup_pipeline_deadman_alarms.sh (sole owner); consumed here.
 BACKSTOP_TOPIC_NAME="alpha-engine-alarm-backstop"
@@ -264,7 +304,8 @@ for label in "${!WATCH_PLANE_FUNCTIONS[@]}"; do
       --comparison-operator "GreaterThanOrEqualToThreshold" \
       --treat-missing-data "$treat" \
       --alarm-actions "$BACKSTOP_TOPIC_ARN" \
-      --ok-actions "$BACKSTOP_TOPIC_ARN" >/dev/null
+      --ok-actions "$BACKSTOP_TOPIC_ARN" \
+      "$(_actions_flag "$alarm_name")" >/dev/null
   done
 done
 
@@ -329,7 +370,8 @@ for label in "${!WATCH_PLANE_FUNCTIONS[@]}"; do
         --comparison-operator "LessThanOrEqualToThreshold" \
         --treat-missing-data "breaching" \
         --alarm-actions "$BACKSTOP_TOPIC_ARN" \
-        --ok-actions "$BACKSTOP_TOPIC_ARN" >/dev/null
+        --ok-actions "$BACKSTOP_TOPIC_ARN" \
+        "$(_actions_flag "$alarm_name")" >/dev/null
       ;;
   esac
 done
@@ -356,7 +398,8 @@ run aws cloudwatch put-metric-alarm \
   --comparison-operator "GreaterThanOrEqualToThreshold" \
   --treat-missing-data "notBreaching" \
   --alarm-actions "$BACKSTOP_TOPIC_ARN" \
-  --ok-actions "$BACKSTOP_TOPIC_ARN"
+  --ok-actions "$BACKSTOP_TOPIC_ARN" \
+  "$(_actions_flag "alpha-engine-watch-plane-overseer-intake-dlq-depth")"
 
 # --- 5. Overseer intake queue age-of-oldest-message (alpha-engine-config-I2910)
 # The DLQ-depth alarm above only fires once EventBridge has delivered an
@@ -407,7 +450,8 @@ run aws cloudwatch put-metric-alarm \
   --comparison-operator "GreaterThanOrEqualToThreshold" \
   --treat-missing-data "notBreaching" \
   --alarm-actions "$BACKSTOP_TOPIC_ARN" \
-  --ok-actions "$BACKSTOP_TOPIC_ARN"
+  --ok-actions "$BACKSTOP_TOPIC_ARN" \
+  "$(_actions_flag "alpha-engine-watch-plane-overseer-intake-age")"
 
 # --- 6. Backstop Telegram forwarder (alpha-engine-config-I2899) ---------------
 # The backstop alarm topic must have a real-time channel beyond email. The

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -163,6 +163,25 @@ def test_ci_runs_the_pause_check(module):
     assert "if:" not in tail, "the pause check is conditionally skipped"
 
 
+def test_ci_repairs_the_alarm_state_before_it_verifies_it():
+    """Repair and verify are one unit, in that order (alpha-engine-config-I7023).
+
+    `--check` carries no `continue-on-error` (pinned above, deliberately). So
+    when `--enforce --alarms-only` ran AFTER it, the enforce step was skipped on
+    exactly the runs where drift existed — the self-healing loop could only run
+    when there was nothing to heal. Measured 2026-08-14 on run 31819251392:
+    eleven `alarm-unexpectedly-enabled` findings, remediation never reached, and
+    the alarms stayed armed until a human ran the same command by hand.
+    """
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    enforce = wf.index("automation_pause.py --enforce --alarms-only")
+    check = wf.index("automation_pause.py --check")
+    assert enforce < check, (
+        "the alarm-action repair step runs after the check that can fail the "
+        "job, so it is skipped precisely when it is needed"
+    )
+
+
 def test_drift_checker_consults_the_manifest_not_a_hardcoded_list():
     src = DRIFT_CHECKER.read_text(encoding="utf-8")
     assert "automation_pause.paused_names()" in src, (

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -181,6 +181,39 @@ class TestAlarmSemantics:
             "outside this block"
         )
 
+    def test_every_put_metric_alarm_carries_the_pause_aware_actions_flag(
+            self, script_text):
+        """`put-metric-alarm` is an upsert and RESETS ActionsEnabled to true.
+
+        So a call site without `_actions_flag` silently re-arms whatever the
+        automation pause had silenced. Measured 2026-08-14: merging
+        alpha-engine-config-I7023 fired this script's deploy workflow and
+        re-armed all eleven paused-component alarms at once. Asserted over every
+        invocation rather than the ones that existed that day — a new alarm
+        added here without the flag is the same defect again.
+        """
+        calls = script_text.count("put-metric-alarm \\")
+        # `_actions_flag "` counts invocations only — the definition line reads
+        # `_actions_flag() {`, with no space before the argument.
+        flags = script_text.count('_actions_flag "')
+        assert calls > 0, "the call sites this property is about were renamed"
+        assert flags == calls, (
+            f"{calls} put-metric-alarm call(s) but {flags} _actions_flag "
+            f"use(s) — a call site can reset ActionsEnabled on a paused alarm"
+        )
+
+    def test_the_silenced_set_comes_from_the_pause_module_not_a_second_list(
+            self, script_text):
+        """One predicate, three consumers.
+
+        If this script hardcoded its own list of paused alarms it would drift
+        from `--check` and `--enforce --alarms-only` the moment a pause lifted,
+        and the drift would show up as an alarm that is silent while the
+        manifest says it should be armed — the hardest direction to notice.
+        """
+        assert "import automation_pause as ap" in script_text
+        assert "ap.alarm_justified(e)" in script_text
+
     def test_no_label_can_make_errors_or_throttles_breaching(self, script_text):
         """`_effective_treat_missing` returns the default for EVERY label.
 


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7023`

## Why

Merging `nousergon-data-PR1380` — the change that stopped the pause-caused paging — **caused it to
start again.** The merge touched `setup_watch_plane_alarms.sh`, which fired
`deploy-watch-plane-alarms.yml`, which re-armed all eleven paused-component alarms in one shot.
Caught within ten minutes and re-muted by hand; Brian was not paged.

`put-metric-alarm` is an upsert of the whole alarm and **resets `ActionsEnabled` to true**. So every
run of that provisioner has always undone the pause. The pause mechanism was never weak — the
provisioner was overwriting it, silently, and nothing said so.

## Two defects, both structural

**1. The provisioner did not know about the pause.**

`setup_watch_plane_alarms.sh` now computes the currently-justified silenced set from
`automation_pause.alarm_justified()` and passes `--no-actions-enabled` for those alarms. That is the
*same predicate* `--check` and `--enforce --alarms-only` grade against, so the three consumers
cannot disagree about which alarms are paused, and there is no second list to drift.

Fixed at the source rather than by re-muting afterwards: a downstream fix leaves a window in which
the alarms are live and paging, and this script is the thing that knows it is about to reset the
field. It **fails loud** if the manifest or module cannot be read — falling back to arming
everything is exactly the silent overwrite being fixed.

**2. The repair step could not run when repair was needed.**

In `sf-arn-drift-check.yml`, `--enforce --alarms-only` ran **after** `--check`, and `--check`
carries no `continue-on-error` (deliberately — it is the pause assertion). So on exactly the runs
where drift existed, the check failed the job and the repair step was **skipped**. The self-healing
loop could only ever run when there was nothing to heal.

Measured today, run `31819251392`: eleven `alarm-unexpectedly-enabled` findings, remediation never
reached, alarms left armed until a human ran the identical command by hand.

Repair now runs first. That also makes the verify meaningful: a `--check` failure now says
*remediation ran and did not hold*, which is the escalation-worthy condition — rather than
*something drifted and nothing tried*.

## Live verification

Not inferred from tests. A full **real** (non-dry) run of the provisioner, followed immediately by
the pause check:

```
$ AWS_PROFILE=ne-admin bash infrastructure/setup_watch_plane_alarms.sh
  Paused-component alarms (provisioned with actions DISABLED):
    ... 13 names ...
Done.

$ AWS_PROFILE=ne-admin python3 infrastructure/automation_pause.py --check
automation pause — 36 paused / 20 kept trigger(s), 13 silenced / 14 armed alarm(s) checked
  ✓ every paused trigger exists live and is DISABLED
  ✓ every kept trigger exists live and is ENABLED
  ✓ every declared alarm's ActionsEnabled matches its current justification
  ✓ every breaching alarm live in CloudWatch is declared in one block or the other
```

Before this change, that same run re-armed every one of them.

## Tests

- every `put-metric-alarm` call site carries `_actions_flag` — asserted over **all** invocations by
  count, so a new alarm added to this script without the flag fails rather than silently re-arming;
- the silenced set comes from the pause module, not a hardcoded list;
- the repair step precedes the verify step in the workflow.

## Test plan

- `.venv/bin/python -m pytest tests/ -q` → **5724 passed, 9 skipped**
- `bash -n infrastructure/setup_watch_plane_alarms.sh` → clean; workflow YAML parses
- Live: real provisioner run + `--check` green (above)

## Note on scope

No new IAM. The alternative fix — have the deploy workflow re-mute afterwards — would have needed
`cloudwatch:{Enable,Disable}AlarmActions` on `github-actions-lambda-deploy`, which holds only
`PutMetricAlarm` and `DescribeAlarms`. Passing `--no-actions-enabled` on the existing
`PutMetricAlarm` grant is both the narrower permission and the correct layer.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
