### PR TITLE
[P1/mid] fix(sf): resolve krepis.ssm_log_capture through the ops-owned guard (config-I7364)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -679,7 +679,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -890,7 +890,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -1370,7 +1370,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "21600"
                   ]
@@ -1665,7 +1665,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2731,7 +2731,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3103,7 +3103,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]
@@ -3301,7 +3301,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3837,7 +3837,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4002,7 +4002,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4167,7 +4167,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4359,7 +4359,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4575,7 +4575,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4791,7 +4791,7 @@
                   "executionTimeout": [
                     "2700"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 2700
               },
@@ -5053,7 +5053,7 @@
           "executionTimeout": [
             "2700"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 2700
       },
@@ -5271,7 +5271,7 @@
           "executionTimeout": [
             "1800"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1800
       },
@@ -5445,7 +5445,7 @@
           "executionTimeout": [
             "1200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1200
       },
@@ -5636,7 +5636,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
           "executionTimeout": [
             "300"
           ]
@@ -5764,7 +5764,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
           "executionTimeout": [
             "240"
           ]

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -6,7 +6,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh"
   ],
   "DataPhase1": [
     "set -eo pipefail",
@@ -14,14 +14,14 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
   ],
   "DataPhase2": [
     "set -eo pipefail",
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
@@ -38,7 +38,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics"
   ],
   "EvaluatorOptimize": [
     "set -eo pipefail",
@@ -47,7 +47,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize"
   ],
   "MorningEnrich": [
     "set -eo pipefail",
@@ -55,7 +55,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
   ],
   "ParityReplay": [
     "set -eo pipefail",
@@ -64,7 +64,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh"
   ],
   "PitParityCompare": [
     "set -eo pipefail",
@@ -73,7 +73,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh"
   ],
   "PitParityLookahead": [
     "set -eo pipefail",
@@ -82,7 +82,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh"
   ],
   "PitParityWalkforward": [
     "set -eo pipefail",
@@ -91,7 +91,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh"
   ],
   "PortfolioOptimizerBacktest": [
     "set -eo pipefail",
@@ -100,7 +100,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh"
   ],
   "PredictorBacktest": [
     "set -eo pipefail",
@@ -109,7 +109,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh"
   ],
   "PredictorTraining": [
     "set -eo pipefail",
@@ -121,13 +121,13 @@
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
     "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh"
   ],
   "RAGIngestion": [
     "set -eo pipefail",
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"
+    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"
   ]
 }

