### PR TITLE
fix(sf): the krepis guard is not on the spot — 18 weekly stages exit 127 (config-I7382)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -679,7 +679,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -890,7 +890,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -1370,7 +1370,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "21600"
                   ]
@@ -1665,7 +1665,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2731,7 +2731,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3103,7 +3103,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]
@@ -3301,7 +3301,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3837,7 +3837,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4002,7 +4002,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4167,7 +4167,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4359,7 +4359,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4575,7 +4575,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4791,7 +4791,7 @@
                   "executionTimeout": [
                     "2700"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 2700
               },
@@ -5053,7 +5053,7 @@
           "executionTimeout": [
             "2700"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 2700
       },
@@ -5271,7 +5271,7 @@
           "executionTimeout": [
             "1800"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1800
       },
@@ -5445,7 +5445,7 @@
           "executionTimeout": [
             "1200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1200
       },
@@ -5636,7 +5636,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
           "executionTimeout": [
             "300"
           ]
@@ -5764,7 +5764,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
           "executionTimeout": [
             "240"
           ]

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -6,7 +6,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh"
   ],
   "DataPhase1": [
     "set -eo pipefail",
@@ -14,14 +14,14 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
   ],
   "DataPhase2": [
     "set -eo pipefail",
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
   ],
   "DriftDetection": [
     "set -eo pipefail",
@@ -38,7 +38,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics"
   ],
   "EvaluatorOptimize": [
     "set -eo pipefail",
@@ -47,7 +47,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize"
   ],
   "MorningEnrich": [
     "set -eo pipefail",
@@ -55,7 +55,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
   ],
   "ParityReplay": [
     "set -eo pipefail",
@@ -64,7 +64,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh"
   ],
   "PitParityCompare": [
     "set -eo pipefail",
@@ -73,7 +73,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh"
   ],
   "PitParityLookahead": [
     "set -eo pipefail",
@@ -82,7 +82,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh"
   ],
   "PitParityWalkforward": [
     "set -eo pipefail",
@@ -91,7 +91,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh"
   ],
   "PortfolioOptimizerBacktest": [
     "set -eo pipefail",
@@ -100,7 +100,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh"
   ],
   "PredictorBacktest": [
     "set -eo pipefail",
@@ -109,7 +109,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh"
   ],
   "PredictorTraining": [
     "set -eo pipefail",
@@ -121,13 +121,13 @@
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
     "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh"
   ],
   "RAGIngestion": [
     "set -eo pipefail",
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
-    "/opt/nousergon/bin/lib-python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"
+    "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"
   ]
 }

--- a/tests/test_sf_definitions_resolve_the_declared_krepis_guard.py
+++ b/tests/test_sf_definitions_resolve_the_declared_krepis_guard.py
@@ -16,9 +16,16 @@ definitions themselves.
 
 **What this test holds.** Every ``krepis.*`` module invocation found anywhere
 in any SF definition JSON in this repo resolves through
-``/opt/nousergon/bin/lib-python``. Derived from the parsed JSON string
-content, not a line-number list, so a 21st site — or a site in a definition
-that gains one later — is covered automatically.
+``/opt/nousergon/bin/lib-python`` — *unless the command executes on a host
+where that guard is not provisioned*, in which case the site is carved out in
+``KNOWN_UNGUARDED_SITES`` with a tracking issue. Derived from the parsed JSON
+string content, not a line-number list, so a 21st site — or a site in a
+definition that gains one later — is covered automatically.
+
+**The host qualifier is load-bearing, and was added the hard way**
+(`alpha-engine-config-I7382`). The guard is installed only on the dashboard
+box; asserting it against commands that run on an ephemeral spot made every
+weekly spot stage exit 127. See ``KNOWN_UNGUARDED_SITES`` for the measurement.
 
 **What is deliberately OUT of scope**, same rationale as I7343's launcher
 carve-out: a co-tenant venv invocation that does NOT name a ``krepis.*``
@@ -60,24 +67,65 @@ KNOWN_SF_DEFINITIONS = {
     "step_function_groom.json",
 }
 
