### PR TITLE
[P0/mid] fix(spot): cut bootstrap_spot() over to krepis.spot_bootstrap (config-I6922)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -270,106 +270,30 @@ stage_config() {
 
 bootstrap_spot() {
   echo "==> Bootstrapping spot (watchdog, python, clone, config)..."
-  local _spot_env_export
-  _spot_env_export="export S3_STAGING=${_S3_STAGING} BRANCH=${BRANCH}"$'\n'
-  run_ssm "bootstrap" "${_spot_env_export}$(cat <<'BOOTSTRAP'
-set -eo pipefail
-export HOME=/home/ec2-user XDG_CACHE_HOME=/tmp AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1
-
-# systemd watchdog (config#2693). Type=simple, NOT oneshot: ExecStart is an
-# endless supervision loop, and `systemctl start` on a Type=oneshot unit BLOCKS
-# until ExecStart exits (TimeoutStartSec defaults to infinity for oneshot). The
-# original unit declared Type=oneshot + RemainAfterExit=yes, so every bootstrap
-# hung here until SSM SIGKILLed the command at its budget — rc=137 at exactly
-# PT5M0.1S, stderr ending on the `systemctl enable` symlink line with nothing
-# after it. Latent from #1122 until #1269 repointed the weekly SF onto these
-# per-stage scripts on 2026-08-09; the first weekly run on the new path
-# (2026-08-10) failed at MorningEnrich twice, and DataPhase1 + RAGIngestion
-# would have failed identically. The retired spot_data_weekly.sh monolith never
-# hit it: it arms its watchdog with a transient `systemd-run --on-active` timer,
-# not a unit file.
-if ! systemctl is-enabled ec2-spot-watchdog 2>/dev/null; then
-  cat > /tmp/ec2-spot-watchdog.service <<'UNIT'
-[Unit]
-Description=EC2 Spot Watchdog
-After=amazon-ssm-agent.service
-Requires=amazon-ssm-agent.service
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/ec2-spot-watchdog.sh
-Restart=always
-RestartSec=30
-[Install]
-WantedBy=multi-user.target
-UNIT
-  cat > /usr/local/bin/ec2-spot-watchdog.sh <<'WDSH'
-#!/usr/bin/env bash
-set -euo pipefail
-while true; do
-  if ! systemctl is-active amazon-ssm-agent >/dev/null 2>&1; then
-    sleep 60
-    if ! systemctl is-active amazon-ssm-agent >/dev/null 2>&1; then
-      shutdown -h now
-    fi
-  fi
-  sleep 60
-done
-WDSH
-  chmod +x /usr/local/bin/ec2-spot-watchdog.sh
-  cp /tmp/ec2-spot-watchdog.service /etc/systemd/system/
-  # `timeout` so a future unit-shape regression fails in seconds WITH a message,
-  # instead of consuming the whole SSM budget and dying under SIGKILL with no
-  # output — that silence is what made the 2026-08-10 hang read as "bootstrap
-  # is slow" rather than "systemctl is blocked forever".
-  timeout 60 systemctl enable --now ec2-spot-watchdog || {
-    echo "ERROR: enabling ec2-spot-watchdog did not return within 60s — the unit is misdeclared (an endless ExecStart under Type=oneshot blocks systemctl start forever)" >&2
-    exit 1
-  }
-fi
-
-# Install the interpreter — the AL2023 spot AMI does not ship python3.12.
-# The retired spot_data_weekly.sh monolith installed it here; the per-stage
-# split (#1122) replaced the install with a bare assertion, encoding an AMI
-# contract nothing provides. Latent until #1269 repointed the weekly SF onto
-# these scripts (2026-08-09); the first run over the new path died on
-# "ERROR: python3.12 not found" (watch-rerun-2026-08-10-3, 2026-08-11).
-# gcc + devel are needed by source-built wheels in requirements.txt; git for
-# the clone below. Measured on the monolith's own successful bootstraps
-# (2026-08-07 and 08-08): this whole step ran in 48-49s, well inside the 300s
-# budget, so the budget stays as it is.
-dnf install -y -q python3.12 python3.12-pip python3.12-devel git gcc 2>/dev/null || \
-    dnf install -y -q python3 python3-pip python3-devel git gcc
-
-# Post-condition, not a precondition: the install above is what makes this
-# true, and a silent fallback to a system python3 is exactly the drift the
-# per-stage scripts must not inherit (requirements.txt is resolved against
-# 3.12).
-command -v python3.12 >/dev/null || { echo "ERROR: python3.12 not found after dnf install" >&2; exit 1; }
-echo "Using: $(python3.12 --version)"
-
-if [ ! -d /home/ec2-user/data/.git ]; then
-  rm -rf /home/ec2-user/data
-  git clone --depth 1 --branch "${BRANCH:-main}" https://github.com/nousergon/nousergon-data.git /home/ec2-user/data
-fi
-
-# Destination must be a path weekly_collector.load_config actually searches.
-# It delegates to nousergon_lib.config.resolve_experiment_config("data",
-# "config.yaml", repo_root=<checkout>, repo_local_fallback=Path("config.yaml")),
-# so with the clone at /home/ec2-user/data the candidates are
-# /home/ec2-user/alpha-engine-config/{experiments/reference/,}data/config.yaml
-# plus the CWD-relative config.yaml — /home/ec2-user/data/config/config.yaml is
-# in none of them. The retired spot_data_weekly.sh monolith staged to the
-# alpha-engine-config path below; the per-stage split (#1122) changed the
-# destination and #1269 made that live, so MorningEnrich died on
-# FileNotFoundError (config#6846). No per-stage workload reads the old path —
-# it is dropped rather than written twice. tests/test_spot_bootstrap_config_
-# lands_where_the_resolver_looks.py derives the candidate list from the
-# resolver, so a resolver change fails CI instead of production.
-mkdir -p /home/ec2-user/alpha-engine-config/data
-aws s3 cp "${S3_STAGING}/config.yaml" "/home/ec2-user/alpha-engine-config/data/config.yaml" --region "${AWS_REGION:-us-east-1}" --quiet
-chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-config
-BOOTSTRAP
-)" 300
+  # Rendered by krepis.spot_bootstrap (alpha-engine-config-I6922) rather than
+  # built as an inline heredoc. That module is the fleet's single canonical
+  # source for the watchdog unit, the interpreter install and the clone/config
+  # shape this heredoc used to hand-carry (nousergon-data#1294, #1296;
+  # crucible-predictor#461, #462, #463 were the same defects reaching the
+  # sibling copy hours to days later). Region and branch are passed as
+  # LAUNCHER-SIDE LITERALS rather than left for the remote shell to expand —
+  # the predictor's REPO_URL/BRANCH class of bug (crucible-predictor#463: a
+  # value interpolated into the heredoc but never actually exported, so the
+  # remote expansion silently resolved to an empty string) cannot happen when
+  # the value is baked into the rendered script instead of read from the
+  # remote environment. `--region us-east-1` mirrors this heredoc's prior
+  # hardcode exactly (it never read the outer $AWS_REGION); tests/
+  # test_spot_bootstrap_invariants.py and its siblings assert the rendered
+  # output stays byte-for-byte equivalent on the parts that must not drift.
+  local _script
+  _script="$("$LIB_PYTHON" -m krepis.spot_bootstrap render \
+    --repo-url https://github.com/nousergon/nousergon-data.git \
+    --checkout /home/ec2-user/data \
+    --branch "${BRANCH:-main}" \
+    --region us-east-1 \
+    --export "S3_STAGING=${_S3_STAGING}" \
+    --config-copy config.yaml:/home/ec2-user/alpha-engine-config/data/config.yaml:/home/ec2-user/alpha-engine-config)"
+  run_ssm "bootstrap" "$_script" 300
   echo "  Bootstrap complete."
 }
 

