### PR TITLE
fix(alert-drain): a bound that binds, and only a reclaim may relaunch (config-I7400)

### DIFF
--- a/.github/workflows/deploy-alert-drain-liveness-probe.yml
+++ b/.github/workflows/deploy-alert-drain-liveness-probe.yml
@@ -1,0 +1,93 @@
+name: Deploy alert-drain-liveness-probe
+
+# Auto-deploy the alpha-engine-alert-drain-liveness-probe Lambda CODE on merge
+# to main (alpha-engine-config-I7400).
+#
+# THIS WORKFLOW DID NOT EXIST until 2026-08-15, and its absence is why the
+# probe's defects were operator-gated: every sibling in this family
+# (alert-drain-dispatcher, overseer-liveness-probe, ci-watch-dispatcher, ...)
+# has one, so a merged fix to any of THEM ships and a merged fix to this one
+# sat inert until somebody remembered `deploy.sh` by hand. A Lambda with no
+# deploy workflow is a Lambda whose repo is not its source of truth.
+#
+# Code-only: deploy.sh's default/flagless run performs no iam:CreateRole and
+# no Lambda creation (those are --bootstrap), so no new grant is needed --
+# LambdaUpdate already covers arn:...:function:alpha-engine-*
+# (nous-ergon-ops/infrastructure/iam/github-actions-lambda-deploy/).
+#
+# It DOES re-assert the two EC2 reclaim EventBridge rules' pattern and
+# ENABLED/DISABLED state from infrastructure/automation_pause.json (deploy.sh
+# step 4b) via events:PutRule, which the deploy role already holds. That is
+# deliberate: the armed state of a control must be owned by the repo and
+# re-asserted by the merge, not left to an operator command after it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/alert-drain-liveness-probe/**'
+      - '.github/workflows/deploy-alert-drain-liveness-probe.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-alert-drain-liveness-probe-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy alert-drain-liveness-probe Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy alert-drain-liveness-probe (code-only — no --bootstrap)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          # Tolerate a not-yet-bootstrapped function: deploy.sh gracefully skips
+          # the code update until an operator runs --bootstrap (the OIDC role
+          # can't create the Lambda), so this report must NOT hard-fail the job
+          # when the function does not exist yet — matching the deploy step's
+          # own guard (alpha-engine-config-I2831 first-merge red-main fix).
+          aws lambda get-function \
+            --function-name alpha-engine-alert-drain-liveness-probe \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text \
+            || echo "(function not bootstrapped yet — code deploy was skipped)"
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-alert-drain-liveness-probe.yml
+
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/lambdas/alert-drain-dispatcher/index.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/index.py
@@ -87,6 +87,12 @@ VOLUME_SIZE_GB = int(os.environ.get("ALERT_DRAIN_VOLUME_SIZE_GB", "40"))
 
 DRAIN_TAG_NAME = "alpha-engine-alert-drain-spot"
 DRAIN_RUN_ID_TAG_KEY = "alert-drain-run-id"
+# config-I7400: the relaunch-chain identity. Minted once, by a chain's FIRST
+# run (where it equals that run's run_id), and carried forward by every
+# relaunch. The liveness probe's exactly-one relaunch bound keys on THIS, not
+# on run_id -- which this dispatcher re-mints on every launch, so a run_id
+# ledger is reset by the very act it is supposed to bound.
+DRAIN_LINEAGE_TAG_KEY = "alert-drain-lineage-id"
 # Fleet-wide drill marker — SAME tag key as sf/ci watch (config#2223): one
 # discriminator every consumer can filter on.
 DRAIN_DRILL_TAG_KEY = "sf-watch-drill"
