### PR TITLE
chore(pause): classify alpha-engine-director-plan-latency as deliberately armed (config-I7023)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -219,6 +219,9 @@
     },
     "router-degraded-mode-drill-stale": {
       "reason": "daily freshness of the router degraded-mode drill heartbeat; running."
+    },
+    "alpha-engine-director-plan-latency": {
+      "reason": "Director plan-LLM latency amber line on the weekly SF (alpha-engine-config-I7311), created 2026-08-14. Stays ARMED: the weekly SF is one of the three pipelines the 2026-08-07 ruling explicitly KEPT, so the Director runs and this alarm is measuring something live. Its treat_missing_data=breaching is deliberate per its own description - the Director emits on every plan attempt including timeouts, so no datapoint means it did not run or its emitter is dead. Found by the alarm-undeclared check the same day that check shipped (I7023): the alarm was created between that PR's snapshot and its merge, which is exactly the gap the check exists to close."
     }
   }
 }


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7023`

## Why

The `alarm-undeclared` check shipped in `nousergon-data-PR1381` caught something on its **first run
on main**, which is the entire point of it.

`alpha-engine-director-plan-latency` (`alpha-engine-config-I7311`) was created between PR1380's
snapshot of live CloudWatch and PR1380's merge. For a few hours it existed as an unclassified
`TreatMissingData=breaching` alarm — able to latch ALARM from silence alone, in neither manifest
block — and nothing other than this check would have said so.

That is precisely the gap the check exists to close, and it closed it the same day.

## What changed

One `armed_alarms` entry. **Armed, not silenced:** it watches the weekly SF Director, and the
weekly SF is one of the three pipelines the 2026-08-07 ruling explicitly KEPT. It is measuring
something that runs. Its `breaching` treatment is deliberate per its own alarm description — the
Director emits on every plan attempt including timeouts, so no datapoint means it did not run or
its emitter is dead, which `observability-policy` §9 forbids rendering as green.

## Test plan

- `AWS_PROFILE=ne-admin python3 infrastructure/automation_pause.py --check` → green live,
  **13 silenced / 15 armed alarm(s) checked**
- `.venv/bin/python -m pytest tests/test_automation_pause.py tests/test_pause_reconcile.py -q` →
  **74 passed**

Manifest-only; no code, no IAM, nothing to run after merging.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