--- a/tests/test_embedded_systemd_unit_shapes.py
+++ b/tests/test_embedded_systemd_unit_shapes.py
@@ -25,15 +25,28 @@ service type that waits for it to finish.
 Scope note: a genuinely one-shot job (a timer-driven backup, a drift check)
 is correctly ``Type=oneshot`` and is not flagged — the test keys on the
 ExecStart script's own body containing an unbounded loop, not on the type.
+
+## Post-cutover (alpha-engine-config-I6922, 2026-08-14)
+
+``_spot_common.sh``'s ``bootstrap_spot()`` no longer embeds the
+``ec2-spot-watchdog`` unit as heredoc text — it dispatches
+``krepis.spot_bootstrap render`` and sends the rendered script over SSM. The
+generic ``*.sh`` sweep below still runs unmodified (it finds nothing embedded
+in this file now, and that is correct — the unit lives in krepis). The two
+anchored assertions on the specific unit that hung the pipeline are rendered
+from the same argv ``bootstrap_spot()`` actually passes, so they still catch a
+future regression, just against the rendered script.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
 import pytest
 
+from krepis.spot_bootstrap import ConfigCopy, SpotBootstrapSpec, render_bootstrap
 from nousergon_lib.shell_guards import (
     embedded_units,
     endless_execstart_violations,
@@ -56,14 +69,42 @@ def test_endless_execstart_is_never_a_blocking_service_type(script: Path):
     )
 
 