@@ -103,6 +109,10 @@ CW_LOG_GROUP = os.environ.get("ALERT_DRAIN_CW_LOG_GROUP", "/alpha-engine/alert-d
 
 _BOOL_RE = re.compile(r"^(true|false)$")
 _TRIGGER_RE = re.compile(r"^[a-z0-9_-]{0,64}$")
+# A lineage id is a run_id by construction (the chain root's own), so it
+# carries the same shape: `drain-`/`drill-` prefix + an ISO minute stamp.
+# Anchored allow-list because it becomes an EC2 tag value.
+_LINEAGE_RE = re.compile(r"^((drain|drill)-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{4}Z)?$")
 # config-I3293 — optional registry-declared model, injected by the overseer
 # router from playbooks.yaml. Empty = absent = run-script inline default.
 # alpha-engine-config-I4478/I4516: provider-agnostic, mirroring
@@ -119,10 +129,16 @@ class _InvalidEvent(ValueError):
     """A required event field is missing or fails its allowlist."""
 
 
-def _resolve_event_fields(event: dict) -> tuple[str, str, str, str]:
+def _resolve_event_fields(event: dict) -> tuple[str, str, str, str, str]:
     """Validate + synthesize the run identity. A drill's run id ALWAYS carries
     the ``drill-`` prefix (drill-vs-real isolation on the completion-marker
-    and ledger keys, config#2223 pattern) and a real run's never does."""
+    and ledger keys, config#2223 pattern) and a real run's never does.
+
+    Also resolves the LINEAGE id (config-I7400): an inbound ``lineage_id``
+    means this launch is a relaunch and must inherit the chain's identity; its
+    absence means this launch STARTS a chain, so the lineage is its own fresh
+    run_id. Defaulting to the run_id rather than to empty is what makes the
+    probe's ledger key total -- there is no launch with no lineage."""
     is_drill = str(event.get("is_drill") or "false").strip()
     if not _BOOL_RE.match(is_drill):
         raise _InvalidEvent(f"malformed 'is_drill' in event: {is_drill!r}")
@@ -132,10 +148,13 @@ def _resolve_event_fields(event: dict) -> tuple[str, str, str, str]:
     model = str(event.get("model") or "").strip()
     if not _MODEL_RE.match(model):
         raise _InvalidEvent(f"malformed 'model' in event: {model!r}")
+    lineage_id = str(event.get("lineage_id") or "").strip()
+    if not _LINEAGE_RE.match(lineage_id):
+        raise _InvalidEvent(f"malformed 'lineage_id' in event: {lineage_id!r}")
     now = datetime.now(timezone.utc)
     prefix = "drill-" if is_drill == "true" else "drain-"
     run_id = f"{prefix}{now:%Y-%m-%dT%H%MZ}"
-    return run_id, is_drill, trigger, model
+    return run_id, is_drill, trigger, model, lineage_id or run_id
 
 
 def _bootstrap_command(run_id: str, is_drill: str, model: str = "") -> str:
@@ -197,10 +216,11 @@ def _running_drain_instance_ids() -> list[str]:
     return spot_dispatch.running_instance_ids(DRAIN_TAG_NAME, {}, region=REGION)
 
 
-def _launch_instance(run_id: str, is_drill: str) -> tuple[str, str]:
+def _launch_instance(run_id: str, is_drill: str, lineage_id: str = "") -> tuple[str, str]:
     """Launch the drain box; spot first, on-demand fallback. Discriminator
     tags ride the RunInstances call atomically via extra_tags (config#2292)."""
-    extra_tags = {DRAIN_RUN_ID_TAG_KEY: run_id}
+    extra_tags = {DRAIN_RUN_ID_TAG_KEY: run_id,
+                  DRAIN_LINEAGE_TAG_KEY: lineage_id or run_id}
     if is_drill == "true":
         extra_tags[DRAIN_DRILL_TAG_KEY] = "true"
     return spot_dispatch.launch_with_fallback(
@@ -248,7 +268,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     ``{"launched": false, "reason": ...}``, never raises."""
     event = event or {}
     try:
-        run_id, is_drill, trigger, model = _resolve_event_fields(event)
+        run_id, is_drill, trigger, model, lineage_id = _resolve_event_fields(event)
     except _InvalidEvent as exc:
         logger.error("invalid alert-drain event: %s", exc)
         return {"launched": False, "reason": "invalid_event", "error": str(exc)}
@@ -283,13 +303,14 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
                 "existing_instance_ids": existing}
 
     try:
-        instance_id, market = _launch_instance(run_id, is_drill)
+        instance_id, market = _launch_instance(run_id, is_drill, lineage_id)
     except SpotLaunchError as exc:
         logger.error("alert-drain spot launch failed: %s: %s", type(exc).__name__, exc)
         return {"launched": False, "reason": "launch_failed", "error": str(exc)}
 
-    logger.info("launched alert-drain box %s (%s) run_id=%s%s", instance_id, market,
-                run_id, " dedupe_degraded=true" if dedupe_degraded else "")
+    logger.info("launched alert-drain box %s (%s) run_id=%s lineage=%s%s",
+                instance_id, market, run_id, lineage_id,
+                " dedupe_degraded=true" if dedupe_degraded else "")
 
     try:
         _wait_ssm_online(instance_id)
@@ -309,6 +330,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "market": market,
         "command_id": command_id,
         "run_id": run_id,
+        "lineage_id": lineage_id,
         "trigger": trigger,
         "is_drill": is_drill == "true",
         "dedupe_degraded": dedupe_degraded,

--- a/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-dispatcher/test_handler.py
@@ -167,3 +167,56 @@ def test_malformed_model_rejected():
     out = index.handler({"trigger": "x", "model": 'claude-$(rm -rf /)'}, None)
     assert out == {"launched": False, "reason": "invalid_event",
                    "error": out["error"]}
+
+
+class TestLineageIdentity:
+    """config-I7400 — the relaunch chain's identity.
+
+    The dispatcher mints a fresh ``run_id`` on every launch, so the liveness
+    probe's exactly-one relaunch bound could never bind while it keyed on
+    run_id: each relaunched box was its own run_id's FIRST death. On
+    2026-08-15 that produced 17 t3.medium boxes in 70 minutes against a
+    deterministic failure, every page reading "attempt 1/1". The lineage id is
+    the key that survives a relaunch.
+    """
+
+    def test_a_fresh_run_is_its_own_lineage_root(self, index_mod):
+        index, sd = index_mod
+        out = index.handler({"trigger": "scheduled-1000utc"}, None)
+        assert out["lineage_id"] == out["run_id"]
+        tags = sd.launch_with_fallback.call_args.kwargs["extra_tags"]
+        assert tags[index.DRAIN_LINEAGE_TAG_KEY] == out["run_id"]
+
+    def test_a_relaunch_inherits_the_lineage_and_gets_a_new_run_id(self, index_mod):
+        index, sd = index_mod
+        root = "drain-2026-07-22T1100Z"
+        out = index.handler(
+            {"trigger": "reclaim-relaunch", "lineage_id": root}, None,
+        )
+        assert out["lineage_id"] == root
+        assert out["run_id"] != root, "the run identity must still be fresh"
+        tags = sd.launch_with_fallback.call_args.kwargs["extra_tags"]
+        assert tags[index.DRAIN_LINEAGE_TAG_KEY] == root
+        assert tags[index.DRAIN_RUN_ID_TAG_KEY] == out["run_id"]
+
+    def test_a_drill_lineage_is_accepted(self, index_mod):
+        index, sd = index_mod
+        out = index.handler(
+            {"is_drill": "true", "lineage_id": "drill-2026-07-22T1100Z"}, None,
+        )
+        assert out["lineage_id"] == "drill-2026-07-22T1100Z"
+
+    @pytest.mark.parametrize("bad", [
+        "'; rm -rf /",
+        "drain-2026-07-22T1100Z extra",
+        "not-a-run-id",
+        "drain-2026-7-22T1100Z",
+        "x" * 80,
+    ])
+    def test_a_malformed_lineage_is_rejected_not_sanitised(self, index_mod, bad):
+        """It becomes an EC2 tag value, so the allow-list is the guard."""
+        index, sd = index_mod
+        out = index.handler({"lineage_id": bad}, None)
+        assert out["launched"] is False
+        assert out["reason"] == "invalid_event"
+        sd.launch_with_fallback.assert_not_called()

--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -199,6 +199,43 @@ TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal"
 # being sourced at all, aborts the deploy under `set -e`.
 apply_iam_policy_on_deploy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
+# ----- 4b. Reconcile the reclaim rules from the repo (always, idempotent) ---
+# config-I7400. The rules' definition and ENABLED/DISABLED bit used to be
+# written ONLY under --bootstrap, so a code-only deploy could never correct
+# either. On 2026-08-15 `alpha-engine-alert-drain-instance-terminated` was
+# hand-disabled to contain a relaunch loop, and nothing in a merge would ever
+# have put it back -- re-arming was an operator step, which
+# pull-request-policy.md 4.2 does not permit as a post-merge action.
+#
+# Re-asserting here makes this repo the SOLE writer of each reclaim rule's
+# pattern and armed state -- the repo-is-the-only-writer property
+# (sf-pipeline-policy.md 2.4), which a bootstrap-gated setting does not have.
+# A hand-disable becomes drift the next merge corrects, visibly, in the deploy
+# log, instead of surviving unrecorded until it is forgotten.
+#
+# `put-rule` rather than `enable-rule`/`disable-rule`: the deploy identity
+# (github-actions-lambda-deploy) holds `events:PutRule` but NOT
+# `events:EnableRule`, and widening a CI identity's authority to avoid one
+# extra argument is the wrong trade. put-rule does not touch targets, which
+# stay bootstrap-owned above.
+#
+# Ordered AFTER the code update on purpose: a rule must never be armed onto a
+# stale handler.
+for i in "${!RECLAIM_RULE_NAMES[@]}"; do
+  rule="${RECLAIM_RULE_NAMES[$i]}"
+  echo "  Reclaim rule ${rule}: asserting state from automation_pause.json"
+  # pause_state is inlined into the put-rule statement, not hoisted into a
+  # variable: tests/test_automation_pause.py scans each EventBridge write
+  # STATEMENT for it, and a hoisted value reads to that guard exactly like a
+  # hardcoded literal would.
+  run aws events put-rule \
+    --name "${rule}" --state "$(pause_state "${rule}")" \
+    --event-pattern "${RECLAIM_RULE_PATTERNS[$i]}" \
+    --description "${RECLAIM_RULE_DESCRIPTIONS[$i]}" \
+    --region "${REGION}" \
+    --query 'RuleArn' --output text
+done
+
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."
 run aws lambda update-function-configuration \
   --function-name "${FUNCTION_NAME}" \

--- a/infrastructure/lambdas/alert-drain-liveness-probe/index.py
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/index.py
@@ -32,17 +32,32 @@ box's own Name tag). For an `alpha-engine-alert-drain-spot` box:
      (`overseer/_control/completed/alert-drain-{run_id}.json`, the same key
      scripts/alert_drain_run.sh writes). Present = clean finish.
   4. Absent = died mid-run. Read the relaunch ledger
-     (`overseer/_control/relaunch/alert-drain-{run_id}.json`): a record
+     (`overseer/_control/relaunch/alert-drain-{LINEAGE_id}.json`): a record
      naming THIS dead instance is a duplicate notification (both EC2 event
      types fire for one death); a record naming a DIFFERENT instance is a
-     second death for the same run_id — the exactly-one relaunch bound is
+     second death in the same lineage — the exactly-one relaunch bound is
      spent, escalate LOUD instead of relaunching again.
-  5. First death: record the relaunch decision FIRST (exactly-one bound),
-     THEN invoke alpha-engine-alert-drain-dispatcher DIRECTLY (bypassing the
-     Overseer router and the twice-daily schedule entirely, mirroring
-     sf-watch-reclaim-sweep-handler's direct invoke of the spot dispatcher) with a
-     fresh `{"is_drill": "false", "trigger": "reclaim-relaunch"}` — the drain
-     needs no fields from the dead run, only to run again.
+  5. Classify (config-I7400). ONLY an `EC2 Spot Instance Interruption
+     Warning` is evidence the SUBSTRATE was taken. A bare `terminated`
+     state-change is not: the drain box shuts ITSELF down on any non-zero
+     exit, so a deterministic workload failure emits the same event a reclaim
+     does. A non-reclaim death escalates LOUD and is never relaunched.
+  6. First reclaim death: record the relaunch decision FIRST (exactly-one
+     bound), THEN invoke alpha-engine-alert-drain-dispatcher DIRECTLY
+     (bypassing the Overseer router and the twice-daily schedule entirely,
+     mirroring sf-watch-reclaim-sweep-handler's direct invoke of the spot
+     dispatcher) with `{"is_drill": "false", "trigger": "reclaim-relaunch",
+     "lineage_id": …}` — the drain needs no fields from the dead run, only to
+     run again, but it MUST inherit the lineage.
+
+THE BOUND KEYS ON LINEAGE, NOT RUN_ID (config-I7400, measured 2026-08-15).
+The dispatcher mints a fresh `run_id` on every launch, so a ledger keyed on
+run_id is re-minted by the very act it exists to bound: every relaunched box
+is its own run_id's FIRST death, forever. On 2026-08-15 that produced 17
+t3.medium boxes in 70 minutes, each page reading "attempt 1/1", against a
+deterministic failure (a missing IAM grant, then an unresolvable router
+class) that no number of relaunches could clear. The lineage id is minted
+once by the chain's first run and carried through every relaunch.
 
 Fail-loud (CLAUDE.md no-silent-fails): DescribeTags and the ledger/marker
 reads RAISE on any error OTHER than genuine absence. The Telegram send and
@@ -82,6 +97,14 @@ WATCH_BUCKET = os.environ.get("WATCH_BUCKET", "alpha-engine-research")
 
 ALERT_DRAIN_SPOT_TAG_NAME = "alpha-engine-alert-drain-spot"
 ALERT_DRAIN_RUN_ID_TAG_KEY = "alert-drain-run-id"
+# config-I7400: the relaunch bound's key. A relaunched drain gets a NEW
+# run_id from the dispatcher, so a ledger keyed on run_id can never bind — it
+# is re-minted by the very act it is supposed to bound. The lineage id is
+# minted ONCE, by the first run of a chain, and carried forward by every
+# relaunch, so "this chain has already used its one relaunch" is answerable.
+# A box tagged before this shipped has no lineage tag and falls back to its
+# run_id, which is exactly the lineage root a first run would have written.
+ALERT_DRAIN_LINEAGE_TAG_KEY = "alert-drain-lineage-id"
 COMPLETION_MARKER_PREFIX = "overseer/_control/completed/"
 RELAUNCH_LEDGER_PREFIX = "overseer/_control/relaunch/"
 
@@ -128,8 +151,10 @@ def _completion_key(run_id: str) -> str:
     return f"{COMPLETION_MARKER_PREFIX}alert-drain-{run_id}.json"
 
 
-def _relaunch_key(run_id: str) -> str:
-    return f"{RELAUNCH_LEDGER_PREFIX}alert-drain-{run_id}.json"
+def _relaunch_key(lineage_id: str) -> str:
+    """Keyed on the LINEAGE, not the run (config-I7400). See
+    ALERT_DRAIN_LINEAGE_TAG_KEY."""
+    return f"{RELAUNCH_LEDGER_PREFIX}alert-drain-{lineage_id}.json"
 
 
 def _completion_marker_exists(s3, run_id: str) -> bool:
@@ -161,15 +186,17 @@ def _read_json(s3, key: str) -> dict | None:
         return None
 
 
-def _record_relaunch(s3, run_id: str, dead_instance_id: str) -> None:
+def _record_relaunch(s3, lineage_id: str, dead_instance_id: str, run_id: str) -> None:
     """PRIMARY deliverable of the relaunch path — RAISES on failure, runs
     BEFORE the dispatcher invoke (the exactly-one bound must never depend on
     the invoke succeeding)."""
     s3.put_object(
         Bucket=WATCH_BUCKET,
-        Key=_relaunch_key(run_id),
+        Key=_relaunch_key(lineage_id),
         Body=json.dumps({
             "dead_instance_id": dead_instance_id,
+            "dead_run_id": run_id,
+            "lineage_id": lineage_id,
             "relaunched_at": datetime.now(timezone.utc).isoformat(),
         }).encode("utf-8"),
         ContentType="application/json",
@@ -242,7 +269,11 @@ def _handle_reclaim_event(event: dict) -> dict:
         return {**base, "watch_box": True, "handled": False,
                 "reason": "missing_discriminator_tag", "escalated": alerted}
 
-    key_ctx = {"instance_id": instance_id, "run_id": run_id}
+    # config-I7400: the lineage this box belongs to. Pre-lineage boxes fall
+    # back to their own run_id, which is the lineage root a first run writes.
+    lineage_id = tags.get(ALERT_DRAIN_LINEAGE_TAG_KEY) or run_id
+    key_ctx = {"instance_id": instance_id, "run_id": run_id, "lineage_id": lineage_id}
+    base = {**base, "lineage_id": lineage_id}
     s3 = _s3_client()
 
     # Drill isolation (config#2223 pattern): a drill's run_id ALWAYS carries
@@ -265,7 +296,7 @@ def _handle_reclaim_event(event: dict) -> dict:
         return {**base, "watch_box": True, "completed": True}
 
     # No completion marker: the box died mid-run.
-    relaunch_record = _read_json(s3, _relaunch_key(run_id))
+    relaunch_record = _read_json(s3, _relaunch_key(lineage_id))
     if relaunch_record is not None:
         if relaunch_record.get("dead_instance_id") == instance_id:
             logger.info("reclaim check: death of %s already handled — duplicate notification",
@@ -273,21 +304,60 @@ def _handle_reclaim_event(event: dict) -> dict:
             return {**base, "watch_box": True, "completed": False, "duplicate_notification": True}
         alerted = _escalate(
             "\U0001f6a8 *Alert-Drain reclaim checker — SECOND watch-box death*\n"
-            f"run_id={run_id}: relaunched box `{instance_id}` ALSO died "
-            "without a completion marker (prior relaunch: "
-            f"`{relaunch_record.get('dead_instance_id', '?')}`). The bounded "
-            "relaunch budget is spent — human needed (config#3173).",
-            dedup_key=f"{_FLOW_NAME}:second_death:{run_id}",
+            f"lineage={lineage_id} (run_id={run_id}): relaunched box "
+            f"`{instance_id}` ALSO died without a completion marker (prior "
+            f"relaunch: `{relaunch_record.get('dead_instance_id', '?')}`). The "
+            "bounded relaunch budget is spent — human needed (config#3173).",
+            dedup_key=f"{_FLOW_NAME}:second_death:{lineage_id}",
             context_info=key_ctx,
         )
         return {**base, "watch_box": True, "completed": False, "relaunched": False,
                 "reason": "second_death", "escalated": alerted}
 
+    # config-I7400: ONLY a spot-interruption warning is evidence that the
+    # SUBSTRATE was taken. A bare `terminated` state-change is not: the drain
+    # box shuts ITSELF down on any non-zero exit, so a deterministic workload
+    # failure produces exactly the same event a reclaim does. On 2026-08-15
+    # that made 17 boxes in 70 minutes -- each self-shutdown read as a
+    # reclaim, relaunched onto the same broken workload, which is precisely
+    # what sf-pipeline-policy.md 3 obligation 2 forbids ("never auto-retry an
+    # unchanged kill; a relaunch is legitimate ONLY when the substrate
+    # changed").
+    #
+    # The discriminator is the EVENT TYPE, which the fleet already routes on
+    # two separate rules, rather than a DescribeInstances read of
+    # StateReason.Code -- that would need an IAM grant this Lambda does not
+    # have, and a Lambda IAM change is not applied by the merge button
+    # (pull-request-policy.md 4.2). If a genuine reclaim's warning event is
+    # ever missed, this path escalates loud instead of relaunching, which is
+    # the safe direction to be wrong in.
+    if detail_type != RECLAIM_INTERRUPTION_DETAIL_TYPE:
+        alerted = _escalate(
+            "\U0001f6a8 *Alert-Drain — box died WITHOUT finishing, and it was "
+            "NOT reclaimed*\n"
+            f"Box `{instance_id}` (run_id={run_id}, lineage={lineage_id}) "
+            "terminated with no completion marker and no spot-interruption "
+            "warning — it shut itself down, i.e. the drain exited non-zero. "
+            "NOT relaunching: the workload is unchanged and would fail "
+            "identically. Read the run log at "
+            f"`overseer/run_logs/alert-drain/…/{run_id}.log` (config-I7400).",
+            dedup_key=f"{_FLOW_NAME}:workload_failure:{lineage_id}",
+            context_info=key_ctx,
+        )
+        return {**base, "watch_box": True, "completed": False, "relaunched": False,
+                "reason": "workload_failure_not_reclaim", "escalated": alerted}
+
     # First mid-run death: record FIRST (exactly-one bound), then invoke —
     # no dispatch-record reconstruction needed (unlike ci-watch): a fresh
     # drain run carries no per-run fields, only "run again".
-    _record_relaunch(s3, run_id, instance_id)
-    payload = {"is_drill": "false", "trigger": "reclaim-relaunch"}
+    _record_relaunch(s3, lineage_id, instance_id, run_id)
+    payload = {
+        "is_drill": "false",
+        "trigger": "reclaim-relaunch",
+        # Carry the lineage forward so the relaunched box's own death lands on
+        # the SAME ledger key and spends the budget instead of resetting it.
+        "lineage_id": lineage_id,
+    }
     try:
         _lambda_client().invoke(
             FunctionName=ALERT_DRAIN_DISPATCHER_FUNCTION,
@@ -312,7 +382,7 @@ def _handle_reclaim_event(event: dict) -> dict:
             f"Watch box `{instance_id}` (run_id={run_id}) was reclaimed "
             "mid-drain — a fresh drain was relaunched (attempt 1/1; a second "
             "death escalates loud, config#3173).",
-            dedup_key=f"{_FLOW_NAME}:relaunch:{run_id}:{instance_id}",
+            dedup_key=f"{_FLOW_NAME}:relaunch:{lineage_id}:{instance_id}",
             context_info=key_ctx,
         )
         return {**base, "watch_box": True, "completed": False, "relaunched": True,
@@ -324,7 +394,7 @@ def _handle_reclaim_event(event: dict) -> dict:
         "decision was recorded but invoking "
         f"`{ALERT_DRAIN_DISPATCHER_FUNCTION}` failed — no fresh box was "
         "actually launched. Relaunch manually (config#3173).",
-        dedup_key=f"{_FLOW_NAME}:invoke_failed:{run_id}",
+        dedup_key=f"{_FLOW_NAME}:invoke_failed:{lineage_id}",
         context_info=key_ctx,
     )
     return {**base, "watch_box": True, "completed": False, "relaunched": False,

--- a/infrastructure/lambdas/alert-drain-liveness-probe/test_handler.py
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/test_handler.py
@@ -159,7 +159,13 @@ def test_first_mid_run_death_relaunches_once_with_record_before_invoke():
     assert kwargs["FunctionName"] == index.ALERT_DRAIN_DISPATCHER_FUNCTION
     assert kwargs["InvocationType"] == "Event"
     payload = json.loads(kwargs["Payload"])
-    assert payload == {"is_drill": "false", "trigger": "reclaim-relaunch"}
+    assert payload == {
+        "is_drill": "false",
+        "trigger": "reclaim-relaunch",
+        # config-I7400: the relaunch MUST inherit the lineage, or the fresh
+        # run_id the dispatcher mints resets the bound it is supposed to spend.
+        "lineage_id": RUN_ID,
+    }
     index.notify_via_flow_doctor.assert_called_once()
     assert index.notify_via_flow_doctor.call_args.kwargs["silent"] is True
 
@@ -223,3 +229,116 @@ def test_completed_drill_box_is_clean_no_relaunch_no_page():
 def test_keys_derived_from_run_id():
     assert index._completion_key(RUN_ID) == COMPLETION_KEY
     assert index._relaunch_key(RUN_ID) == RELAUNCH_KEY
+
+
+# ── config-I7400 ────────────────────────────────────────────────────────────
+# Two defects that together turned one deterministic failure into 17 spot
+# boxes in 70 minutes on 2026-08-15, every page reading "attempt 1/1".
+
+LINEAGE_ID = "drain-2026-07-22T1100Z"
+LINEAGE_RELAUNCH_KEY = f"overseer/_control/relaunch/alert-drain-{LINEAGE_ID}.json"
+
+_STATE_CHANGE = "EC2 Instance State-change Notification"
+
+
+def _terminated_event(instance_id="i-dead"):
+    """The event a SELF-SHUTDOWN produces — indistinguishable, at the event
+    level, from the one a reclaim produces after the warning."""
+    return _reclaim_event(detail_type=_STATE_CHANGE, instance_id=instance_id,
+                          state="terminated")
+
+
+class TestOnlyAReclaimMayRelaunch:
+    def test_bare_termination_without_a_warning_escalates_and_does_not_relaunch(self):
+        result, _, s3, lam = _run(_terminated_event())
+        assert result["relaunched"] is False
+        assert result["reason"] == "workload_failure_not_reclaim"
+        assert result["escalated"] is True
+        lam.invoke.assert_not_called(), "a deterministic failure was retried unchanged"
+        s3.put_object.assert_not_called()
+
+    def test_that_escalation_is_loud(self):
+        _run(_terminated_event())
+        kwargs = index.notify_via_flow_doctor.call_args.kwargs
+        assert kwargs["silent"] is False
+        assert kwargs["severity"] == "error"
+        assert "NOT reclaimed" in index.notify_via_flow_doctor.call_args.args[0]
+
+    def test_a_spot_interruption_warning_still_relaunches(self):
+        """The fix must not disarm the case the probe exists for."""
+        result, _, _, lam = _run(_reclaim_event())
+        assert result["relaunched"] is True
+        lam.invoke.assert_called_once()
+
+    def test_a_completed_box_is_still_clean_on_a_bare_termination(self):
+        """The normal end of every healthy drain: it finishes, writes its
+        marker, and shuts itself down. That must not page."""
+        result, _, _, lam = _run(_terminated_event(), s3=_make_s3(marker_exists=True))
+        assert result["completed"] is True
+        assert "reason" not in result
+        lam.invoke.assert_not_called()
+        index.notify_via_flow_doctor.assert_not_called()
+
+    def test_the_workload_failure_page_dedups_per_lineage(self):
+        """A stuck lane pages once per chain, not once per box."""
+        _run(_terminated_event())
+        key = index.notify_via_flow_doctor.call_args.kwargs["dedup_key"]
+        assert key.endswith(f":workload_failure:{RUN_ID}")
+
+
+class TestTheBoundKeysOnLineage:
+    def test_ledger_key_uses_the_lineage_tag_when_present(self):
+        tags = {**WATCH_TAGS, "alert-drain-lineage-id": LINEAGE_ID}
+        result, _, s3, _ = _run(_reclaim_event(), ec2=_make_ec2(tags=tags))
+        assert result["lineage_id"] == LINEAGE_ID
+        assert s3.put_object.call_args.kwargs["Key"] == LINEAGE_RELAUNCH_KEY
+
+    def test_ledger_key_falls_back_to_run_id_for_a_pre_lineage_box(self):
+        """A box launched before this shipped carries no lineage tag. Its own
+        run_id IS the lineage root, so nothing is stranded."""
+        result, _, s3, _ = _run(_reclaim_event())
+        assert result["lineage_id"] == RUN_ID
+        assert s3.put_object.call_args.kwargs["Key"] == RELAUNCH_KEY
+
+    def test_the_relaunched_box_spends_the_bound_instead_of_resetting_it(self):
+        """THE REGRESSION. Box A (run_id=RUN_ID) is reclaimed and relaunched.
+        Box B inherits the lineage but gets a NEW run_id. Box B is then also
+        reclaimed. Before this fix B's ledger key was derived from B's own
+        run_id, which had no record, so B relaunched too -- and so on without
+        end. Keyed on lineage, B's death finds A's record and escalates."""
+        b_tags = {
+            "Name": "alpha-engine-alert-drain-spot",
+            "alert-drain-run-id": "drain-2026-07-22T1204Z",   # freshly minted
+            "alert-drain-lineage-id": LINEAGE_ID,             # inherited
+        }
+        s3 = _make_s3()
+        docs = {LINEAGE_RELAUNCH_KEY: {"dead_instance_id": "i-box-a"}}
+
+        def get_object(Bucket, Key):  # noqa: N803 — boto3 kwarg names
+            if Key not in docs:
+                raise FakeClientError("NoSuchKey")
+            body = MagicMock()
+            body.read.return_value = json.dumps(docs[Key]).encode()
+            return {"Body": body}
+
+        s3.get_object.side_effect = get_object
+
+        result, _, s3, lam = _run(
+            _reclaim_event(instance_id="i-box-b"), ec2=_make_ec2(tags=b_tags), s3=s3,
+        )
+        assert result["reason"] == "second_death"
+        assert result["escalated"] is True
+        lam.invoke.assert_not_called()
+
+    def test_second_death_page_dedups_per_lineage(self):
+        s3 = _make_s3(relaunch={"dead_instance_id": "i-first"})
+        _run(_reclaim_event(instance_id="i-second"), s3=s3)
+        key = index.notify_via_flow_doctor.call_args.kwargs["dedup_key"]
+        assert key.endswith(f":second_death:{RUN_ID}")
+
+    def test_the_ledger_records_both_identities(self):
+        _, _, s3, _ = _run(_reclaim_event(instance_id="i-dead"))
+        ledger = json.loads(s3.put_object.call_args.kwargs["Body"])
+        assert ledger["dead_instance_id"] == "i-dead"
+        assert ledger["dead_run_id"] == RUN_ID
+        assert ledger["lineage_id"] == RUN_ID


### PR DESCRIPTION
## The incident

On 2026-08-15 **one deterministic failure produced 17 `t3.medium` spot boxes in 70 minutes**, one every ~3.5 minutes, each with a Telegram page reading *"attempt 1/1; a second death escalates loud"*. It never escalated. Two independent defects, both in this repo.

## 1. Only a reclaim may relaunch

The drain box shuts **itself** down on any non-zero exit, so a deterministic workload failure emits exactly the same `EC2 Instance State-change Notification (terminated)` event a reclaim does. Every one of the 17 carried `StateReason: Client.InstanceInitiatedShutdown` — none was `Server.SpotInstanceTermination`. The probe read any termination-without-a-marker as a mid-run reclaim and relaunched onto the unchanged workload.

`sf-pipeline-policy.md` §3, obligation 2: *"never auto-retry an unchanged kill … a relaunch is legitimate ONLY when the substrate changed."*

Now only an `EC2 Spot Instance Interruption Warning` counts as evidence of substrate loss. A bare termination escalates **loud** and never relaunches.

The discriminator is the **event type**, which the fleet already routes on two separate rules, rather than a `DescribeInstances` read of `StateReason.Code`. That would need an IAM grant this Lambda does not have, and a Lambda IAM change is **not** applied by the merge button (`pull-request-policy.md` §4.2). If a genuine reclaim's warning event is ever missed, this path escalates instead of relaunching — the safe direction to be wrong in.

## 2. The bound keys on lineage, not run_id

The dispatcher mints a fresh `run_id` on **every** launch, so the exactly-one relaunch ledger (`overseer/_control/relaunch/alert-drain-{run_id}.json`) was re-minted by the very act it existed to bound. Every relaunched box was its own run_id's *first* death. Forever.

A **lineage id** is now minted once by a chain's first run (where it equals that run's `run_id`), tagged on the box as `alert-drain-lineage-id`, carried in the relaunch payload, and used as the ledger key. A box launched before this ships carries no lineage tag and falls back to its own `run_id` — exactly the lineage root a first run writes, so nothing is stranded.

## 3. The probe had no deploy workflow at all

Every sibling in this family has one — `deploy-alert-drain-dispatcher.yml`, `deploy-overseer-liveness-probe.yml`, `deploy-ci-watch-dispatcher.yml`. This one did not, so a merged fix to it sat inert until somebody remembered `deploy.sh` by hand. **A Lambda with no deploy workflow is a Lambda whose repo is not its source of truth.** Added `deploy-alert-drain-liveness-probe.yml`.

## 4. The reclaim rules' armed state was bootstrap-only

The rules' pattern and `ENABLED`/`DISABLED` bit were written only inside `deploy.sh`'s `--bootstrap` block, so a code-only deploy could correct neither. `alpha-engine-alert-drain-instance-terminated` was hand-disabled today to contain the loop, and nothing in a merge would ever have put it back — re-arming was an operator step, which §4.2 does not permit as a post-merge action.

`deploy.sh` now re-asserts both from `infrastructure/automation_pause.json` on **every** deploy, ordered **after** the code update so a rule is never armed onto a stale handler. `put-rule` rather than `enable-rule`: the deploy identity holds `events:PutRule` but not `events:EnableRule`, and widening a CI identity's authority to save one argument is the wrong trade.

## Consequence, stated rather than buried

**Merging RE-ARMS the currently-disabled rule**, in the same deploy that lands the fix. That is intended — it is `config-I7400`'s closes-when 5 — and it is safe because after (1) the drain's current deterministic failure (`krepis.router could not resolve class='med'`) escalates once per lineage instead of relaunching.

## Validation

| | before | after |
|---|---|---|
| `alert-drain-liveness-probe/test_handler.py` | 15 | **23** |
| `alert-drain-dispatcher/test_handler.py` | 13 | **21** |

- **Mutation-checked**: all 8 new probe assertions fail against `origin/main`'s handler — including the end-to-end `test_the_relaunched_box_spends_the_bound_instead_of_resetting_it`, which reproduces the loop exactly (box A reclaimed → relaunched; box B inherits the lineage, gets a new run_id, is reclaimed; before the fix B relaunched too).
- Repo suite `tests/`: **no new failures** — the FAILED set is byte-identical to the pre-change baseline. The standing 180 failures / 80 collection errors are a local venv missing `yfinance` and current `krepis` extras; CI is the arbiter.
- `bash -n` and `shellcheck -S error` clean on `deploy.sh`; the new workflow parses as YAML.
- `tests/test_automation_pause.py::test_every_trigger_write_derives_state_from_the_manifest` passes — the new write derives `--state` from the manifest inline, as that guard requires.

Rehearsal-path: `infrastructure/lambdas/alert-drain-liveness-probe/test_handler.py` — the probe is pure event-handling over mocked AWS clients, so both the classification and the lineage bound are exercised end-to-end in-process against the real handler. The deploy half is asserted statically by `tests/test_automation_pause.py`.

## Tracked

`alpha-engine-config-I7400` deliverables 2, 3 and closes-when 5. Deliverable 1 shipped in `nous-ergon-ops-PR690` (merged). Deliverables 4 and 5 (denial-rendered-as-absence, in the drain bootstrap and in `overseer_run.sh`) are `alpha-engine-config` scripts and land separately.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)