### PR TITLE
[P1/mid] fix(iam): apply_iam_policy unreachable in one deploy.sh; the swallow named the wrong cause (config-I7338)

### DIFF
--- a/infrastructure/lambdas/_shared/apply_iam_policy.sh
+++ b/infrastructure/lambdas/_shared/apply_iam_policy.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+#
 # apply_iam_policy.sh — shared idempotent IAM role/policy apply, sourced by
 # every lambda's deploy.sh (alpha-engine-config#2825).
 #
@@ -50,4 +52,97 @@ apply_iam_policy() {
     --role-name "${role_name}" \
     --policy-name "${policy_name}" \
     --policy-document "file://${policy_file}"
+}
+
+# apply_iam_policy_on_deploy — the "#4472 auto-apply on merge" call site.
+#
+# Same arguments as apply_iam_policy. Tolerates EXACTLY ONE failure: the
+# caller is an identity without iam:PutRolePolicy / iam:CreateRole. That is
+# the CI auto-deploy role by design (see the single-writer note above), and
+# check-drift.py is its backstop. EVERY OTHER failure is a broken applier and
+# exits non-zero, which aborts the deploy under the callers' `set -euo
+# pipefail`.
+#
+# WHY this exists (alpha-engine-config-I7338). The four #4472 call sites each
+# wrote their own tolerance inline:
+#
+#   apply_iam_policy ... || echo "WARN: IAM auto-apply failed (expected in CI
+#                                 — role lacks iam:PutRolePolicy)"
+#
+# That `||` swallowed every cause and asserted one. On 2026-08-14, running as
+# `ne-admin` — an identity that DOES hold iam:PutRolePolicy —
+# alert-drain-liveness-probe/deploy.sh printed:
+#
+#   deploy.sh: line 188: apply_iam_policy: command not found
+#   WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)
+#
+# It had never sourced this file. The WARN named a cause that could not have
+# been true, read as benign, and the auto-apply feature had therefore never
+# executed on that lambda since #4472 shipped — which is the content-drift
+# half of alpha-engine-config-I6299.
+#
+# Two properties close that class, and both depend on the tolerance living
+# HERE rather than at the call site:
+#
+#   1. A `command not found` (rc 127) reaches the classifier as an unmatched
+#      stderr string and is reported LOUDLY, not as a permission note.
+#   2. If a deploy.sh forgets to source this file at all, the call site has no
+#      `||` of its own, so `apply_iam_policy_on_deploy: command not found`
+#      aborts the deploy under `set -e` instead of printing a reassurance.
+#
+# tests/test_deploy_shell_functions_are_defined.py is the derived guard for
+# the sourcing itself, so a 35th deploy.sh cannot repeat this.
+apply_iam_policy_on_deploy() {
+  local role_name="${1:?apply_iam_policy_on_deploy: role name required}"
+  local policy_name="${2:?apply_iam_policy_on_deploy: policy name required}"
+  local policy_file="${3:?apply_iam_policy_on_deploy: policy file required}"
+  local trust_policy="${4:?apply_iam_policy_on_deploy: trust policy required}"
+
+  # stderr is captured to a file rather than streamed through a process
+  # substitution: `tee` in a `>(...)` is not reaped by the `||`, so the
+  # classifier can race the flush and read an EMPTY stderr for a genuine
+  # AccessDenied. Captured stderr is replayed verbatim on both paths below,
+  # so nothing is hidden — only deferred to the end of the command.
+  local err_file rc=0 stderr_text
+  err_file="$(mktemp)"
+
+  apply_iam_policy "${role_name}" "${policy_name}" "${policy_file}" "${trust_policy}" \
+    2>"${err_file}" || rc=$?
+
+  stderr_text="$(cat "${err_file}" 2>/dev/null || true)"
+  rm -f "${err_file}"
+
+  if [ "${rc}" -eq 0 ]; then
+    if [ -n "${stderr_text}" ]; then
+      printf '%s\n' "${stderr_text}" >&2
+    fi
+    return 0
+  fi
+
+  # The ONLY tolerated cause. Matched against what the AWS CLI actually
+  # emits for a denied IAM write: an explicit `AccessDenied`/
+  # `AccessDeniedException` error code, the `is not authorized to perform`
+  # sentence, or an SCP/boundary explicit deny.
+  if printf '%s' "${stderr_text}" | grep -qiE \
+      'AccessDenied|is not authorized to perform|explicit deny|ExpiredToken|InvalidClientTokenId|UnrecognizedClientException'; then
+    echo "WARN: IAM auto-apply skipped — this caller lacks iam:PutRolePolicy/iam:CreateRole." >&2
+    echo "WARN: role=${role_name} policy=${policy_name}. This is expected for the CI" >&2
+    echo "WARN: auto-deploy OIDC role (single-writer rule). check-drift.py is the backstop;" >&2
+    echo "WARN: an operator must run this deploy.sh --apply-iam to land the change." >&2
+    return 0
+  fi
+
+  # Anything else is a BROKEN APPLIER, not a permission boundary. Loud, and
+  # non-zero so `set -e` aborts the deploy rather than shipping code whose
+  # IAM policy silently did not move.
+  echo "ERROR: IAM auto-apply FAILED for role=${role_name} policy=${policy_name} (exit ${rc})." >&2
+  echo "ERROR: This is NOT the known CI permission boundary — the stderr below carries no" >&2
+  echo "ERROR: AccessDenied. The apply mechanism itself is broken; live IAM is now unknown" >&2
+  echo "ERROR: relative to ${policy_file}." >&2
+  if [ -n "${stderr_text}" ]; then
+    printf 'ERROR: --- captured stderr ---\n%s\nERROR: --- end stderr ---\n' "${stderr_text}" >&2
+  else
+    echo "ERROR: (the failing command produced no stderr — exit ${rc} alone)" >&2
+  fi
+  return "${rc}"
 }

