### PR TITLE
fix(launchers): the krepis guard is not on the spot, one layer down (config-I7386)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -31,16 +31,35 @@ KEY_NAME="alpha-engine-key"
 SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
-# Lib CLI path: every spot launcher on the dispatcher box resolves its
-# interpreter through the ops-owned guard /opt/nousergon/bin/lib-python
-# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python).
-# That guard execs the box's DECLARED krepis venv and aborts with EX_CONFIG
-# (78), naming the version it found, when the venv is absent or below the
-# launcher floor. It never falls back to a co-tenant checkout — the silent
-# fallback is exactly the defect alpha-engine-config-I6931/I7343 removes.
+# Lib CLI path. The ops-owned guard /opt/nousergon/bin/lib-python
+# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python)
+# execs the box's DECLARED krepis venv and aborts with EX_CONFIG (78), naming
+# the version it found, rather than silently falling back to a co-tenant
+# checkout — the defect alpha-engine-config-I6931/I7343 removes.
+#
+# It is NOT the default here, because THIS SCRIPT DOES NOT RUN ON THAT BOX
+# (alpha-engine-config-I7386). The guard is installed by
+# nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh,
+# whose whole tree provisions the DASHBOARD BOX. This file is sourced by
+# spot_morning_enrich.sh / spot_data_phase1.sh / spot_rag_ingestion.sh, which
+# the weekly SF delivers as ssm:sendCommand payloads to $.ec2_instance_id —
+# the ephemeral weekly-freshness spot. That spot is bootstrapped by
+# infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+# (_bootstrap_command): it clones four repos and builds
+# /home/ec2-user/alpha-engine-dashboard/.venv, and never creates
+# /opt/nousergon. Measured on execution
+# friday-shell-2026-08-14-validate-i7382, MorningEnrich:
+# "_spot_common.sh: line 128: /opt/nousergon/bin/lib-python: No such file or
+# directory", exit 127.
+#
+# So the default names the interpreter that host actually has. The
+# ${LIB_PYTHON:-...} override is preserved, so a caller ON a box that does
+# have the guard still names it explicitly and gets the declared floor.
 # Do NOT add a guard block here: the contract lives ONCE, in the repo that
-# owns this box's provisioning (nine copies across five repos is I6922).
-LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"
+# owns the box's provisioning (nine copies across five repos is I6922). The
+# SOTA close — install the guard on the spot too, then restore this default —
+# is alpha-engine-config-I7383.
+LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
 
 # Spot-reclaim relaunch (#883)
 MAX_SPOT_ATTEMPTS="${MAX_SPOT_ATTEMPTS:-2}"

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -183,16 +183,35 @@ SECURITY_GROUP="sg-03cd3c4bd91e610b0"
 # update via `aws ec2 describe-subnets --filters Name=vpc-id,Values=vpc-566f002e`.
 SUBNETS="${SUBNETS:-subnet-a61ec0fb,subnet-1e58307a,subnet-789d3857,subnet-c670118d,subnet-7cff7c43,subnet-e07166ec}"
 IAM_PROFILE="alpha-engine-executor-profile"
-# Lib CLI path: every spot launcher on the dispatcher box resolves its
-# interpreter through the ops-owned guard /opt/nousergon/bin/lib-python
-# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python).
-# That guard execs the box's DECLARED krepis venv and aborts with EX_CONFIG
-# (78), naming the version it found, when the venv is absent or below the
-# launcher floor. It never falls back to a co-tenant checkout — the silent
-# fallback is exactly the defect alpha-engine-config-I6931/I7343 removes.
+# Lib CLI path. The ops-owned guard /opt/nousergon/bin/lib-python
+# (nous-ergon-ops: alpha-engine-dashboard/live/infrastructure/bin/lib-python)
+# execs the box's DECLARED krepis venv and aborts with EX_CONFIG (78), naming
+# the version it found, rather than silently falling back to a co-tenant
+# checkout — the defect alpha-engine-config-I6931/I7343 removes.
+#
+# It is NOT the default here, because THIS SCRIPT DOES NOT RUN ON THAT BOX
+# (alpha-engine-config-I7386). The guard is installed by
+# nous-ergon-ops/alpha-engine-dashboard/live/infrastructure/bin/install-box-config.sh,
+# whose whole tree provisions the DASHBOARD BOX. This file is sourced by
+# spot_morning_enrich.sh / spot_data_phase1.sh / spot_rag_ingestion.sh, which
+# the weekly SF delivers as ssm:sendCommand payloads to $.ec2_instance_id —
+# the ephemeral weekly-freshness spot. That spot is bootstrapped by
+# infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+# (_bootstrap_command): it clones four repos and builds
+# /home/ec2-user/alpha-engine-dashboard/.venv, and never creates
+# /opt/nousergon. Measured on execution
+# friday-shell-2026-08-14-validate-i7382, MorningEnrich:
+# "_spot_common.sh: line 128: /opt/nousergon/bin/lib-python: No such file or
+# directory", exit 127.
+#
+# So the default names the interpreter that host actually has. The
+# ${LIB_PYTHON:-...} override is preserved, so a caller ON a box that does
+# have the guard still names it explicitly and gets the declared floor.
 # Do NOT add a guard block here: the contract lives ONCE, in the repo that
