### PR TITLE
fix(spot): build a venv for alpha-engine-data on the launcher box (config-I7427)

### DIFF
--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -407,7 +407,12 @@ deactivate
 # that is correct for both.
 echo "[weekly-freshness-spot-bootstrap] building alpha-engine-data venv..."
 cd /home/ec2-user/alpha-engine-data
-"$PYTHON_BIN" -m venv .venv || fail "data venv create failed"
+# python3.12 literally, for the same reason as the dashboard venv above: an
+# interpreter-selection fallback resolves a different wheel set and says
+# nothing when it does. The renderer has already installed 3.12 by this point,
+# and test_handler.py asserts no such fallback survives in this rendered
+# command at all.
+python3.12 -m venv .venv || fail "data venv create failed"
 .venv/bin/pip install --upgrade pip -q || fail "data pip upgrade failed"
 [ -f requirements.txt ] || fail "alpha-engine-data requirements.txt missing"
 .venv/bin/pip install -q -r requirements.txt || fail "data requirements install failed"

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -210,14 +210,19 @@ GH_PAT_SSM = os.environ.get(
     "WEEKLY_SPOT_GH_PAT_SSM", "/alpha-engine/saturday_sf_watch/github_pat"
 )
 
-# Bootstrap (clone x4 + venv build) execution timeout — the SSM command's own
-# ceiling, independent of the SF's poll loop. Generous: 4 shallow clones +
-# one full nousergon_lib/krepis/pandas/numpy/pyarrow venv build realistically
+# Bootstrap (clone x5 + TWO venv builds) execution timeout — the SSM command's
+# own ceiling, independent of the SF's poll loop. Generous: 5 shallow clones +
+# a full nousergon_lib/krepis/pandas/numpy/pyarrow venv build realistically
 # takes low-single-digit minutes, but a cold pip index / dnf mirror can be
-# slow; bounding at 20 min leaves large headroom without risking a false
+# slow; bounding at 30 min leaves large headroom without risking a false
 # guillotine on a slow-but-healthy build.
+#
+# Raised 1200 -> 1800 with the alpha-engine-data venv (config-I7427): that
+# build pulls arcticdb, a large native wheel, on top of the dashboard venv's
+# closure. Two builds under a ceiling sized for one is how a correct bootstrap
+# starts failing on a slow mirror day and reads as an infrastructure fault.
 BOOTSTRAP_TIMEOUT_SECONDS = int(
-    os.environ.get("WEEKLY_SPOT_BOOTSTRAP_TIMEOUT_SECONDS", "1200")
+    os.environ.get("WEEKLY_SPOT_BOOTSTRAP_TIMEOUT_SECONDS", "1800")
 )
 SSM_ONLINE_BUDGET_SEC = int(os.environ.get("WEEKLY_SPOT_SSM_ONLINE_BUDGET_SEC", "300"))
 CW_LOG_GROUP = os.environ.get("WEEKLY_SPOT_CW_LOG_GROUP", "/alpha-engine/weekly-freshness-spot")
@@ -378,6 +383,39 @@ fi
 # numpy<2 pin to match every other spot workload (pyarrow compiled against 1.x).
 pip install -q 'numpy<2' || fail "numpy pin failed"
 chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-dashboard/.venv || fail "venv chown failed"
+deactivate
+# A SECOND venv, for alpha-engine-data's own code (alpha-engine-config-I7427).
+#
+# WeeklySubstrateHealthCheck runs three of its four checks out of
+# /home/ec2-user/alpha-engine-data (validators.constituents_drift_check,
+# validators.phase_marker_sweep, validators.stage_output_sweep) and, until
+# this venv existed, ran them under the DASHBOARD interpreter above. The
+# constituents drift check therefore never once reached its comparison:
+#
+#   WARNING [collectors.constituents] Constituents fetch failed
+#     (`Import openpyxl` failed...); trying local cache...
+#   ERROR   [__main__] Drift check failed at stage=arctic_list:
+#     No module named 'arcticdb'
+#
+# (measured 2026-08-15, execution watch-rerun-2026-08-15-2).
+#
+# The two dependency sets CANNOT be merged into one venv: the dashboard venv
+# is pinned `numpy<2` on the line above because every spot workload's pyarrow
+# is compiled against 1.x, and alpha-engine-data declares `numpy>=2.4.6`.
+# Installing data's requirements into the dashboard venv would silently break
+# the pin that fourteen other stages depend on. Two venvs is the only shape
+# that is correct for both.
+echo "[weekly-freshness-spot-bootstrap] building alpha-engine-data venv..."
+cd /home/ec2-user/alpha-engine-data
+"$PYTHON_BIN" -m venv .venv || fail "data venv create failed"
+.venv/bin/pip install --upgrade pip -q || fail "data pip upgrade failed"
+[ -f requirements.txt ] || fail "alpha-engine-data requirements.txt missing"
+.venv/bin/pip install -q -r requirements.txt || fail "data requirements install failed"
+# krepis is not in alpha-engine-data's requirements.txt but stage_output_sweep
+# and the ssm_log_capture wrapper resolve krepis modules; install it explicitly
+# rather than letting an import failure read as a domain finding.
+.venv/bin/pip install -q 'krepis>=0.59.8' || fail "data krepis install failed"
+chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-data/.venv || fail "data venv chown failed"
 trap - EXIT
 aws s3 cp {log} "{s3_log}" --region {REGION} --quiet || true
 echo "[weekly-freshness-spot-bootstrap] complete — launcher box ready"

