### PR TITLE
fix(preflight): assert skip_* claims against live artifacts before spot spend (config-I7443)

### DIFF
--- a/infrastructure/lambdas/weekly-preflight/index.py
+++ b/infrastructure/lambdas/weekly-preflight/index.py
@@ -72,9 +72,23 @@ def handler(event: dict, context) -> dict:
             "traceback": traceback.format_exc(),
         }
 
+    # alpha-engine-config-I7443: the SF Task passes no explicit Payload, so
+    # `event` IS the whole state input — run_date and every skip_* flag are
+    # already here. Forwarding them lets check_skip_flag_artifact_coherence
+    # assert that each skip CLAIM is backed by a real artifact for this
+    # run_date, before AcquireMutex and before any spot dispatch. Absent
+    # (a bare {} test invoke) => that check reports "nothing claimed", never
+    # a failure: this gate must not start halting the pipeline over a payload
+    # shape it previously ignored.
+    run_date = event.get("run_date")
+    skip_flags = {k: v for k, v in event.items() if k.startswith("skip_")}
+
     try:
         n_fail, results = sfp.run_preflight(
-            bucket=bucket, capabilities=sfp.LAMBDA_CAPABILITIES
+            bucket=bucket,
+            capabilities=sfp.LAMBDA_CAPABILITIES,
+            run_date=run_date,
+            skip_flags=skip_flags,
         )
     except Exception as exc:
         return {

--- a/infrastructure/lambdas/weekly-preflight/test_handler.py
+++ b/infrastructure/lambdas/weekly-preflight/test_handler.py
@@ -41,9 +41,15 @@ def _install_stub(results, n_fail=None, raises=None):
     stub.LAMBDA_CAPABILITIES = frozenset({"aws"})
     stub.FULL_CAPABILITIES = frozenset({"aws", "arctic", "repo_modules", "checkout", "polygon"})
 
-    def run_preflight(bucket=None, capabilities=None):
+    def run_preflight(bucket=None, capabilities=None, run_date=None, skip_flags=None):
         recorded["bucket"] = bucket
         recorded["capabilities"] = capabilities
+        # alpha-engine-config-I7443: the handler forwards the SF execution
+        # input so check_skip_flag_artifact_coherence can verify each skip
+        # claim before spot spend. Recorded so the forwarding is asserted,
+        # not assumed.
+        recorded["run_date"] = run_date
+        recorded["skip_flags"] = skip_flags
         if raises is not None:
             raise raises
         fails = n_fail if n_fail is not None else sum(1 for r in results if r.status == "fail")
@@ -123,6 +129,67 @@ class WeeklyPreflightHandlerTests(unittest.TestCase):
         recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
         self._handler()({"bucket": "some-other-bucket"}, None)
         self.assertEqual(recorded["bucket"], "some-other-bucket")
+
+
+class WeeklyPreflightExecutionInputForwardingTests(unittest.TestCase):
+    """alpha-engine-config-I7443.
+
+    The SF Task invokes this Lambda with no explicit Payload, so the whole
+    state input arrives as ``event`` — run_date and every skip_* flag are
+    already present and were simply discarded. Forwarding them is what lets
+    the pre-spend gate reject an incoherent recovery input (a skip claim
+    with no artifact for that run_date) in seconds, instead of the in-SF
+    guard catching it after a spot dispatch and ~18 minutes.
+    """
+
+    def tearDown(self):
+        sys.modules.pop("sf_preflight", None)
+        sys.modules.pop("index", None)
+
+    def _handler(self):
+        sys.modules.pop("index", None)
+        import index
+        return index.handler
+
+    def test_run_date_and_skip_flags_reach_run_preflight(self):
+        recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
+        event = {
+            "run_date": "2026-08-16",
+            "skip_predictor_training": True,
+            "skip_scanner": True,
+            "skip_aggregate_costs": False,
+            "pipeline_role": "watch-rerun",
+            "sns_topic_arn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        }
+        self._handler()(event, None)
+        self.assertEqual(recorded["run_date"], "2026-08-16")
+        self.assertEqual(
+            recorded["skip_flags"],
+            {
+                "skip_predictor_training": True,
+                "skip_scanner": True,
+                "skip_aggregate_costs": False,
+            },
+        )
+
+    def test_non_skip_keys_are_not_forwarded_as_skip_flags(self):
+        """Only skip_* keys — pipeline_role and sns_topic_arn are not claims."""
+        recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
+        self._handler()(
+            {"run_date": "2026-08-16", "pipeline_role": "watch-rerun"}, None
+        )
+        self.assertEqual(recorded["skip_flags"], {})
+
+    def test_bare_event_forwards_nothing_and_still_passes(self):
+        """A bare {} test invoke must keep working. An absent payload is
+        'nothing claimed', never a violation — this gate must not begin
+        halting the pipeline over a shape it previously ignored."""
+        recorded = _install_stub([_Result("sf_iam_reachability", "ok")])
+        out = self._handler()({}, None)
+        self.assertIsNone(recorded["run_date"])
+        self.assertEqual(recorded["skip_flags"], {})
+        self.assertEqual(out["status"], "OK")
+        self.assertFalse(out["has_violation"])
 
 
 if __name__ == "__main__":

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -406,11 +406,12 @@
     },
     "WeeklyPreflight": {
       "Type": "Task",
-      "Comment": "I4494: pre-spend gate \u2014 runs sf_preflight.py checks against live AWS state before the pipeline spends on any spot or mutex acquisition. Checks: IAM reachability, tool contracts, definition input coherence, Lambda memory headroom. Fail-hard on assertion failure (preflight is cheaper than a Saturday spot run that would die for the same reason). Routes failures through ExtractWeeklyPreflightError \u2192 NormalizeFailureContext (the same chokepoint all pre-spend gate failures use), NOT directly to HandleFailure. Reads-only: no writes, no cost, no side effects. <60s target.",
+      "Comment": "I4494: pre-spend gate \u2014 runs sf_preflight.py checks against live AWS state before the pipeline spends on any spot or mutex acquisition. Checks: IAM reachability, tool contracts, definition input coherence, Lambda memory headroom. Fail-hard on assertion failure (preflight is cheaper than a Saturday spot run that would die for the same reason). Routes failures through ExtractWeeklyPreflightError \u2192 NormalizeFailureContext (the same chokepoint all pre-spend gate failures use), NOT directly to HandleFailure. Reads-only: no writes, no cost, no side effects. <60s target. | alpha-engine-config-I7443: passes Payload.$=\"$\". This was the ONLY lambda:invoke task in this definition with no Payload at all, so the handler received {} on every real execution and its documented bucket/sf_name event overrides were unreachable from the SF. The gate now sees the execution input it is gating, which is what lets check_skip_flag_artifact_coherence verify each skip_* CLAIM against a live artifact for THIS run_date before AcquireMutex and before any spot spend (the 2026-08-15 cycle burned two ~18-minute dispatches on a skip_predictor_training claim the in-SF guard correctly rejected far later). Deliberately the whole input rather than this definition's usual narrow projection: the skip_* set is ~25 dynamic keys, so an enumerated projection would silently stop covering any stage added later -- coverage must be a function of sf_preflight's registry, not of a list duplicated here. No secrets transit: the input holds run_date, role, skip flags, an SNS topic ARN and an instance id.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "TimeoutSeconds": 60,
       "Parameters": {
-        "FunctionName": "alpha-engine-weekly-preflight:live"
+        "FunctionName": "alpha-engine-weekly-preflight:live",
+        "Payload.$": "$"
       },
       "Retry": [
         {

--- a/sf_preflight.py
+++ b/sf_preflight.py
@@ -34,6 +34,8 @@ What this catches (mapped to today's incidents):
     Tool-contract flag/version mismatch   — check_tool_contracts (Leg 2)
     Unresolvable JSONPath in SF def       — check_definition_input_coherence (Leg 3)
     Lambda alias memory headroom breach   — check_lambda_memory_headroom (Leg 4)
+    Recovery input claiming a skip whose
+      artifact does not exist for run_date — check_skip_flag_artifact_coherence
 
 What this CANNOT catch:
     - Polygon coverage flipping AFTER preflight succeeds (transient
@@ -116,6 +118,15 @@ class PreflightContext:
     bucket: str
     today: str  # YYYY-MM-DD
     prior_trading_day: str  # YYYY-MM-DD
+    # The execution input's own run_date and skip_* flags, when the caller
+    # has them (alpha-engine-config-I7443). The WeeklyPreflight Lambda is
+    # invoked with the whole SF state as its payload, so it does; the CLI
+    # normally does not. Absent => check_skip_flag_artifact_coherence reports
+    # "ok (nothing claimed)" rather than failing — a caller that cannot see
+    # the input has not observed a violation, it has observed nothing, and
+    # the in-SF guards remain the authority either way.
+    run_date: "str | None" = None
+    skip_flags: dict = field(default_factory=dict)
     fresh_constituents: "set[str] | None" = None  # populated by check_constituents_fetch
     arctic_universe_symbols: "set[str] | None" = None  # populated by check_arctic_connectivity
     polygon_returned_tickers: "set[str] | None" = None  # populated by check_polygon_grouped_coverage
@@ -1322,6 +1333,194 @@ _CLOUDWATCH_METRIC_DAYS = 30  # lookback window
 _CLOUDWATCH_PERIOD = 86400  # 1-day period (granular enough for a weekly pipeline)
 
 
+# ── Skip-flag artifact coherence (check_skip_flag_artifact_coherence) ────────
+#
+# alpha-engine-config-I7443. A recovery rerun's input is a CLAIM: every
+# ``skip_X: true`` asserts "stage X already produced its artifact for this
+# run_date, so do not spend on it again". When the claim is false the run
+# does not merely waste a dispatch — it would silently build on a stale
+# artifact, which is why the SF carries in-pipeline guards for it at all.
+#
+# The measured cost of asserting this LATE (2026-08-15 cycle): two recovery
+# executions, `watch-rerun-2026-08-16-1` and `-2`, each carried
+# `skip_predictor_training: true` alongside `run_date: 2026-08-16` while the
+# weights manifest was last written 2026-08-15. Both died on
+# `PredictorSkipWeightsStale` — the guard worked — but only after
+# WeeklyFreshnessSpotBootstrap had dispatched a spot and ~18 minutes had
+# elapsed, twice. sf-pipeline-policy §2.2 is explicit that this is the wrong
+# layer: "Everything cheaply knowable before spend must be known before
+# spend." A HeadObject is cheaply knowable.
+#
+# This check does NOT replace the in-SF guards; they remain the authority and
+# the last line (a preflight pass is not a promise about a later instant).
+# It moves the same predicate to the pre-spend gate so an incoherent input —
+# from the rerun helper, from sf-watch, or hand-authored — fails in seconds
+# rather than after a spot launch. `tests/test_sf_preflight.py` pins this
+# predicate against the SF definition's own Choice so the two cannot drift.
+
+
+@dataclass(frozen=True)
+class SkipArtifactPredicate:
+    """What must be true for one ``skip_*`` claim to be honest."""
+
+    flag: str          # the execution-input key, e.g. "skip_predictor_training"
+    stage: str         # human name for the message
+    key: str           # S3 key, may contain "{run_date}"
+    kind: str          # "last_modified_gte_run_date" | "key_exists"
+    sf_guard: str      # the in-SF state that owns the authoritative check
+    note: str = ""
+
+
+# Registry. Deliberately small and evidence-backed: an entry is added only
+# when the SF itself carries the matching guard, so the predicate here is a
+# copy of a rule that already exists rather than a new rule invented at the
+# preflight layer. Adding a stage without its `sf_guard` counterpart would
+# make this gate the sole author of a correctness rule, which is exactly the
+# drift the pinning test exists to prevent.
+SKIP_ARTIFACT_PREDICATES: "tuple[SkipArtifactPredicate, ...]" = (
+    SkipArtifactPredicate(
+        flag="skip_predictor_training",
+        stage="PredictorTraining",
+        key="predictor/weights/meta/manifest.json",
+        kind="last_modified_gte_run_date",
+        sf_guard="CheckPredictorSkipWeightsFresh",
+        note=(
+            "manifest LastModified date >= run_date proves a non-dry training "
+            "run completed FOR THIS run_date; an earlier date means the skip "
+            "would silently reuse the previous cycle's weights"
+        ),
+    ),
+)
+
+
+def check_skip_flag_artifact_coherence(ctx: PreflightContext) -> CheckResult:
+    """Every ``skip_X: true`` in the execution input must be backed by X's
+    artifact existing for ``run_date`` — asserted BEFORE any spot spend."""
+    import time
+    t0 = time.time()
+    name = "skip_flag_artifact_coherence"
+
+    if not ctx.run_date or not ctx.skip_flags:
+        # Not a violation — this caller simply was not handed the execution
+        # input. Reported as ok with an explicit reason so the gate's own
+        # coverage is legible rather than looking like a silent pass.
+        return CheckResult(
+            name=name,
+            status="ok",
+            message=(
+                "no execution input available to this caller "
+                f"(run_date={ctx.run_date!r}, {len(ctx.skip_flags)} skip flags) "
+                "— nothing claimed, nothing to verify"
+            ),
+            details={"claims_checked": 0},
+            elapsed_seconds=time.time() - t0,
+        )
+
+    claimed = [p for p in SKIP_ARTIFACT_PREDICATES if ctx.skip_flags.get(p.flag) is True]
+    if not claimed:
+        return CheckResult(
+            name=name,
+            status="ok",
+            message=(
+                f"run_date={ctx.run_date}: no registered skip_* flag is claimed "
+                f"({len(SKIP_ARTIFACT_PREDICATES)} registered)"
+            ),
+            details={"claims_checked": 0, "run_date": ctx.run_date},
+            elapsed_seconds=time.time() - t0,
+        )
+
+    import boto3 as _boto3
+    s3 = _boto3.client("s3")
+    violations: list[str] = []
+    verified: list[str] = []
+
+    for pred in claimed:
+        key = pred.key.replace("{run_date}", ctx.run_date)
+        try:
+            head = s3.head_object(Bucket=ctx.bucket, Key=key)
+        except Exception as exc:
+            code = ""
+            resp = getattr(exc, "response", None)
+            if isinstance(resp, dict):
+                code = (resp.get("Error") or {}).get("Code", "")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                violations.append(
+                    f"{pred.flag}=true but s3://{ctx.bucket}/{key} does not exist "
+                    f"— {pred.stage} never produced its artifact"
+                )
+            else:
+                # Any other S3 error is UNKNOWN, never a pass (§2.3a). Fail
+                # loud: an unreadable artifact cannot witness a skip claim.
+                violations.append(
+                    f"{pred.flag}=true but s3://{ctx.bucket}/{key} is unreadable "
+                    f"({type(exc).__name__}: {exc}) — cannot verify the claim"
+                )
+            continue
+
+        if pred.kind == "key_exists":
+            verified.append(f"{pred.flag} (artifact present)")
+            continue
+
+        # last_modified_gte_run_date — mirrors CheckPredictorSkipWeightsFresh:
+        # the ISO date part, shape-guarded, compared lexicographically.
+        last_modified = head.get("LastModified")
+        lm_date = (
+            last_modified.strftime("%Y-%m-%d")
+            if hasattr(last_modified, "strftime")
+            else str(last_modified)[:10]
+        )
+        # The SF's own StringMatches '20*-*-*' shape guard, replicated: a
+        # non-ISO serialization must become a LOUD failure, never a silent
+        # lexicographic wrong-pass.
+        if not (len(lm_date) == 10 and lm_date.startswith("20")
+                and lm_date[4] == "-" and lm_date[7] == "-"):
+            violations.append(
+                f"{pred.flag}=true but s3://{ctx.bucket}/{key} LastModified "
+                f"parsed as {lm_date!r}, which is not YYYY-MM-DD — cannot "
+                f"compare against run_date {ctx.run_date}"
+            )
+            continue
+        if lm_date < ctx.run_date:
+            violations.append(
+                f"{pred.flag}=true but s3://{ctx.bucket}/{key} LastModified date "
+                f"{lm_date} < run_date {ctx.run_date} — no completed {pred.stage} "
+                f"for this run_date. Either re-run WITHOUT {pred.flag}, or pass "
+                f"the ORIGINAL run_date if this is a cross-UTC-midnight recovery "
+                f"rerun (see {pred.sf_guard})"
+            )
+            continue
+        verified.append(f"{pred.flag} (artifact dated {lm_date} >= {ctx.run_date})")
+
+    if violations:
+        return CheckResult(
+            name=name,
+            status="fail",
+            message=(
+                f"{len(violations)} incoherent skip claim(s) for run_date "
+                f"{ctx.run_date} — halting before spot spend: {violations[0]}"
+            ),
+            details={
+                "run_date": ctx.run_date,
+                "violations": violations,
+                "verified": verified,
+                "claims_checked": len(claimed),
+            },
+            elapsed_seconds=time.time() - t0,
+        )
+
+    return CheckResult(
+        name=name,
+        status="ok",
+        message=(
+            f"run_date={ctx.run_date}: {len(verified)} skip claim(s) backed by "
+            f"a live artifact ({'; '.join(verified)})"
+        ),
+        details={"run_date": ctx.run_date, "verified": verified,
+                 "claims_checked": len(claimed)},
+        elapsed_seconds=time.time() - t0,
+    )
+
+
 def check_lambda_memory_headroom(ctx: PreflightContext) -> CheckResult:
     """Each SF-invoked Lambda's alias-resolved memory exceeds its observed
     30d ``maxMemoryUsed`` high-water mark by a stated margin.
@@ -1912,6 +2111,8 @@ CHECKS = [
     check_tool_contracts,
     check_definition_input_coherence,
     check_lambda_memory_headroom,
+    # alpha-engine-config-I7443:
+    check_skip_flag_artifact_coherence,
 ]
 
 
@@ -1965,6 +2166,7 @@ CHECK_CAPABILITIES: "dict[str, frozenset[str]]" = {
     "check_tool_contracts": frozenset({CAP_AWS, CAP_CHECKOUT}),
     "check_definition_input_coherence": frozenset({CAP_AWS}),
     "check_lambda_memory_headroom": frozenset({CAP_AWS}),
+    "check_skip_flag_artifact_coherence": frozenset({CAP_AWS}),
 }
 
 
@@ -1988,6 +2190,8 @@ def _previous_trading_day_str() -> str:
 def run_preflight(
     bucket: str = DEFAULT_BUCKET,
     capabilities: "frozenset[str] | set[str] | None" = None,
+    run_date: "str | None" = None,
+    skip_flags: "dict | None" = None,
 ) -> tuple[int, list[CheckResult]]:
     """Execute the checks this environment can run. Returns (n_failures, results).
 
@@ -1997,13 +2201,21 @@ def run_preflight(
     ``LAMBDA_CAPABILITIES``, the laptop and spot box have FULL_CAPABILITIES
     (the default, so the CLI and every existing caller are unchanged).
 
+    ``run_date`` / ``skip_flags`` carry the SF execution input when the caller
+    has it (alpha-engine-config-I7443). Both default to absent so every
+    existing caller — the CLI, the spot box — is unchanged and
+    ``check_skip_flag_artifact_coherence`` reports "nothing claimed".
+
     Each check runs in its own try/except — a single check raising must
     not abort the others (we want the full picture, not first-fail-bail).
     """
     caps = frozenset(capabilities) if capabilities is not None else FULL_CAPABILITIES
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     prior = _previous_trading_day_str()
-    ctx = PreflightContext(bucket=bucket, today=today, prior_trading_day=prior)
+    ctx = PreflightContext(
+        bucket=bucket, today=today, prior_trading_day=prior,
+        run_date=run_date, skip_flags=dict(skip_flags or {}),
+    )
 
     results: list[CheckResult] = []
     for check_fn in CHECKS:

--- a/tests/test_sf_preflight.py
+++ b/tests/test_sf_preflight.py
@@ -1090,3 +1090,225 @@ def test_definition_input_coherence_ignores_mid_flow_refs():
     assert result.status == "ok", result.details
     assert result.details["undecidable_refs"] >= 3
     assert result.details["checked"] >= 1  # $.pipeline_role still verified
+
+
+# ── check_skip_flag_artifact_coherence (alpha-engine-config-I7443) ────────────
+#
+# The live shape these reproduce: on 2026-08-15's cycle, two recovery
+# executions carried `skip_predictor_training: true` with `run_date:
+# 2026-08-16` while the weights manifest was last written 2026-08-15. Both
+# died on the in-SF `PredictorSkipWeightsStale` guard — correct, but only
+# after a spot dispatch and ~18 minutes, twice. This check asserts the same
+# predicate at the pre-spend gate (sf-pipeline-policy §2.2).
+
+
+from datetime import datetime as _dt, timezone as _tz  # noqa: E402
+
+
+class _NotFound(Exception):
+    def __init__(self):
+        super().__init__("Not Found")
+        self.response = {"Error": {"Code": "404"}}
+
+
+def _skip_ctx(run_date="2026-08-16", **flags) -> sfp.PreflightContext:
+    return sfp.PreflightContext(
+        bucket="alpha-engine-research",
+        today="2026-08-16",
+        prior_trading_day="2026-08-14",
+        run_date=run_date,
+        skip_flags=dict(flags),
+    )
+
+
+def _s3_with_last_modified(day: str) -> MagicMock:
+    s3 = MagicMock()
+    s3.head_object.return_value = {
+        "LastModified": _dt.fromisoformat(f"{day}T12:00:00+00:00").astimezone(_tz.utc)
+    }
+    return s3
+
+
+def test_skip_coherence_fails_when_artifact_predates_run_date():
+    """THE regression: manifest dated 2026-08-15, run_date 2026-08-16."""
+    ctx = _skip_ctx(run_date="2026-08-16", skip_predictor_training=True)
+    with patch("boto3.client", return_value=_s3_with_last_modified("2026-08-15")):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "fail"
+    assert "2026-08-15 < run_date 2026-08-16" in res.details["violations"][0]
+    assert "CheckPredictorSkipWeightsFresh" in res.details["violations"][0]
+
+
+def test_skip_coherence_passes_when_artifact_is_current():
+    ctx = _skip_ctx(run_date="2026-08-15", skip_predictor_training=True)
+    with patch("boto3.client", return_value=_s3_with_last_modified("2026-08-15")):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "ok"
+    assert res.details["claims_checked"] == 1
+
+
+def test_skip_coherence_fails_when_the_artifact_does_not_exist():
+    ctx = _skip_ctx(skip_predictor_training=True)
+    s3 = MagicMock()
+    s3.head_object.side_effect = _NotFound()
+    with patch("boto3.client", return_value=s3):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "fail"
+    assert "does not exist" in res.details["violations"][0]
+
+
+def test_skip_coherence_unreadable_artifact_is_unknown_not_pass():
+    """§2.3a: a verdict that cannot be read is UNKNOWN, never a pass. An S3
+    error other than 404 must fail loudly rather than waving the claim
+    through — the same rule that made the watchdog's UNREADABLE page."""
+    ctx = _skip_ctx(skip_predictor_training=True)
+    s3 = MagicMock()
+    s3.head_object.side_effect = RuntimeError("s3 5xx")
+    with patch("boto3.client", return_value=s3):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "fail"
+    assert "unreadable" in res.details["violations"][0]
+
+
+def test_skip_coherence_rejects_a_non_iso_last_modified_instead_of_wrong_passing():
+    """The SF's StringMatches '20*-*-*' shape guard, replicated. A non-ISO
+    serialization compared lexicographically could SILENTLY wrong-pass; it
+    must become the loud path instead."""
+    ctx = _skip_ctx(skip_predictor_training=True)
+    s3 = MagicMock()
+    s3.head_object.return_value = {"LastModified": "Sat, 15 Aug 2026 12:00:00 GMT"}
+    with patch("boto3.client", return_value=s3):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "fail"
+    assert "not YYYY-MM-DD" in res.details["violations"][0]
+
+
+def test_skip_coherence_is_silent_when_the_flag_is_not_claimed():
+    """An unclaimed skip must cost zero S3 calls — this runs on every
+    weekly execution, including the clean Saturday one."""
+    ctx = _skip_ctx(skip_scanner=True)  # registered flags not among them
+    s3 = MagicMock()
+    with patch("boto3.client", return_value=s3):
+        res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "ok"
+    assert res.details["claims_checked"] == 0
+    s3.head_object.assert_not_called()
+
+
+def test_skip_coherence_without_execution_input_is_ok_not_fail():
+    """The CLI and the spot box call run_preflight without the SF input.
+    That is 'nothing observed', not 'violation' — this gate must not start
+    halting the pipeline for callers that never passed a payload."""
+    ctx = _ctx()  # no run_date, no skip_flags
+    res = sfp.check_skip_flag_artifact_coherence(ctx)
+    assert res.status == "ok"
+    assert res.details["claims_checked"] == 0
+
+
+def test_skip_predicate_matches_the_sf_definitions_own_guard():
+    """Anti-drift pin. This check duplicates a predicate the SF already
+    owns; duplication is only safe while the two agree, so assert against
+    the definition itself rather than against a copy of it.
+
+    Every registry entry must name a real state in step_function.json, and
+    the predictor entry's S3 object path must be the one that state heads.
+    """
+    import json
+    from pathlib import Path
+
+    defn = json.loads(
+        (Path(__file__).resolve().parents[1] / "infrastructure" / "step_function.json").read_text()
+    )
+
+    def walk(states):
+        for n, s in states.items():
+            yield n, s
+            if s.get("Type") == "Parallel":
+                for b in s.get("Branches", []):
+                    yield from walk(b.get("States", {}))
+            if s.get("Type") == "Map":
+                it = s.get("Iterator") or s.get("ItemProcessor") or {}
+                yield from walk(it.get("States", {}))
+
+    states = dict(walk(defn["States"]))
+
+    assert sfp.SKIP_ARTIFACT_PREDICATES, "registry must not be empty"
+    for pred in sfp.SKIP_ARTIFACT_PREDICATES:
+        assert pred.sf_guard in states, (
+            f"{pred.flag} names sf_guard={pred.sf_guard!r}, which is not a state "
+            f"in step_function.json — this check would be the SOLE author of a "
+            f"correctness rule instead of an early copy of the SF's own"
+        )
+
+    # The predictor entry specifically: the object path must match the
+    # HeadObject the SF performs, or the preflight asserts against a
+    # different artifact than the guard it claims to mirror.
+    validate = states["ValidatePredictorSkipWeightsFresh"]
+    sf_target = validate["Parameters"]["Key"]
+    pred = next(p for p in sfp.SKIP_ARTIFACT_PREDICATES
+                if p.flag == "skip_predictor_training")
+    assert pred.key == sf_target, (
+        f"preflight checks {pred.key!r} but ValidatePredictorSkipWeightsFresh "
+        f"heads {sf_target!r} — the two have drifted"
+    )
+
+    # ...and the comparison must still be >= run_date, not something else.
+    choice = states["CheckPredictorSkipWeightsFresh"]["Choices"][0]["And"]
+    assert any(
+        c.get("StringGreaterThanEqualsPath") == "$.run_date" for c in choice
+    ), (
+        "CheckPredictorSkipWeightsFresh no longer compares >= $.run_date; "
+        "check_skip_flag_artifact_coherence's last_modified_gte_run_date "
+        "predicate is now wrong"
+    )
+
+
+def test_weekly_preflight_receives_the_execution_input():
+    """alpha-engine-config-I7443 — structural pin on the definition.
+
+    WeeklyPreflight was the ONLY ``lambda:invoke`` task in this definition
+    with no ``Payload`` at all. Under the optimized Lambda integration an
+    omitted Payload means the function is invoked with no event, so the
+    handler received ``{}`` on every real execution: its documented
+    ``bucket`` / ``sf_name`` overrides were dead code in production, and
+    ``check_skip_flag_artifact_coherence`` would have had nothing to check.
+
+    A gate that cannot see the input it is gating is not a gate. This pins
+    that it can — and that every other lambda:invoke still passes one, so
+    the omission cannot silently reappear on a new state.
+    """
+    import json
+    from pathlib import Path
+
+    defn = json.loads(
+        (Path(__file__).resolve().parents[1] / "infrastructure" / "step_function.json").read_text()
+    )
+
+    def walk(states):
+        for n, s in states.items():
+            yield n, s
+            if s.get("Type") == "Parallel":
+                for b in s.get("Branches", []):
+                    yield from walk(b.get("States", {}))
+            if s.get("Type") == "Map":
+                it = s.get("Iterator") or s.get("ItemProcessor") or {}
+                yield from walk(it.get("States", {}))
+
+    states = dict(walk(defn["States"]))
+
+    params = states["WeeklyPreflight"]["Parameters"]
+    assert params.get("Payload.$") == "$", (
+        "WeeklyPreflight must receive the whole execution input; without it "
+        "check_skip_flag_artifact_coherence sees no run_date and no skip_* "
+        "flags and silently reports 'nothing claimed' on every run"
+    )
+
+    missing = [
+        name for name, s in states.items()
+        if s.get("Resource", "").endswith("lambda:invoke")
+        and not any(k.startswith("Payload") for k in s.get("Parameters", {}))
+    ]
+    assert not missing, (
+        f"lambda:invoke states with no Payload receive an empty event: {missing}. "
+        f"Every handler's event contract is dead code until one is passed."
+    )


### PR DESCRIPTION
## What this fixes

A recovery rerun's input is a **claim**: every `skip_X: true` asserts *"stage X already produced its artifact for this `run_date`, so do not spend on it again."* The SF carries in-pipeline guards for when that claim is false — but they fire **late**.

Measured on the 2026-08-15 cycle: `watch-rerun-2026-08-16-1` and `-2` each carried `skip_predictor_training: true` alongside `run_date: 2026-08-16`, while the weights manifest was last written `2026-08-15`. Both died on `PredictorSkipWeightsStale` — the guard worked — but only after the spot bootstrap had dispatched and ~18 minutes had elapsed, **twice**.

> sf-pipeline-policy §2.2: *"Everything cheaply knowable before spend must be known before spend."*

A `HeadObject` is cheaply knowable. Tracker: `alpha-engine-config-I7443`.

## What changed

**`check_skip_flag_artifact_coherence`** moves that predicate to the existing `WeeklyPreflight` pre-spend gate, which already runs fail-hard before `AcquireMutex` and before any spot dispatch. It does **not** replace the in-SF guards — they remain the authority and the last line, since a preflight pass is not a promise about a later instant — but an incoherent input now fails in seconds rather than after a spot launch, **whatever authored it**: the rerun helper, `sf-watch`, or a hand-written `StartExecution`.

That last point is why this is the right layer. Investigation for `I7443` established that `weekly_sf_rerun.py` is *not* at fault — a live `--dry-run` against the same source execution derives `run_date: 2026-08-15` correctly, with provenance *"explicit run_date in the failed execution's input"*. The two bad reruns carried `skip_aggregate_costs: false` and `skip_replay_concordance: false`, and the helper never emits a `false` skip flag (it omits dropped keys entirely), so those inputs were hand-authored and bypassed the helper. Hardening the helper would not have prevented this; asserting at the gate does.

### The definition change, and why it was necessary

`WeeklyPreflight` was the **only** `lambda:invoke` task in `step_function.json` with no `Payload` at all:

```
WeeklyPreflight                     Payload keys: NONE
LibPinDriftCheck                    Payload keys: ['Payload']
PipelineContractCheck               Payload keys: ['Payload']
SubstrateHealthGate                 Payload keys: ['Payload']
...24 others                        Payload keys: ['Payload']
```

Under the optimized Lambda integration an omitted `Payload` means the function is invoked with no event. So the handler received `{}` on **every real execution**, its documented `bucket` / `sf_name` overrides were dead code in production, and `test_bucket_override_from_event` pinned behaviour the definition made unreachable. A gate that cannot see the input it is gating is not a gate.

It now receives `Payload.$: "$"` — deliberately the whole input rather than this definition's usual narrow projection. The `skip_*` set is ~25 dynamic keys, so an enumerated projection would **silently stop covering any stage added later**, and coverage must be a function of `sf_preflight`'s registry rather than of a list duplicated in the definition. A structural test pins that no `lambda:invoke` state lacks a `Payload`, so the omission cannot silently reappear on a new state.

**SOTA / delta:** the institutional approach is a narrow, explicit payload projection, and this deviates. The delta is stated above and is deliberate: with a dynamic key set, an explicit projection trades a silent coverage gap for a stylistic match. No secrets transit — the input holds `run_date`, the role, skip flags, an SNS topic ARN and an instance id.

### Anti-drift, because this duplicates an existing rule

The registry is deliberately small and evidence-backed: an entry is added **only** when the SF already carries the matching guard, so this is an early copy of an existing rule, never a new rule invented at the preflight layer. `test_skip_predicate_matches_the_sf_definitions_own_guard` asserts against `step_function.json` directly — every entry's `sf_guard` must name a real state, the S3 object path must equal the one `ValidatePredictorSkipWeightsFresh` heads, and the comparison must still be `>= $.run_date`. If the SF's rule moves, this test goes red rather than the copy silently going stale.

## It cannot spuriously halt the pipeline

This is a fail-hard gate on the Saturday critical path, so that property matters more than the feature:

| Situation | Result |
|---|---|
| Clean Saturday cron run (no registered skip claimed) | `ok`, **zero S3 calls** |
| Caller with no execution input (CLI, spot box) | `ok`, "nothing claimed" — absence is not a violation |
| Skip claimed, artifact current | `ok` |
| Skip claimed, artifact stale or missing | `fail` — the intended catch |
| S3 error other than 404 | `fail` — UNKNOWN is never a pass (§2.3a) |
| `LastModified` non-ISO | `fail` — replicates the SF's own `StringMatches '20*-*-*'` shape guard, so a lexicographic compare cannot silently wrong-pass |

## Validation

- `tests/test_sf_preflight.py` — **62 passed** (9 new + the structural pin)
- `infrastructure/lambdas/weekly-preflight/test_handler.py` — **9 passed**, under pytest *and* as a direct script (CI invokes it both ways; the new class was initially appended after the `__main__` guard, where a direct run would never have collected it — fixed)
- All SF/definition suites: `2195 passed`
- Every new test verified to **fail against the unfixed source** (11 of 12; the 12th is a behaviour-preservation guard)
- Failures diffed against pristine `origin/main`: **4 before, 4 after, zero introduced** — all local-environment (`pyarrow` absent, two bootstrap tests need sibling private checkouts), which CI provides

Rehearsal-path: .github/workflows/canary-replay.yml

The nominated mechanism is `canary-replay.yml` ("Canary Replay", dispatched per-PR via the `canary:replay` label) — it exercises the live definition path including `WeeklyPreflight`, which is what the `Payload.$` change alters. The check logic itself is fully CI-validated above (§7.2 route 1); the canary covers the definition half that unit tests structurally cannot.

**Verified-when:** after deploy, a `WeeklyPreflight` invocation reports `skip_flag_artifact_coherence` with a non-null `run_date` in its `details` — proving the payload now arrives — and an execution carrying a stale `skip_predictor_training` claim halts at `WeeklyPreflightGate` rather than at `PredictorSkipWeightsStale`.

**No IAM change:** the role's `ReadS3Config` already grants `s3:GetObject` on `alpha-engine-research/*`. No operator step.

## Related

- Closes-when for `alpha-engine-config-I7443` (cross-repo, so it will be closed by hand after live verification)
- `alpha-engine-config-I7441` closed as `premise-false` from the same investigation — degradation *does* survive a rerun; `#6055`'s `degraded_witness` retries every degraded stage, and cycle 2026-08-15's `SUCCEEDED` marker was honest
- `alpha-engine-config-I7442` (unrecoverable failure cause) and `#7444` (`--apply-iam` ships code) remain open

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