-# owns this box's provisioning (nine copies across five repos is I6922).
-LIB_PYTHON="${LIB_PYTHON:-/opt/nousergon/bin/lib-python}"
+# owns the box's provisioning (nine copies across five repos is I6922). The
+# SOTA close — install the guard on the spot too, then restore this default —
+# is alpha-engine-config-I7383.
+LIB_PYTHON="${LIB_PYTHON:-/home/ec2-user/alpha-engine-dashboard/.venv/bin/python}"
 
 # Stage-coverage window (alpha-engine-config-I7214): the instant this launcher
 # started. An artifact whose LastModified predates it is a leftover from a

--- a/tests/test_launchers_resolve_the_declared_krepis_guard.py
+++ b/tests/test_launchers_resolve_the_declared_krepis_guard.py
@@ -21,13 +21,41 @@ line naming it — writing the guard per launcher would be nine copies of one
 contract across five repos, which is the `alpha-engine-config-I6922` defect one
 layer down.
 
-**What this test holds.** That the launchers in THIS repo keep resolving through
-the guard, and that no launcher re-acquires a private fallback. Every assertion
-is derived from the scripts on disk — no line numbers, because these files move.
+**What this test holds.** That every launcher in THIS repo resolves through the
+interpreter *the host that executes it actually has*, and that no launcher
+re-acquires a private fallback. Every assertion is derived from the scripts on
+disk — no line numbers, because these files move.
+
+**The host qualifier was added the hard way** (`alpha-engine-config-I7386`).
+`I7343` pointed these defaults at the guard on the premise that a spot launcher
+runs "on the dispatcher box". These two do not: they are sourced by
+``spot_morning_enrich.sh`` / ``spot_data_phase1.sh`` / ``spot_rag_ingestion.sh``,
+which the weekly SF delivers as ``ssm:sendCommand`` payloads to
+``$.ec2_instance_id`` — the ephemeral weekly-freshness spot, whose bootstrap
+(``infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py``,
+``_bootstrap_command``) builds ``/home/ec2-user/alpha-engine-dashboard/.venv``
+and never creates ``/opt/nousergon``. Measured on execution
+``friday-shell-2026-08-14-validate-i7382``, state ``MorningEnrich``::
+
+    _spot_common.sh: line 128: /opt/nousergon/bin/lib-python:
+      No such file or directory
+    failed to run commands: exit status 127
+
+So the rule is per host, not per repo:
+
+* a launcher executed on the dashboard box -> the guard, always;
+* a launcher executed on an ephemeral spot -> the interpreter that spot's own
+  bootstrap builds. Nothing else exists there to resolve.
+
+This is the exact twin of the SF-definition layer's carve-out in
+``tests/test_sf_definitions_resolve_the_declared_krepis_guard.py``
+(`alpha-engine-config-I7382`). The SOTA close for both — install the guard on
+the spot, then restore both defaults — is `alpha-engine-config-I7383`.
 """
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -45,6 +73,23 @@ CO_TENANT = "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python"
 #: a DELETION must not silently drop coverage, which is what the membership
 #: assertion below catches. Filenames only — never line numbers.
 KNOWN_LAUNCHERS = {'_spot_common.sh', 'spot_data_weekly.sh'}
+
+#: Launchers that execute ON THE EPHEMERAL SPOT rather than on the dashboard
+#: box, and therefore cannot resolve `GUARD` — see the module docstring for the
+#: measurement. Each must default to `CO_TENANT`, the venv the spot's own
+#: bootstrap builds, until `alpha-engine-config-I7383` puts the guard there too.
+#:
+#: Not a blanket amnesty: `test_spot_hosted_launchers_are_really_spot_hosted`
+#: below re-derives this membership from `infrastructure/step_function.json` —
+#: a script listed here must actually be reachable from an SSM command array
+#: that targets `$.ec2_instance_id` — so a dashboard-box launcher cannot be
+#: added to this set to make a failing assertion go away.
+SPOT_HOSTED_LAUNCHERS = {'_spot_common.sh', 'spot_data_weekly.sh'}
+
+
+def _expected_default(name: str) -> str:
+    """The interpreter this launcher's host actually provides."""
+    return CO_TENANT if name in SPOT_HOSTED_LAUNCHERS else GUARD
 
 _ASSIGN = re.compile(r'^([ \t]*)LIB_PYTHON=(.*)$', re.M)
 _DEFAULTED = re.compile(r'^[ \t]*LIB_PYTHON="\$\{LIB_PYTHON:-([^}]*)\}"[ \t]*$')