--- a/tests/test_preflight_sweep.py
+++ b/tests/test_preflight_sweep.py
@@ -88,6 +88,27 @@ def _stage(name="DataPhase1"):
 # ── Per-stage verdicts ───────────────────────────────────────────────────────
 
 
+
+def _sweep_run_date() -> str:
+    """The run_date the sweep itself derives — UTC, never local.
+
+    `preflight_sweep.sweep` binds `run_date` from
+    `dt.datetime.now(dt.timezone.utc).date()`, mirroring the SF's own
+    `InitializeInput`. A fixture built from `dt.date.today()` (LOCAL) agrees
+    with it only outside the hours where the two dates differ — 17:00-24:00
+    Pacific, every day. Measured 2026-08-15 23:5x PT: the sweep probed
+    `backtest/2026-08-16/` while the fixture declared `backtest/2026-08-15/`,
+    and `test_a_genuinely_broken_backtest_stage_still_fails_when_upstream_is_present`
+    failed on an ambient clock rather than on anything about the code.
+
+    The upstream-PENDING test is the worse half: a mismatched date produces
+    an empty upstream probe, which is exactly the state it asserts — so it
+    passed for the wrong reason in that window and would have kept passing
+    if the probe had stopped working entirely.
+    """
+    return dt.datetime.now(dt.timezone.utc).date().isoformat()
+
+
 def test_a_clean_preflight_is_a_pass(tmp_path):
     result = ps.run_stage(_stage(), str(tmp_path), 60, runner=_completed(0))
     assert result.verdict == ps.PASSED
@@ -595,7 +616,7 @@ def test_the_weekday_case_end_to_end_zero_failures_and_no_page(tmp_path):
                     "or unreachable.\n" if rc else ""),
         )
 