-#: Sites deliberately NOT yet resolving the guard, pending a separate fix.
-#: (definition filename, interpreter) -> tracking issue. This is NOT the
-#: dashboard co-tenant venv `CO_TENANT` I7364 targets — it is the
-#: `crucible-executor` module's OWN dedicated live-trading box's venv
-#: (local dir `alpha-engine`, distinct from `alpha-engine-dashboard`).
+#: Sites deliberately NOT resolving the guard, each with a tracking issue.
+#: (definition filename, interpreter) -> tracking issue.
+#:
 #: `/opt/nousergon/bin/lib-python` is installed by
-#: `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh`,
-#: scoped to the dashboard box and the ephemeral spot instances I7343's
-#: launchers provision — there is no evidence it is provisioned on the
-#: executor's own persistent box, and repointing this blind risks breaking
-#: `krepis.ssm_log_capture` on the LIVE weekday preopen trading pipeline.
-#: Tracked: alpha-engine-config-I7365. Remove this entry once resolved there.
+#: `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh`.
+#: Everything that script provisions lives under that repo's
+#: `alpha-engine-dashboard/live/` tree, so the guard exists on the DASHBOARD
+#: BOX and nowhere else.
+#:
+#: This module's original docstring claimed the guard was also provisioned on
+#: "the ephemeral spot instances I7343's launchers provision". That was FALSE,
+#: and the assertion built on it took the weekly pipeline down
+#: (alpha-engine-config-I7382). The ephemeral weekly-freshness spot is
+#: bootstrapped by
+#: `infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py`, whose
+#: `_bootstrap_command` clones four repos and builds
+#: `/home/ec2-user/alpha-engine-dashboard/.venv`. It never creates
+#: `/opt/nousergon`. Measured 2026-08-14 on execution
+#: `friday-shell-2026-08-14-verify-i7376-b`, instance `i-07e65950cfeb6405b`,
+#: state `MorningEnrich`::
+#:
+#:     /opt/nousergon/bin/lib-python: No such file or directory
+#:     failed to run commands: exit status 127
+#:
+#: The distinction the guard turns on is therefore WHICH HOST RUNS THE
+#: COMMAND, not which definition it sits in:
+#:
+#:   * a command executed on the dashboard box  -> the guard, always;
+#:   * a command executed on an ephemeral spot  -> the interpreter that spot's
+#:     own bootstrap actually builds. Nothing else exists there to resolve.
+#:
+#: All 18 krepis sites in `step_function.json` target `$.ec2_instance_id` —
+#: the per-execution spot — so all 18 are in the second category. They are
+#: carved out here rather than asserted, and the SOTA close (install the
+#: ops-owned guard on the spot as part of its bootstrap, so I7364's declared
+#: floor and fail-loud hold on the spot too) is tracked as
+#: alpha-engine-config-I7383. Remove this entry once that ships.
+#:
+#: The `step_function_daily.json` entry is a different box again: the
+#: `crucible-executor` module's OWN dedicated live-trading venv (local dir
+#: `alpha-engine`, distinct from `alpha-engine-dashboard`). Tracked as
+#: alpha-engine-config-I7365.
 KNOWN_UNGUARDED_SITES: dict[tuple[str, str], str] = {
+    (
+        "step_function.json",
+        "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python",
+    ): "alpha-engine-config-I7383",
     (
         "step_function_daily.json",
         "/home/ec2-user/alpha-engine/.venv/bin/python",
     ): "alpha-engine-config-I7365",
 }
+
+#: Definitions whose krepis commands run on an ephemeral spot rather than on
+#: the dashboard box. A definition listed here MUST have every krepis site
+#: targeting `$.ec2_instance_id`; `test_spot_definitions_really_target_a_spot`
+#: below re-derives that from the JSON rather than trusting this list, so the
+#: carve-out above cannot quietly grow to cover a dashboard-box site.
+SPOT_HOSTED_DEFINITIONS = {"step_function.json"}
 
 #: interpreter path immediately followed by `-m krepis.<module>` — matched as
 #: literal substrings inside JSON string values (State.Format templates
@@ -112,6 +160,39 @@ def _krepis_invocations(path: Path) -> list[tuple[str, str]]:
     for s in _iter_strings(data):
         hits.extend(_KREPIS_INVOCATION.findall(s))
     return hits
