### PR TITLE
fix(watchdog): a weekly cycle recovered by a rerun can clear its own detector (config-I7440)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
+++ b/infrastructure/lambdas/pipeline-watchdog/iam-policy.json
@@ -73,7 +73,8 @@
       ],
       "Resource": [
         "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-preopen-trading-pipeline/*",
-        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-postclose-trading-pipeline/*"
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-postclose-trading-pipeline/*",
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-weekly-freshness-pipeline/*"
       ]
     },
     {
@@ -98,7 +99,8 @@
             "_alerts/_dedup",
             "_alerts/_dedup/*",
             "_sf_completion/ne-preopen-trading-pipeline/*",
-            "_sf_completion/ne-postclose-trading-pipeline/*"
+            "_sf_completion/ne-postclose-trading-pipeline/*",
+            "_sf_completion/ne-weekly-freshness-pipeline/*"
           ]
         }
       }

--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -1254,28 +1254,55 @@ def _last_due_weekly_day(now_utc: datetime) -> Optional[date]:
 
 
 def _weekly_real_statuses_for_day(client: object, target_date: date) -> "dict[str, int]":
-    """Status counts of REAL (``pipeline_role="weekly"``, non-gate-noop)
-    executions on ``target_date`` (alpha-engine-config-I7036).
+    """Status counts of REAL, non-gate-noop executions of the weekly CYCLE
+    ``target_date`` (alpha-engine-config-I7036, corrected by -I7440).
 
-    Reuses ``weekly_sf_silence_deadman.fetch_execution_records`` (role read
-    from each execution's own input, never inferred from name — no launch
-    path passes an explicit SF ``Name``) and ``_is_gate_noop`` (excludes a
-    SUCCEEDED execution that finished in under
-    ``GATE_NOOP_MAX_SECONDS`` — ``WeeklyRunDayGateChoice``'s designed ~2s
-    skip on a THU/FRI cron firing that isn't the real cycle day). An
-    ``exercise``-role execution never matches ``role != "weekly"``; a
-    ``shell-run`` (Friday-PM preflight) execution's role normalizes to
-    ``None`` and is excluded the same way. window_days=10 comfortably
-    covers ``target_date`` even on the longest holiday-shortened weeks
-    while capping the ``describe_execution`` fan-out this makes.
+    Reuses ``weekly_sf_silence_deadman.fetch_execution_records`` (role and
+    run_date read from each execution's own input, never inferred from name —
+    no launch path passes an explicit SF ``Name``) and ``_is_gate_noop``
+    (excludes a SUCCEEDED execution that finished in under
+    ``GATE_NOOP_MAX_SECONDS`` — ``WeeklyRunDayGateChoice``'s designed ~2s skip
+    on a THU/FRI cron firing that isn't the real cycle day). window_days=12
+    covers ``target_date`` even on the longest holiday-shortened weeks, plus
+    the multi-day recovery tail below, while capping the
+    ``describe_execution`` fan-out this makes.
+
+    **Two corrections, either of which alone false-paged cycle 2026-08-15**
+    (alpha-engine-config-I7440 — the cycle recovered to a SUCCEEDED terminal
+    and this check paged anyway):
+
+    1. **Role set.** This counted only ``role == "weekly"`` — the Saturday
+       cron — so every execution from the §2.5 mechanical recovery path
+       (``watch-rerun``) and every sf-watch substrate relaunch (``recovery``)
+       was discarded. A cycle whose cron run failed and whose rerun succeeded
+       could therefore NEVER clear this check: the policy-mandated recovery
+       mechanism was invisible to the detector watching the thing it
+       recovers. It now uses ``WEEKLY_CADENCE_ROLES``, the same constant the
+       liveness check above already passes as its ``role_filter`` — which is
+       what the block comment above always claimed ("can never disagree") and
+       what was measurably false on 2026-08-16, when the two checks in this
+       one invocation saw 1 execution and 24 executions for the same SF on
+       the same day and reached opposite verdicts.
+    2. **Cycle key.** This matched on the execution's UTC START date. A
+       recovery rerun of Saturday's cycle legitimately starts Sunday — the
+       run that closed cycle 2026-08-15 started 2026-08-16T03:21Z — so
+       matching on start excludes exactly the executions recovery produces.
+       It now matches the execution's own ``run_date`` input, which is the
+       key the run-slot mutex and the completion marker's ``cycle_key``
+       already use. Records with no parseable run_date fall back to the UTC
+       start date, preserving the old behaviour for anything that predates
+       run_date being carried.
     """
     since_anchor = target_date + timedelta(days=2)
-    records = fetch_execution_records(client, window_days=10, today=since_anchor)
+    records = fetch_execution_records(client, window_days=12, today=since_anchor)
     counts: "dict[str, int]" = {}
     for record in records:
-        if record.role != "weekly":
+        if record.role not in WEEKLY_CADENCE_ROLES:
             continue
-        if record.start.astimezone(timezone.utc).date() != target_date:
+        cycle = getattr(record, "run_date", None)
+        if cycle is None:
+            cycle = record.start.astimezone(timezone.utc).date()
+        if cycle != target_date:
             continue
         if _is_gate_noop(record):
             continue
@@ -1386,6 +1413,35 @@ def _check_failed_day(
         logger.info(
             "failed-day clear (degraded-by-design): sf=%s day=%s marker=DEGRADED",
             sf_label, target_date,
+        )
+        return FailedDayCheckResult(
+            sf_label=sf_label,
+            checked=True,
+            target_trading_day=target_date.isoformat(),
+            executions_on_day=total,
+            succeeded_on_day=0,
+            marker_status=marker_status,
+        )
+
+    if marker_status == "SUCCEEDED":
+        # The day's own pipeline wrote a SUCCEEDED marker, which only its
+        # WriteCompletionMarker state on a SUCCEEDED terminal does — that is
+        # a real verdict, and §2.3a's rule is that a MISSING verdict is
+        # UNKNOWN, not that a present one may be overruled by this check's
+        # own execution walk. Clear, do not page.
+        #
+        # But the walk and the marker have now DISAGREED, and exactly one of
+        # them is wrong. Say so at warning severity rather than clearing
+        # quietly: a counting bug in the walk (which is what
+        # alpha-engine-config-I7440 was) is otherwise completely invisible
+        # from the moment the marker starts covering for it.
+        logger.warning(
+            "failed-day clear (marker SUCCEEDED) but the execution walk found "
+            "0 SUCCEEDED of %d on sf=%s day=%s — the walk and the completion "
+            "marker disagree; one of them is wrong. Not paging (the marker is "
+            "the authoritative verdict), but the walk's role/cycle-key "
+            "filtering needs checking (alpha-engine-config-I7440).",
+            total, sf_label, target_date,
         )
         return FailedDayCheckResult(
             sf_label=sf_label,

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -50,6 +50,13 @@ sys.modules["flow_doctor_telegram"] = _fd_mod
 sys.path.insert(0, str(Path(__file__).parent))
 import index  # noqa: E402
 
+# Importable only AFTER `index`, whose own import block puts the in-repo
+# scripts/ dir on sys.path for the non-deployed layout. Tested directly
+# because its role vocabulary and the watchdog's role FILTER have to agree,
+# and nothing asserted that until they silently disagreed in production
+# (alpha-engine-config-I7440).
+import weekly_sf_silence_deadman as _deadman  # noqa: E402
+
 
 SAT_ARN = index.SATURDAY_SF_ARN
 WKD_ARN = index.WEEKDAY_SF_ARN
@@ -1689,3 +1696,265 @@ def test_handler_includes_weekly_silence_check_in_summary():
     assert silence["degraded_reason"] is None
     assert silence["critical"] == 4  # Mon-Thu, no executions in the mock
     assert silence["critical_slots"][-1] == "2026-08-06:exercise"
+
+
+# ── Weekly failed-CYCLE check (alpha-engine-config-I7440) ────────────────
+#
+# The live false page these cover, in full: cycle day 2026-08-15's Saturday
+# cron run FAILED at PredictorBacktest, six `watch-rerun` executions
+# recovered it, and the last one SUCCEEDED at 2026-08-16T03:29Z writing a
+# `status: SUCCEEDED` marker with `cycle_key: 2026-08-15`. The watchdog
+# paged anyway, reporting "1 execution(s) started, none SUCCEEDED".
+#
+# FOUR independent defects produced that, and each one alone is sufficient —
+# so each gets its own test. Fixing three of four would still page.
+#   1. role set     — `watch-rerun`/`recovery` discarded, so the §2.5
+#                     recovery path was invisible to the detector.
+#   2. normalizer   — `normalize_role` collapsed both to None upstream, which
+#                     is WHY `WEEKLY_CADENCE_ROLES` could never match.
+#   3. cycle key    — matched on UTC start date, so a Sunday rerun of
+#                     Saturday's cycle never counted toward it.
+#   4. marker clear — only a DEGRADED marker cleared; a SUCCEEDED one paged.
+
+
+_CYCLE = date(2026, 8, 15)
+
+
+def _make_weekly_cycle_client(rows):
+    """Weekly-SF stand-in for the failed-cycle check's live fetch.
+
+    ``rows`` — dicts with ``start`` (aware UTC datetime), ``role``,
+    ``status``, optional ``run_date`` and ``duration`` (seconds; default
+    well above GATE_NOOP_MAX_SECONDS so rows are real runs unless a test
+    says otherwise). Role and run_date are readable ONLY via
+    ``describe_execution``, exactly as in production.
+    """
+    execs, inputs = [], {}
+    for i, row in enumerate(rows):
+        arn = f"{_WEEKLY_EXEC_ARN_PREFIX}c{i}"
+        start = row["start"]
+        execs.append({
+            "name": f"c{i}",
+            "executionArn": arn,
+            "status": row["status"],
+            "startDate": start,
+            "stopDate": start + timedelta(seconds=row.get("duration", 1800)),
+        })
+        payload = {}
+        if row.get("role"):
+            payload["pipeline_role"] = row["role"]
+        if row.get("run_date"):
+            payload["run_date"] = row["run_date"]
+        inputs[arn] = json.dumps(payload)
+
+    client = MagicMock()
+    client.list_executions.side_effect = lambda **kw: {
+        "executions": execs if kw.get("stateMachineArn") == SAT_ARN else []
+    }
+    client.describe_execution.side_effect = lambda executionArn: {
+        "input": inputs.get(executionArn, "{}")
+    }
+    return client
+
+
+def _cron_failure():
+    """The 2026-08-15 Saturday cron run: real weekly role, FAILED."""
+    return {
+        "start": datetime(2026, 8, 15, 9, 0, tzinfo=timezone.utc),
+        "role": "weekly", "status": "FAILED", "run_date": "2026-08-15",
+    }
+
+
+def _rerun_success():
+    """The run that actually closed cycle 2026-08-15 — started the NEXT UTC
+    day, under the watch-rerun role, carrying the ORIGINAL run_date."""
+    return {
+        "start": datetime(2026, 8, 16, 3, 21, tzinfo=timezone.utc),
+        "role": "watch-rerun", "status": "SUCCEEDED", "run_date": "2026-08-15",
+    }
+
+
+def test_weekly_cycle_recovered_by_a_watch_rerun_does_not_page():
+    """THE regression. The cycle failed on the cron and succeeded on a rerun
+    the next UTC day — the exact live shape of 2026-08-15/16. Before the
+    fix this paged with 'none SUCCEEDED'."""
+    client = _make_weekly_cycle_client([_cron_failure(), _rerun_success()])
+    s3 = MagicMock()
+    result = index._check_failed_day(
+        sf_label="Weekly SF", sf_arn=SAT_ARN,
+        pipeline_name="ne-weekly-freshness-pipeline",
+        target_date=_CYCLE, cadence="weekly", client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is False
+    assert result.succeeded_on_day == 1
+    assert result.executions_on_day == 2
+    # A cleared day must never spend an S3 read on the marker.
+    s3.get_object.assert_not_called()
+    _alerts_mod.publish.assert_not_called()
+
+
+def test_weekly_cycle_counts_the_recovery_role_too():
+    """sf-watch's substrate-reclaim relaunch uses role='recovery'. It is in
+    WEEKLY_CADENCE_ROLES and must count exactly like watch-rerun — a cycle
+    rescued from a spot reclaim is a cycle that succeeded."""
+    recovery = dict(_rerun_success(), role="recovery")
+    client = _make_weekly_cycle_client([_cron_failure(), recovery])
+    result = index._check_failed_day(
+        sf_label="Weekly SF", sf_arn=SAT_ARN,
+        pipeline_name="ne-weekly-freshness-pipeline",
+        target_date=_CYCLE, cadence="weekly", client=client, s3_client=MagicMock(),
+    )
+    assert result.alert_emitted is False
+    assert result.succeeded_on_day == 1
+
+
+def test_weekly_cycle_keys_on_run_date_not_on_utc_start_date():
+    """Defect 3 in isolation: same role, same status, but the rerun starts on
+    2026-08-16 UTC. Keying on the start date drops it; keying on run_date —
+    the mutex's and the marker's own cycle key — keeps it."""
+    client = _make_weekly_cycle_client([_rerun_success()])
+    counts = index._weekly_real_statuses_for_day(client, _CYCLE)
+    assert counts == {"SUCCEEDED": 1}
+    # ...and it belongs to 08-15's cycle, NOT to 08-16's.
+    assert index._weekly_real_statuses_for_day(client, date(2026, 8, 16)) == {}
+
+
+def test_weekly_cycle_without_run_date_falls_back_to_utc_start_date():
+    """Records predating run_date being carried must keep the old behaviour
+    rather than silently vanishing from every cycle."""
+    legacy = {
+        "start": datetime(2026, 8, 15, 9, 0, tzinfo=timezone.utc),
+        "role": "weekly", "status": "FAILED",
+    }
+    client = _make_weekly_cycle_client([legacy])
+    assert index._weekly_real_statuses_for_day(client, _CYCLE) == {"FAILED": 1}
+
+
+def test_weekly_cycle_still_excludes_exercise_and_gate_noop_runs():
+    """The widened role set must not start counting the two things this
+    check has always been required to ignore: the daily chained exercise
+    run, and WeeklyRunDayGateChoice's ~2s designed skip."""
+    exercise = {
+        "start": datetime(2026, 8, 15, 20, 30, tzinfo=timezone.utc),
+        "role": "exercise", "status": "SUCCEEDED", "run_date": "2026-08-15",
+    }
+    gate_noop = {
+        "start": datetime(2026, 8, 15, 9, 0, tzinfo=timezone.utc),
+        "role": "weekly", "status": "SUCCEEDED", "run_date": "2026-08-15",
+        "duration": 2,
+    }
+    client = _make_weekly_cycle_client([exercise, gate_noop])
+    assert index._weekly_real_statuses_for_day(client, _CYCLE) == {}
+
+
+def test_weekly_cycle_with_only_failures_still_pages():
+    """The check must still do its job: a cycle whose cron AND whose reruns
+    all failed, with no marker, is exactly what it exists to catch."""
+    failed_rerun = dict(_rerun_success(), status="FAILED")
+    client = _make_weekly_cycle_client([_cron_failure(), failed_rerun])
+    s3 = _make_s3_marker_client(error=_FakeNoSuchKey())
+    result = index._check_failed_day(
+        sf_label="Weekly SF", sf_arn=SAT_ARN,
+        pipeline_name="ne-weekly-freshness-pipeline",
+        target_date=_CYCLE, cadence="weekly", client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is True
+    assert result.executions_on_day == 2
+    assert result.succeeded_on_day == 0
+    assert _alerts_mod.publish.call_args.kwargs["severity"] == "error"
+    assert "cycle day" in _alerts_mod.publish.call_args.kwargs["message"]
+
+
+def test_succeeded_marker_clears_instead_of_paging():
+    """Defect 4 in isolation. Only DEGRADED used to clear, so a marker
+    reading SUCCEEDED — the single most authoritative statement that the
+    cycle worked — fell through to the error page."""
+    client = _make_weekly_cycle_client([_cron_failure()])
+    s3 = _make_s3_marker_client(marker={"status": "SUCCEEDED"})
+    result = index._check_failed_day(
+        sf_label="Weekly SF", sf_arn=SAT_ARN,
+        pipeline_name="ne-weekly-freshness-pipeline",
+        target_date=_CYCLE, cadence="weekly", client=client, s3_client=s3,
+    )
+    assert result.alert_emitted is False
+    assert result.marker_status == "SUCCEEDED"
+    _alerts_mod.publish.assert_not_called()
+
+
+def test_normalize_role_preserves_the_recovery_vocabulary():
+    """Defect 2 at its own layer — the reason WEEKLY_CADENCE_ROLES could
+    never match. A filter naming roles the fetch layer cannot emit is a
+    filter that is always empty, and nothing said so."""
+    for role in ("weekly", "exercise", "watch-rerun", "recovery", "shell-run"):
+        assert _deadman.normalize_role(role) == role
+    assert _deadman.normalize_role("something-new") is None
+    assert _deadman.normalize_role(None) is None
+
+
+def test_every_weekly_cadence_role_survives_the_fetch_normalizer():
+    """The two layers must agree BY CONSTRUCTION, not by coincidence: every
+    role the watchdog filters on has to be one the fetch layer can produce.
+    This is the assertion whose absence let the two drift apart."""
+    for role in index.WEEKLY_CADENCE_ROLES:
+        assert _deadman.normalize_role(role) == role, (
+            f"WEEKLY_CADENCE_ROLES names {role!r} but normalize_role discards "
+            f"it — the filter can never match and the check is disarmed"
+        )
+
+
+# ── IAM contract: the role can read every marker the code reads ──────────
+#
+# sf-pipeline-policy §2.2: "Identity & permission — every IAM action each
+# stage will call ... asserted by contract test against the codified role."
+#
+# This is the assertion whose absence produced the 2026-08-16 page. The
+# weekly pipeline was added to _FAILED_DAY_PIPELINES (I7036) and its marker
+# prefix was never added to CompletionMarkerRead, so every weekly marker
+# consult returned AccessDenied → UNREADABLE → "UNKNOWN ≠ pass" → error page.
+# Nothing failed at merge, and nothing failed on deploy: the grant is only
+# exercised on the branch reached when a cycle has zero counted successes,
+# so it sat latent until the first day it mattered and then fired as a
+# false alarm about the pipeline rather than about itself.
+
+
+_IAM_POLICY_PATH = Path(__file__).parent / "iam-policy.json"
+
+
+def _statement(sid):
+    doc = _json.loads(_IAM_POLICY_PATH.read_text())
+    for stmt in doc["Statement"]:
+        if stmt.get("Sid") == sid:
+            return stmt
+    raise AssertionError(f"iam-policy.json has no statement with Sid={sid!r}")
+
+
+def test_completion_marker_read_covers_every_pipeline_the_code_reads():
+    """Adding a pipeline to _FAILED_DAY_PIPELINES without extending the role
+    must fail HERE, at merge — not silently in production on the first day
+    the marker branch is reached."""
+    granted = _statement("CompletionMarkerRead")["Resource"]
+    for _label, _arn, pipeline_name, _cadence in index._FAILED_DAY_PIPELINES:
+        expected = (
+            f"arn:aws:s3:::{index.MARKER_BUCKET}/_sf_completion/{pipeline_name}/*"
+        )
+        assert expected in granted, (
+            f"{pipeline_name} is in _FAILED_DAY_PIPELINES, so "
+            f"_completion_marker_status will GetObject its marker, but "
+            f"iam-policy.json's CompletionMarkerRead does not grant "
+            f"{expected}. The check would page 'UNREADABLE' on AccessDenied "
+            f"— a false alarm about the pipeline, caused by the watchdog."
+        )
+
+
+def test_list_bucket_prefix_condition_covers_the_same_pipelines():
+    """The s3:ListBucket prefix condition gates the same reads; a prefix
+    granted in one statement and omitted from the other is the same latent
+    denial one layer down."""
+    prefixes = _statement("DedupMarkerListBucket")["Condition"]["StringLike"]["s3:prefix"]
+    for _label, _arn, pipeline_name, _cadence in index._FAILED_DAY_PIPELINES:
+        expected = f"_sf_completion/{pipeline_name}/*"
+        assert expected in prefixes, (
+            f"DedupMarkerListBucket's prefix condition omits {expected} while "
+            f"CompletionMarkerRead grants the object read — the two must list "
+            f"the same pipelines."
+        )

--- a/scripts/weekly_sf_silence_deadman.py
+++ b/scripts/weekly_sf_silence_deadman.py
@@ -319,10 +319,62 @@ class ExecutionRecord:
     status: str
     start: datetime  # tz-aware UTC
     stop: datetime | None
+    # The execution's own ``run_date`` input — the CYCLE it belongs to, which
+    # is NOT derivable from ``start``: a recovery rerun of Saturday's cycle
+    # legitimately starts on Sunday (or later) and still carries
+    # run_date=<Saturday>. This is the same key the run-slot mutex and the
+    # completion marker's ``cycle_key`` use, so a consumer asking "did cycle
+    # D succeed?" must match on this and never on a wall-clock date in any
+    # zone (alpha-engine-config-I7440). ``None`` when the input carried no
+    # usable run_date; consumers fall back to ``start`` and say so.
+    run_date: date | None = None
+
+
+# The weekly SF's pipeline_role vocabulary, as emitted by its launch paths:
+#   weekly      — the alpha-engine-saturday EventBridge cron (the real cycle)
+#   exercise    — the daily postclose-chained dry exercise run
+#   watch-rerun — scripts/weekly_sf_rerun.py, the §2.5 mechanical recovery
+#   recovery    — sf-watch's substrate-reclaim relaunch
+#   shell-run   — the Friday-PM off-cycle preflight shell
+# Closed on purpose: an unrecognized role normalizes to None so a new launch
+# path cannot silently start counting as a cycle nobody declared.
+KNOWN_ROLES = ("exercise", "weekly", "watch-rerun", "recovery", "shell-run")
+
+
+def _parse_run_date(raw: object) -> date | None:
+    """``run_date`` input → ``date``; ``None`` on anything unparseable.
+
+    Never raises: an execution whose input carries a malformed run_date is a
+    record with ``run_date=None``, which consumers treat as "cycle unknown"
+    and fall back on — it must not take down the whole fetch for the other
+    executions in the window.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
 
 
 def normalize_role(raw: object) -> str | None:
-    return raw if raw in ("exercise", "weekly") else None
+    """Pass a recognized ``pipeline_role`` through unchanged; unknown → None.
+
+    Until 2026-08-16 this collapsed EVERYTHING except ``exercise``/``weekly``
+    to ``None``, which made ``watch-rerun`` and ``recovery`` indistinguishable
+    from an unrecognized launch path. That is why
+    ``pipeline-watchdog``'s ``WEEKLY_CADENCE_ROLES`` filter — which names both
+    — could never match a record produced by ``fetch_execution_records``, and
+    why its weekly failed-day check counted 1 execution on cycle day
+    2026-08-15 while its own liveness check, reading roles by a second
+    unrelated path, counted 24 and returned CLEAR (alpha-engine-config-I7440).
+
+    Widening is behaviour-preserving for this module's own slot matching:
+    ``evaluate_slot`` compares ``e.role == slot.role`` and slot roles are only
+    ``weekly``/``exercise``, so records that were ``None`` and matched nothing
+    are now named and still match nothing.
+    """
+    return raw if raw in KNOWN_ROLES else None
 
 
 @dataclass(frozen=True)
@@ -424,10 +476,12 @@ def fetch_execution_records(
         if start < since:
             continue
         role = None
+        run_date = None
         try:
             desc = sf_client.describe_execution(executionArn=ex["executionArn"])
             inp = json.loads(desc.get("input") or "{}")
             role = normalize_role(inp.get("pipeline_role"))
+            run_date = _parse_run_date(inp.get("run_date"))
         except Exception as exc:  # noqa: BLE001 — best-effort per-execution; unrecognized role is a safe fallback, not a hidden failure (surfaced below)
             print(f"WARN: could not read input of {ex['executionArn']}: {exc}", file=sys.stderr)
         records.append(ExecutionRecord(
@@ -436,6 +490,7 @@ def fetch_execution_records(
             status=ex["status"],
             start=start,
             stop=ex.get("stopDate"),
+            run_date=run_date,
         ))
     return records
 

--- a/tests/test_weekly_sf_silence_deadman.py
+++ b/tests/test_weekly_sf_silence_deadman.py
@@ -342,16 +342,55 @@ class TestMeasuredFortyFiveDayShape:
 
 
 class TestNormalizeRole:
+    """Amended 2026-08-16 (alpha-engine-config-I7440).
+
+    This class previously asserted that ``watch-rerun`` normalizes to
+    ``None`` — it pinned the defect rather than forbidding it. That
+    collapsing is precisely what disarmed ``pipeline-watchdog``'s weekly
+    failed-cycle check: its ``WEEKLY_CADENCE_ROLES`` filter names
+    ``watch-rerun`` and ``recovery``, and this function guaranteed no record
+    could ever carry either, so a weekly cycle recovered by the §2.5
+    mechanical rerun could never clear the detector watching it. The test
+    passed for exactly as long as the bug existed and would have turned CI
+    red on the fix.
+
+    Roles are now passed through for the whole KNOWN_ROLES vocabulary, and
+    the closed-vocabulary property — an UNRECOGNIZED role still normalizes to
+    None, so a new launch path cannot silently start counting as a declared
+    cycle — is what this class asserts instead.
+    """
+
     @pytest.mark.parametrize("raw,expected", [
         ("exercise", "exercise"),
         ("weekly", "weekly"),
+        ("watch-rerun", "watch-rerun"),
+        ("recovery", "recovery"),
+        ("shell-run", "shell-run"),
+        # Not a weekly-SF launch role (it is the postclose SF's operator
+        # replay role) — still discarded.
         ("operator-replay", None),
-        ("watch-rerun", None),
+        ("something-new", None),
         (None, None),
         ("", None),
     ])
-    def test_only_the_two_declared_roles_pass_through(self, mod, raw, expected):
+    def test_known_roles_pass_through_and_unknown_ones_are_discarded(self, mod, raw, expected):
         assert mod.normalize_role(raw) == expected
+
+    def test_slot_matching_is_unchanged_by_the_widening(self, mod):
+        """Behaviour-preservation guard for THIS module. Slot roles are only
+        weekly/exercise, so records that used to be None and matched no slot
+        are now named and must still match no slot — the widening may not
+        let a rerun start satisfying a cron slot."""
+        day = date(2026, 8, 15)
+        start = datetime(2026, 8, 15, 9, 0, tzinfo=timezone.utc)
+        rerun = mod.ExecutionRecord(
+            name="watch-rerun-2026-08-15-1", role="watch-rerun",
+            status="SUCCEEDED", start=start,
+            stop=start + timedelta(seconds=1800), run_date=day,
+        )
+        slot = mod.ExpectedSlot(day=day, role="weekly", gated_off=False, note="")
+        result = mod.evaluate_slot(slot, [rerun])
+        assert result.classification == "CRITICAL"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

On **2026-08-16 14:00 UTC** `pipeline-watchdog` paged that weekly cycle `2026-08-15` had *"1 execution(s) started, none SUCCEEDED, and the completion marker could not be read/parsed (UNKNOWN ≠ pass)"*.

**The cycle had succeeded.** `watch-rerun-2026-08-16-4` reached a SUCCEEDED terminal at `2026-08-16T03:29:47Z` and wrote `_sf_completion/ne-weekly-freshness-pipeline/2026-08-15.json` = `{"status":"SUCCEEDED","cycle_key":"2026-08-15"}`. Seven weekly-cadence executions ran for that cycle; the check saw **one** and read **zero** successes.

Tracker: `alpha-engine-config-I7440`.

## Four defects, each sufficient on its own

Fixing any three of these still pages.

1. **Role set.** `_weekly_real_statuses_for_day` counted only `role == "weekly"` — the Saturday cron — discarding every `watch-rerun` and `recovery` execution. A cycle recovered by the sf-pipeline-policy §2.5 *mechanical rerun* could therefore **never** clear the detector that watches the thing it recovers.
2. **Normalizer.** `normalize_role` collapsed everything except `exercise`/`weekly` to `None` — which is **why** `WEEKLY_CADENCE_ROLES`, a constant naming `watch-rerun` and `recovery`, could never match a fetched record. A filter that is structurally always empty, with nothing asserting otherwise.
3. **Cycle key.** Membership was keyed on the execution's **UTC start date**. A recovery rerun of Saturday's cycle legitimately starts Sunday — the run that closed this cycle started `2026-08-16T03:21Z` — so start-date matching excluded exactly the executions recovery produces. Now keyed on the execution's own `run_date` input, the key the run-slot mutex and the marker's `cycle_key` already use, with a UTC-start fallback for records carrying none.
4. **Marker clearing.** Only a `DEGRADED` marker cleared the check, so a marker reading `SUCCEEDED` fell through to the error page.

### The signal that this was self-inflicted

Both weekly checks ran in the **same Lambda invocation** and disagreed about the same SF on the same day:

| Check | Saw | Verdict |
|---|---|---|
| liveness (`_check_sf`, `role_filter=WEEKLY_CADENCE_ROLES`) | 24 executions | **CLEAR** |
| failed-cycle (`_weekly_real_statuses_for_day`) | 1 execution | **PAGE** |

`index.py`'s own block comment claimed the two "can never disagree about what a real weekly cycle execution looks like". They read roles by two unrelated paths, and nothing asserted the paths agree. A contract test now does.

### The IAM gap

`CompletionMarkerRead` granted the preopen and postclose marker prefixes only. The weekly pipeline joined `_FAILED_DAY_PIPELINES` in `alpha-engine-config#7036` and **its prefix was never added to the role**, so every weekly marker consult returned `AccessDenied` → `UNREADABLE` → "UNKNOWN ≠ pass" → page. That is the literal wording of the alert Brian received. It sat latent because the marker branch is only reached when a cycle has zero counted successes — the first day it mattered, it fired as a false alarm about the pipeline rather than about itself.

## Guards added

- **Contract test — IAM/code parity** (sf-pipeline-policy §2.2, *"a failure class that has broken a live run becomes an assertion before the next run"*): every pipeline in `_FAILED_DAY_PIPELINES` must have its marker prefix in both `CompletionMarkerRead` and `DedupMarkerListBucket`. Adding a pipeline to the check without extending IAM now fails at merge.
- **Contract test — role/filter parity**: every role in `WEEKLY_CADENCE_ROLES` must survive `normalize_role`. The two layers now agree by construction, not by coincidence.
- **Honest disagreement**: when the marker says SUCCEEDED and the execution walk counted zero, the check clears (the marker is the authoritative verdict per §2.3a) **and logs a WARNING naming the disagreement** — so a future counting bug surfaces instead of hiding behind the marker.

## Test amended, not deleted

`TestNormalizeRole` asserted `watch-rerun → None`. It pinned the defect rather than forbidding it — it passed for exactly as long as the bug existed and would have turned CI red on the fix. Amended to assert the property actually wanted: known roles pass through, unrecognized roles are still discarded so a new launch path cannot silently start counting as a declared cycle. A behaviour-preservation test was added alongside it proving the widening does not let a rerun start satisfying a cron slot in the silence deadman.

## Validation

- `infrastructure/lambdas/pipeline-watchdog/test_handler.py` — **81 passed** (was 70; 11 new)
- `tests/test_weekly_sf_silence_deadman.py` + `tests/test_weekly_sf_rerun.py` — **100 passed**
- Every new test was verified to **fail against the unfixed source** (9 of 11 fail; the other 2 are behaviour-preservation guards that correctly pass both ways).
- Full `pytest tests/` diffed against pristine `origin/main`: **180 failures before, 180 after, zero introduced** — all pre-existing local-environment gaps (`bs4`, `yfinance`, `tenacity`, stale `krepis` pin), which CI installs.

**Rehearsal-path:** route 1 of sf-pipeline-policy §7.2 — a CI-validatable alternative. This changes detector logic only, no `step_function*.json` and no pipeline topology, and the live shape that produced the false page is reproduced exactly as a unit test (`test_weekly_cycle_recovered_by_a_watch_rerun_does_not_page`, built from the real 2026-08-15/16 execution set). No live Saturday is needed.

**Verified-when:** the next `pipeline-watchdog` firing after a rerun-recovered cycle reports `Weekly SF ... outcome CLEAR` in its summary rather than emitting a `failed-day` alert.

## ⚠ Operator step required after merge

`iam-policy.json` changed, and this repo's CI **cannot** apply IAM: `github-actions-lambda-deploy` has no `iam:PutRolePolicy` by design (the single-writer rule adopted after four IAM-clobber incidents). This is `pull-request-policy.md` §4.2 **form 3**, with both required halves present — the merge job prints the exact command, and `check-drift.py` (daily 09:35 UTC) stays red until it is run.

Applying it in-session before opening this PR (form 2) was attempted and refused by the agent harness, so it could not be automated away.

```
AWS_PROFILE=ne-admin bash infrastructure/lambdas/pipeline-watchdog/deploy.sh --apply-iam
```

Run from a `nousergon-data` checkout. Verified by dry-run: it emits exactly one mutation, `aws iam put-role-policy --role-name alpha-engine-pipeline-watchdog-role --policy-name alpha-engine-pipeline-watchdog-policy`. **Until it runs, the code fix is live but the marker read still returns AccessDenied** — defects 1–3 stop the false page on their own, so the alert will not recur, but the marker branch (defect 4's clearing path) stays blind.

## Out of scope, filed separately

- `alpha-engine-config-I7441` — cycle 2026-08-15's marker reads `SUCCEEDED` although three of its runs terminated DEGRADED; degradation does not survive a rerun into the marker every machine consumer reads (§2.3/§2.3a).
- `alpha-engine-config-I7442` — the root `PredictorBacktest` failure cause is unrecoverable: truncated behind `--output truncated--` and the full remote log deleted by staging cleanup. Recurrence of `I7216` obligation 3.
- `alpha-engine-config-I7443` — two reruns minted a fresh `run_date` across UTC midnight and failed identically on `PredictorSkipWeightsStale`; §2.5 requires the helper to supply coherent input.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
