### PR TITLE
fix(sf): no automatic launch path runs pit_parity (config-I7309)

### DIFF
--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -295,10 +295,25 @@ Resources:
           # (weight=0.000, dollar=$0)` on all 20 signals -> pit_status
           # no_orders, while current_status is ok on the same date grid).
           #
-          # Scope is the CADENCE trigger only. An operator StartExecution input
-          # without the flag still runs the full parity branch, which is the
-          # loop for working I7309 (and the smoke-pit-parity slice reproduces
-          # the no_orders half in 70s).
+          # Scope WAS the cadence trigger only. Widened 2026-08-14 (Brian
+          # ruling, "disable it in the meantime"): the Friday shell-run trigger
+          # Lambda (infrastructure/lambdas/eod-success-friday-shell-trigger/
+          # index.py::_build_shell_run_input) and both inputs in
+          # infrastructure/run_weekly_offcycle.sh now carry the flag too, so no
+          # AUTOMATIC launch path runs parity until I7309 clears.
+          #
+          # The divergence was itself a defect: the Friday run exists to
+          # rehearse Saturday, and a rehearsal taking a different input
+          # rehearses something production never runs. Measured on execution
+          # friday-shell-2026-08-14-validate-i7386 — it cleared every stage
+          # Saturday actually executes, then died with States.DataLimitExceeded
+          # inside ParityParallel, a state the cadence run skips entirely.
+          #
+          # The working loop for I7309 is unchanged, and is now the ONLY way
+          # parity runs: an operator StartExecution carrying
+          # {"skip_parity": false} overrides these defaults (InitializeInput's
+          # JsonMerge puts user input ABOVE them), and the smoke-pit-parity
+          # slice still reproduces the no_orders half in 70s.
           Input: !Sub |
             {
               "sns_topic_arn": "${AlertsTopic}",

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/index.py
@@ -105,6 +105,26 @@ def _build_shell_run_input() -> str:
             # event-driven path is a faithful replacement, not a surface
             # regression. shell_run=true stays the load-bearing input.
             "pipeline_role": "shell-run",
+            # skip_parity (2026-08-14, Brian ruling — alpha-engine-config-I7309
+            # tracks re-enabling in phase 3). The Saturday CADENCE trigger has
+            # carried this since 2026-08-13 (infrastructure/cloudformation/
+            # alpha-engine-orchestration.yaml). This rehearsal did NOT, and that
+            # divergence was itself the defect: a rehearsal whose input differs
+            # from production's rehearses something production never runs.
+            #
+            # Measured on execution friday-shell-2026-08-14-validate-i7386: the
+            # run cleared every stage Saturday actually executes — MorningEnrich,
+            # DataPhase1, Scanner, PredictorTraining, RegimeSubstrate,
+            # SignalsEnvelope — then died with States.DataLimitExceeded inside
+            # ParityParallel, a state the Saturday run skips entirely. So the
+            # rehearsal reported a failure production could not have, and cost a
+            # diagnosis cycle establishing that.
+            #
+            # The escape hatch the CFN comment describes is unchanged: an
+            # operator StartExecution carrying {"skip_parity": false} still runs
+            # the full parity branch (InitializeInput's JsonMerge puts user input
+            # ABOVE the defaults), which remains the working loop for I7309.
+            "skip_parity": True,
         }
     )
 

--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -143,13 +143,13 @@ next_saturday_utc() {
 
 shell_input() {
   cat <<EOF
-{"sns_topic_arn": "${SNS_TOPIC_ARN}", "shell_run": true, "pipeline_role": "shell-run"}
+{"sns_topic_arn": "${SNS_TOPIC_ARN}", "shell_run": true, "pipeline_role": "shell-run", "skip_parity": true}
 EOF
 }
 
 full_input() {
   cat <<EOF
-{"sns_topic_arn": "${SNS_TOPIC_ARN}", "pipeline_role": "weekly"}
+{"sns_topic_arn": "${SNS_TOPIC_ARN}", "pipeline_role": "weekly", "skip_parity": true}
 EOF
 }
 

--- a/tests/test_run_weekly_offcycle.py
+++ b/tests/test_run_weekly_offcycle.py
@@ -21,6 +21,7 @@ weekly cadence silently dead).
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
@@ -113,14 +114,100 @@ def test_full_input_matches_live_cron_target() -> None:
     assert _dry_run_input("full")["pipeline_role"] == "weekly"
 
 
