### PR TITLE
fix(sf): a degraded run's notification stops announcing SUCCESS (config-I7418)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -6228,8 +6228,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (pre-spend gates DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN; a gate-degraded alert fired earlier in this run. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: pre-spend gates (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN; a gate-degraded alert fired earlier in this run. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -6250,8 +6250,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (health checks DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success; the run's freshness validation is NOT confirmed. Which check degraded is on the execution record: $.health_check_error / $.health_check_poll (freshness) vs $.substrate_check_error / $.substrate_check_poll (substrate). View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: health checks (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success; the run's freshness validation is NOT confirmed. Which check degraded is on the execution record: $.health_check_error / $.health_check_poll (freshness) vs $.substrate_check_error / $.substrate_check_poll (substrate). View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -6272,8 +6272,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (gates + health checks DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT (1) one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN (a gate-degraded alert fired earlier in this run), AND (2) a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success. Specifics are on the execution record: $.health_check_error / $.health_check_poll / $.substrate_check_error / $.substrate_check_poll. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: gates + health checks (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because (1) one or both pre-spend gates (LibPinDriftCheck / PipelineContractCheck) could not check and failed OPEN (a gate-degraded alert fired earlier in this run), AND (2) a post-pipeline health check (SaturdayHealthCheck freshness and/or WeeklySubstrateHealthCheck substrate/constituents-drift) could not run to Success. Specifics are on the execution record: $.health_check_error / $.health_check_poll / $.substrate_check_error / $.substrate_check_poll. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -6294,8 +6294,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (report card DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT ReportCard (the Evaluator Report Card v2 Lambda, advisory grading) failed and did not run; a report-card-degraded alert fired earlier in this run. See $.report_card_error on the execution record for detail. The weekly run's real trading artifacts are unaffected; only the advisory grading layer (report_card.json, and downstream Director) did not run. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: report card (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because ReportCard (the Evaluator Report Card v2 Lambda, advisory grading) failed and did not run; a report-card-degraded alert fired earlier in this run. See $.report_card_error on the execution record for detail. The weekly run's real trading artifacts are unaffected; only the advisory grading layer (report_card.json, and downstream Director) did not run. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -6316,8 +6316,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (run DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT one or more of the following degraded on this run: the pre-spend gates (LibPinDriftCheck/PipelineContractCheck/AcquireMutex), the tail health checks (SaturdayHealthCheck/WeeklySubstrateHealthCheck), the report card advisory grading (ReportCard Lambda), the Parity verdict (pit_parity/replay \u2014 absence of a verdict must NOT be read as a clean pass), and/or an internal ResearchPredictorParallel fail-open (Scanner/RegimeSubstrate/ChallengerShadow/ThinkTank/the eval-judge chain/cost aggregation/the model-zoo rotation). Exact combination is on the execution record: $.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded, with detail at $.report_card_error and (if set) $.health_check_error / $.substrate_check_error / $.parity_error / $.branch_outcomes. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: multiple (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because one or more of the following degraded on this run: the pre-spend gates (LibPinDriftCheck/PipelineContractCheck/AcquireMutex), the tail health checks (SaturdayHealthCheck/WeeklySubstrateHealthCheck), the report card advisory grading (ReportCard Lambda), the Parity verdict (pit_parity/replay \u2014 absence of a verdict must NOT be read as a clean pass), and/or an internal ResearchPredictorParallel fail-open (Scanner/RegimeSubstrate/ChallengerShadow/ThinkTank/the eval-judge chain/cost aggregation/the model-zoo rotation). Exact combination is on the execution record: $.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded, with detail at $.report_card_error and (if set) $.health_check_error / $.substrate_check_error / $.parity_error / $.branch_outcomes. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -6338,8 +6338,8 @@
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Saturday Pipeline \u2014 SUCCESS (parity DEGRADED)",
-        "Message": "All steps completed successfully \u2014 BUT the Parity stage (pit_parity look-ahead/walk-forward contamination check + backtester\u2194executor replay) did not complete; a parity-degraded alert fired earlier in this run. This run produced NO parity verdict \u2014 absence of a verdict must NOT be read as a clean pass. See $.parity_poll / $.parity_error on the execution record for detail. The weekly run's real trading artifacts are unaffected; only the parity verdict is missing. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: parity verdict (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because the Parity stage (pit_parity look-ahead/walk-forward contamination check + backtester\u2194executor replay) did not complete; a parity-degraded alert fired earlier in this run. This run produced NO parity verdict \u2014 absence of a verdict must NOT be read as a clean pass. See $.parity_poll / $.parity_error on the execution record for detail. The weekly run's real trading artifacts are unaffected; only the parity verdict is missing. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [

--- a/tests/test_sf_health_check_honesty_wiring.py
+++ b/tests/test_sf_health_check_honesty_wiring.py
@@ -238,7 +238,16 @@ def test_degraded_notifiers_mirror_config_1819_shape(states, notifier):
     assert "Subject.$" not in st["Parameters"]
     assert "Message.$" not in st["Parameters"]
     subject = st["Parameters"]["Subject"]
-    assert "SUCCESS" in subject and "DEGRADED" in subject
+    # alpha-engine-config-I7418: this used to assert "SUCCESS" in subject.
+    # Since config-I6891 a degraded run routes through CheckDegradedOutcome ->
+    # WriteCompletionMarkerDegraded -> DegradedRun, a **Fail** state — so a
+    # notifier whose subject leads with SUCCESS states the opposite of the
+    # run's own terminal, and the guard was pinning the false claim.
+    assert "DEGRADED" in subject
+    assert "SUCCESS" not in subject, (
+        "a degraded run terminates FAILED (config-I6891); a subject leading "
+        "with SUCCESS contradicts the execution's own status"
+    )
     assert 0 < len(subject) <= 100
     assert "\n" not in subject
     assert "health checks" in subject

--- a/tests/test_sf_parity_gate_notify_wiring.py
+++ b/tests/test_sf_parity_gate_notify_wiring.py
@@ -184,7 +184,16 @@ def test_notify_complete_parity_degraded_mirrors_config_1819_shape(states):
     assert "Subject.$" not in st["Parameters"]
     assert "Message.$" not in st["Parameters"]
     subject = st["Parameters"]["Subject"]
-    assert "SUCCESS" in subject and "DEGRADED" in subject
+    # alpha-engine-config-I7418: this used to assert "SUCCESS" in subject.
+    # Since config-I6891 a degraded run routes through CheckDegradedOutcome ->
+    # WriteCompletionMarkerDegraded -> DegradedRun, a **Fail** state — so a
+    # notifier whose subject leads with SUCCESS states the opposite of the
+    # run's own terminal, and the guard was pinning the false claim.
+    assert "DEGRADED" in subject
+    assert "SUCCESS" not in subject, (
+        "a degraded run terminates FAILED (config-I6891); a subject leading "
+        "with SUCCESS contradicts the execution's own status"
+    )
     assert 0 < len(subject) <= 100
     assert "\n" not in subject
     # config#2857: converges into the SF-envelope completion marker.

--- a/tests/test_sf_prespend_gate_alerting.py
+++ b/tests/test_sf_prespend_gate_alerting.py
@@ -21,7 +21,7 @@ Shape pinned here (mirrors WeeklyRunDayGateFailed's fail-open+alert model):
      config#2275 IsPresent absence route) lands on the SAME degraded chain;
   4. ``gate_degraded`` threads into the completion email:
      CheckShellRunNotify → CheckGateDegradedNotify →
-     NotifyCompleteGatesDegraded (constants-only "SUCCESS (pre-spend gates
+     NotifyCompleteGatesDegraded (constants-only "DEGRADED: pre-spend gates
      DEGRADED)" Subject) | NotifyComplete.
 """
 from __future__ import annotations
@@ -183,7 +183,11 @@ def test_gate_degraded_threads_into_completion_email(states):
     notify = states["NotifyCompleteGatesDegraded"]
     assert notify["Resource"] == "arn:aws:states:::sns:publish"
     assert "DEGRADED" in notify["Parameters"]["Subject"]
-    assert "SUCCESS" in notify["Parameters"]["Subject"]
+    # alpha-engine-config-I7418: was `assert "SUCCESS" in ...`. Since
+    # config-I6891 a degraded run terminates in the DegradedRun **Fail**
+    # state, so a subject leading with SUCCESS contradicts the execution's
+    # own status — the guard was pinning the false claim.
+    assert "SUCCESS" not in notify["Parameters"]["Subject"]
     assert len(notify["Parameters"]["Subject"]) <= 100
     assert "Subject.$" not in notify["Parameters"]
     # config#2857: converges into the SF-envelope completion marker before

--- a/tests/test_sf_report_card_degraded_wiring.py
+++ b/tests/test_sf_report_card_degraded_wiring.py
@@ -194,7 +194,16 @@ def test_new_notifiers_mirror_config_1819_shape(states, notifier):
     assert "Subject.$" not in st["Parameters"]
     assert "Message.$" not in st["Parameters"]
     subject = st["Parameters"]["Subject"]
-    assert "SUCCESS" in subject and "DEGRADED" in subject
+    # alpha-engine-config-I7418: this used to assert "SUCCESS" in subject.
+    # Since config-I6891 a degraded run routes through CheckDegradedOutcome ->
+    # WriteCompletionMarkerDegraded -> DegradedRun, a **Fail** state — so a
+    # notifier whose subject leads with SUCCESS states the opposite of the
+    # run's own terminal, and the guard was pinning the false claim.
+    assert "DEGRADED" in subject
+    assert "SUCCESS" not in subject, (
+        "a degraded run terminates FAILED (config-I6891); a subject leading "
+        "with SUCCESS contradicts the execution's own status"
+    )
     assert 0 < len(subject) <= 100
     assert "\n" not in subject
     # config#2857: converges into the SF-envelope completion marker.

--- a/tests/test_sf_research_predictor_degraded_wiring.py
+++ b/tests/test_sf_research_predictor_degraded_wiring.py
@@ -392,7 +392,16 @@ def test_multiple_degraded_names_research_predictor(states):
     subject = st["Parameters"]["Subject"]
     message = st["Parameters"]["Message"]
     assert "research_predictor_degraded" in message
-    assert "SUCCESS" in subject and "DEGRADED" in subject
+    # alpha-engine-config-I7418: this used to assert "SUCCESS" in subject.
+    # Since config-I6891 a degraded run routes through CheckDegradedOutcome ->
+    # WriteCompletionMarkerDegraded -> DegradedRun, a **Fail** state — so a
+    # notifier whose subject leads with SUCCESS states the opposite of the
+    # run's own terminal, and the guard was pinning the false claim.
+    assert "DEGRADED" in subject
+    assert "SUCCESS" not in subject, (
+        "a degraded run terminates FAILED (config-I6891); a subject leading "
+        "with SUCCESS contradicts the execution's own status"
+    )
     assert 0 < len(subject) <= 100
 
 

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -1405,3 +1405,36 @@ def test_no_stale_degraded_flag_exemptions(sf_file: str):
         f"present in the definition: {stale} — remove the stale entry "
         f"(alpha-engine-config#6715)"
     )
+
+
+# ---------------------------------------------------------------------------
+# alpha-engine-config-I7418 — a degraded run's notification may not claim SUCCESS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sf_file", _DEGRADED_FLAG_SF_FILES)
+def test_no_degraded_notifier_subject_claims_success(sf_file: str):
+    """Since config-I6891 a degraded run terminates in a **Fail** state, so an
+    SNS subject leading with SUCCESS states the opposite of the execution's own
+    status.
+
+    Asserted as a class rather than per-notifier: the weekly definition carried
+    SIX of these subjects (gates / health / gates+health / report card /
+    parity / multiple), all reading `SUCCESS (<something> DEGRADED)`, and four
+    separate wiring tests asserted `"SUCCESS" in subject` — the guards pinned
+    the false claim. Fixing the six without this test leaves the seventh
+    notifier free to reintroduce it.
+    """
+    flat = _flat_index(_load(sf_file))
+    offenders = []
+    for name, state in flat.items():
+        params = state.get("Parameters") or {}
+        subject = params.get("Subject")
+        if not isinstance(subject, str):
+            continue
+        if "DEGRADED" in subject.upper() and "SUCCESS" in subject.upper():
+            offenders.append(f"{name}: {subject}")
+    assert not offenders, (
+        f"{sf_file}: notifier subject(s) claim SUCCESS for a degraded run, "
+        f"which terminates FAILED since config-I6891: {offenders}"
+    )


### PR DESCRIPTION
Tracked as `alpha-engine-config-I7418`. No closing keyword — the tracker is in another repo.

## What & why

`config-I6891` (2026-08-12) routes a degraded weekly run through `CheckDegradedOutcome` → `WriteCompletionMarkerDegraded` → `DegradedRun`, a **Fail** state. The six completion notifiers were not updated with it.

Measured on `ne-weekly-freshness-pipeline` execution `watch-rerun-2026-08-15-1` (2026-08-15), which terminated FAILED and published:

```
Subject: Alpha Engine Saturday Pipeline — SUCCESS (run DEGRADED)
Message: All steps completed successfully — BUT one or more of the following degraded ...
```

The subject is what an operator reads first, and it says the opposite of the execution's own terminal status. `sf-pipeline-policy.md` §2.3: a degraded run *"must not terminate as a clean success"* — the state machine complies; the message it sends does not.

Six subjects carried the shape (`gates` / `health` / `gates+health` / `report card` / `parity` / `multiple`).

## The change

- Subjects → `Alpha Engine Saturday Pipeline — DEGRADED: <family> (run terminates FAILED)`.
- Messages lead with *"Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md §2.3 Option A) because ..."* — the distinction that matters is kept (the work happened; the run is not trustworthy) without the word that contradicts the terminal.
- Constants-only Subject/Message preserved (`config#1819`); no topology, no routing, no Choice rule touched.

## Five tests pinned the false claim

`test_sf_health_check_honesty_wiring.py`, `test_sf_parity_gate_notify_wiring.py`, `test_sf_research_predictor_degraded_wiring.py`, `test_sf_report_card_degraded_wiring.py` and `test_sf_prespend_gate_alerting.py` each asserted `"SUCCESS" in subject`, so the correct fix failed CI until they were corrected. Each now asserts `"SUCCESS" not in subject` and carries why. Same shape as `config-I7393`'s literal-constant guard.

**And a class-level guard so the seventh notifier cannot reintroduce it:** `test_sf_structural_contract.py::test_no_degraded_notifier_subject_claims_success`, parameterized across all three scheduled definitions — no state's SNS `Subject` may contain both DEGRADED and SUCCESS.

## Test plan — run before opening

`PYTHONPATH=. .venv/bin/python -m pytest tests/ -q` → **5659 passed, 10 skipped**. (5656 before the new guard's three parameterizations.)

## Rehearsal path

Rehearsal-path: tests/test_sf_structural_contract.py

That suite plus the four wiring suites exercise the exact definition path — these are constants in existing states, so the structural suite is a genuine pre-merge validation rather than an approximation. `deploy-infrastructure.yml` redeploys the definition on merge; no operator step.

## Related

Same arc, independent merges: `crucible-research-PR614`, `crucible-backtester-PR648`, `crucible-evaluator-PR197` (config-I7179 cost producers), `nousergon-lib-PR320` (config-I7393), `crucible-dashboard-PR693` (config-I7415).

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)


<!-- re-trigger rehearsal-path-guard against the current body -->
