### PR TITLE
fix(deploy): the friday-shell --smoke never fired — derive a real Friday and assert the result (config-I7379)

### DIFF
--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -218,8 +218,30 @@ if $SMOKE; then
   echo ""
   echo "Smoke-testing via direct invoke (synthetic Friday-EOD SUCCEEDED event)..."
   RESP=$(mktemp)
-  # 2026-05-22 (Friday) 20:25 UTC = 13:25 PT — normal Friday EOD success window
-  PAYLOAD=$(cat <<'EOF'
+  # The event timestamps are DERIVED, not hardcoded (alpha-engine-config-I7378).
+  # This block previously embedded stopDate=1779828300000 under a comment
+  # claiming "2026-05-22 (Friday) 20:25 UTC". That epoch is actually
+  # 2026-05-26T20:45Z — a TUESDAY — so the handler answered
+  # {"fired": false, "reason": "not_friday"} on every --smoke since the value
+  # was written, printed it, and exited 0. A smoke test that cannot reach the
+  # code path it exists to exercise reports success for a dead trigger, which
+  # is precisely the shape that let I7376's stale deploy sit undetected.
+  #
+  # Deriving the most recent Friday at 20:25 UTC (13:25 PT — the normal Friday
+  # EOD success window) keeps the payload correct forever instead of correct
+  # until someone re-reads the epoch.
+  SMOKE_STOP_MS=$(python3 -c "
+import datetime
+now = datetime.datetime.now(datetime.timezone.utc)
+d = now.date()
+d -= datetime.timedelta(days=(d.weekday() - 4) % 7)
+stop = datetime.datetime.combine(d, datetime.time(20, 25), datetime.timezone.utc)
+if stop > now:
+    stop -= datetime.timedelta(days=7)
+print(int(stop.timestamp() * 1000))
+")
+  SMOKE_START_MS=$((SMOKE_STOP_MS - 600000))
+  PAYLOAD=$(cat <<EOF
 {
   "source": "aws.states",
   "detail-type": "Step Functions Execution Status Change",
@@ -228,14 +250,15 @@ if $SMOKE; then
     "stateMachineArn": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline",
     "executionArn": "arn:aws:states:us-east-1:711398986525:execution:ne-postclose-trading-pipeline:smoke-test",
     "name": "smoke-test",
-    "startDate": 1779827700000,
-    "stopDate": 1779828300000
+    "startDate": ${SMOKE_START_MS},
+    "stopDate": ${SMOKE_STOP_MS}
   }
 }
 EOF
 )
-  echo "WARNING: --smoke will START a real saturday-pipeline shell run if the embedded date is a Friday."
-  echo "         Confirm before proceeding or omit --smoke and rely on unit tests + first live event."
+  echo "WARNING: --smoke WILL START a real saturday-pipeline shell run — the payload"
+  echo "         now derives a genuine Friday, so the fire path is actually reached."
+  echo "         Omit --smoke and rely on unit tests + the first live event if that is not wanted."
   aws lambda invoke \
     --function-name "${FUNCTION_NAME}" \
     --cli-binary-format raw-in-base64-out \
@@ -244,5 +267,18 @@ EOF
     "${RESP}" >/dev/null
   cat "${RESP}"
   echo ""
+  # Assert the outcome. Printing the response and exiting 0 regardless is what
+  # made the broken payload survive: the operator saw output and read it as a
+  # pass.
+  if ! grep -q '"fired": *true' "${RESP}"; then
+    echo "SMOKE FAILED: the handler did not fire on a synthetic Friday EOD success." >&2
+    echo "  If reason=not_friday, the most recent Friday was an exchange holiday and" >&2
+    echo "  last_closed_trading_day() walked back to Thursday — re-run next week or" >&2
+    echo "  pass a known-good trading Friday by hand. Any other reason is a real" >&2
+    echo "  regression in index.py's handler." >&2
+    rm -f "${RESP}"
+    exit 1
+  fi
+  echo "✓ Smoke passed: handler fired and started a shell run."
   rm -f "${RESP}"
 fi


### PR DESCRIPTION
## What this fixes

`infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh --smoke` embedded `stopDate=1779828300000` under a comment claiming *"2026-05-22 (Friday) 20:25 UTC"*. That epoch is **2026-05-26T20:45Z — a Tuesday**.

Measured live 2026-08-14 by invoking the deployed handler with exactly that payload:

```
{"fired": false, "reason": "not_friday", "trading_day": "2026-05-26"}
```

The block then `cat`s the response and falls through to `exit 0`. `--smoke` has therefore never once reached the fire path it exists to exercise, and reported success for what could be a completely dead trigger.

## Why it matters

Same failure shape as `alpha-engine-config-I7376`, on the same Lambda. That issue's stale deploy left the Friday rehearsal probing the wrong substrate (the always-on dashboard box instead of the ephemeral weekly-freshness spot) for three weeks — and `--smoke`, the one tool an operator would reach for to check the trigger, would have answered "fine" the entire time. A smoke test whose success criterion is never evaluated is worse than no smoke test, because it is read as evidence.

## Changes

- **Derive** the payload timestamps at run time — most recent Friday at 20:25 UTC (13:25 PT, the normal Friday EOD success window) — via inline `python3`, already a dependency of this script's test step. A derived value stays correct; a hardcoded epoch is correct only until someone re-reads it.
- **Assert** the outcome: `grep -q '"fired": *true'`, `exit 1` with a diagnostic otherwise. The diagnostic separates the one legitimate `not_friday` (the most recent Friday was an exchange holiday, so `last_closed_trading_day()` walked back to Thursday) from a real handler regression.
- **Sharpen the warning.** It read "will START a real shell run **if the embedded date is a Friday**" — a conditional that was silently false. It now states unconditionally that the fire path is reached.

## Verification

- `bash -n` clean.
- `shellcheck` introduces no new findings; the 4 reported are pre-existing (3× SC1091 on sourced `_shared/` scripts, 1× SC2064 on the line-93 trap).
- The derivation returns `1786739100000` = `2026-08-14T20:25:00Z`, a Friday.
- The handler's own 13 unit tests pass (run by this script's own test step during the I7376 deploy earlier today).

## Out of scope, filed not fixed

Swept the rest of `infrastructure/lambdas/`: no other `deploy.sh` carries a day-of-week-sensitive hardcoded epoch — `saturday-sf-watch-dispatcher` and `sf-telegram-notifier` use `0`/`60000` sentinels against handlers with no calendar logic.

The wider finding is on `alpha-engine-config-I7379`: **28 of 29 `--smoke` blocks in this tree never assert their result at all.** Fixing that class here would make this PR about something else.

## Tracking

- `alpha-engine-config-I7379` — this defect. Left open for Brian to close per fleet convention (a cross-repo closing keyword is inert, and agent-opened PRs do not close issues they did not open).
- `alpha-engine-config-I7376` — the stale deploy this was found while fixing.
- `alpha-engine-config-I7377` — no deploy-drift detector for the 41 operator-deployed Lambdas.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