+def _lambda_shell_input() -> dict:
+    """The dict literal `_build_shell_run_input` returns, parsed from source.
+
+    Derived with `ast` rather than substring-matched. The previous version of
+    the lockstep test below hand-checked two NAMED keys, so a field added to
+    one side and not the other was invisible to it — which is exactly how
+    `skip_parity` came to be on the Saturday cadence input and absent from
+    this one for a day (alpha-engine-config-I7309). Comparing the whole key
+    set is the only form of this assertion that actually holds.
+    """
+    tree = ast.parse(_LAMBDA.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_build_shell_run_input":
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Dict):
+                    out = {}
+                    for k, v in zip(sub.keys, sub.values):
+                        assert isinstance(k, ast.Constant), (
+                            "_build_shell_run_input has a non-literal key; this "
+                            "derivation needs updating"
+                        )
+                        out[k.value] = (
+                            v.value if isinstance(v, ast.Constant) else "<non-literal>"
+                        )
+                    return out
+    raise AssertionError(
+        "_build_shell_run_input not found (or returns no dict literal) in "
+        f"{_LAMBDA.name} — re-derive this helper before trusting the lockstep test"
+    )
+
+
 def test_shell_input_matches_lambda() -> None:
-    """The ``shell`` builder must reproduce the friday-shell Lambda input."""
-    lam = _LAMBDA.read_text()
-    assert '"shell_run": True' in lam or '"shell_run": true' in lam.lower()
-    assert '"pipeline_role"' in lam and "shell-run" in lam
+    """The ``shell`` builder must reproduce the friday-shell Lambda input —
+    KEY FOR KEY, not just on the two keys someone remembered to list.
+
+    ``sns_topic_arn`` is compared by presence only: the Lambda reads it from
+    the process environment and the runner from its own literal, so the two
+    VALUES legitimately differ in source form while naming the same topic.
+    """
+    lam_input = _lambda_shell_input()
     obj = _dry_run_input("shell")
+
+    assert set(obj) == set(lam_input), (
+        "the off-cycle `shell` input and the friday-shell Lambda input have "
+        f"diverged: runner-only={sorted(set(obj) - set(lam_input))}, "
+        f"lambda-only={sorted(set(lam_input) - set(obj))}. The whole point of "
+        "the shell verb is that an off-cycle rehearsal is identical to the "
+        "automatic one; a key on one side only means the two rehearse "
+        "different pipelines."
+    )
+    for key in sorted(set(obj) - {"sns_topic_arn"}):
+        assert obj[key] == lam_input[key], (
+            f"{key}: runner={obj[key]!r} but Lambda={lam_input[key]!r}"
+        )
+
+    # The two values every caller of this contract depends on.
     assert obj["shell_run"] is True
     assert obj["pipeline_role"] == "shell-run"
+
+
+#: Brian ruling 2026-08-14 ("disable it in the meantime"): no AUTOMATIC launch
+#: path may run pit_parity until alpha-engine-config-I7309 clears. An operator
+#: StartExecution passing {"skip_parity": false} still overrides it — that
+#: override is the working loop for I7309 and is deliberately NOT closed here.
+_NO_AUTOMATIC_PARITY_RULING = "alpha-engine-config-I7309"
+
+
+def test_no_automatic_launch_path_runs_parity() -> None:
+    """Checked across ALL THREE automatic inputs at once, not one at a time.
+
+    Parity was disabled on the Saturday cadence trigger on 2026-08-13 and left
+    enabled on the Friday rehearsal, so the rehearsal ran a stage production
+    skips — and died in it (execution friday-shell-2026-08-14-validate-i7386,
+    States.DataLimitExceeded inside ParityParallel) after clearing every stage
+    Saturday actually runs. A per-path assertion would have passed in that
+    state; this one does not.
+    """
+    lam_input = _lambda_shell_input()
+    assert lam_input.get("skip_parity") is True, (
+        "the friday-shell trigger Lambda no longer sets skip_parity — the "
+        "rehearsal would run a stage the cadence run skips "
+        f"({_NO_AUTOMATIC_PARITY_RULING})"
+    )
+    for verb in ("shell", "full"):
+        obj = _dry_run_input(verb)
+        assert obj.get("skip_parity") is True, (
+            f"run_weekly_offcycle.sh `{verb}` input no longer sets skip_parity "
+            f"({_NO_AUTOMATIC_PARITY_RULING})"
+        )
+    cfn = _CFN.read_text()
+    assert '"skip_parity": true' in cfn, (
+        "the Saturday cadence trigger's CFN Input no longer sets skip_parity "
+        f"({_NO_AUTOMATIC_PARITY_RULING})"
+    )
 
 
 def test_full_targets_correct_state_machine(runner_text: str) -> None:


### PR DESCRIPTION
> Brian ruling 2026-08-14: *"set milestone to phase 3 and disable it in the meantime."* This is the disable half.

## What was already true, and what wasn't

