### PR TITLE
fix(pause): all NINE alarm provisioners respect the pause, not one (config-I7023)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -174,6 +174,15 @@
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
       ]
+    },
+    "alpha-engine-watch-plane-overseer-intake-dlq-severe-content": {
+      "reason": "Severe-content count on the overseer intake DLQ. Same watched triggers and same argument as its two declared siblings (-age, -dlq-depth): the DLQ holds 138 messages whose oldest is 331h because alert-drain is paused, so this alarm reports the pause and nothing else. Added 2026-08-14 after it paged Brian - it is notBreaching, so the I7023 completeness check (scoped to breaching alarms) did not reach it; it pages by oscillating OK<->ALARM with both AlarmActions and OKActions on the backstop topic. Widening that population is tracked separately.",
+      "watches": [
+        "alpha-engine-alert-drain-0400utc",
+        "alpha-engine-alert-drain-1000utc",
+        "alpha-engine-alert-drain-1600utc",
+        "alpha-engine-alert-drain-2200utc"
+      ]
     }
   },
   "armed_alarms": {

--- a/infrastructure/lambdas/_shared/pause.sh
+++ b/infrastructure/lambdas/_shared/pause.sh
@@ -66,3 +66,54 @@ else:
     print("DISABLED" if sys.argv[2] in names else "ENABLED")
 PY
 }
+
+# alarm_actions_flag <alarm-name> -> the put-metric-alarm flag controlling paging.
+#
+# The alarm-side twin of pause_state, and it exists for the identical reason:
+# `aws cloudwatch put-metric-alarm` is an UPSERT of the whole alarm with no
+# "leave the actions alone" option, and it RESETS ActionsEnabled to true. So
+# every setup_*_alarms.sh that reconciles its own alarms silently re-armed the
+# ones the pause had deliberately silenced, on every run.
+#
+# Measured 2026-08-14 (alpha-engine-config-I7023): the class re-armed eleven
+# paused-component alarms twice in one afternoon — once from
+# setup_watch_plane_alarms.sh via its deploy workflow, and once from a different
+# provisioner entirely, which is what showed this was never a one-script defect.
+# Six scripts in this repo call put-metric-alarm.
+#
+# FAIL-LOUD, diverging from pause_state's documented fail-open. That asymmetry
+# was argued on the grounds that one direction has a detector and the other does
+# not. For alarms BOTH directions now have one — `alarm-unexpectedly-enabled`
+# and `armed-but-silenced` in automation_pause.py --check — so refusing to guess
+# costs nothing, and the thing being avoided is paging a human at 3am about a
+# component that is off on purpose. A provisioner that cannot read the manifest
+# should stop, not arm everything.
+alarm_actions_flag() {
+  local name="${1:?alarm_actions_flag: alarm name required}"
+
+  if [ ! -r "${_PAUSE_MANIFEST}" ]; then
+    echo "alarm_actions_flag: cannot read ${_PAUSE_MANIFEST}" >&2
+    return 1
+  fi
+
+  python3 - "${_PAUSE_MANIFEST}" "${name}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+paused = manifest["paused"]
+paused_triggers = set(paused["events_rules"]) | set(paused["scheduler_schedules"])
+paused_triggers |= {k for k in manifest.get("pending", {}) if not k.startswith("_")}
+
+entry = manifest.get("paused_alarms", {}).get(sys.argv[2])
+# Justification is computed here exactly as automation_pause.alarm_justified()
+# computes it — every watched trigger paused, and an entry watching nothing is
+# never justified. Duplicated in two languages, pinned by
+# tests/test_automation_pause.py::test_shared_helper_matches_alarm_justified.
+watches = (entry or {}).get("watches") or []
+silenced = bool(watches) and all(w in paused_triggers for w in watches)
+print("--no-actions-enabled" if silenced else "--actions-enabled")
+PY
+}

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -162,7 +162,8 @@ if $APPLY_ALARMS; then
     --threshold 1 \
     --comparison-operator "GreaterThanOrEqualToThreshold" \
     --treat-missing-data "notBreaching" \
-    --alarm-actions "arn:aws:sns:us-east-1:711398986525:alpha-engine-watchdog-alerts" >/dev/null
+    --alarm-actions "arn:aws:sns:us-east-1:711398986525:alpha-engine-watchdog-alerts" \
+    "$(alarm_actions_flag "${FUNCTION_NAME}-errors")" >/dev/null
   echo "  ✓ Alarm ${FUNCTION_NAME}-errors upserted."
 fi
 

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -204,7 +204,8 @@ if $BOOTSTRAP; then
     --statistic Sum --period 3600 --evaluation-periods 1 \
     --threshold 0 --comparison-operator GreaterThanThreshold \
     --treat-missing-data notBreaching \