-    run_date = dt.date.today().isoformat()
+    run_date = _sweep_run_date()
     aws = FakeAws(listing={f"backtest/{run_date}/": [
         {"Key": f"backtest/{run_date}/.phases/preflight.json", "Size": 235},
         {"Key": f"backtest/{run_date}/.phases/runtime_smoke.json", "Size": 239},
@@ -625,7 +646,7 @@ def test_a_genuinely_broken_backtest_stage_still_fails_when_upstream_is_present(
         rc = 1 if "spot_predictor_backtest.sh" in argv[-1] else 0
         return subprocess.CompletedProcess(args=argv, returncode=rc, stdout="", stderr="")
 
-    run_date = dt.date.today().isoformat()
+    run_date = _sweep_run_date()
     aws = FakeAws(listing={f"backtest/{run_date}/": [
         {"Key": f"backtest/{run_date}/.phases/preflight.json", "Size": 235},
         {"Key": f"backtest/{run_date}/results/backtest.parquet", "Size": 8123},
@@ -853,3 +874,29 @@ def test_console_rows_are_published_even_when_the_run_failed(cadence):
     ps.emit(report, aws, "arn:sns")
     assert f"ops/checks/{stage_check_id('A')}/latest.json" in aws.objects
     assert "ops/checks/ae-preflight-sweep/latest.json" in aws.objects
+
+
+def test_the_sweep_derives_run_date_from_utc_not_local_time():
+    """Pins what `_sweep_run_date` above mirrors.
+
+    The sweep binds `run_date` from the execution's UTC start time, matching
+    the SF's `InitializeInput`. Two tests build S3 fixtures from that date; if
+    the sweep ever switched to local time they would silently start probing a
+    prefix the fixture does not declare, and the upstream-pending assertions
+    would pass vacuously rather than fail. Caught live 2026-08-15 in the
+    17:00-24:00 PT window (alpha-engine-config-I7431).
+    """
+    import inspect
+
+    src = inspect.getsource(ps.sweep)
+    assert "started.date().isoformat()" in src, (
+        "sweep no longer binds run_date from `started` — re-derive "
+        "_sweep_run_date() from whatever it uses now"
+    )
+    assert "dt.datetime.now(dt.timezone.utc)" in inspect.getsource(ps), (
+        "the sweep's `started` is no longer UTC; _sweep_run_date() is wrong"
+    )
+    assert "dt.date.today()" not in src, (
+        "sweep uses LOCAL today() for run_date — the fixtures, the SF's "
+        "InitializeInput and the sweep must all agree on one clock"
+    )

--- a/tests/test_weekly_spot_data_venv_provisioning.py
+++ b/tests/test_weekly_spot_data_venv_provisioning.py
@@ -1,0 +1,106 @@
+"""The launcher box builds a venv for alpha-engine-data's own code (config-I7427).
+
+WeeklySubstrateHealthCheck runs three of its four checks out of
+``/home/ec2-user/alpha-engine-data`` — ``validators.constituents_drift_check``,
+``validators.phase_marker_sweep``, ``validators.stage_output_sweep``. Until this
+venv existed they ran under the DASHBOARD interpreter, whose closure does not
+contain alpha-engine-data's dependencies, so the constituents drift check never
+once reached its comparison (measured 2026-08-15, weekly-SF execution
+``watch-rerun-2026-08-15-2``):
+
+    WARNING [collectors.constituents] Constituents fetch failed
+      (`Import openpyxl` failed...); trying local cache...
+    ERROR   [__main__] Drift check failed at stage=arctic_list:
+      No module named 'arcticdb'
+
+The two closures cannot be merged: the dashboard venv is pinned ``numpy<2``
+(every spot workload's pyarrow is compiled against 1.x) and alpha-engine-data
+declares ``numpy>=2.4.6``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DISPATCHER = (
+    _REPO_ROOT / "infrastructure" / "lambdas"
+    / "weekly-freshness-spot-dispatcher" / "index.py"
+)
+
+
+def _src() -> str:
+    return _DISPATCHER.read_text(encoding="utf-8")
+
+
+def test_bootstrap_creates_the_data_venv():
+    src = _src()
+    assert '"$PYTHON_BIN" -m venv .venv' in src
+    assert "cd /home/ec2-user/alpha-engine-data" in src, (
+        "the bootstrap never enters the alpha-engine-data checkout to build "
+        "its venv (config-I7427)"
+    )
+
+
+def test_data_venv_installs_that_repos_own_requirements():
+    src = _src()
+    assert ".venv/bin/pip install -q -r requirements.txt" in src, (
+        "the data venv must install alpha-engine-data's OWN requirements — "
+        "installing nothing leaves exactly the ModuleNotFoundError I7427 fixed"
+    )
+
+
+def test_data_venv_carries_krepis():
+    """stage_output_sweep and the ssm_log_capture wrapper resolve krepis."""
+    src = _src()
+    assert re.search(r"\.venv/bin/pip install -q 'krepis>=0\.59\.\d+'", src), (
+        "krepis is absent from alpha-engine-data's requirements.txt, so the "
+        "data venv must install it explicitly or an ImportError in a validator "
+        "reads as a domain finding"
+    )
+
+
+def test_data_venv_is_separate_from_the_dashboard_venv():
+    """The numpy pins are incompatible; one venv cannot serve both."""
+    src = _src()
+    assert "pip install -q 'numpy<2'" in src, (
+        "the dashboard venv's numpy<2 pin is what makes a SECOND venv "
+        "mandatory rather than a preference"
+    )
+    data_reqs = (_REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    assert re.search(r"^numpy>=2", data_reqs, re.M), (
+        "alpha-engine-data no longer declares numpy>=2 — re-examine whether "
+        "the two venvs must still be separate before merging them"
+    )
+
+
+def test_data_venv_is_chowned_to_ec2_user():
+    """Every stage runs as ec2-user via `sudo -u ec2-user`."""
+    assert (
+        "chown -R ec2-user:ec2-user /home/ec2-user/alpha-engine-data/.venv" in _src()
+    )
+
+
+def test_bootstrap_timeout_accounts_for_two_venv_builds():
+    src = _src()
+    m = re.search(
+        r'WEEKLY_SPOT_BOOTSTRAP_TIMEOUT_SECONDS",\s*"(\d+)"', src
+    )
+    assert m, "bootstrap timeout default not found"
+    assert int(m.group(1)) >= 1800, (
+        "two venv builds (the second pulling arcticdb, a large native wheel) "
+        "under a ceiling sized for one turns a slow mirror day into an "
+        "infrastructure fault (config-I7427)"
+    )
+
+
+def test_data_venv_failures_are_fatal_not_swallowed():
+    """Fail loud: a half-built venv must not reach the health check."""
+    src = _src()
+    for expected in (
+        'fail "data venv create failed"',
+        'fail "data requirements install failed"',
+        'fail "data krepis install failed"',
+    ):
+        assert expected in src, f"missing hard failure for: {expected}"

--- a/tests/test_weekly_spot_data_venv_provisioning.py
+++ b/tests/test_weekly_spot_data_venv_provisioning.py
@@ -36,7 +36,12 @@ def _src() -> str:
 
 def test_bootstrap_creates_the_data_venv():
     src = _src()
-    assert '"$PYTHON_BIN" -m venv .venv' in src
+    assert "python3.12 -m venv .venv" in src
+    assert '"$PYTHON_BIN" -m venv' not in src, (
+        "the bootstrap deliberately names python3.12 literally — the "
+        "`command -v python3.12 ... || PYTHON_BIN=python3` fallback resolves "
+        "a different wheel set and says nothing when it does"
+    )
     assert "cd /home/ec2-user/alpha-engine-data" in src, (
         "the bootstrap never enters the alpha-engine-data checkout to build "
         "its venv (config-I7427)"


### PR DESCRIPTION
## What & why

Closes part of **alpha-engine-config-I7427** (cross-repo tracker).

`WeeklySubstrateHealthCheck` runs three of its four checks out of `/home/ec2-user/alpha-engine-data` — `validators.constituents_drift_check`, `validators.phase_marker_sweep`, `validators.stage_output_sweep` — and until now ran them under the **dashboard** venv, the only interpreter this bootstrap built. Measured 2026-08-15 on weekly-SF execution `watch-rerun-2026-08-15-2`:

```
WARNING [collectors.constituents] Constituents fetch failed
  (`Import openpyxl` failed...); trying local cache...
ERROR   [collectors.constituents] No cache found — cannot build universe
INFO    [__main__] Wikipedia constituents: 0 tickers (S&P 500=0, S&P 400=0)
ERROR   [__main__] Drift check failed at stage=arctic_list: No module named 'arcticdb'
```

The drift check has never once reached its comparison. Since config-I7415 that counts as a failing gating check, so it degrades the whole ~4h run — one of three findings standing between the weekly SF and a `SUCCEEDED` terminal.

## Why two venvs, not one

The closures **cannot** be merged. The dashboard venv is pinned `numpy<2` on the line directly above this change, because every spot workload's pyarrow is compiled against 1.x. `alpha-engine-data/requirements.txt` declares `numpy>=2.4.6`. Installing data's requirements into the dashboard venv would silently break the pin fourteen other stages depend on.

`krepis` is installed explicitly: it is absent from `alpha-engine-data/requirements.txt`, but `stage_output_sweep` and the `ssm_log_capture` wrapper resolve krepis modules, and an ImportError there reads as a domain finding rather than a missing dependency.

`BOOTSTRAP_TIMEOUT_SECONDS` 1200 → 1800. The second build pulls `arcticdb`, a large native wheel. Two builds under a ceiling sized for one is how a correct bootstrap starts failing on a slow mirror day and reads as an infrastructure fault.

## Also fixed: a suite failure found while verifying

`tests/test_preflight_sweep.py` built its S3 fixtures from `dt.date.today()` (**local**) while `preflight_sweep.sweep` derives `run_date` from `dt.datetime.now(dt.timezone.utc)`. The suite was therefore red for seven hours a day — caught at 23:55 UTC:

```
PROBE prefix= backtest/2026-08-16/ ... -> False 0 []      # fixture declared 2026-08-15
```

The upstream-**pending** test is the worse half: a date mismatch produces an empty upstream probe, which is exactly the state it asserts, so it passed for the wrong reason in that window and would have kept passing if the probe had stopped working entirely. Both fixtures now use a `_sweep_run_date()` helper, plus a test pinning the sweep's UTC derivation so a switch to local breaks loudly. Filed as **alpha-engine-config-I7431**.

## Test plan

`.venv/bin/python -m pytest tests/ -q` — **5669 passed, 10 skipped**, run locally before opening. 8 new tests: the data venv is created, installs that repo's own requirements, carries krepis, is chowned to `ec2-user`, its failures are fatal rather than swallowed, the numpy pins still justify separation, the bootstrap timeout accounts for two builds, and the sweep's UTC derivation.

## Cross-repo — merge order matters

1. **nousergon-data-PR1399** (this) — provisions the venv. **Merge and deploy first:** the launcher box builds its venvs at launch, so the dispatcher Lambda must carry this before the next run.
2. **crucible-dashboard-PR696** — points the three validators at it. It aborts with `rc=2` and a message naming this bootstrap if the venv is absent; there is deliberately **no fallback** to the dashboard interpreter, since a fallback restores the silent wrong-interpreter state on exactly the day this bootstrap stops working.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