pit_parity was disabled on the **Saturday cadence trigger** on 2026-08-13 (`infrastructure/cloudformation/alpha-engine-orchestration.yaml`, `skip_parity: true`). The Friday shell-run rehearsal and both `run_weekly_offcycle.sh` inputs were deliberately left without it — the CFN comment states *"Scope is the CADENCE trigger only"*, so an operator run stayed the working loop for `alpha-engine-config-I7309`.

**That divergence was itself a defect.** The Friday run exists to *rehearse* Saturday, and a rehearsal taking a different input rehearses something production never runs.

Measured on execution `friday-shell-2026-08-14-validate-i7386`: it cleared every stage the Saturday run actually executes — `MorningEnrich`, `DataPhase1`, `Scanner`, `PredictorTraining`, `RegimeSubstrate`, `SignalsEnvelope`, all Success — then failed with `States.DataLimitExceeded` **inside `ParityParallel`, a state the cadence run skips entirely**. The rehearsal reported a failure production could not have had, and cost a diagnosis cycle establishing that.

## Change

`skip_parity: true` is now carried by all three automatic inputs:

| Path | File |
|---|---|
| Friday shell rehearsal | `infrastructure/lambdas/eod-success-friday-shell-trigger/index.py` (`_build_shell_run_input`) |
| Off-cycle `shell` + `full` | `infrastructure/run_weekly_offcycle.sh` |
| Saturday cadence | CFN Input — already had it |

The working loop for I7309 is unchanged, and is now the **only** way parity runs: an operator `StartExecution` carrying `{"skip_parity": false}` overrides these defaults, because `InitializeInput`'s `JsonMerge` puts user input *above* them.

The CFN comment's "Scope is the CADENCE trigger only" claim is corrected in place rather than left to contradict the code beside it.

## The guard that should have prevented this, and did not

`tests/test_run_weekly_offcycle.py::test_shell_input_matches_lambda` claims *"the shell builder must reproduce the friday-shell Lambda input"* — but it hand-checked two **named** keys (`shell_run`, `pipeline_role`).

**Verified by experiment:** with `skip_parity` present on the runner and absent from the Lambda, the old assertion **passed**. A field added to one side and not the other was invisible to the one test whose entire purpose is catching that.

It now parses `_build_shell_run_input`'s dict literal with `ast` and compares the whole **key set** — `sns_topic_arn` by presence only, since the Lambda reads it from the process environment and the runner from its own literal, so the source forms legitimately differ while naming one topic.

Added `test_no_automatic_launch_path_runs_parity`, asserting the ruling across all **three** automatic inputs in one test rather than one at a time — a per-path assertion would have passed in exactly the state that produced this bug.

Both new guards were **negative-tested, not assumed**: removing `skip_parity` from the Lambda alone fails both and restoring it passes both. The old assertion was run in that same state and passed, which is how the gap was measured rather than argued.

## Rehearsal

Rehearsal-path: tests/test_run_weekly_offcycle.py

That module runs `run_weekly_offcycle.sh --dry-run` for both verbs and parses the EXPANDED execution input, so the change is exercised through the real launch path rather than asserted against a copy of it. The new `test_no_automatic_launch_path_runs_parity` checks all three automatic inputs — the two the runner builds and the CFN cadence Input — in one place.

The defect this fixes was itself found by a live rehearsal, not review: execution `friday-shell-2026-08-14-validate-i7386` reached a real dispatched spot, cleared every stage the cadence run executes, and died in the one it skips.

## Test plan

- Full suite, repo venv (`python 3.12.13`): **5654 passed, 10 skipped**.
- `bash -n` on the runner, `ast.parse` on the Lambda, YAML parse on the CFN template.
- Negative tests above.

**One pre-existing failure, not caused by this change and not in its scope:** `tests/test_preflight_sweep.py::test_a_genuinely_broken_backtest_stage_still_fails_when_upstream_is_present` fails on this laptop and passes in CI. Measured — it fails under `TZ=America/Los_Angeles`, passes under `TZ=UTC`, and has failed locally at every commit since it was introduced (`20eb95cc`) while CI is green on all of them. Filed separately: a test whose verdict depends on the machine's timezone is a detector that disagrees with itself.

## Post-merge

The `eod-success-friday-shell-trigger` Lambda is operator-deployed (outside CloudFormation, to keep the OIDC role's blast radius narrow), so this repo's merge alone does not update it — the same property that caused `alpha-engine-config-I7376`. **The deploy is run in-session by the author immediately after merge**, under the authorization Brian gave this session, and the result is reported back on I7309. Nothing is left for the merger to run.

## Tracking

`alpha-engine-config-I7309` — re-enabling pit_parity, which already carries the `phase-3` label and `gate:milestone`. This PR closes only the "disable it in the meantime" half.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