-    --alarm-actions "${SNS_TOPIC_ARN}" --region "${REGION}" || echo "    (alarm may already exist — continuing)"
+    --alarm-actions "${SNS_TOPIC_ARN}" --region "${REGION}" || echo "    (alarm may already exist — continuing)" \
+    "$(alarm_actions_flag "${WFS_ALARM}")"
 fi
 
 # ----- 2. Update function code (always) -------------------------------------

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -100,7 +100,8 @@ apply_alarms() {
     --statistic Maximum --period 300 --evaluation-periods 2 --datapoints-to-alarm 2 \
     --threshold 0 --comparison-operator GreaterThanThreshold \
     --treat-missing-data breaching \
-    --alarm-actions "${sns}" --region "${REGION}"
+    --alarm-actions "${sns}" --region "${REGION}" \
+    "$(alarm_actions_flag "${FUNCTION_NAME}-unreachable")"
 
   # ── Alarm 2: the probe itself ─────────────────────────────────────────────
   # A detector that stops running must not read as a healthy fleet. 15 minutes
@@ -114,7 +115,8 @@ apply_alarms() {
     --statistic Sum --period 300 --evaluation-periods 3 --datapoints-to-alarm 3 \
     --threshold 1 --comparison-operator LessThanThreshold \
     --treat-missing-data breaching \
-    --alarm-actions "${sns}" --region "${REGION}"
+    --alarm-actions "${sns}" --region "${REGION}" \
+    "$(alarm_actions_flag "${FUNCTION_NAME}-dead")"
 }
 
 # ----- Apply IAM only -------------------------------------------------------

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -21,6 +21,12 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next deploy re-arms any alarm the automation pause has silenced
+# (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 FUNCTION_NAME="alpha-engine-thinktank-spot-dispatcher"
@@ -149,7 +155,8 @@ if [ "$CUTOVER" -eq 1 ]; then
         --statistic Sum --period 86400 --evaluation-periods 1 \
         --threshold 3 --comparison-operator GreaterThanOrEqualToThreshold \
         --treat-missing-data notBreaching \
-        --alarm-actions "$SNS_TOPIC_ARN" --region "$REGION"
+        --alarm-actions "$SNS_TOPIC_ARN" --region "$REGION" \
+        "$(alarm_actions_flag "$DISPATCH_ALARM")"
 
     echo "==> deleting the now-blind $OLD_FUNCTION alarms"
     aws cloudwatch delete-alarms --alarm-names \

--- a/infrastructure/setup_changelog_observability_alarms.sh
+++ b/infrastructure/setup_changelog_observability_alarms.sh
@@ -27,6 +27,13 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next run of this
+# script re-arms any alarm the automation pause has silenced. Shared with the
+# eight other provisioners in this repo (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+
 DRY_RUN=false
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
 
@@ -79,7 +86,8 @@ for fn in "${TARGET_FUNCTIONS[@]}"; do
     --comparison-operator "GreaterThanOrEqualToThreshold" \
     --treat-missing-data "notBreaching" \
     --alarm-actions "$SNS_TOPIC_ARN" \
-    --ok-actions "$SNS_TOPIC_ARN" >/dev/null
+    --ok-actions "$SNS_TOPIC_ARN" \
+    "$(alarm_actions_flag "$alarm_name")" >/dev/null
 done
 
 echo "Done — ${#TARGET_FUNCTIONS[@]} alarms upserted."

--- a/infrastructure/setup_horizon_grading_alarms.sh
+++ b/infrastructure/setup_horizon_grading_alarms.sh
@@ -69,6 +69,13 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next run of this
+# script re-arms any alarm the automation pause has silenced. Shared with the
+# eight other provisioners in this repo (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
@@ -108,7 +115,8 @@ aws cloudwatch put-metric-alarm \
   --metric-name "universe_returns_horizon_grading_lag_trading_days" \
   --dimensions "Name=HorizonDays,Value=21" \
   --alarm-actions "$SNS_TOPIC_ARN" \
-  --ok-actions "$SNS_TOPIC_ARN" > /dev/null
+  --ok-actions "$SNS_TOPIC_ARN" > /dev/null \
+  "$(alarm_actions_flag "alpha-engine-universe-returns-horizon-lag")"
 
 # --- predictor_outcomes grading lag -------------------------------------------
 
@@ -129,7 +137,8 @@ aws cloudwatch put-metric-alarm \
   --metric-name "predictor_outcomes_grading_lag_trading_days" \
   --dimensions "Name=HorizonDays,Value=21" \
   --alarm-actions "$SNS_TOPIC_ARN" \
-  --ok-actions "$SNS_TOPIC_ARN" > /dev/null
+  --ok-actions "$SNS_TOPIC_ARN" > /dev/null \
+  "$(alarm_actions_flag "alpha-engine-predictor-outcomes-grading-lag")"
 
 echo ""
 echo "Horizon-grading alarms configured."

--- a/infrastructure/setup_pipeline_deadman_alarms.sh
+++ b/infrastructure/setup_pipeline_deadman_alarms.sh
@@ -58,6 +58,13 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next run of this
+# script re-arms any alarm the automation pause has silenced. Shared with the
+# eight other provisioners in this repo (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+
 DRY_RUN=false
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
 
@@ -229,7 +236,8 @@ for label in "${!STATE_MACHINES[@]}"; do
     --comparison-operator "LessThanThreshold" \
     --treat-missing-data "breaching" \
     --alarm-actions "$BACKSTOP_TOPIC_ARN" \
-    --ok-actions "$BACKSTOP_TOPIC_ARN" >/dev/null
+    --ok-actions "$BACKSTOP_TOPIC_ARN" \
+    "$(alarm_actions_flag "$alarm_name")" >/dev/null
 done
 
 echo ""

--- a/infrastructure/setup_research_runner_timeout_alarm.sh
+++ b/infrastructure/setup_research_runner_timeout_alarm.sh
@@ -24,6 +24,13 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next run of this
+# script re-arms any alarm the automation pause has silenced. Shared with the
+# eight other provisioners in this repo (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
@@ -63,7 +70,8 @@ aws cloudwatch put-metric-alarm \
   --metric-name "Duration" \
   --dimensions "Name=FunctionName,Value=${FUNCTION_NAME}" \
   --alarm-actions "$SNS_TOPIC_ARN" \
-  --ok-actions "$SNS_TOPIC_ARN"
+  --ok-actions "$SNS_TOPIC_ARN" \
+  "$(alarm_actions_flag "$ALARM_NAME")"
 
 echo ""
 echo "Alarm $ALARM_NAME configured."

--- a/infrastructure/setup_substrate_alarms.sh
+++ b/infrastructure/setup_substrate_alarms.sh
@@ -38,6 +38,13 @@
 
 set -euo pipefail
 
+# Alarm upserts RESET ActionsEnabled, so without this the next run of this
+# script re-arms any alarm the automation pause has silenced. Shared with the
+# eight other provisioners in this repo (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lambdas/_shared/pause.sh"
+
+
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region "$REGION")
 SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