--- a/tests/test_sf_definitions_resolve_the_declared_krepis_guard.py
+++ b/tests/test_sf_definitions_resolve_the_declared_krepis_guard.py
@@ -1,0 +1,178 @@
+"""Every Step Functions command array that invokes a ``krepis.*`` module
+resolves through the ops-owned guard, not a co-tenant venv.
+
+**The defect** (`alpha-engine-config-I7364`, one frame above `I7343`). Every
+state that launches a spot stage wraps its launcher in a log-capture command::
+
+    /home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run ...
+
+hardcoded to `crucible-dashboard`'s own venv — a co-tenant service's
+dependency surface, with no declared floor and no fail-loud. `I7343` guarded
+the NINE launcher scripts' own `LIB_PYTHON` default
+(`tests/test_launchers_resolve_the_declared_krepis_guard.py`); that test's
+surface is `spot_*.sh` / `_spot*.sh` shell scripts and cannot see a JSON state
+machine definition. This test covers the layer `I7343` does not reach: the SF
+definitions themselves.
+
+**What this test holds.** Every ``krepis.*`` module invocation found anywhere
+in any SF definition JSON in this repo resolves through
+``/opt/nousergon/bin/lib-python``. Derived from the parsed JSON string
+content, not a line-number list, so a 21st site — or a site in a definition
+that gains one later — is covered automatically.
+
+**What is deliberately OUT of scope**, same rationale as I7343's launcher
+carve-out: a co-tenant venv invocation that does NOT name a ``krepis.*``
+module. Two such sites exist today in ``step_function.json``:
+
+- ``-m training.model_zoo`` — needs `crucible-predictor`'s own environment,
+  not krepis.
+- the wrapped payload of the health-check state,
+  ``.../alpha-engine-dashboard/.venv/bin/python health_checker.py --alert``
+  — `crucible-dashboard`'s own script, needing that repo's own dependencies
+  (``nousergon_lib``, ``boto3``, dashboard-specific packages), not krepis.
+  Its OUTER wrapper (the ``krepis.ssm_log_capture`` call around it) is in
+  scope and is asserted below like every other site.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_INFRA = Path(__file__).resolve().parents[1] / "infrastructure"
+
+#: The one interpreter every krepis module invocation in an SF definition
+#: must resolve through. Same guard `I7343`'s launchers assert.
+GUARD = "/opt/nousergon/bin/lib-python"
+
+#: The pre-fix default. Its reappearance in front of a krepis module call is
+#: the regression.
+CO_TENANT = "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python"
+
+#: Every SF definition this repo owns, checked for the same shape. Filenames
+#: only, and a DELETION or RENAME must update this set deliberately — the
+#: coverage-membership test below catches a silent drop.
+KNOWN_SF_DEFINITIONS = {
+    "step_function.json",
+    "step_function_daily.json",
+    "step_function_eod.json",
+    "step_function_groom.json",
+}
+
+#: Sites deliberately NOT yet resolving the guard, pending a separate fix.
+#: (definition filename, interpreter) -> tracking issue. This is NOT the
+#: dashboard co-tenant venv `CO_TENANT` I7364 targets — it is the
+#: `crucible-executor` module's OWN dedicated live-trading box's venv
+#: (local dir `alpha-engine`, distinct from `alpha-engine-dashboard`).
+#: `/opt/nousergon/bin/lib-python` is installed by
+#: `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh`,
+#: scoped to the dashboard box and the ephemeral spot instances I7343's
+#: launchers provision — there is no evidence it is provisioned on the
+#: executor's own persistent box, and repointing this blind risks breaking
+#: `krepis.ssm_log_capture` on the LIVE weekday preopen trading pipeline.
+#: Tracked: alpha-engine-config-I7365. Remove this entry once resolved there.
+KNOWN_UNGUARDED_SITES: dict[tuple[str, str], str] = {
+    (
+        "step_function_daily.json",
+        "/home/ec2-user/alpha-engine/.venv/bin/python",
+    ): "alpha-engine-config-I7365",
+}
+
+#: interpreter path immediately followed by `-m krepis.<module>` — matched as
+#: literal substrings inside JSON string values (State.Format templates
+#: included), so no ASL intrinsic-function evaluation is needed. The
+#: interpreter group is restricted to path characters (starts with `/`, no
+#: quotes/commas/parens) so it does not walk back across the comma-joined
+#: `States.Format(...)` argument list that precedes it with no whitespace.
+_KREPIS_INVOCATION = re.compile(r"(/[^\s,'\"()]*) -m (krepis\.[^\s'\"]*)")
+
+
+def _existing_definitions() -> list[Path]:
+    return sorted(p for p in _INFRA.glob("*.json") if p.name in KNOWN_SF_DEFINITIONS)
+
+
+def _iter_strings(obj):
+    """Yield every string leaf in a parsed JSON document, recursively."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _iter_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _iter_strings(v)
+
+
+def _krepis_invocations(path: Path) -> list[tuple[str, str]]:
+    """[(interpreter, module), ...] for every `<interpreter> -m krepis.<mod>`
+    substring found anywhere in the parsed JSON's string values."""
+    data = json.loads(path.read_text())
+    hits: list[tuple[str, str]] = []
+    for s in _iter_strings(data):
+        hits.extend(_KREPIS_INVOCATION.findall(s))
+    return hits
+
+
+def test_every_known_sf_definition_is_present():
+    """A definition file renamed or deleted must be a deliberate, reviewed
+    diff to this set — not a silent shrink of what this test covers."""
+    found = {p.name for p in _INFRA.glob("*.json") if p.name.startswith("step_function")}
+    missing = KNOWN_SF_DEFINITIONS - found
+    assert not missing, (
+        f"expected SF definitions not found on disk: {sorted(missing)}. If one "
+        "was renamed, update KNOWN_SF_DEFINITIONS; if deleted, this test's "
+        "coverage shrank and that must be a deliberate, reviewed diff."
+    )
+
+
+def test_at_least_one_krepis_invocation_is_found():
+    """Guards the regex itself: if the JSON shape changes such that
+    `_krepis_invocations` silently stops matching anything, the two tests
+    below would pass vacuously. This fails loud instead."""
+    total = sum(len(_krepis_invocations(p)) for p in _existing_definitions())
+    assert total > 0, (
+        "no `<interpreter> -m krepis.<module>` invocation found in any SF "
+        "definition — either the fleet's krepis invocations have all been "
+        "removed (update this test) or `_krepis_invocations` no longer "
+        "matches the JSON's shape (fix the regex/derivation)."
+    )
+
+
+def test_every_krepis_module_invocation_resolves_the_guard():
+    """The load-bearing assertion: every krepis module invocation, in every SF
+    definition, names the ops-owned guard as its interpreter — except a site
+    explicitly named in KNOWN_UNGUARDED_SITES with a tracking issue."""
+    for path in _existing_definitions():
+        offenders = [
+            (interp, mod)
+            for interp, mod in _krepis_invocations(path)
+            if interp != GUARD
+            and (path.name, interp) not in KNOWN_UNGUARDED_SITES
+        ]
+        assert not offenders, (
+            f"{path.name}: krepis module invocation(s) not resolving "
+            f"{GUARD!r}: {offenders}. A co-tenant venv fronting a krepis "
+            "module call means the version that captures these stages' logs "
+            "is governed by another service's requirements.txt, with no "
+            "declared floor and no fail-loud — the alpha-engine-config-I6931 "
+            "failure mode, one frame above the launchers."
+        )
+
+
+def test_no_sf_definition_invokes_a_co_tenant_venv_for_a_krepis_module():
+    """Belt-and-suspenders on the same defect: the exact conjoined substring
+    `<co-tenant venv> -m krepis.` never appears, by direct substring search
+    rather than the regex derivation above. Checked as one joined string
+    (not per-line) because a single command line legitimately combines an
+    in-scope krepis wrapper with an out-of-scope co-tenant payload script —
+    e.g. the health-check state's `... -m krepis.ssm_log_capture run ... --
+    <co-tenant venv> health_checker.py --alert` — and a line-level search
+    would false-positive on that shape."""
+    needle = f"{CO_TENANT} -m krepis."
+    for path in _existing_definitions():
+        text = path.read_text()
+        assert needle not in text, (
+            f"{path.name}: contains {needle!r} — a krepis module invoked "
+            "through the co-tenant venv."
+        )

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -549,6 +549,17 @@ def orig_spot_cmds() -> dict:
       to a checkout, not of the Parallel state that happened to expose it.
       See `tests/test_sf_git_pull_serialized.py`.
 
