### PR TITLE
[P1/mid] fix(launchers): resolve LIB_PYTHON through the ops-owned krepis guard (config-I7343)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -31,7 +31,16 @@ KEY_NAME="alpha-engine-key"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
-LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
+# Lib CLI path: every spot launcher on the dispatcher box resolves its
+# interpreter through the ops-owned guard /opt/nousergon/bin/lib-python
+# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python).
+# That guard execs the box's DECLARED krepis venv and aborts with EX_CONFIG
+# (78), naming the version it found, when the venv is absent or below the
+# launcher floor. It never falls back to a co-tenant checkout — the silent
+# fallback is exactly the defect alpha-engine-config-I6931/I7343 removes.
+# Do NOT add a guard block here: the contract lives ONCE, in the repo that
+# owns this box's provisioning (nine copies across five repos is I6922).
+LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"
 
 # Spot-reclaim relaunch (#883)
 MAX_SPOT_ATTEMPTS="${MAX_SPOT_ATTEMPTS:-2}"

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -83,8 +83,9 @@
 #     DescribeInstances / SendCommand / GetCommandInvocation /
 #     ssm:SendCommand on the spot's SSM document
 #   - alpha-engine-data checked out at the script's parent dir
-#   - alpha-engine-lib installed in ae-dashboard's .venv (LIB_PYTHON
-#     points at it) — provides both `ec2_spot` and `ssm_dispatcher` CLIs
+#   - /opt/nousergon/bin/lib-python present on the launching host — the
+#     ops-owned guard over the box's declared krepis venv, which provides
+#     both the `ec2_spot` and `ssm_dispatcher` CLIs (LIB_PYTHON names it)
 #
 # Secrets resolve from SSM at Python startup via
 # nousergon_lib.secrets.get_secret(); the spot's IAM profile
@@ -182,12 +183,16 @@ SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 # update via `aws ec2 describe-subnets --filters Name=vpc-id,Values=vpc-566f002e`.
 SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
-# Lib CLI path: ae-dashboard is the SSM target instance ($MicroInstanceId)
-# for all 8 Saturday-SF spot states; the dispatcher's .venv has
-# alpha-engine-lib installed (see deploy-on-merge.sh in the dashboard
-# repo). Bare `python3` resolves to system python which does NOT carry
-# the lib — use the full venv path.
-LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
+# Lib CLI path: every spot launcher on the dispatcher box resolves its
+# interpreter through the ops-owned guard /opt/nousergon/bin/lib-python
+# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python).
+# That guard execs the box's DECLARED krepis venv and aborts with EX_CONFIG
+# (78), naming the version it found, when the venv is absent or below the
+# launcher floor. It never falls back to a co-tenant checkout — the silent
+# fallback is exactly the defect alpha-engine-config-I6931/I7343 removes.
+# Do NOT add a guard block here: the contract lives ONCE, in the repo that
+# owns this box's provisioning (nine copies across five repos is I6922).
+LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"
 
 # Stage-coverage window (alpha-engine-config-I7214): the instant this launcher
 # started. An artifact whose LastModified predates it is a leftover from a