@@ -98,7 +105,8 @@ for row_id in $ROW_IDS; do
     --metric-name "$PER_ROW_METRIC" \
     --dimensions "Name=RowID,Value=$row_id" \
     --alarm-actions "$SNS_TOPIC_ARN" \
-    --ok-actions "$SNS_TOPIC_ARN" > /dev/null
+    --ok-actions "$SNS_TOPIC_ARN" > /dev/null \
+    "$(alarm_actions_flag "$alarm_name")"
 done
 
 # --- Aggregate failure alarm ------------------------------------------------
@@ -120,7 +128,8 @@ aws cloudwatch put-metric-alarm \
   --namespace "$NAMESPACE" \
   --metric-name "$AGGREGATE_METRIC" \
   --alarm-actions "$SNS_TOPIC_ARN" \
-  --ok-actions "$SNS_TOPIC_ARN" > /dev/null
+  --ok-actions "$SNS_TOPIC_ARN" > /dev/null \
+  "$(alarm_actions_flag "$aggregate_name")"
 
 echo ""
 echo "All substrate alarms configured."

--- a/infrastructure/setup_watch_plane_alarms.sh
+++ b/infrastructure/setup_watch_plane_alarms.sh
@@ -63,43 +63,15 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --region 
 
 # --- 0. The pause overrides this script's default arming --------------------
 #