+def _rendered_bootstrap() -> str:
+    """Render the actual script bootstrap_spot() sends, from its real argv."""
+    text = (_INFRA / "_spot_common.sh").read_text()
+    block_m = re.search(r"bootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
+    assert block_m, "bootstrap_spot() not found in _spot_common.sh"
+    call_m = re.search(
+        r'"\$LIB_PYTHON"\s+-m\s+krepis\.spot_bootstrap\s+render\s*\\(.*?)\)"',
+        block_m.group(1),
+        re.S,
+    )
+    assert call_m, "bootstrap_spot() no longer dispatches krepis.spot_bootstrap render"
+    args = shlex.split(call_m.group(1).replace("\\\n", " "))
+
+    def flag(name: str) -> str:
+        return args[args.index(name) + 1]
+
+    source, dest, chown = flag("--config-copy").split(":")
+    spec = SpotBootstrapSpec(
+        repo_url=flag("--repo-url"),
+        checkout=flag("--checkout"),
+        region=flag("--region"),
+        branch="main",
+        config_copies=(ConfigCopy(source_name=source, dest=dest, chown=chown),),
+        exports={"S3_STAGING": "s3://placeholder/staging"},
+    )
+    return render_bootstrap(spec)
+
+
 def test_the_spot_watchdog_unit_is_a_simple_service():
     """Anchored assertion on the specific unit that hung the pipeline."""
-    text = (_INFRA / "_spot_common.sh").read_text()
+    text = _rendered_bootstrap()
     units = [
         u for u in embedded_units(text)
         if "ec2-spot-watchdog" in u.body or "EC2 Spot Watchdog" in u.body
     ]
-    assert units, "ec2-spot-watchdog unit not found in _spot_common.sh"
+    assert units, "ec2-spot-watchdog unit not found in _spot_common.sh's rendered bootstrap"
     for unit in units:
         assert unit.service_type == "simple", unit.body
         assert "RemainAfterExit" not in unit.body, (
@@ -76,7 +117,7 @@ def test_the_watchdog_enable_call_is_time_bounded():
     """A future regression must fail loudly in seconds, not silently at the
     SSM budget. The 2026-08-10 hang produced NO stderr past the symlink line,
     which is why it read as a slow bootstrap rather than a blocked systemctl."""
-    text = (_INFRA / "_spot_common.sh").read_text()
+    text = _rendered_bootstrap()
     assert re.search(r"timeout\s+\d+\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog", text), (
         "the watchdog enable call must be wrapped in `timeout N systemctl "
         "enable --now ec2-spot-watchdog` with an explicit error message"

--- a/tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py
+++ b/tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py
@@ -18,13 +18,25 @@ is exactly the coupling nothing else checks.
 The candidate list here is DERIVED from
 ``nousergon_lib.config.resolve_experiment_config`` rather than hardcoded: if the
 resolver's search order changes, this test fails instead of the pipeline.
+
+## Post-cutover (alpha-engine-config-I6922, 2026-08-14)
+
+``bootstrap_spot()`` no longer writes an ``aws s3 cp`` literal into
+``_spot_common.sh`` — it passes a ``--config-copy source:dest:chown`` argument
+to ``krepis.spot_bootstrap render`` and dispatches the rendered script. This
+test now extracts that argument and renders the actual script through
+``krepis.spot_bootstrap.render_bootstrap`` before asserting the ``aws s3 cp``
+destination against the resolver, so it is exercising exactly what the spot
+box receives, not a hand-parsed proxy for it.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
+from krepis.spot_bootstrap import ConfigCopy, SpotBootstrapSpec, render_bootstrap
 from nousergon_lib.config import resolve_experiment_config
 
 # Where the bootstrap clones nousergon-data on the spot box, and the working
@@ -32,12 +44,39 @@ from nousergon_lib.config import resolve_experiment_config
 _REMOTE_CHECKOUT = Path("/home/ec2-user/data")
 
 _SPOT_COMMON = Path(__file__).resolve().parents[1] / "infrastructure" / "_spot_common.sh"
-_SRC = _SPOT_COMMON.read_text(encoding="utf-8")
 
-# `aws s3 cp "${S3_STAGING}/config.yaml" "<dest>"` inside the bootstrap heredoc.
+# `aws s3 cp "${S3_STAGING}/config.yaml" "<dest>"` inside the RENDERED script.
 _STAGE_CP = re.compile(
     r'aws\s+s3\s+cp\s+"\$\{S3_STAGING\}/config\.yaml"\s+"?(?P<dest>[^"\s]+)"?'
 )
+
+
+def _rendered_bootstrap() -> str:
+    """Render the actual script bootstrap_spot() sends, from its real argv."""
+    text = _SPOT_COMMON.read_text(encoding="utf-8")
+    block_m = re.search(r"\nbootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
+    assert block_m, f"bootstrap_spot() not found in {_SPOT_COMMON.name}"
+    call_m = re.search(
+        r'"\$LIB_PYTHON"\s+-m\s+krepis\.spot_bootstrap\s+render\s*\\(.*?)\)"',
+        block_m.group(1),
+        re.S,
+    )
+    assert call_m, "bootstrap_spot() no longer dispatches krepis.spot_bootstrap render"
+    args = shlex.split(call_m.group(1).replace("\\\n", " "))
+
+    def flag(name: str) -> str:
+        return args[args.index(name) + 1]
+
+    source, dest, chown = flag("--config-copy").split(":")
+    spec = SpotBootstrapSpec(
+        repo_url=flag("--repo-url"),
+        checkout=flag("--checkout"),
+        region=flag("--region"),
+        branch="main",
+        config_copies=(ConfigCopy(source_name=source, dest=dest, chown=chown),),
+        exports={"S3_STAGING": "s3://placeholder/staging"},
+    )
+    return render_bootstrap(spec)
 
 
 def _resolver_candidates() -> list[str]:
@@ -59,11 +98,12 @@ def _resolver_candidates() -> list[str]:
 
 
 def test_bootstrap_stages_config_to_a_resolver_candidate():
-    dests = [m.group("dest") for m in _STAGE_CP.finditer(_SRC)]
+    src = _rendered_bootstrap()
+    dests = [m.group("dest") for m in _STAGE_CP.finditer(src)]
     assert dests, (
-        f"{_SPOT_COMMON.name} no longer stages config.yaml in its bootstrap — if that "
-        "is deliberate (prebaked image), delete this test with the reason; otherwise "
-        "the stages will fail on a fresh box."
+        f"{_SPOT_COMMON.name}'s rendered bootstrap no longer stages config.yaml — if "
+        "that is deliberate (prebaked image), delete this test with the reason; "
+        "otherwise the stages will fail on a fresh box."
     )
 
     candidates = _resolver_candidates()
@@ -78,12 +118,13 @@ def test_bootstrap_stages_config_to_a_resolver_candidate():
 
 def test_staged_config_is_readable_by_the_stage_user():
     """The bootstrap runs as root; every stage workload runs as ec2-user."""
-    dests = [m.group("dest") for m in _STAGE_CP.finditer(_SRC)]
+    src = _rendered_bootstrap()
+    dests = [m.group("dest") for m in _STAGE_CP.finditer(src)]
     for dest in dests:
         owner_root = str(Path(dest).parent.parent)
         assert re.search(
-            rf"chown -R ec2-user:ec2-user {re.escape(owner_root)}\b", _SRC
-        ) or re.search(rf"chown -R ec2-user:ec2-user {re.escape(str(Path(dest).parent))}\b", _SRC), (
+            rf"chown -R ec2-user:ec2-user {re.escape(owner_root)}\b", src
+        ) or re.search(rf"chown -R ec2-user:ec2-user {re.escape(str(Path(dest).parent))}\b", src), (
             f"config staged to {dest} by the root bootstrap is never chowned to "
             "ec2-user, which is the uid every stage's SSM heredoc runs under"
         )

--- a/tests/test_spot_bootstrap_invariants.py
+++ b/tests/test_spot_bootstrap_invariants.py
@@ -2,11 +2,12 @@
 
 ## Why this test exists
 
-``infrastructure/_spot_common.sh`` exists twice in the fleet — here and in
-``crucible-predictor`` — as two independently-written implementations of the
-same spot bootstrap. Neither was forked from the other; both were built by
-applying the same written standard (ARCHITECTURE.md §111), eight days apart,
-and the standard named a *shape* and no implementation. They then diverged.
+``infrastructure/_spot_common.sh`` used to carry its own hand-written copy of
+the spot bootstrap — watchdog unit, interpreter install, clone, config
+staging — independently from ``crucible-predictor``'s copy of the same shape.
+Neither was forked from the other; both were built by applying the same
+written standard (ARCHITECTURE.md §111), eight days apart, and the standard
+named a *shape* and no implementation. They then diverged.
 
 What that cost, measured on the weekly Step Function over 2026-08-10/11
 (alpha-engine-config-I6922):
@@ -16,51 +17,44 @@ What that cost, measured on the weekly Step Function over 2026-08-10/11
 | watchdog unit ``Type=oneshot`` blocks its own bootstrap | `nousergon-data#1294` | `crucible-predictor#461`, 16h later |
 | bootstrap ASSERTS ``python3.12`` instead of installing it | `nousergon-data#1296` | `crucible-predictor#462`, 23h later |
 
-Both defects live in the two blocks this test guards. Each port cost a failed
-weekly run to discover, because the second copy's defect stays invisible until
-the first copy's is fixed and the pipeline gets far enough to reach it.
+## The cutover (alpha-engine-config-I6922, 2026-08-14)
 
-## What it asserts, and why it is not a second hardcoded copy
+``bootstrap_spot()`` no longer builds a heredoc at all — it calls
+``krepis.spot_bootstrap`` (shipped 0.46.0) via the same ``$LIB_PYTHON``
+interpreter ``run_ssm`` already uses, and pipes the rendered script straight
+into ``run_ssm``. The blocker that kept this a duplicated heredoc instead of a
+shared renderer — ``LIB_PYTHON`` resolving to a co-tenant's venv with no
+declared floor — cleared in ``alpha-engine-config-I7343``: the launcher now
+resolves through ``/opt/nousergon/bin/lib-python``, the ops-owned guard with an
+enforced floor.
 
-The invariants are **derived from** ``krepis.spot_bootstrap``, the fleet's
-canonical renderer (shipped 0.46.0, alpha-engine-config-I6922 phase 1) — not
-restated here. ``krepis`` is already a pinned dependency of this repo, so the
-check is hermetic and needs no network and no sibling checkout.
+## What this test asserts, and why it is not a second hardcoded copy
 
-Deriving rather than restating is the whole point: a third repo, or a change to
-the canonical renderer, moves this test's expectations automatically. A test
-that hardcoded ``Type=simple`` would be a *third* copy of the invariant and
-would drift exactly like the first two.
+1. There is no inline systemd unit / ``dnf install`` / ``git clone`` left in
+   ``bootstrap_spot()`` — the anti-regression against the heredoc creeping
+   back.
+2. The CLI arguments ``bootstrap_spot()`` actually passes to
+   ``krepis.spot_bootstrap render`` are extracted and asserted against the
+   spec this repo owes the renderer (repo, checkout, config destination,
+   chown, the ``S3_STAGING`` export) — so a wrong argument fails here, not on
+   a Saturday.
+3. Those extracted arguments are fed through
+   ``krepis.spot_bootstrap.render_bootstrap`` and the invariants below are
+   re-run against the RENDERED output. The invariants are unchanged from
+   before the cutover; only their subject moved from a heredoc literal to a
+   rendered string, because the shared parts (watchdog, interpreter) are now
+   owned by ``krepis``, not restated here.
 
-## Why the Bash copy still exists at all
-
-``krepis.spot_bootstrap`` could not simply replace this heredoc while the
-launcher resolved its interpreter as::
-
-    LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
-
-— the *shared application host's* venv, whose krepis version was governed by
-``crucible-dashboard/requirements.txt``, a file no merge in this repo can see.
-A cutover therefore carried a runtime dependency this repo could not pin, and
-when that venv was behind, the bootstrap did not degrade — it died with
-``ModuleNotFoundError`` on every spot stage of every pipeline. So the dependency
-that could not safely exist at RUNTIME lived in a TEST instead: the Bash copies
-stay, and CI asserts they agree with the canonical renderer.
-
-**That blocker is now cleared** (`alpha-engine-config-I7343`, 2026-08-14). The
-launcher resolves through ``/opt/nousergon/bin/lib-python``, the ops-owned guard
-over the box's DECLARED krepis venv, which aborts with ``EX_CONFIG`` (78) naming
-the version it found when that venv is below the launcher floor — a declared,
-enforced, fail-loud floor, which is what I6931 owed. The cutover to
-``krepis.spot_bootstrap`` is therefore unblocked and becomes a deletion;
-``alpha-engine-config-I6922`` owns it, and this test is what will prove the
-deletion changed nothing. Resolution is pinned by
-``tests/test_launchers_resolve_the_declared_krepis_guard.py``.
+Deriving rather than restating is the whole point: a change to the canonical
+renderer moves this test's expectations automatically. A test that hardcoded
+``Type=simple`` would be a *new* copy of the invariant and would drift exactly
+like the two heredocs did.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
 import pytest
@@ -68,6 +62,7 @@ import pytest
 from krepis.spot_bootstrap import (
     PYTHON,
     SYSTEMCTL_ENABLE_TIMEOUT_SEC,
+    ConfigCopy,
     SpotBootstrapSpec,
     render_bootstrap,
 )
@@ -75,26 +70,143 @@ from krepis.spot_bootstrap import (
 _SPOT_COMMON = Path(__file__).resolve().parents[1] / "infrastructure" / "_spot_common.sh"
 
 
-# A spec's values do not matter here: this test compares the parts of the
-# rendered script that are the SAME for every workload — the watchdog unit and
-# the interpreter install. The repo-specific tail (clone target, config
-# destinations) is asserted by the per-repo tests beside this one.
-_CANONICAL = render_bootstrap(
-    SpotBootstrapSpec(repo_url="https://example.invalid/x.git", checkout="/tmp/x")
-)
-
-
 @pytest.fixture(scope="module")
 def bootstrap_block() -> str:
-    """The body of ``bootstrap_spot()`` — launcher glue plus the remote heredoc."""
+    """The body of ``bootstrap_spot()`` — now just the krepis dispatch."""
     text = _SPOT_COMMON.read_text(encoding="utf-8")
     m = re.search(r"\nbootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
     assert m, f"bootstrap_spot() not found in {_SPOT_COMMON.name}"
     return m.group(1)
 
 
+@pytest.fixture(scope="module")
+def render_args(bootstrap_block: str) -> list[str]:
+    """The literal argv passed to ``krepis.spot_bootstrap render``.
+
+    Extracted from the multi-line ``"$LIB_PYTHON" -m krepis.spot_bootstrap
+    render \\`` invocation by stripping line continuations and shlex-splitting
+    what remains, so this test reads the actual call rather than restating it.
+    """
+    m = re.search(
+        r'"\$LIB_PYTHON"\s+-m\s+krepis\.spot_bootstrap\s+render\s*\\(.*?)\)"',
+        bootstrap_block,
+        re.S,
+    )
+    assert m, "bootstrap_spot() no longer dispatches krepis.spot_bootstrap render"
+    joined = m.group(1).replace("\\\n", " ")
+    return shlex.split(joined)
+
+
+def _flag_value(args: list[str], flag: str) -> str:
+    assert flag in args, f"{flag} missing from the krepis.spot_bootstrap render call"
+    return args[args.index(flag) + 1]
+
+
+@pytest.fixture(scope="module")
+def rendered(render_args: list[str]) -> str:
+    """The actual script this repo's bootstrap sends, rendered exactly as
+    ``bootstrap_spot()`` would — same repo, checkout, config-copy shape.
+
+    ``--branch`` is ``${BRANCH:-main}`` in the shell (a runtime shell
+    expansion, asserted separately below) and ``--export`` embeds the runtime
+    ``$_S3_STAGING`` value — neither is a literal this test can read without a
+    shell, so both are substituted with a placeholder here. Neither affects
+    the watchdog or interpreter blocks this test asserts against.
+    """
+    config_copy_raw = _flag_value(render_args, "--config-copy")
+    parts = config_copy_raw.split(":")
+    assert len(parts) == 3, f"--config-copy must be source:dest:chown, got {config_copy_raw!r}"
+    spec = SpotBootstrapSpec(
+        repo_url=_flag_value(render_args, "--repo-url"),
+        checkout=_flag_value(render_args, "--checkout"),
+        region=_flag_value(render_args, "--region"),
+        branch="main",
+        config_copies=(ConfigCopy(source_name=parts[0], dest=parts[1], chown=parts[2]),),
+        exports={"S3_STAGING": "s3://placeholder/staging"},
+    )
+    return render_bootstrap(spec)
+
+
+# ── The dispatch itself — no heredoc creeping back ───────────────────────────
+
+
+def test_bootstrap_spot_no_longer_inlines_the_heredoc(bootstrap_block: str):
+    """Anti-regression: the whole point of the cutover is this heredoc is gone."""
+    assert "systemctl enable" not in bootstrap_block, (
+        "bootstrap_spot() still inlines the systemd watchdog unit — the cutover to "
+        "krepis.spot_bootstrap (alpha-engine-config-I6922) is meant to delete it, "
+        "not duplicate it"
+    )
+    assert "dnf install" not in bootstrap_block, (
+        "bootstrap_spot() still inlines a dnf install — that belongs in "
+        "krepis.spot_bootstrap._interpreter_block() now"
+    )
+    assert "git clone" not in bootstrap_block, (
+        "bootstrap_spot() still inlines a git clone — that belongs in "
+        "krepis.spot_bootstrap._clone_block() now"
+    )
+
+
+def test_bootstrap_spot_dispatches_through_lib_python(bootstrap_block: str):
+    assert '"$LIB_PYTHON" -m krepis.spot_bootstrap render' in bootstrap_block.replace(
+        "\\\n", " "
+    ) or re.search(r'"\$LIB_PYTHON"\s+-m\s+krepis\.spot_bootstrap\s+render', bootstrap_block), (
+        "bootstrap_spot() must render via \"$LIB_PYTHON\" -m krepis.spot_bootstrap, "
+        "the same interpreter run_ssm() already dispatches through"
+    )
+
+
+# ── The spec bootstrap_spot() owes the renderer ──────────────────────────────
+
+
+def test_repo_url_and_checkout(render_args: list[str]):
+    assert _flag_value(render_args, "--repo-url") == (
+        "https://github.com/nousergon/nousergon-data.git"
+    )
+    assert _flag_value(render_args, "--checkout") == "/home/ec2-user/data"
+
+
+def test_branch_is_a_launcher_side_literal_with_the_main_default(bootstrap_block: str):
+    """Passed as ``"${BRANCH:-main}"`` — a literal baked at render time, not a
+    remote shell expansion. crucible-predictor#463: a value interpolated into
+    the heredoc but never exported resolved to an empty string on the spot;
+    passing it through the renderer's argv removes that class of bug entirely.
+    """
+    assert re.search(r'--branch\s+"\$\{BRANCH:-main\}"', bootstrap_block), (
+        'bootstrap_spot() must pass --branch "${BRANCH:-main}" — a launcher-side '
+        "literal preserving the pre-cutover default, not a remote expansion"
+    )
+
+
+def test_s3_staging_export_is_load_bearing(render_args: list[str], bootstrap_block: str):
+    """The config-copy block's `${S3_STAGING}/...` needs this in the remote env."""
+    assert re.search(r'--export\s+"S3_STAGING=\$\{_S3_STAGING\}"', bootstrap_block), (
+        "bootstrap_spot() must pass --export \"S3_STAGING=${_S3_STAGING}\" — the "
+        "config-copy block's aws s3 cp references ${S3_STAGING} in the remote "
+        "environment and dies without it"
+    )
+
+
+def test_config_copy_spec(render_args: list[str]):
+    raw = _flag_value(render_args, "--config-copy")
+    source, dest, chown = raw.split(":")
+    assert source == "config.yaml"
+    assert dest == "/home/ec2-user/alpha-engine-config/data/config.yaml"
+    assert chown == "/home/ec2-user/alpha-engine-config"
+
+
+def test_region_is_the_pre_cutover_literal(render_args: list[str]):
+    """The old heredoc hardcoded us-east-1 and never read $AWS_REGION — this
+    preserves that exactly, rather than silently picking up whatever
+    $AWS_REGION happens to resolve to at call time.
+    """
+    assert _flag_value(render_args, "--region") == "us-east-1"
+
+
+# ── The watchdog unit (asserted against the RENDERED output) ────────────────
+
+
 def _service_directives(script: str) -> set[str]:
-    """``KEY=VALUE`` lines in the systemd unit's ``[Service]`` section."""
     m = re.search(r"\[Service\]\n(.*?)(?=\n\[|\nUNIT\b)", script, re.S)
     assert m, "no [Service] section found in the systemd unit"
     return {
@@ -104,47 +216,13 @@ def _service_directives(script: str) -> set[str]:
     }
 
 
-# ── The watchdog unit ────────────────────────────────────────────────────────
-
-
-def test_watchdog_unit_carries_every_directive_the_canonical_unit_declares(
-    bootstrap_block: str,
-):
-    """Derived, not restated — krepis owns what the unit must say.
-
-    The 2026-08-10 hang was a missing/incorrect ``Type``. Asserting the whole
-    ``[Service]`` section rather than that one field means the next divergence
-    in this unit — whatever field it lands on — also fails here.
-    """
-    canonical = _service_directives(_CANONICAL)
-    local = _service_directives(bootstrap_block)
-    missing = canonical - local
-    assert not missing, (
-        f"{_SPOT_COMMON.name}'s ec2-spot-watchdog unit is missing "
-        f"{sorted(missing)}, which krepis.spot_bootstrap declares. This is the "
-        "alpha-engine-config-I6922 drift class: the two fleet copies of this "
-        "unit diverged and a weekly run paid for it. Reconcile against "
-        "krepis.spot_bootstrap._watchdog_block()."
-    )
-
-
-def test_watchdog_unit_is_never_oneshot(bootstrap_block: str):
+def test_watchdog_unit_is_never_oneshot(rendered: str):
     """The anchored instance, kept explicit because it cost two weekly runs.
 
     ``systemctl start`` on a ``Type=oneshot`` unit BLOCKS until ``ExecStart``
-    exits, and ``TimeoutStartSec`` defaults to infinity for oneshot. This
-    unit's ``ExecStart`` is an endless supervision loop, so the unit declared
-    ``Type=oneshot`` + ``RemainAfterExit=yes`` hung every bootstrap until SSM
-    SIGKILLed it at its budget — rc=137 at exactly the timeout, with stderr
-    ending on the ``systemctl enable`` symlink line and nothing after it.
-
-    Scoped to the PARSED ``[Service]`` directives, never a substring search of
-    the script: both copies explain this defect in a comment that contains the
-    literal ``Type=oneshot``, and a naive ``not in`` reports the explanation as
-    the defect. A checker that cannot tell a comment from a directive fails in
-    the alarming direction on the very file that documents the fix.
+    exits, and ``TimeoutStartSec`` defaults to infinity for oneshot.
     """
-    assert "Type=oneshot" not in _service_directives(bootstrap_block), (
+    assert "Type=oneshot" not in _service_directives(rendered), (
         "the ec2-spot-watchdog unit declares Type=oneshot; its ExecStart never "
         "returns, so `systemctl enable --now` blocks forever and the whole "
         "bootstrap dies under SIGKILL with no output (nousergon-data#1294, "
@@ -152,32 +230,21 @@ def test_watchdog_unit_is_never_oneshot(bootstrap_block: str):
     )
 
 
-def test_enabling_the_watchdog_is_bounded_by_the_canonical_timeout(
-    bootstrap_block: str,
-):
-    """A misdeclared unit must fail in seconds WITH a message.
-
-    The bound is what turns "bootstrap is slow" into "systemctl is blocked
-    forever". Its value comes from krepis so the two copies cannot pick
-    different budgets.
-    """
+def test_enabling_the_watchdog_is_bounded_by_the_canonical_timeout(rendered: str):
     assert re.search(
         rf"timeout\s+{SYSTEMCTL_ENABLE_TIMEOUT_SEC}\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog",
-        bootstrap_block,
+        rendered,
     ), (
         "`systemctl enable --now ec2-spot-watchdog` must be wrapped in "
         f"`timeout {SYSTEMCTL_ENABLE_TIMEOUT_SEC}` "
-        "(krepis.spot_bootstrap.SYSTEMCTL_ENABLE_TIMEOUT_SEC), so a future "
-        "unit-shape regression fails fast and loud instead of consuming the "
-        "whole SSM budget in silence"
+        "(krepis.spot_bootstrap.SYSTEMCTL_ENABLE_TIMEOUT_SEC)"
     )
 
 
-def test_a_failed_enable_explains_itself_and_aborts(bootstrap_block: str):
-    """Silence is what made the 2026-08-10 hang unreadable for a day."""
+def test_a_failed_enable_explains_itself_and_aborts(rendered: str):
     m = re.search(
         r"timeout\s+\d+\s+systemctl\s+enable\s+--now\s+ec2-spot-watchdog\s*\|\|\s*\{(.*?)\}",
-        bootstrap_block,
+        rendered,
         re.S,
     )
     assert m, "the guarded enable must have a `|| { ... }` failure branch"
@@ -186,45 +253,26 @@ def test_a_failed_enable_explains_itself_and_aborts(bootstrap_block: str):
     assert ">&2" in branch, "the failure must reach stderr, which is what SSM captures"
 
 
-# ── The interpreter ──────────────────────────────────────────────────────────
+# ── The interpreter (asserted against the RENDERED output) ──────────────────
 
 
-def test_the_interpreter_is_installed_not_merely_asserted(bootstrap_block: str):
-    """A bootstrap establishes preconditions; it does not require them.
-
-    The per-stage split replaced the monolith's ``dnf install`` with a bare
-    ``command -v`` assertion, encoding an AMI contract nothing provides. The
-    AL2023 spot AMI does not ship python3.12.
-    """
-    assert re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", bootstrap_block), (
+def test_the_interpreter_is_installed_not_merely_asserted(rendered: str):
+    assert re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", rendered), (
         f"the bootstrap must install {PYTHON} explicitly — the AL2023 spot AMI "
         f"does not ship it (nousergon-data#1296, crucible-predictor#462)"
     )
 
 
-def test_the_interpreter_check_is_a_postcondition_not_a_precondition(
-    bootstrap_block: str,
-):
-    """Ordering is the actual invariant — both copies had the check, one had it alone."""
-    install = re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", bootstrap_block)
-    check = re.search(rf"command -v {re.escape(PYTHON)}\b", bootstrap_block)
+def test_the_interpreter_check_is_a_postcondition_not_a_precondition(rendered: str):
+    install = re.search(rf"dnf install[^\n]*{re.escape(PYTHON)}\b", rendered)
+    check = re.search(rf"command -v {re.escape(PYTHON)}\b", rendered)
     assert install and check, "expected both a dnf install and a command -v guard"
     assert install.start() < check.start(), (
-        f"`command -v {PYTHON}` appears BEFORE the dnf install that provides it. "
-        "That is a precondition on an image we do not build — which is exactly "
-        "the defect that killed MorningEnrich and PredictorTraining on "
-        "consecutive weekly runs."
+        f"`command -v {PYTHON}` appears BEFORE the dnf install that provides it."
     )
 
 
-def test_a_missing_interpreter_after_install_is_fatal(bootstrap_block: str):
-    """No silent fallback to the AMI's system python3.
-
-    requirements.txt is resolved against 3.12; a fallback resolves different
-    wheels and fails later, elsewhere, with the install log gone.
-    """
-    m = re.search(
-        rf"command -v {re.escape(PYTHON)} >/dev/null \|\| \{{(.*?)\}}", bootstrap_block
-    )
+def test_a_missing_interpreter_after_install_is_fatal(rendered: str):
+    m = re.search(rf"command -v {re.escape(PYTHON)} >/dev/null \|\| \{{(.*?)\}}", rendered)
     assert m, f"the post-install `command -v {PYTHON}` guard is missing its abort branch"
     assert "exit 1" in m.group(1)

--- a/tests/test_spot_bootstrap_provides_what_it_asserts.py
+++ b/tests/test_spot_bootstrap_provides_what_it_asserts.py
@@ -16,32 +16,63 @@ An assertion that a tool exists is a PRECONDITION on the image. A bootstrap's
 job is to establish preconditions, not to require them — so every `command -v`
 guard here must be preceded, in the same script, by something that provides the
 binary.
+
+## Post-cutover (alpha-engine-config-I6922, 2026-08-14)
+
+``bootstrap_spot()`` no longer writes ``dnf install`` / ``command -v`` lines
+into ``_spot_common.sh`` directly — it dispatches ``krepis.spot_bootstrap
+render`` and sends the RENDERED script over SSM. This test now renders that
+script, from the actual argv ``bootstrap_spot()`` passes, and asserts the
+install-before-assert invariant against the render instead of the local file
+text.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
 import pytest
 
+from krepis.spot_bootstrap import ConfigCopy, SpotBootstrapSpec, render_bootstrap
 from nousergon_lib.shell_guards import BINARY_PROVIDERS, unprovided_binary_violations
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _COMMON = _REPO_ROOT / "infrastructure" / "_spot_common.sh"
 
 
-def _bootstrap_block() -> str:
+def _rendered_bootstrap() -> str:
     text = _COMMON.read_text()
-    m = re.search(r"bootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
-    assert m, "bootstrap_spot() not found in _spot_common.sh"
-    return m.group(1)
+    block_m = re.search(r"bootstrap_spot\(\)\s*\{(.*?)\n\}", text, re.S)
+    assert block_m, "bootstrap_spot() not found in _spot_common.sh"
+    call_m = re.search(
+        r'"\$LIB_PYTHON"\s+-m\s+krepis\.spot_bootstrap\s+render\s*\\(.*?)\)"',
+        block_m.group(1),
+        re.S,
+    )
+    assert call_m, "bootstrap_spot() no longer dispatches krepis.spot_bootstrap render"
+    args = shlex.split(call_m.group(1).replace("\\\n", " "))
+
+    def flag(name: str) -> str:
+        return args[args.index(name) + 1]
+
+    source, dest, chown = flag("--config-copy").split(":")
+    spec = SpotBootstrapSpec(
+        repo_url=flag("--repo-url"),
+        checkout=flag("--checkout"),
+        region=flag("--region"),
+        branch="main",
+        config_copies=(ConfigCopy(source_name=source, dest=dest, chown=chown),),
+        exports={"S3_STAGING": "s3://placeholder/staging"},
+    )
+    return render_bootstrap(spec)
 
 
 def test_every_asserted_binary_is_installed_first():
-    violations = unprovided_binary_violations(_bootstrap_block())
+    violations = unprovided_binary_violations(_rendered_bootstrap())
     assert not violations, (
-        "_spot_common.sh: " + "; ".join(violations) +
+        "_spot_common.sh's rendered bootstrap: " + "; ".join(violations) +
         " This is the 2026-08-11 MorningEnrich failure "
         "(`ERROR: python3.12 not found`), inherited by DataPhase1 and "
         "RAGIngestion too."
@@ -50,7 +81,7 @@ def test_every_asserted_binary_is_installed_first():
 
 def test_bootstrap_installs_python312_explicitly():
     """Anchored: the interpreter the whole stage depends on."""
-    assert re.search(r"dnf install[^\n]*python3\.12", _bootstrap_block()), (
+    assert re.search(r"dnf install[^\n]*python3\.12", _rendered_bootstrap()), (
         "the bootstrap must install python3.12 explicitly"
     )
 
@@ -58,7 +89,7 @@ def test_bootstrap_installs_python312_explicitly():
 @pytest.mark.parametrize("tool", ["git", "gcc"])
 def test_bootstrap_installs_the_tools_the_later_steps_use(tool):
     """git for the clone, gcc for source-built wheels in requirements.txt."""
-    block = _bootstrap_block()
+    block = _rendered_bootstrap()
     assert any(p in block for p in BINARY_PROVIDERS) and tool in block, (
         f"{tool} is used by the bootstrap or the deps step but is not installed"
     )


### PR DESCRIPTION
## What

`infrastructure/_spot_common.sh`'s `bootstrap_spot()` no longer builds an inline `<<'BOOTSTRAP'` heredoc. It now renders the script via `"$LIB_PYTHON" -m krepis.spot_bootstrap render` — the same interpreter and dispatch style `run_ssm()` already uses — and pipes the rendered script into `run_ssm()`.

`--repo-url`, `--checkout`, `--branch "${BRANCH:-main}"` and `--region us-east-1` are launcher-side literals rather than left for the remote shell to expand, which removes the unexported-variable class that cost `crucible-predictor#463` (a value interpolated into a heredoc but never exported, silently resolving to an empty string on the spot). `--export "S3_STAGING=${_S3_STAGING}"` and `--config-copy config.yaml:/home/ec2-user/alpha-engine-config/data/config.yaml:/home/ec2-user/alpha-engine-config` preserve the load-bearing config-staging behavior exactly.

`install_deps()` is untouched — separate SSM step, separate budget, out of scope this pass.

## Why now

The blocker that kept this a duplicated heredoc instead of a shared renderer — `LIB_PYTHON` resolving to a co-tenant's venv with no declared floor (`alpha-engine-config-I6931`) — cleared today via `alpha-engine-config-I7343`: `_spot_common.sh:43` now reads `LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"`, an ops-owned guard enforcing a floor of krepis 0.59.2, and `nousergon-data` pins `krepis==0.56.0` (imports fine in CI). `tests/test_spot_bootstrap_invariants.py`'s own docstring (already on `main`) states the cutover "becomes a deletion" and names this test as the proof it changed nothing.

## Dependency / merge order

**`krepis-PR152` merges and publishes FIRST.** It raises `krepis.spot_bootstrap` to a superset of what the two forked heredocs (this repo's and `crucible-predictor`'s) independently carry. Without it, this repo would migrate onto a renderer that is not a strict superset of current behavior. This PR is written against `krepis.spot_bootstrap` as it exists at `krepis==0.56.0`/site-packages today (already a superset for this repo's needs — verified by the render-vs-heredoc diff below), so it can merge once krepis-PR152 lands and republishes.

`crucible-predictor` has a **sibling PR doing the same cutover for its own `_spot_common.sh`**; the two PRs are independent of each other (different repos, no shared file).

## Render-vs-heredoc equivalence (mechanically verified)

Rendered the new call's actual script and diffed it against the heredoc body extracted from the pre-cutover file, both stripped of comments/blank lines:

```diff
--- old (heredoc)
+++ new (rendered)
@@ -1,9 +1,10 @@
 set -eo pipefail
 export HOME=/home/ec2-user XDG_CACHE_HOME=/tmp AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1
+export S3_STAGING=s3://alpha-engine-research/tmp/spot_data_weekly/EXAMPLE
 if ! systemctl is-enabled ec2-spot-watchdog 2>/dev/null; then
-  cat > /tmp/ec2-spot-watchdog.service <<'UNIT'
+  cat > /etc/systemd/system/ec2-spot-watchdog.service <<'UNIT'
 [Unit]
-Description=EC2 Spot Watchdog
+Description=EC2 Spot Watchdog — self-terminate on SSM agent stoppage
 After=amazon-ssm-agent.service
 Requires=amazon-ssm-agent.service
 [Service]
@@ -27,7 +28,6 @@
 done
 WDSH
   chmod +x /usr/local/bin/ec2-spot-watchdog.sh
-  cp /tmp/ec2-spot-watchdog.service /etc/systemd/system/
   timeout 60 systemctl enable --now ec2-spot-watchdog || {
     echo "ERROR: enabling ec2-spot-watchdog did not return within 60s..." >&2
     exit 1
@@ -39,8 +39,8 @@
 echo "Using: $(python3.12 --version)"
 if [ ! -d /home/ec2-user/data/.git ]; then
   rm -rf /home/ec2-user/data
-  git clone --depth 1 --branch "${BRANCH:-main}" https://github.com/nousergon/nousergon-data.git /home/ec2-user/data
+  git clone --depth 1 --branch main https://github.com/nousergon/nousergon-data.git /home/ec2-user/data
 fi
 mkdir -p /home/ec2-user/alpha-engine-config/data
-aws s3 cp "${S3_STAGING}/config.yaml" "/home/ec2-user/alpha-engine-config/data/config.yaml" --region "${AWS_REGION:-us-east-1}" --quiet
+aws s3 cp "${S3_STAGING}/config.yaml" /home/ec2-user/alpha-engine-config/data/config.yaml --region us-east-1 --quiet
 chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-config
```

Every difference is either pure formatting/relocation (S3_STAGING export moved into the main export block instead of prepended separately; unit written directly to `/etc/systemd/system` instead of via `/tmp` + `cp`, same end state; a cosmetic `Description=` string) or the intended, in-scope improvement (branch and region baked in as literals instead of remote-expanded, per the task). **No emitted command's behavior changed.**

## Tests

`tests/test_spot_bootstrap_invariants.py` (rewritten per its own docstring's mandate): extracts the real argv `bootstrap_spot()` passes to `krepis.spot_bootstrap render`, asserts the spec (repo, checkout, branch literal, region literal, S3_STAGING export, config-copy shape) against it, then renders it and re-runs the watchdog/interpreter invariants against the rendered output instead of a heredoc literal — no assertion deleted, only its subject moved.

Also rewritten, for the same reason (they regexed the heredoc literal directly and would otherwise silently stop asserting anything after the deletion):
- `tests/test_spot_bootstrap_config_lands_where_the_resolver_looks.py`
- `tests/test_spot_bootstrap_provides_what_it_asserts.py`
- `tests/test_embedded_systemd_unit_shapes.py` (its generic `*.sh` sweep is untouched; its two anchored assertions on the specific watchdog unit are now rendered from the real argv, same as above)

`tests/test_weekly_spot_bootstrap_*.py` were checked and found **out of scope**: they parse `infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py`, a separate, independent Lambda bootstrap (clones five repos, provisions symlinks) that duplicates similar logic but is not `_spot_common.sh` and is not covered by `krepis.spot_bootstrap`'s single-repo `SpotBootstrapSpec` shape. Left unchanged — a separate cutover, not this one.

Full suite: `5738 passed, 9 skipped` (pre-existing skips), local venv built to the repo's own `krepis==0.56.0` pin.

## Refs

`alpha-engine-config-I4992`, `alpha-engine-config-I6922` — neither closed by this PR (I6922 also covers the `crucible-predictor` side and phase-1 renderer work already shipped; I4992 is krepis-PR152's own issue).

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