+
+
+def _krepis_command_states(data) -> list[tuple[str, dict]]:
+    """[(state_name, Parameters), ...] for every state whose SSM command array
+    invokes a `krepis.*` module.
+
+    Walks `States` maps at any depth (Parallel branches, Map ItemProcessors),
+    so a stage nested inside `ResearchPredictorParallel` or `ModelZooTrainMap`
+    is found exactly like a top-level one.
+    """
+    found: list[tuple[str, dict]] = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for name, state in (node.get("States") or {}).items():
+                if isinstance(state, dict):
+                    params = state.get("Parameters")
+                    if isinstance(params, dict):
+                        commands = params.get("commands.$")
+                        if commands is None:
+                            inner = params.get("Parameters")
+                            if isinstance(inner, dict):
+                                commands = inner.get("commands.$")
+                        if commands and "-m krepis." in str(commands):
+                            found.append((name, params))
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    return found
 
 
 def test_every_known_sf_definition_is_present():
@@ -160,6 +241,54 @@ def test_every_krepis_module_invocation_resolves_the_guard():
         )
 
 
+def test_spot_definitions_really_target_a_spot():
+    """The carve-out above is only legitimate for commands that run somewhere
+    the guard is not installed. Re-derive that from the JSON instead of
+    trusting `SPOT_HOSTED_DEFINITIONS`: in a spot-hosted definition, every
+    state carrying a krepis command array must target `$.ec2_instance_id` —
+    the per-execution ephemeral instance — and never a fixed instance id or
+    the dashboard box.
+
+    Without this, `KNOWN_UNGUARDED_SITES` would be a blanket amnesty on the
+    whole file, and a NEW dashboard-box state added to `step_function.json`
+    later would inherit the exemption silently. That is the shape this test
+    exists to prevent, one level up.
+    """
+    for path in _existing_definitions():
+        if path.name not in SPOT_HOSTED_DEFINITIONS:
+            continue
+        data = json.loads(path.read_text())
+        offenders = []
+        for state_name, params in _krepis_command_states(data):
+            target = params.get("InstanceIds.$")
+            if target != "$.ec2_instance_id":
+                offenders.append((state_name, target or params.get("InstanceIds")))
+        assert not offenders, (
+            f"{path.name} is listed in SPOT_HOSTED_DEFINITIONS, so its krepis "
+            "commands are exempted from the guard on the grounds that they run "
+            "on an ephemeral spot that does not have it. These states do not "
+            f"target $.ec2_instance_id: {offenders}. Either they run on the "
+            "dashboard box — in which case they must resolve the guard and the "
+            "exemption does not apply to them — or this definition no longer "
+            "belongs in SPOT_HOSTED_DEFINITIONS."
+        )
+
+
+def test_at_least_one_spot_hosted_krepis_state_is_found():
+    """Guards the derivation in the test above: if `_krepis_command_states`
+    stops matching the JSON's shape, that test would pass vacuously while the
+    blanket-amnesty hole it exists to close silently reopened."""
+    total = 0
+    for path in _existing_definitions():
+        if path.name in SPOT_HOSTED_DEFINITIONS:
+            total += len(_krepis_command_states(json.loads(path.read_text())))
+    assert total > 0, (
+        "no krepis-bearing command state found in any spot-hosted definition — "
+        "either `SPOT_HOSTED_DEFINITIONS` is stale or `_krepis_command_states` "
+        "no longer matches the JSON's shape."
+    )
+
+
 def test_no_sf_definition_invokes_a_co_tenant_venv_for_a_krepis_module():
     """Belt-and-suspenders on the same defect: the exact conjoined substring
     `<co-tenant venv> -m krepis.` never appears, by direct substring search
@@ -171,6 +300,13 @@ def test_no_sf_definition_invokes_a_co_tenant_venv_for_a_krepis_module():
     would false-positive on that shape."""
     needle = f"{CO_TENANT} -m krepis."
     for path in _existing_definitions():