+    - **Regenerated 2026-08-14** (alpha-engine-config-I7364): every
+      `krepis.ssm_log_capture` wrapper's interpreter moved from the
+      crucible-dashboard co-tenant venv
+      (`/home/ec2-user/alpha-engine-dashboard/.venv/bin/python`) to the
+      ops-owned guard (`/opt/nousergon/bin/lib-python`) — the same guard
+      `I7343` pointed the launcher scripts' own `LIB_PYTHON` default at, one
+      frame up the stack. A deliberate, reviewed absent-path change confined
+      to the interpreter token; every other argument is unchanged. 14 of the
+      15 keys here changed (all except `DriftDetection`, a stale key with no
+      corresponding live SF state).
+
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
     resolved spot commands from the new `origin/main` SF.
@@ -910,6 +921,10 @@ class TestByteIdenticalAbsentPath:
         The lib CLI internalizes tee + S3-ship; --preflight-only still
         sits immediately after the launcher's mode token so the
         orthogonal-modifier shape is preserved.
+
+        2026-08-14 (alpha-engine-config-I7364): the interpreter token moved
+        from the crucible-dashboard co-tenant venv to the ops-owned guard
+        `/opt/nousergon/bin/lib-python`; everything after it is unchanged.
         """
         token, log = _SPOT_STATES[name]
         slug = Path(log).stem
@@ -918,7 +933,7 @@ class TestByteIdenticalAbsentPath:
         )
         final = cmds[-1]
         expected = (
-            "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python "
+            "/opt/nousergon/bin/lib-python "
             "-m krepis.ssm_log_capture run "
             f"--correlation-id {_CONTEXT_OBJECT['Execution.Name']} "
             f"--slug {slug} --log {log} -- "


### PR DESCRIPTION
## Summary

Re-measured `alpha-engine-config-I7364`'s stated 20 occurrences on current `origin/main`: **20 confirmed** (`grep -o "alpha-engine-dashboard/.venv/bin/python"` → 20; across 19 lines, one line has two). Of those:

- **18** are `krepis.ssm_log_capture` wrapper sites — **repointed** from the crucible-dashboard co-tenant venv (`/home/ec2-user/alpha-engine-dashboard/.venv/bin/python`) to the ops-owned guard `/opt/nousergon/bin/lib-python`, matching what `alpha-engine-config-I7343`'s five launcher PRs did one frame down the stack.
- **1** is `-m training.model_zoo` — left untouched (needs `crucible-predictor`'s own environment, per I7364's explicit carve-out).
- **1** is the health-check state's wrapped payload, `.../alpha-engine-dashboard/.venv/bin/python health_checker.py --alert` — left untouched (`crucible-dashboard`'s own script, needs that repo's own deps — `nousergon_lib`, `boto3`, dashboard-specific packages — not krepis; same rationale as the `training.model_zoo` carve-out). Its outer `krepis.ssm_log_capture` wrapper IS repointed like every other site.

## Derived test

`tests/test_sf_definitions_resolve_the_declared_krepis_guard.py` — walks the parsed JSON of all four SF definitions (`step_function.json`, `_daily.json`, `_eod.json`, `_groom.json`) for any `<interpreter> -m krepis.<module>` invocation and asserts the interpreter is the guard. Derived from the definition, not a line list, so a 21st site is covered automatically.

**Verified fail-before-fix**: reverted `step_function.json` alone (`git stash`), re-ran → **2 of 4 tests failed** (`test_every_krepis_module_invocation_resolves_the_guard`, `test_no_sf_definition_invokes_a_co_tenant_venv_for_a_krepis_module`), both citing the co-tenant path. Restored, re-ran → 4/4 pass.

## Other SF definitions — same shape?

- `step_function_daily.json`, `_eod.json`, `_groom.json`: **0** occurrences of the dashboard co-tenant path (confirmed by both the issue's original grep and this PR's re-measure).
- BUT the new derived test caught a **structurally identical, distinct** site the issue's grep pattern didn't name: `step_function_daily.json`'s executor stage fronts `krepis.ssm_log_capture` through `/home/ec2-user/alpha-engine/.venv/bin/python` — the `crucible-executor` module's own dedicated **live-trading** box's venv (not `-dashboard`, not co-tenant). `/opt/nousergon/bin/lib-python` is installed by `nous-ergon-ops`'s `install-box-config.sh`, scoped to the dashboard box + ephemeral spot instances — no evidence it's provisioned on the executor's own persistent box. Repointing this blind, on the live preopen trading pipeline, without box verification (which this PR's constraints forbid) is unsafe. **Filed separately: `alpha-engine-config-I7365`.** The test allowlists this one known site with a comment citing the issue; every other site in every definition is asserted against the guard.

## Also fixed (required by the repoint, not scope creep)

- `tests/fixtures/sf_prekeystone_spot_commands.json` — the frozen absent-path baseline `test_sf_friday_shell_run_wiring.py`'s `TestByteIdenticalAbsentPath` pins byte-for-byte. Regenerated for the 14 changed keys (matches the 18 repointed sites; `DriftDetection` untouched — stale key, no live SF state).
- Two hardcoded expected-string literals in `tests/test_sf_friday_shell_run_wiring.py` updated to the new interpreter.

## Also found, filed separately (not folded in — pre-existing, unrelated)

`alpha-engine-config-I7366`: `sf_preflight.py::check_tool_contracts` has never matched the real `States.Array(...)`-wrapped `commands.$` shape — its `.split()` extraction produces `parts[0] == "States.Array('set"` on every real site, so `checked` has always been 0 and it reports `status="ok"` while checking nothing. Verified this is true on BOTH sides of this PR's diff (pre-existing since before I7364).

## Test evidence

Full suite (using `nousergon-data/.venv`, krepis 0.56.0 — matches this repo's declared pin; the ephemeral worktree venv was below floor and missing deps, so not used for the real run): **5736 passed, 9 skipped, 0 failed.**

## Deploy

`step_function.json` auto-deploys on merge (confirmed via `.github/workflows/deploy-weekly-freshness-spot-dispatcher.yml`'s own comment: "since step_function.json ALSO auto-deploys on merge"). No manual post-merge step.

## Merge order

Lands after `alpha-engine-config-I7343`'s five launcher PRs — `nousergon-data-PR1386` merged 2026-08-14T18:40:23Z, already on `main` at this branch's base.

Closes alpha-engine-config-I7364

---
Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_sf_definitions_resolve_the_declared_krepis_guard.py