@@ -100,10 +145,17 @@ def test_every_known_launcher_still_declares_its_interpreter():
     )
 
 
-def test_every_launcher_defaults_to_the_ops_owned_guard():
-    """The load-bearing assertion: the default names the guard, in every script
-    that assigns it — including any launcher added after this test was written."""
+def test_every_launcher_defaults_to_the_interpreter_its_host_has():
+    """The load-bearing assertion: the default names the guard on the dashboard
+    box, and the spot's own venv on a spot-hosted launcher — in every script
+    that assigns it, including any launcher added after this test was written.
+
+    A launcher NOT listed in SPOT_HOSTED_LAUNCHERS gets the strict I7343 rule
+    with no softening: it runs where the guard exists, so nothing else is
+    acceptable there.
+    """
     for name, lines in sorted(_assignment_sites().items()):
+        expected = _expected_default(name)
         for line in lines:
             match = _DEFAULTED.match(line)
             assert match, (
@@ -112,13 +164,88 @@ def test_every_launcher_defaults_to_the_ops_owned_guard():
                 "override idiom is what lets a rehearsal point at another "
                 "interpreter without editing the script."
             )
-            assert match.group(1) == GUARD, (
-                f"{name}: LIB_PYTHON defaults to {match.group(1)!r}, not the "
-                f"ops-owned guard {GUARD!r}. Pointing a launcher at a repo-local "
-                "or co-tenant venv restores the alpha-engine-config-I6931 defect: "
-                "the krepis version that launches every spot stage becomes "
-                "whatever that checkout happens to hold, with no declared floor."
-            )
+            if expected is GUARD:
+                assert match.group(1) == GUARD, (
+                    f"{name}: LIB_PYTHON defaults to {match.group(1)!r}, not the "
+                    f"ops-owned guard {GUARD!r}. This launcher runs on the "
+                    "dashboard box, where the guard exists; pointing it at a "
+                    "repo-local or co-tenant venv restores the "
+                    "alpha-engine-config-I6931 defect — the krepis version that "
+                    "launches every spot stage becomes whatever that checkout "
+                    "happens to hold, with no declared floor."
+                )
+            else:
+                assert match.group(1) == CO_TENANT, (
+                    f"{name}: LIB_PYTHON defaults to {match.group(1)!r}. This "
+                    "launcher is delivered by ssm:sendCommand to the ephemeral "
+                    "weekly-freshness spot, which has no /opt/nousergon — "
+                    f"defaulting to {GUARD!r} there makes every stage exit 127 "
+                    "(alpha-engine-config-I7386). It must name "
+                    f"{CO_TENANT!r}, the venv that spot's own bootstrap builds, "
+                    "until alpha-engine-config-I7383 installs the guard there."
+                )
+
+
+def test_spot_hosted_launchers_are_really_spot_hosted():
+    """SPOT_HOSTED_LAUNCHERS is an exemption from the strict guard rule, so its
+    membership is re-derived rather than trusted: a script named there must be
+    reachable from an SSM command array in `infrastructure/step_function.json`
+    that targets `$.ec2_instance_id`.
+
+    Without this, a dashboard-box launcher could be added to the set to silence
+    a failing assertion, which is the shape this test exists to prevent one
+    level up.
+    """
+    sf_path = _INFRA / "step_function.json"
+    data = json.loads(sf_path.read_text())
+
+    spot_targeted_text: list[str] = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            for state in (node.get("States") or {}).values():
+                if not isinstance(state, dict):
+                    continue
+                params = state.get("Parameters")
+                if isinstance(params, dict) and params.get("InstanceIds.$") == "$.ec2_instance_id":
+                    spot_targeted_text.append(json.dumps(params))
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    assert spot_targeted_text, (
+        "no state in step_function.json targets $.ec2_instance_id — either the "
+        "definition's shape moved or the spot dispatch was removed; this "
+        "derivation must be fixed before its exemption can be trusted."
+    )
+    joined = "\n".join(spot_targeted_text)
+
+    # `_spot_common.sh` is never named in a command array — it is SOURCED by the
+    # spot_*.sh scripts that are. Treat it as spot-hosted iff at least one
+    # script that sources it is.
+    sourcing_common = {
+        p.name
+        for p in _shell_scripts()
+        if "_spot_common.sh" in p.read_text() and p.name != "_spot_common.sh"
+    }
+
+    for name in sorted(SPOT_HOSTED_LAUNCHERS):
+        if name == "_spot_common.sh":
+            reached = any(n in joined for n in sourcing_common)
+            detail = f"no script sourcing it appears in a spot-targeted command (checked {sorted(sourcing_common)})"
+        else:
+            reached = name in joined
+            detail = "it appears in no spot-targeted command array"
+        assert reached, (
+            f"{name} is exempted from the {GUARD!r} rule on the grounds that it "
+            f"runs on the ephemeral spot, but {detail}. Either it runs on the "
+            "dashboard box — in which case it must resolve the guard and the "
+            "exemption does not apply — or this derivation no longer matches "
+            "the definition's shape."
+        )
 
 
 def test_the_env_var_override_is_preserved():