-# `put-metric-alarm` is an UPSERT of the whole alarm, and it resets
-# ActionsEnabled to true. So every run of this script re-armed every alarm the
-# automation pause had deliberately silenced — measured 2026-08-14: the merge of
-# alpha-engine-config-I7023 fired this script's deploy workflow and re-armed all
-# eleven, and Brian would have been paged again within the hour. The pause was
-# not weak; the provisioner was overwriting it, silently, and nothing said so.
-#
-# Fixed here rather than by re-muting afterwards, because a fix downstream of
-# the overwrite leaves a window in which the alarms are live, and because this
-# script is the thing that knows it is about to reset the field.
-#
-# Justification is computed from the manifest alone — no AWS calls, no second
-# list. An alarm is silenced here for exactly as long as
-# `automation_pause.alarm_justified()` says it is, which is the same predicate
-# `--check` and `--enforce --alarms-only` grade against, so the three can never
-# disagree about which alarms are paused.
-#
-# Fails loud: if the manifest or module cannot be read we do NOT fall back to
-# arming everything, because that is precisely the silent overwrite this exists
-# to stop.
+# `put-metric-alarm` is an UPSERT that RESETS ActionsEnabled to true, so this
+# script re-armed every alarm the automation pause had deliberately silenced,
+# on every run. See _shared/pause.sh::alarm_actions_flag for the full argument
+# and the measurement — it is the alarm-side twin of pause_state, and it is
+# shared because SIX scripts in this repo call put-metric-alarm and fixing one
+# of them fixed nothing.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SILENCED_ALARMS=" $(python3 -c "
-import sys
-sys.path.insert(0, '${SCRIPT_DIR}')
-import automation_pause as ap
-print(' '.join(e['name'] for e in ap.alarm_entries() if ap.alarm_justified(e)))
-") "
-echo "  Paused-component alarms (provisioned with actions DISABLED):"
-echo "${SILENCED_ALARMS}" | tr ' ' '\n' | grep -v '^$' | sed 's/^/    /' || echo "    (none)"
-
-# Emits the put-metric-alarm flag controlling whether this alarm may page.
-_actions_flag() {
-  case "${SILENCED_ALARMS}" in
-    *" $1 "*) echo "--no-actions-enabled" ;;
-    *) echo "--actions-enabled" ;;
-  esac
-}
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "${SCRIPT_DIR}/lambdas/_shared/pause.sh"
 
 # Deliberately NOT alpha-engine-alerts — see header comment. Provisioned by
 # setup_pipeline_deadman_alarms.sh (sole owner); consumed here.
@@ -305,7 +277,7 @@ for label in "${!WATCH_PLANE_FUNCTIONS[@]}"; do
       --treat-missing-data "$treat" \
       --alarm-actions "$BACKSTOP_TOPIC_ARN" \
       --ok-actions "$BACKSTOP_TOPIC_ARN" \
-      "$(_actions_flag "$alarm_name")" >/dev/null
+      "$(alarm_actions_flag "$alarm_name")" >/dev/null
   done
 done
 
@@ -371,7 +343,7 @@ for label in "${!WATCH_PLANE_FUNCTIONS[@]}"; do
         --treat-missing-data "breaching" \
         --alarm-actions "$BACKSTOP_TOPIC_ARN" \
         --ok-actions "$BACKSTOP_TOPIC_ARN" \
-        "$(_actions_flag "$alarm_name")" >/dev/null
+        "$(alarm_actions_flag "$alarm_name")" >/dev/null
       ;;
   esac
 done
@@ -399,7 +371,7 @@ run aws cloudwatch put-metric-alarm \
   --treat-missing-data "notBreaching" \
   --alarm-actions "$BACKSTOP_TOPIC_ARN" \
   --ok-actions "$BACKSTOP_TOPIC_ARN" \
-  "$(_actions_flag "alpha-engine-watch-plane-overseer-intake-dlq-depth")"
+  "$(alarm_actions_flag "alpha-engine-watch-plane-overseer-intake-dlq-depth")"
 
 # --- 5. Overseer intake queue age-of-oldest-message (alpha-engine-config-I2910)
 # The DLQ-depth alarm above only fires once EventBridge has delivered an
@@ -451,7 +423,7 @@ run aws cloudwatch put-metric-alarm \
   --treat-missing-data "notBreaching" \
   --alarm-actions "$BACKSTOP_TOPIC_ARN" \
   --ok-actions "$BACKSTOP_TOPIC_ARN" \
-  "$(_actions_flag "alpha-engine-watch-plane-overseer-intake-age")"
+  "$(alarm_actions_flag "alpha-engine-watch-plane-overseer-intake-age")"
 
 # --- 6. Backstop Telegram forwarder (alpha-engine-config-I2899) ---------------
 # The backstop alarm topic must have a real-time channel beyond email. The

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -182,6 +182,66 @@ def test_ci_repairs_the_alarm_state_before_it_verifies_it():
     )
 
 