--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -195,7 +195,10 @@ fi
 # step. Gracefully fails when the caller lacks iam:PutRolePolicy (CI auto-
 # deploy role); the drift check backstops any missed apply.
 TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}" \
-  || echo "WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)"
+# No `||` here on purpose (alpha-engine-config-I7338): the ONE tolerated
+# failure — this caller lacks iam:PutRolePolicy — is classified inside
+# _shared/apply_iam_policy.sh. Every other cause, including this helper not
+# being sourced at all, aborts the deploy under `set -e`.
+apply_iam_policy_on_deploy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
 echo "Done."

--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -44,6 +44,14 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# alpha-engine-config-I7338: this source was MISSING while the script called
+# apply_iam_policy at the #4472 auto-apply site below, so that call failed
+# with `command not found` on every run — privileged or not — and the old
+# `|| echo "WARN: ... expected in CI"` reported it as a permission boundary.
+# shellcheck source=infrastructure/lambdas/_shared/apply_iam_policy.sh
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
+
 FUNCTION_NAME="alpha-engine-alert-drain-liveness-probe"
 ROLE_NAME="alpha-engine-alert-drain-liveness-probe-role"
 POLICY_NAME="alpha-engine-alert-drain-liveness-probe-policy"
@@ -185,8 +193,11 @@ echo "✓ Code deployed."
 # step. Gracefully fails when the caller lacks iam:PutRolePolicy (CI auto-
 # deploy role); the drift check backstops any missed apply.
 TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}" \
-  || echo "WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)"
+# No `||` here on purpose (alpha-engine-config-I7338): the ONE tolerated
+# failure — this caller lacks iam:PutRolePolicy — is classified inside
+# _shared/apply_iam_policy.sh. Every other cause, including this helper not
+# being sourced at all, aborts the deploy under `set -e`.
+apply_iam_policy_on_deploy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \

--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -185,8 +185,11 @@ run aws lambda put-function-event-invoke-config \
 # step. Gracefully fails when the caller lacks iam:PutRolePolicy (CI auto-
 # deploy role); the drift check backstops any missed apply.
 TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}" \
-  || echo "WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)"
+# No `||` here on purpose (alpha-engine-config-I7338): the ONE tolerated
+# failure — this caller lacks iam:PutRolePolicy — is classified inside
+# _shared/apply_iam_policy.sh. Every other cause, including this helper not
+# being sourced at all, aborts the deploy under `set -e`.
+apply_iam_policy_on_deploy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
 # ----- 6. Publish alert_classes projection to S3 (alpha-engine-config#5200) -----
 # The alert-drain box clones only alpha-engine-config, so the registry at