@@ -141,11 +268,23 @@ def test_no_launcher_falls_back_to_a_co_tenant_checkout():
     """
     for path in _shell_scripts():
         offenders = [line for line in _executable_lines(path) if CO_TENANT in line]
+        if path.name in SPOT_HOSTED_LAUNCHERS:
+            # The ONE declaration line is the host's real interpreter, not a
+            # fallback — see the module docstring. Any OTHER executable mention
+            # is still the defect this test exists for, so only the single
+            # LIB_PYTHON default is forgiven, and only if there is exactly one.
+            declarations = [line for line in offenders if _DEFAULTED.match(line)]
+            assert len(declarations) == 1, (
+                f"{path.name}: expected exactly one LIB_PYTHON default naming "
+                f"{CO_TENANT!r}, found {len(declarations)}: {declarations}"
+            )
+            offenders = [line for line in offenders if line not in declarations]
         assert not offenders, (
-            f"{path.name}: executable line(s) still name the co-tenant venv "
-            f"{CO_TENANT!r}: {offenders}. The launcher must resolve through "
-            f"{GUARD!r} and nothing else — the guard aborts rather than "
-            "degrading, and a fallback here silently removes that."
+            f"{path.name}: executable line(s) name the co-tenant venv "
+            f"{CO_TENANT!r} outside the single LIB_PYTHON default: {offenders}. "
+            "The launcher must resolve ONE interpreter and nothing else — a "
+            "second candidate path silently restores the fallback the declared "
+            "floor exists to remove."
         )
 
 


### PR DESCRIPTION
> **Merge before the Saturday 02:00 PT run.** `alpha-engine-config-I7382` un-broke the SF layer; the weekly pipeline still dies at `MorningEnrich` without this.

## The same false premise, one layer down

`nousergon-data#1386` (config-I7343, merged 2026-08-14 11:40 PT, ~1h before #1387) repointed `LIB_PYTHON` in `infrastructure/_spot_common.sh` and `infrastructure/spot_data_weekly.sh` to `/opt/nousergon/bin/lib-python`, on the premise that "every spot launcher on the dispatcher box" resolves it there.

These two do not run on the dispatcher box. They are sourced by `spot_morning_enrich.sh` / `spot_data_phase1.sh` / `spot_rag_ingestion.sh`, which the weekly SF delivers as `ssm:sendCommand` payloads to `$.ec2_instance_id` — the ephemeral weekly-freshness spot, whose bootstrap (`infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py::_bootstrap_command`) builds `/home/ec2-user/alpha-engine-dashboard/.venv` and never creates `/opt/nousergon`.

## Measured after I7382 was merged and deployed

Execution `friday-shell-2026-08-14-validate-i7382`, run against the corrected SF definition (verified live: 0 occurrences of the guard path, 18 of the spot venv):

```
ssm_log_capture: ERROR: [morning-enrich] failed (rc=127) —
  /home/ec2-user/alpha-engine-data/infrastructure/_spot_common.sh: line 128:
  /opt/nousergon/bin/lib-python: No such file or directory
ssm_log_capture: shipped s3://alpha-engine-research/_ssm_logs/morning-enrich/2026-08-14/...
failed to run commands: exit status 127
```

That same line confirms I7382 worked: `krepis.ssm_log_capture` now **runs**, emits its own diagnostic and ships the log to S3 — none of which it could do before. The failure moved from the wrapper into the script the wrapper invokes. The run cleared `WeeklyPreflight` → `AcquireMutex` → `DispatchWeeklyFreshnessSpot` → bootstrap Success → `SubstrateHealthGate` HEALTHY before reaching it.

## This is a stopgap, and says so

Reverting reinstates the floorless co-tenant venv I7343 removed. The SOTA close is `alpha-engine-config-I7383` — install the guard on the spot, then restore every layer together. Not done here because the guard execs the box's **declared** krepis venv, which the spot has no box-config to declare: a real design question, and the Saturday 02:00 run is hours away.

The `${LIB_PYTHON:-...}` override is preserved, so a caller on a box that *does* have the guard still gets the declared floor by naming it.

## The invariant is made host-aware, not deleted

A launcher **not** in `SPOT_HOSTED_LAUNCHERS` still gets I7343's strict rule with no softening. The exemption is re-derived rather than trusted: `test_spot_hosted_launchers_are_really_spot_hosted` parses `infrastructure/step_function.json` and requires an exempted script to be reachable from an SSM command array targeting `$.ec2_instance_id` (for `_spot_common.sh`, via a script that sources it) — so a dashboard-box launcher cannot be added to the set to silence a failing assertion. The co-tenant sweep now forgives exactly one `LIB_PYTHON` declaration line in an exempted launcher and still fails on any second candidate path.

The module docstring's "on the dispatcher box" premise is corrected in place with the measurement, since it is what the whole assertion rested on.

## Fleet sweep

This repo is 2 of the 9 sites I7343 names. Measured on `origin/main` of every launcher repo:

| Repo | Site | On the spot path? |
|---|---|---|
| `nousergon-data` | `_spot_common.sh:43`, `spot_data_weekly.sh:195` | yes — **this PR** |
| `crucible-backtester` | `_spot_common.sh:99` (sourced by 9 SF-invoked scripts), `spot_backtest.sh:161` | yes — `crucible-backtester-PR672` |
| `crucible-predictor` | `_spot_common.sh:67` (sourced by 3 SF-invoked scripts), `spot_train.sh:192` | yes — `crucible-predictor-PR506` |
| `crucible-dashboard` | `spot_backtest.sh:134`, `spot_train.sh:167` | not SF-invoked by those names — classify on I7386 |
| `crucible-research` | `spot_research_weekly.sh:100` | research runs via Lambda, not a spot SSM payload — classify on I7386 |

## Test plan

- Full suite, repo venv (`python 3.12.13`): **5644 passed, 10 skipped** — run before opening.
- `bash -n` clean on both launchers.

## Rehearsal

Rehearsal-path: infrastructure/run_weekly_offcycle.sh

The defect was found by a live rehearsal, not review — `friday-shell-2026-08-14-validate-i7382`, quoted above, reached a real dispatched spot and produced the exit-127 measurement. The post-merge confirmation is the same mechanism reaching `MorningEnrich Status=Success`, which is `alpha-engine-config-I7386`'s closes-when 2.

## Post-merge

None for this repo — the launchers are `git pull`ed by the spot at stage start, so the merge is the whole action.

## Tracking

- `alpha-engine-config-I7386` — this defect and the fleet sweep.
- `alpha-engine-config-I7382` — the SF-definition layer, merged as `nousergon-data-PR1392`.
- `alpha-engine-config-I7383` — the SOTA close for every layer.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