--- a/tests/test_launchers_resolve_the_declared_krepis_guard.py
+++ b/tests/test_launchers_resolve_the_declared_krepis_guard.py
@@ -1,0 +1,165 @@
+"""Every spot launcher in this repo resolves through the ops-owned krepis guard.
+
+**The defect** (`alpha-engine-config-I6931`, second half tracked as
+`alpha-engine-config-I7343`). Until 2026-08-14 every spot launcher in the fleet
+defaulted its interpreter to a co-tenant's checkout::
+
+    LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
+
+— NINE such lines across FIVE repos. So the version of ``krepis.ec2_spot``,
+``krepis.ssm_dispatcher`` and ``krepis.spot_bootstrap`` that launches every spot
+workload of all three Step Functions pipelines was governed by
+``crucible-dashboard/requirements.txt``, which no merge in this repo can see, and
+an absent or too-old venv produced a ``ModuleNotFoundError`` at launch rather
+than a statement of what was wrong.
+
+**The fix** is one ops-owned wrapper, ``/opt/nousergon/bin/lib-python``
+(`nous-ergon-ops-PR676`), which execs the box's DECLARED krepis venv and aborts
+with ``EX_CONFIG`` (78) naming the version it found when that venv is absent or
+below the launcher floor. It never falls back. Each launcher's diff is the one
+line naming it — writing the guard per launcher would be nine copies of one
+contract across five repos, which is the `alpha-engine-config-I6922` defect one
+layer down.
+
+**What this test holds.** That the launchers in THIS repo keep resolving through
+the guard, and that no launcher re-acquires a private fallback. Every assertion
+is derived from the scripts on disk — no line numbers, because these files move.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_INFRA = Path(__file__).resolve().parents[1] / "infrastructure"
+
+#: The one path every launcher repo's LIB_PYTHON default must name. Declared and
+#: installed by nous-ergon-ops (``bin/lib-python`` +
+#: ``bin/install-box-config.sh``); asserted identically in all five repos.
+GUARD = "/opt/nousergon/bin/lib-python"
+
+#: The pre-I7343 default. Its reappearance anywhere executable is the regression.
+CO_TENANT = "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python"
+
+#: Launcher scripts this repo is known to own. A rename must update this list;
+#: a DELETION must not silently drop coverage, which is what the membership
+#: assertion below catches. Filenames only — never line numbers.
+KNOWN_LAUNCHERS = {'_spot_common.sh', 'spot_data_weekly.sh'}
+
+_ASSIGN = re.compile(r'^([ \t]*)LIB_PYTHON=(.*)$', re.M)
+_DEFAULTED = re.compile(r'^[ \t]*LIB_PYTHON="\$\{LIB_PYTHON:-([^}]*)\}"[ \t]*$')
+
+
+def _shell_scripts() -> list[Path]:
+    """The SPOT-LAUNCHER surface, derived from the naming convention rather than
+    listed: ``spot_*.sh`` plus the ``_spot_common.sh`` they source.
+
+    Scoped this way on purpose. Other scripts under ``infrastructure/`` — the
+    dashboard box's own health, alert and deploy units — legitimately name that
+    box's venv for their own service; they are not launching a spot and I7343
+    does not touch them. A filename denylist would need editing every time a box
+    service is added; this derivation does not.
+    """
+    return sorted(
+        p
+        for p in _INFRA.rglob("*.sh")
+        if p.is_file() and (p.name.startswith("spot_") or p.name.startswith("_spot"))
+    )
+
+
+def _assignment_sites() -> dict[str, list[str]]:
+    """{script name: [each raw LIB_PYTHON assignment line]} — derived, not listed."""
+    out: dict[str, list[str]] = {}
+    for path in _shell_scripts():
+        hits = [m.group(0) for m in _ASSIGN.finditer(path.read_text())]
+        if hits:
+            out[path.name] = hits
+    return out
+
+
+def _executable_lines(path: Path) -> list[str]:
+    """Non-comment, non-blank lines. Comments legitimately quote the old default
+    (the whole rationale is about it), so the sweeps run over code only."""
+    return [
+        line
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def test_every_known_launcher_still_declares_its_interpreter():
+    """A launcher that stops assigning LIB_PYTHON has not become safe — it has
+    become one that inherits whatever the caller's environment happens to hold,
+    which is the pre-guard behaviour with no line to grep for."""
+    found = _assignment_sites()
+    missing = KNOWN_LAUNCHERS - set(found)
+    assert not missing, (
+        f"launchers with no LIB_PYTHON assignment: {sorted(missing)}. If one was "
+        "renamed, update KNOWN_LAUNCHERS; if one was deleted, this test's coverage "
+        "shrank and that must be a deliberate, reviewed diff."
+    )
+
+
+def test_every_launcher_defaults_to_the_ops_owned_guard():
+    """The load-bearing assertion: the default names the guard, in every script
+    that assigns it — including any launcher added after this test was written."""
+    for name, lines in sorted(_assignment_sites().items()):
+        for line in lines:
+            match = _DEFAULTED.match(line)
+            assert match, (
+                f"{name}: LIB_PYTHON assignment is not the "
+                'LIB_PYTHON="${LIB_PYTHON:-<path>}" form: {line.strip()!r}. The '
+                "override idiom is what lets a rehearsal point at another "
+                "interpreter without editing the script."
+            )
+            assert match.group(1) == GUARD, (
+                f"{name}: LIB_PYTHON defaults to {match.group(1)!r}, not the "
+                f"ops-owned guard {GUARD!r}. Pointing a launcher at a repo-local "
+                "or co-tenant venv restores the alpha-engine-config-I6931 defect: "
+                "the krepis version that launches every spot stage becomes "
+                "whatever that checkout happens to hold, with no declared floor."
+            )
+
+
+def test_the_env_var_override_is_preserved():
+    """``LIB_PYTHON=... script.sh`` must still win. The guard is the DEFAULT, not
+    a hardcode — a rehearsal or a second box needs the override."""
+    for name, lines in sorted(_assignment_sites().items()):
+        for line in lines:
+            assert "${LIB_PYTHON:-" in line, (
+                f"{name}: LIB_PYTHON is hardcoded, losing the env override: "
+                f"{line.strip()!r}"
+            )
+
+
+def test_no_launcher_falls_back_to_a_co_tenant_checkout():
+    """The whole defect was a silent fallback to whichever checkout was newest.
+
+    A launcher that keeps a second candidate path — as a fallback branch, a
+    ``||``, or a bare reference — recreates it invisibly, and does so while a
+    declaration exists to point at, which is worse than the original.
+    """
+    for path in _shell_scripts():
+        offenders = [line for line in _executable_lines(path) if CO_TENANT in line]
+        assert not offenders, (
+            f"{path.name}: executable line(s) still name the co-tenant venv "
+            f"{CO_TENANT!r}: {offenders}. The launcher must resolve through "
+            f"{GUARD!r} and nothing else — the guard aborts rather than "
+            "degrading, and a fallback here silently removes that."
+        )
+
+
+def test_no_launcher_reimplements_the_guard_locally():
+    """Nine copies of one fail-loud contract across five repos is exactly the
+    `alpha-engine-config-I6922` defect. The version check lives in
+    ``bin/lib-python``, in the repo that owns the box's provisioning — a
+    launcher-side ``krepis.__version__`` comparison is that defect returning."""
+    for path in _shell_scripts():
+        text = path.read_text()
+        for line in _executable_lines(path):
+            assert "krepis.__version__" not in line, (
+                f"{path.name}: a launcher-local krepis version check "
+                f"({line.strip()!r}) duplicates the contract "
+                f"{GUARD!r} already enforces for all five repos."
+            )
+        del text

--- a/tests/test_spot_bootstrap_invariants.py
+++ b/tests/test_spot_bootstrap_invariants.py
@@ -34,24 +34,28 @@ would drift exactly like the first two.
 
 ## Why the Bash copy still exists at all
 
-``krepis.spot_bootstrap`` cannot simply replace this heredoc yet. The launcher
-resolves its interpreter as::
+``krepis.spot_bootstrap`` could not simply replace this heredoc while the
+launcher resolved its interpreter as::
 
     LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
 
-— the *shared application host's* venv, whose krepis version is governed by
+— the *shared application host's* venv, whose krepis version was governed by
 ``crucible-dashboard/requirements.txt``, a file no merge in this repo can see.
-A cutover therefore carries a runtime dependency this repo cannot pin, and when
-that venv is behind, the bootstrap does not degrade — it dies with
-``ModuleNotFoundError`` on every spot stage of every pipeline. Measured
-2026-08-13 the host is at krepis 0.54.0 and ``krepis.spot_bootstrap`` imports
-cleanly, but nothing *declares* or *enforces* that floor; ``alpha-engine-config
--I6931`` owns making it a fail-loud, declared version.
+A cutover therefore carried a runtime dependency this repo could not pin, and
+when that venv was behind, the bootstrap did not degrade — it died with
+``ModuleNotFoundError`` on every spot stage of every pipeline. So the dependency
+that could not safely exist at RUNTIME lived in a TEST instead: the Bash copies
+stay, and CI asserts they agree with the canonical renderer.
 
-So the dependency that cannot safely exist at RUNTIME lives in a TEST instead:
-the Bash copies stay, and CI asserts they agree with the canonical renderer.
-When I6931 lands its version floor, the cutover becomes a deletion and this
-test is what proves the deletion changed nothing.
+**That blocker is now cleared** (`alpha-engine-config-I7343`, 2026-08-14). The
+launcher resolves through ``/opt/nousergon/bin/lib-python``, the ops-owned guard
+over the box's DECLARED krepis venv, which aborts with ``EX_CONFIG`` (78) naming
+the version it found when that venv is below the launcher floor — a declared,
+enforced, fail-loud floor, which is what I6931 owed. The cutover to
+``krepis.spot_bootstrap`` is therefore unblocked and becomes a deletion;
+``alpha-engine-config-I6922`` owns it, and this test is what will prove the
+deletion changed nothing. Resolution is pinned by
+``tests/test_launchers_resolve_the_declared_krepis_guard.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Deploy mechanism

**Deploy-mechanism:** none of its own. These launchers are executed on the ae-dashboard dispatcher box from that box's checkout of this repo, and every Step Functions state that invokes one runs `git pull --ff-only origin main` on that checkout in the same SSM command array immediately before the `bash infrastructure/spot_*.sh` line (`nousergon-data/infrastructure/step_function.json`). **The merge button is the whole deploy** — no post-merge command, no operator step.

## What this changes

`Two sites: `infrastructure/_spot_common.sh` and `infrastructure/spot_data_weekly.sh`.`

```diff
-LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
+LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"
```

Plus the stale comment above each site (which described the co-tenant venv as the interpreter) and, where present, the file's Prerequisites header.

## Why

Until now every spot launcher in the fleet — **nine lines across five repos**, measured on `origin/main` 2026-08-14 — defaulted its interpreter to a co-tenant's checkout. So the version of `krepis.ec2_spot`, `krepis.ssm_dispatcher` and `krepis.spot_bootstrap` that launches **every spot stage of all three Step Functions pipelines** was governed by `crucible-dashboard/requirements.txt`, a file no merge in most of these repos can see, with no declared floor. When that venv was behind, the launch did not degrade — it died with `ModuleNotFoundError`, naming nothing useful.

`/opt/nousergon/bin/lib-python` (`nous-ergon-ops-PR676`) is the ops-owned wrapper over the box's **declared** krepis venv. It execs that venv's interpreter with the arguments it was given, and when the venv is absent or below the launcher floor it aborts with `EX_CONFIG` (78) **naming the version it found**. It never falls back — that fallback is the defect being removed.

**No guard block is added at the call site.** Writing the fail-loud check per launcher would be nine copies of one contract across five repos, which is `alpha-engine-config-I6922`'s defect one layer down. The contract lives once, in the repo that owns this box's provisioning.

The `${LIB_PYTHON:-…}` override idiom is preserved at every site, so a rehearsal can still point at another interpreter without editing the script.

## Precondition — already satisfied

`/opt/nousergon/krepis-venv` had to reach the pin before any of these may merge, or every spot stage aborts at launch. Measured live on `i-09b539c844515d549`, 2026-08-14, before this PR was written:

```
KREPIS-VENV: OK — krepis 0.59.4 at /opt/nousergon/krepis-venv matches the pin,
  satisfies the generator floor (>=0.52.0) and the launcher floor (>=0.59.2)
LAUNCHER-KREPIS: OK — 7 krepis submodule(s) invoked by 106 launcher script(s)
  are importable by /opt/nousergon/krepis-venv/bin/python
```

`/opt/nousergon/bin/lib-python` is installed (`-rwxr-xr-x`, root). The previous default resolved krepis **0.59.3**; the declared venv is **0.59.4** — a forward move, and the submodule-importability assertion above covers what these launchers actually invoke. This PR was written and verified from `origin/main`; the box's own repo checkouts were not read, because they are stale by design until the SF's `git pull` runs.

## MANDATORY MERGE ORDER

Out of order breaks every spot stage of all three pipelines. `crucible-dashboard` is **last** on purpose: its `.venv` is the fallback every other launcher currently lands on, so while it is unchanged it remains the escape hatch if an earlier step has to be reverted.

1. `nousergon-data` — nousergon-data-PR1386 (**this PR**)
2. `crucible-predictor` — crucible-predictor-PR502
3. `crucible-research` — crucible-research-PR631
4. `crucible-backtester` — crucible-backtester-PR670
5. `crucible-dashboard` — crucible-dashboard-PR689 ← **LAST**

## Test

`tests/test_launchers_resolve_the_declared_krepis_guard.py` (5 assertions). Everything is **derived from the scripts on disk** — the spot-launcher surface is discovered by the `spot_*.sh` / `_spot*.sh` naming convention, and every assertion reads the assignment lines themselves. No line numbers: these files move, and the issue's own table was already stale by the time it was written.

- every known launcher still declares `LIB_PYTHON` (a launcher that stops assigning it silently inherits the caller's environment)
- every `LIB_PYTHON` default names `/opt/nousergon/bin/lib-python` — including any launcher added after this test
- the `${LIB_PYTHON:-…}` env override survives (the guard is the default, not a hardcode)
- no launcher names the co-tenant venv on an **executable** line (comments legitimately quote it — the rationale is about it)
- no launcher reimplements the krepis version check locally (that is I6922 returning)

Negative-controlled: reverting one site to the old default fails assertions 2 and 4.

## Local suite

`5730 passed, 9 skipped` on branch vs `5725 passed, 9 skipped` on `main` (`nousergon-data/.venv`).

Zero new failures, `+5` passed (this PR's test). 

## Out of scope, named rather than silently left

- The Step Functions command arrays still invoke `krepis.ssm_log_capture` through `/home/ec2-user/alpha-engine-dashboard/.venv/bin/python` directly (`nousergon-data/infrastructure/step_function*.json`). That is a **tenth** co-tenant-venv dependency, outside I7343's `LIB_PYTHON` surface, and it is not repointed here.
- On `crucible-dashboard`, the box's own service scripts (`box_health.sh`, `alert_*.sh`, `substrate_health_check*.sh`, `boot-pull.sh`, `deploy-on-merge.sh`) legitimately name that box's venv for their own purpose. They are not spot launchers and are untouched; the test's launcher-surface derivation excludes them by construction rather than by a filename denylist.

## Tracker

`alpha-engine-config-I7343` — closed only when all five merge. Predecessor `alpha-engine-config-I6931`; unblocks `alpha-engine-config-I6922` (the `krepis.spot_bootstrap` cutover, whose blocker was precisely the absence of a declared, enforced krepis floor on the launching host).

Rehearsal-path: tests/test_launchers_resolve_the_declared_krepis_guard.py

The change is a one-line default per launcher and the rehearsal is the test itself: it derives the launcher surface from the scripts on disk and asserts the resolved interpreter, so a wrong path cannot reach `main`. A live spot launch is deliberately NOT used as the rehearsal — launching one to "test" this would burn spot capacity to re-measure what `/opt/nousergon/bin/lib-python`'s own fail-loud contract already asserts on the box, which was verified live before this branch was cut.

---
Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