--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -274,8 +274,11 @@ echo "✓ Code deployed."
 # step. Gracefully fails when the caller lacks iam:PutRolePolicy (CI auto-
 # deploy role); the drift check backstops any missed apply.
 TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
-apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}" \
-  || echo "WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)"
+# No `||` here on purpose (alpha-engine-config-I7338): the ONE tolerated
+# failure — this caller lacks iam:PutRolePolicy — is classified inside
+# _shared/apply_iam_policy.sh. Every other cause, including this helper not
+# being sourced at all, aborts the deploy under `set -e`.
+apply_iam_policy_on_deploy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \

--- a/tests/test_deploy_shell_functions_are_defined.py
+++ b/tests/test_deploy_shell_functions_are_defined.py
@@ -1,0 +1,256 @@
+"""Every shell script that CALLS a repo-defined shell function must define it
+or (transitively) source a file that does.
+
+alpha-engine-config-I7338. `infrastructure/lambdas/alert-drain-liveness-probe/
+deploy.sh` called `apply_iam_policy` at its "#4472 auto-apply IAM on merge"
+site and never sourced `_shared/apply_iam_policy.sh`. Measured 2026-08-14
+running as `ne-admin`, an identity that DOES hold iam:PutRolePolicy:
+
+    .../alert-drain-liveness-probe/deploy.sh: line 188: apply_iam_policy: command not found
+    WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)
+
+The `||` beneath the call asserted a cause that could not have been true, so
+the failure read as benign and the auto-apply feature never executed on that
+lambda — the content-drift half of alpha-engine-config-I6299.
+
+WHY A DERIVED TEST AND NOT A LIST. 34 deploy.sh scripts call
+`apply_iam_policy`; 33 sourced it. A test enumerating those 34 leaves the 35th
+script with the identical hole, and this repo grows a lambda most weeks. So
+both sides are derived from the tree:
+
+  * the UNIVERSE of function names is every `name() { ... }` defined in any
+    tracked shell file under infrastructure/ — nothing is hardcoded;
+  * the CALL SITES are every command-position occurrence of one of those
+    names in any tracked shell file.
+
+A new helper in `_shared/` and a new deploy.sh calling it are both covered on
+the day they land, with no edit here.
+
+WHY SHELLCHECK DOES NOT COVER THIS. shellcheck resolves `source` only when the
+path is a literal it can follow, and every deploy.sh here reaches _shared/
+through `${SCRIPT_DIR}` or a `$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)`
+expansion. With the path unresolvable, SC1091 downgrades to an *info* about
+the source line and shellcheck then treats the callee as an external command —
+it emits nothing at all for the call. Verified against the pre-fix revision:
+`shellcheck --severity=warning` on alert-drain-liveness-probe/deploy.sh
+reports zero findings for `apply_iam_policy`.
+
+FAIL-LOUD (fleet rule). This test never skips and never silently narrows. If a
+`source` line cannot be resolved to a file on disk it is a FAILURE, not an
+ignored line — an unresolvable source is exactly how a guard like this decays
+into one that passes while measuring nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_INFRA = _REPO_ROOT / "infrastructure"
+
+# `name() {`, `name () {`, `function name {`, `function name() {`.
+_DEF_RE = re.compile(
+    r"^[ \t]*(?:function[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*\([ \t]*\)[ \t]*\{"
+    r"|^[ \t]*function[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\{",
+    re.MULTILINE,
+)
+
+# `source X` / `. X`, capturing the (possibly quoted, possibly interpolated)
+# path argument. Rest-of-line rather than `\S+`: the dominant idiom here is
+# `source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/x.sh"`,
+# which contains spaces, and a `\S+` capture truncates it to `"$(cd`.
+_SOURCE_RE = re.compile(r"^[ \t]*(?:source|\.)[ \t]+(.+?)[ \t]*$", re.MULTILINE)
+
+# A shell comment, so a call inside a comment is not counted as a call site.
+_COMMENT_RE = re.compile(r"(?<!\$)#.*$", re.MULTILINE)
+
+# Heredoc bodies are data, not code in THIS script's scope. Stripped so a
+# generated remote script that calls a function it defines itself is not
+# attributed to the outer file.
+_HEREDOC_RE = re.compile(
+    r"<<-?[ \t]*'?\"?([A-Za-z_][A-Za-z0-9_]*)'?\"?.*?\n.*?^[ \t]*\1[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _tracked_shell_files() -> list[Path]:
+    """Every git-tracked *.sh under infrastructure/.
+
+    Uses git rather than glob so an untracked scratch script in a worktree
+    cannot fail the suite, and a tracked one can never be missed.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "--", "infrastructure/**/*.sh", "infrastructure/*.sh"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    files = sorted({_REPO_ROOT / p for p in out})
+    assert files, (
+        "derived-test precondition failed: found ZERO tracked shell files under "
+        "infrastructure/. This guard measures nothing in that state."
+    )
+    return files
+
+
+def _blank(match: re.Match[str]) -> str:
+    """Replace a match with blanks, preserving byte offsets and line count.
+
+    Offset-preserving so a reported violation's line number refers to the
+    ORIGINAL file. A stripping `sub("")` shifts every subsequent line and the
+    guard then points an engineer at the wrong code — which is how a correct
+    finding gets dismissed as noise.
+    """
+    return re.sub(r"[^\n]", " ", match.group(0))
+
+
+def _code(text: str) -> str:
+    """Script text with heredoc bodies and comments blanked out."""
+    return _COMMENT_RE.sub(_blank, _HEREDOC_RE.sub(_blank, text))
+
+
+def _defined_in(text: str) -> set[str]:
+    return {m.group(1) or m.group(2) for m in _DEF_RE.finditer(text)}
+
+
+def _resolve_source(raw: str, script: Path) -> Path:
+    """Resolve a `source` argument to a path on disk.
+
+    Handles the four idioms present in this repo:
+        "${SCRIPT_DIR}/../_shared/pause.sh"
+        "$SCRIPT_DIR/_spot_common.sh"
+        "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+        "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+    All four denote a path relative to the SCRIPT'S OWN directory, so the
+    leading expansion is replaced by that directory. An argument that still
+    contains a `$` after substitution is unresolvable and the caller fails.
+    """
+    arg = raw.strip().strip("\"'")
+    here = script.parent
+
+    # `$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)` and `${SCRIPT_DIR}` /
+    # `$SCRIPT_DIR` all mean "the directory holding this script".
+    arg = re.sub(r'^\$\(cd\s+"\$\(dirname\s+"\$\{BASH_SOURCE\[0\]\}"\)"\s*&&\s*pwd\)', str(here), arg)
+    arg = re.sub(r"^\$\{SCRIPT_DIR\}|^\$SCRIPT_DIR", str(here), arg)
+
+    return Path(arg)
+
+
+def _sourced_closure(script: Path, _seen: set[Path] | None = None) -> tuple[set[Path], list[str]]:
+    """Files transitively sourced by `script`, plus any unresolvable args."""
+    seen = _seen if _seen is not None else set()
+    unresolved: list[str] = []
+    if script in seen or not script.is_file():
+        return seen, unresolved
+    seen.add(script)
+
+    for raw in _SOURCE_RE.findall(_code(script.read_text())):
+        target = _resolve_source(raw, script)
+        if "$" in str(target) or not target.is_file():
+            unresolved.append(f"{script.relative_to(_REPO_ROOT)}: source {raw}")
+            continue
+        child_seen, child_unresolved = _sourced_closure(target.resolve(), seen)
+        seen |= child_seen
+        unresolved.extend(child_unresolved)
+
+    return seen, unresolved
+
+
+def test_every_called_shell_function_is_reachable() -> None:
+    files = _tracked_shell_files()
+    texts = {f: f.read_text() for f in files}
+    code = {f: _code(t) for f, t in texts.items()}
+
+    # The universe: every function name defined anywhere in the shell tree.
+    universe: set[str] = set()
+    for f in files:
+        universe |= _defined_in(code[f])
+    assert "apply_iam_policy" in universe, (
+        "derived-test precondition failed: apply_iam_policy is not in the "
+        "discovered function universe, so this guard is not measuring the "
+        "class it exists for."
+    )
+
+    # A call is a command-position occurrence: start of line, or after a
+    # separator (`;` `|` `&` `(` `{`), or after `then`/`do`/`else`. Bash
+    # keywords only — an English word in a quoted message is NOT a call site
+    # (`|| echo "...did not run for X..."` is prose, not an invocation of a
+    # function named `run`).
+    call_res = {
+        name: re.compile(
+            r"(?:^|(?<=[;|&(){])|(?<=\bthen\b)|(?<=\bdo\b)|(?<=\belse\b))"
+            r"[ \t]*" + re.escape(name) + r"(?=[ \t]|$)",
+            re.MULTILINE,
+        )
+        for name in universe
+    }
+    # ...and never inside a quoted string, which is where the prose lives.
+    _dquote_re = re.compile(r'"(?:\\.|[^"\\])*"', re.DOTALL)
+    _squote_re = re.compile(r"'[^']*'", re.DOTALL)
+
+    def _call_sites(body: str) -> dict[str, int]:
+        """{function name -> 1-based line of its first command-position call}."""
+        scan = _squote_re.sub(_blank, _dquote_re.sub(_blank, body))
+        out: dict[str, int] = {}
+        for name in universe:
+            m = call_res[name].search(scan)
+            if m is not None:
+                out[name] = scan[: m.start()].count("\n") + 1
+        return out
+
+    # Reachability is a property of an ENTRY POINT — a script that is executed,
+    # not sourced — because that is what bash actually flattens at runtime. A
+    # file under _shared/ legitimately calls `run()`, which its consumers
+    # define; checking it standalone would report a false violation and
+    # checking every file standalone is not the runtime rule. So: resolve each
+    # entry point's full source closure, then require every call made ANYWHERE
+    # in that closure to be defined SOMEWHERE in it. A library sourced by
+    # nobody is its own entry point and is still checked.
+    closures: dict[Path, set[Path]] = {}
+    unresolved_all: list[str] = []
+    sourced_by_someone: set[Path] = set()
+
+    for f in files:
+        closure, unresolved = _sourced_closure(f)
+        closures[f] = closure
+        unresolved_all.extend(unresolved)
+        sourced_by_someone |= closure - {f}
+
+    entry_points = [f for f in files if f not in sourced_by_someone]
+    assert entry_points, (
+        "derived-test precondition failed: every shell file is sourced by "
+        "another, so there is no entry point to check."
+    )
+
+    violations: list[str] = []
+    for entry in entry_points:
+        members = sorted(closures[entry])
+        reachable: set[str] = set()
+        for m in members:
+            reachable |= _defined_in(code.get(m) or _code(m.read_text()))
+
+        for m in members:
+            for name, line in _call_sites(code.get(m) or _code(m.read_text())).items():
+                if name in reachable:
+                    continue
+                where = f"{m.relative_to(_REPO_ROOT)}:~{line}"
+                via = "" if m == entry else f" (reached from {entry.relative_to(_REPO_ROOT)})"
+                violations.append(
+                    f"{where}: calls `{name}` but neither it nor anything it "
+                    f"sources defines it{via}"
+                )
+
+    assert not unresolved_all, (
+        "unresolvable `source` argument(s) — this guard cannot see past them, "
+        "and a source it cannot follow is indistinguishable from a missing "
+        "one. Add the idiom to _resolve_source():\n  "
+        + "\n  ".join(sorted(unresolved_all))
+    )
+    assert not violations, (
+        f"{len(violations)} shell call site(s) reach a repo-defined function that is "
+        "not reachable from them — the alpha-engine-config-I7338 class "
+        "(`command not found` at runtime):\n  " + "\n  ".join(sorted(violations))
+    )