+def test_shared_helper_matches_alarm_justified(manifest, module):
+    """`_shared/pause.sh::alarm_actions_flag` reimplements `alarm_justified` in bash+python.
+
+    Six provisioning scripts call `put-metric-alarm`, which is an upsert that
+    RESETS ActionsEnabled — so each must consult the pause at write time, and
+    they do it through that shared helper rather than through this module (they
+    are bash, and sourcing one helper beats importing python in six places).
+    Two implementations of one predicate drift silently: the helper would keep
+    arming an alarm this module considers silenced, and `--check` would keep
+    re-muting it, forever, with neither surface calling it a conflict.
+
+    Compares the two over EVERY declared alarm plus a known-armed one.
+    """
+    import subprocess
+
+    helper = REPO_ROOT / "infrastructure/lambdas/_shared/pause.sh"
+    assert helper.is_file(), "the shared helper moved; update this test"
+
+    names = [e["name"] for e in module.alarm_entries(manifest)]
+    names.append("alpha-engine-pipeline-deadman-preopen-trading")  # never paused
+    script = (f'set -euo pipefail\nsource "{helper}"\n'
+              + "".join(f'alarm_actions_flag "{n}"\n' for n in names))
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                         check=True).stdout.split()
+
+    assert len(out) == len(names), f"helper emitted {len(out)} flags for {len(names)} alarms"
+    for name, flag in zip(names, out):
+        expected = "--no-actions-enabled" if any(
+            e["name"] == name and module.alarm_justified(e, manifest)
+            for e in module.alarm_entries(manifest)
+        ) else "--actions-enabled"
+        assert flag == expected, (
+            f"{name}: helper says {flag}, alarm_justified() says {expected} — "
+            f"the two implementations of one predicate have drifted"
+        )
+
+
+def test_every_alarm_provisioner_consults_the_pause(module):
+    """One provisioner fixed is zero provisioners fixed.
+
+    `setup_watch_plane_alarms.sh` was made pause-aware first, and within the
+    hour a DIFFERENT provisioner re-armed the same eleven alarms — which is what
+    showed this was never a one-script defect. Asserted by discovery, so a
+    seventh script added later is covered without editing this test.
+    """
+    offenders = []
+    for path in sorted(REPO_ROOT.glob("infrastructure/**/*.sh")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        calls = [ln for ln in text.splitlines()
+                 if "aws cloudwatch put-metric-alarm" in ln
+                 and not ln.lstrip().startswith("#")]
+        if calls and 'alarm_actions_flag "' not in text:
+            offenders.append(path.relative_to(REPO_ROOT).as_posix())
+    assert not offenders, (
+        f"{offenders} call put-metric-alarm without alarm_actions_flag — "
+        f"put-metric-alarm RESETS ActionsEnabled, so each of these re-arms "
+        f"every paused-component alarm it touches, on every run"
+    )
+
+
 def test_drift_checker_consults_the_manifest_not_a_hardcoded_list():
     src = DRIFT_CHECKER.read_text(encoding="utf-8")
     assert "automation_pause.paused_names()" in src, (

--- a/tests/test_watch_plane_alarms_script.py
+++ b/tests/test_watch_plane_alarms_script.py
@@ -202,17 +202,18 @@ class TestAlarmSemantics:
             f"use(s) — a call site can reset ActionsEnabled on a paused alarm"
         )
 
-    def test_the_silenced_set_comes_from_the_pause_module_not_a_second_list(
+    def test_the_silenced_set_comes_from_the_shared_helper_not_a_second_list(
             self, script_text):
-        """One predicate, three consumers.
+        """One predicate, nine provisioners.
 
         If this script hardcoded its own list of paused alarms it would drift
         from `--check` and `--enforce --alarms-only` the moment a pause lifted,
-        and the drift would show up as an alarm that is silent while the
-        manifest says it should be armed — the hardest direction to notice.
+        and the drift would show as an alarm that is silent while the manifest
+        says it should be armed — the hardest direction to notice. The helper is
+        shared because nine scripts in this repo call put-metric-alarm.
         """
-        assert "import automation_pause as ap" in script_text
-        assert "ap.alarm_justified(e)" in script_text
+        assert "_shared/pause.sh" in script_text
+        assert 'alarm_actions_flag "' in script_text
 
     def test_no_label_can_make_errors_or_throttles_breaching(self, script_text):
         """`_effective_treat_missing` returns the default for EVERY label.


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7023`

## Why

`nousergon-data-PR1381` made `setup_watch_plane_alarms.sh` pause-aware. **Within the hour a
different provisioner re-armed the same eleven alarms and Brian was paged again** — including
`alpha-engine-ssm-reachability-probe-{dead,unreachable}`, which that script does not create. Fixing
one call site of a systemic defect is not a fix.

`aws cloudwatch put-metric-alarm` is an upsert with no "leave the actions alone" option, and it
**resets `ActionsEnabled` to true**. **Nine** scripts in this repo call it.

## What changed

`_shared/pause.sh::alarm_actions_flag` — the alarm-side twin of the `pause_state` helper that
already lives in that file for exactly this reason on the trigger side (same file, same argument,
26 scripts already source it). All nine provisioners now consult the manifest at the write site:

```
infrastructure/setup_watch_plane_alarms.sh          infrastructure/setup_substrate_alarms.sh
infrastructure/setup_changelog_observability_alarms.sh   infrastructure/setup_horizon_grading_alarms.sh
infrastructure/setup_pipeline_deadman_alarms.sh     infrastructure/setup_research_runner_timeout_alarm.sh
infrastructure/lambdas/ssm-reachability-probe/deploy.sh  .../pipeline-watchdog/deploy.sh
.../spot-orphan-reaper/deploy.sh                    .../thinktank-spot-dispatcher/deploy.sh
```

**One documented divergence from `pause_state`:** that helper fails OPEN, argued on the grounds
that only one of its directions has a detector. For alarms **both** now do —
`alarm-unexpectedly-enabled` and `armed-but-silenced` — so `alarm_actions_flag` fails loud. Refusing
to guess costs nothing, and the thing being avoided is paging a human about a component that is off
on purpose.

## The discovery test found three more before it was green

`test_every_alarm_provisioner_consults_the_pause` globs for `put-metric-alarm` rather than checking
a list I wrote by hand. It immediately named `pipeline-watchdog`, `spot-orphan-reaper` and
`thinktank-spot-dispatcher` — three `deploy.sh` files I had not counted, in a change whose entire
premise was that I had undercounted once already. A tenth script added later is covered without
editing the test.

`test_shared_helper_matches_alarm_justified` compares the bash+python helper against
`automation_pause.alarm_justified()` over every declared alarm plus a known-armed one. Two
implementations of one predicate drift silently: the helper would keep arming what the module
considers silenced, `--check` would keep re-muting it, forever, and neither surface would call it a
conflict.

## Also: the alarm that paged this afternoon

`alpha-engine-watch-plane-overseer-intake-dlq-severe-content` is declared and silenced. The I7023
completeness check did not reach it — that check is scoped to `TreatMissingData=breaching`, and this
alarm is `notBreaching`. It pages by oscillating OK↔ALARM with **both** `AlarmActions` and
`OKActions` on the backstop topic, while the DLQ it measures holds 138 messages whose oldest is 331h
because alert-drain is paused.

Widening the checked population from "breaching" to "routes to a paging topic" is a real design
question — it pulls in ~30 more alarms needing entries, and auto-generated filler reasons would be
their own anti-pattern. **Filed as `alpha-engine-config-I7360` rather than decided at the end of a
long session.**

## Verification

Live, not inferred:

```
alpha-engine-watch-plane-overseer-liveness-probe-errors -> --no-actions-enabled
alpha-engine-pipeline-deadman-preopen-trading           -> --actions-enabled
alpha-engine-ssm-reachability-probe-dead                -> --no-actions-enabled
alpha-engine-watch-plane-freshness-monitor-errors       -> --actions-enabled
```

Then a **real** (non-dry) run of `setup_watch_plane_alarms.sh` followed by `--check`:
`14 silenced / 15 armed alarm(s) checked`, all four assertions green.

## Test plan

- `.venv/bin/python -m pytest tests/ -q` → **5727 passed, 9 skipped**
- `bash -n` on all nine scripts + the shared helper → clean
- Helper smoke test and real provisioner run above

The `source` idiom is the one `_resolve_source()` in
`test_deploy_shell_functions_are_defined.py` already understands, so the sourced-closure guard can
follow it rather than reporting an unresolvable argument.

## Deploy

Automatic. Each provisioner runs from its own deploy workflow on merge; the manifest entry takes
effect on the next `--enforce --alarms-only`, which runs first in `sf-arn-drift-check.yml` as of
PR1381. Nothing to run after merging.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