+        if (path.name, CO_TENANT) in KNOWN_UNGUARDED_SITES:
+            # Spot-hosted: the guard is not installed on the ephemeral
+            # instance, so this venv — the one that spot's own bootstrap
+            # builds — is the only interpreter that exists there. Scoped by
+            # the same carve-out the assertion above uses, and bounded by
+            # test_spot_definitions_really_target_a_spot.
+            continue
         text = path.read_text()
         assert needle not in text, (
             f"{path.name}: contains {needle!r} — a krepis module invoked "

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -560,6 +560,23 @@ def orig_spot_cmds() -> dict:
       15 keys here changed (all except `DriftDetection`, a stale key with no
       corresponding live SF state).
 
+    - **Regenerated again the same day** (alpha-engine-config-I7382): the
+      same 14 keys moved BACK to the co-tenant venv. `I7343`'s guard is
+      correct for the LAUNCHER SCRIPTS, which run on the dashboard box where
+      `install-box-config.sh` provisions `/opt/nousergon/bin/lib-python`.
+      These 14 commands do not run there — they are `ssm:sendCommand`
+      payloads delivered to `$.ec2_instance_id`, the ephemeral
+      weekly-freshness spot, whose bootstrap
+      (`infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py`,
+      `_bootstrap_command`) builds
+      `/home/ec2-user/alpha-engine-dashboard/.venv` and never creates
+      `/opt/nousergon`. Measured: execution
+      `friday-shell-2026-08-14-verify-i7376-b`, instance
+      `i-07e65950cfeb6405b`, MorningEnrich — `No such file or directory`,
+      exit 127, on both the initial attempt and the re-issue. Every spot
+      stage of the weekly pipeline was broken between the two merges.
+      Tracked SOTA close: alpha-engine-config-I7383.
+
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
     resolved spot commands from the new `origin/main` SF.
@@ -925,6 +942,20 @@ class TestByteIdenticalAbsentPath:
         2026-08-14 (alpha-engine-config-I7364): the interpreter token moved
         from the crucible-dashboard co-tenant venv to the ops-owned guard
         `/opt/nousergon/bin/lib-python`; everything after it is unchanged.
+
+        2026-08-14, same day (alpha-engine-config-I7382): moved BACK. These
+        commands execute on the ephemeral weekly-freshness spot, and the guard
+        is installed only on the dashboard box —
+        `weekly-freshness-spot-dispatcher`'s `_bootstrap_command` builds
+        `/home/ec2-user/alpha-engine-dashboard/.venv` and never creates
+        `/opt/nousergon`. Measured on execution
+        `friday-shell-2026-08-14-verify-i7376-b`, instance
+        `i-07e65950cfeb6405b`, state MorningEnrich: `No such file or
+        directory`, exit 127. Every spot stage of the weekly pipeline was
+        broken for the ~10 hours between the two merges. The SOTA close —
+        install the guard on the spot as part of its bootstrap, so I7364's
+        declared floor holds there too — is tracked as
+        alpha-engine-config-I7383.
         """
         token, log = _SPOT_STATES[name]
         slug = Path(log).stem
@@ -933,7 +964,7 @@ class TestByteIdenticalAbsentPath:
         )
         final = cmds[-1]
         expected = (
-            "/opt/nousergon/bin/lib-python "
+            "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python "
             "-m krepis.ssm_log_capture run "
             f"--correlation-id {_CONTEXT_OBJECT['Execution.Name']} "
             f"--slug {slug} --log {log} -- "


### PR DESCRIPTION
> **Merge before the Saturday 02:00 PT run.** `main` currently deploys a weekly pipeline that dies at its first spot stage.

## The defect

`nousergon-data#1387` (config-I7364, merged today 12:34 PT) repointed all 18 `krepis.ssm_log_capture` wrappers in `infrastructure/step_function.json` from the crucible-dashboard co-tenant venv to `/opt/nousergon/bin/lib-python`.

**All 18 are `ssm:sendCommand` payloads delivered to `$.ec2_instance_id`** — the ephemeral weekly-freshness spot — not commands run on the dashboard box. The guard is installed by `nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh`, whose entire tree provisions the **dashboard box**. The spot is bootstrapped by `infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py::_bootstrap_command`, which clones four repos and builds `/home/ec2-user/alpha-engine-dashboard/.venv`. It never creates `/opt/nousergon`.

Measured on execution `friday-shell-2026-08-14-verify-i7376-b`, instance `i-07e65950cfeb6405b`, state `MorningEnrich` — on the first attempt and again on `MorningEnrichReissue`:

```
/opt/nousergon/bin/lib-python: No such file or directory
failed to run commands: exit status 127
```

`SubstrateHealthGate` immediately before it returned `HEALTHY` (disk 8%, SSM responsive), so this is the interpreter, not the box.

`deploy-infrastructure.yml` deploys `step_function.json` on every push to `main`, so the live pipeline has carried this since 12:34 PT.

I7343's guard is correct for the **launcher scripts** (`spot_*.sh`, `_spot_common.sh`) — those run on the dashboard box. I7364 lifted the same path one frame up, onto commands that run on the other host.

## This is a stopgap, and says so

Moving the 18 sites back to the spot's own venv reinstates exactly the defect I7364 named: a co-tenant venv with no declared floor fronting a krepis module call.

The SOTA close — install the ops-owned guard on the spot as part of its bootstrap — is `alpha-engine-config-I7383`. It is not in this PR because the spot does not clone `nous-ergon-ops`, so staging the guard there is a real design decision needing a live spot rehearsal, and the Saturday 02:00 run is in ~11 hours. Copying the guard's body into the bootstrap string was rejected: that would be the tenth fork of a contract `config-I6922` exists to de-duplicate.

## The invariant is made host-aware, not deleted

In `tests/test_sf_definitions_resolve_the_declared_krepis_guard.py` the guard is still required for any krepis invocation executed on the dashboard box. The spot sites are carved out in `KNOWN_UNGUARDED_SITES` against I7383, and two new tests keep the carve-out honest:

- `test_spot_definitions_really_target_a_spot` re-derives `InstanceIds.$` from the JSON, so a dashboard-box state added to `step_function.json` later cannot inherit the exemption silently.
- `test_at_least_one_spot_hosted_krepis_state_is_found` stops that derivation passing vacuously if the JSON shape moves.

That module's docstring asserted the guard was provisioned on "the dashboard box **and the ephemeral spot instances** I7343's launchers provision". The second half was false, and it is the premise the whole assertion rested on — corrected in place, with the measurement.

## Test plan

- Full suite, repo venv (`python 3.12.13`): **5744 passed, 9 skipped** — run before opening.
- `tests/fixtures/sf_prekeystone_spot_commands.json` regenerated for the same 14 keys #1387 changed. The 28 `TestByteIdenticalAbsentPath` failures the revert produced are green after regeneration.
- `infrastructure/step_function.json` parses; 18 occurrences replaced, verified by count.

## Rehearsal

Rehearsal-path: tests/test_sf_friday_shell_run_wiring.py

That module resolves each spot state's command array on both the absent path (`preflight_args=""`) and the shell-run path (`" --preflight-only"`) and compares against the frozen `tests/fixtures/sf_prekeystone_spot_commands.json` baseline, so the interpreter token is asserted character-for-character for all 14 spot stages rather than spot-checked.

Beyond the test path, the defect itself was found by a **live rehearsal, not by review**: execution `friday-shell-2026-08-14-verify-i7376-b` was started deliberately today via the redeployed `eod-success-friday-shell-trigger` (see `alpha-engine-config-I7376`), reached a real dispatched spot, and produced the exit-127 measurement quoted above. The post-merge confirmation is the same mechanism — `infrastructure/run_weekly_offcycle.sh shell`, or the next automatic Friday rehearsal — reaching `MorningEnrich Status=Success`, which is `alpha-engine-config-I7382`'s closes-when 2.

## Post-merge

None. `deploy-infrastructure.yml` deploys the definition on push to `main` — the merge button is the whole action.

## Tracking

- `alpha-engine-config-I7382` — this defect.
- `alpha-engine-config-I7383` — the SOTA close deferred here.
- `alpha-engine-config-I7365` — the same shape on the executor's live-trading box; I7383 should close both or state why not.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