### PR DESCRIPTION
## What

`infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh` called `apply_iam_policy` at its "#4472 auto-apply IAM on merge" site and **never sourced** `_shared/apply_iam_policy.sh`. Measured 2026-08-14 running as `ne-admin`, an identity that *does* hold `iam:PutRolePolicy`:

```
deploy.sh: line 188: apply_iam_policy: command not found
WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)
```

The `|| echo "WARN..."` asserted a cause that could not have been true. The failure read as benign, so the auto-apply feature had never once executed on that lambda since #4472 shipped — the content-drift half of `alpha-engine-config-I6299`.

**Scope, measured on a clean `origin/main`:** 34 `deploy.sh` scripts call `apply_iam_policy`; **33 already sourced it**. This one did not. (The issue's "defined or sourced by none" was measured against a checkout 39 commits behind — `_shared/apply_iam_policy.sh` and 33 of the sourcing lines landed in the interim under nousergon-data#918. The defect is real and was live on `main`; its blast radius is one lambda, not 34.)

## The fix

**1. The missing `source`.** One line, matching the established `_shared/` idiom.

**2. The swallow stops lying.** The tolerance moves off the call site and into the shared helper as `apply_iam_policy_on_deploy`, which **classifies** the failure:

- **Tolerated, exit 0** — stderr carries `AccessDenied` / `is not authorized to perform` / `explicit deny` / an expired-credential code. That is the CI auto-deploy OIDC role by design (single-writer rule); `check-drift.py` is its backstop, and the WARN now says which role, which policy, and that an operator must run `--apply-iam`.
- **Loud, non-zero** — anything else. Prints `ERROR` plus the captured stderr verbatim and returns the original exit code, aborting the deploy under the callers' `set -euo pipefail`. A producer that could not do its job does not exit 0.

Two properties follow from the tolerance living in the helper rather than at the call site, and both are the point:

- a `command not found` (rc 127) reaches the classifier as unmatched stderr and is reported **loudly**, not as a permission note;
- a `deploy.sh` that forgets to source the helper **at all** now dies on `apply_iam_policy_on_deploy: command not found` under `set -e`, because the call site no longer carries an `||` of its own.

The four #4472 call sites (`alert-drain-dispatcher`, `alert-drain-liveness-probe`, `overseer-dispatcher`, `overseer-liveness-probe`) are converted. The ~30 `--bootstrap` / `--apply-iam` call sites already had no `||` and already failed loudly; they are unchanged.

Verified empirically, all four cases: helper undefined → rc 127 loud · AccessDenied → rc 0 tolerated · MalformedPolicyDocument → rc 254 loud · success → rc 0 quiet.

**3. A derived guard — `tests/test_deploy_shell_functions_are_defined.py`.**

Not an enumeration; the 35th script has to be covered without anyone remembering. Both sides come from the tree:

- the **universe** of function names is every `name() {}` defined in any *git-tracked* shell file under `infrastructure/`;
- the **call sites** are every command-position occurrence of one of those names;
- **reachability is resolved per ENTRY POINT** — a script that is executed, not sourced — over its full transitive `source` closure. That is what bash actually flattens at runtime, and it is why `_shared/apply_iam_policy.sh` calling `run()` (which its consumers define) is correctly *not* a violation while the I7338 shape is.

**It fails against the pre-fix tree.** Verified by stashing the fix and re-running: exactly **1 violation**, reported at `alert-drain-liveness-probe/deploy.sh:~188` — the same line the live run named. Restored, it passes.

**shellcheck does not cover this class.** Every `deploy.sh` reaches `_shared/` through a `${SCRIPT_DIR}` or `$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)` expansion it cannot resolve, so SC1091 degrades to info and the callee is treated as an external command. Confirmed against the pre-fix revision: `shellcheck --severity=warning` emits **zero** findings mentioning `apply_iam_policy`.

The guard fails loud on its own blind spots rather than narrowing silently — an unresolvable `source` argument, a zero-file scan, and a missing `apply_iam_policy` in the discovered universe are each an explicit failure. Violation line numbers are offset-preserving, so they point at the real line in the real file.

## Drift reconciliation (deliverable 4)

Run from this clean checkout after the fix:

```
AWS_PROFILE=ne-admin python3 ../nous-ergon-ops/infrastructure/iam/check-drift.py --lambdas-root infrastructure/lambdas
OK: no IAM drift across 24 orchestration role(s), 41 lambda role(s)
```

**No residual content drift** — the `I6299` operator procedure run earlier today already reconciled it. **No second PR is needed**, which is why this PR satisfies the issue's `Closes-when` in full.

## Test plan

- Full suite on the repo interpreter: **5725 passed, 9 skipped** (90s).
- New guard passes post-fix, fails pre-fix with the 1 expected violation.
- `bash -n` clean on all five changed scripts.
- `shellcheck --severity=warning` introduces no new findings; the remaining SC2064/SC2148 are pre-existing. `_shared/apply_iam_policy.sh` gains the `# shellcheck shell=bash` directive `pause.sh` already carries.

**No AWS mutation in this PR.** All verification was read-only; no `--bootstrap`, no `PutRolePolicy`. The eight lambdas bootstrapped earlier today are untouched and `iam-drift-check` stays green.

Closes nousergon/alpha-engine-config#7338

---
Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
