### PR TITLE
fix(deploy): --apply-iam applies IAM and nothing else, and says when it changed nothing (config-I7444)

### DIFF
--- a/infrastructure/lambdas/_shared/apply_iam_policy.sh
+++ b/infrastructure/lambdas/_shared/apply_iam_policy.sh
@@ -47,11 +47,66 @@ apply_iam_policy() {
     echo "  IAM role exists: ${role_name}"
   fi
 
+  # Report whether this apply actually CHANGES anything
+  # (alpha-engine-config-I7444).
+  #
+  # put-role-policy is idempotent, so re-applying an unchanged document
+  # succeeds exactly like a real change and the caller's "IAM applied" line
+  # prints either way. The command is therefore indistinguishable from a
+  # no-op by reading its output — which is precisely how, on 2026-08-16, an
+  # operator ran this from a checkout on `main` while the changed
+  # iam-policy.json lived on an unmerged PR branch, saw the success line,
+  # and reasonably believed the grant had landed. It had not: the file that
+  # was applied was main's, identical to what was already live. The
+  # iam-policy-change-guard stayed red and the cause was invisible.
+  #
+  # Comparing live against the file first costs one read and converts an
+  # unfalsifiable "applied" into a statement with content. Best-effort by
+  # design: if the read or the comparison cannot be done, say so and apply
+  # anyway — a diagnostic must never be able to block the apply itself.
+  local live_doc="" verdict="unknown"
+  if live_doc="$(aws iam get-role-policy \
+        --role-name "${role_name}" \
+        --policy-name "${policy_name}" \
+        --query 'PolicyDocument' --output json 2>/dev/null)"; then
+    if command -v python3 >/dev/null 2>&1; then
+      verdict="$(python3 -c '
+import json, sys
+try:
+    live = json.loads(sys.argv[1])
+    disk = json.load(open(sys.argv[2]))
+except Exception:
+    print("unknown"); raise SystemExit(0)
+# Key-order- and whitespace-insensitive: only the semantic document matters.
+print("same" if json.dumps(live, sort_keys=True) == json.dumps(disk, sort_keys=True)
+      else "different")
+' "${live_doc}" "${policy_file}" 2>/dev/null || echo unknown)"
+    fi
+  else
+    # No inline policy of that name yet — a first apply is by definition a change.
+    verdict="absent"
+  fi
+
   echo "  Applying inline policy: ${policy_name}"
+  case "${verdict}" in
+    same)
+      echo "  NOTE: live policy already matches ${policy_file} — this apply is a NO-OP." >&2
+      echo "  NOTE: If you expected a change, you are almost certainly running from the" >&2
+      echo "  NOTE: wrong checkout: this reads iam-policy.json from the working tree, so" >&2
+      echo "  NOTE: a policy edit that lives on an unmerged branch requires running from" >&2
+      echo "  NOTE: THAT BRANCH (alpha-engine-config-I7444)." >&2
+      ;;
+    different) echo "  live policy DIFFERS from ${policy_file} — applying the change." ;;
+    absent)    echo "  no inline policy ${policy_name} on the role yet — first apply." ;;
+    *)         echo "  (could not compare live policy against ${policy_file}; applying anyway)" >&2 ;;
+  esac
+
   run aws iam put-role-policy \
     --role-name "${role_name}" \
     --policy-name "${policy_name}" \
     --policy-document "file://${policy_file}"
+
+  APPLY_IAM_POLICY_VERDICT="${verdict}"
 }
 
 # apply_iam_policy_on_deploy — the "#4472 auto-apply on merge" call site.

--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -89,7 +89,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
+++ b/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
@@ -96,7 +96,8 @@ if $APPLY_IAM; then
     --role-name "${ROLE_NAME}" \
     --policy-name "${POLICY_NAME}" \
     --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 # Package the handler into a zip in /tmp.

--- a/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
@@ -136,7 +136,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -127,7 +127,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -111,7 +111,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -188,7 +188,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -115,7 +115,8 @@ if $APPLY_IAM; then
     --role-name "${ROLE_NAME}" \
     --policy-name "${POLICY_NAME}" \
     --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 # Ensure the live Lambda env has the new structured-prefix var. Idempotent —

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -144,7 +144,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -105,7 +105,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -130,7 +130,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -117,7 +117,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/eod-precondition-probe/deploy.sh
+++ b/infrastructure/lambdas/eod-precondition-probe/deploy.sh
@@ -96,7 +96,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/eod-snapshot-existence-check/deploy.sh
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/deploy.sh
@@ -117,7 +117,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -111,7 +111,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/expense-collector/deploy.sh
+++ b/infrastructure/lambdas/expense-collector/deploy.sh
@@ -195,7 +195,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP_IAM; then

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -89,7 +89,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -98,7 +98,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -160,7 +160,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -137,7 +137,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 # ----- Apply alarms only -----------------------------------------------------

--- a/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
@@ -137,7 +137,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -85,7 +85,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -125,7 +125,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -270,7 +270,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP_IAM; then

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -111,7 +111,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
@@ -179,7 +179,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP_IAM; then

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -164,7 +164,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
+++ b/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
@@ -102,7 +102,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 # ----- 2. Bootstrap ----------------------------------------------------------

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -110,7 +110,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
+++ b/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
@@ -104,7 +104,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -102,7 +102,7 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
   exit 0
 fi
 

--- a/infrastructure/lambdas/substrate-health-gate/deploy.sh
+++ b/infrastructure/lambdas/substrate-health-gate/deploy.sh
@@ -94,7 +94,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
+++ b/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
@@ -82,7 +82,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
@@ -119,7 +119,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/infrastructure/lambdas/weekly-preflight/deploy.sh
+++ b/infrastructure/lambdas/weekly-preflight/deploy.sh
@@ -92,7 +92,8 @@ if $APPLY_IAM; then
   echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
   TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
   apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
-  echo "  ✓ IAM applied."
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
 fi
 
 if $BOOTSTRAP; then

--- a/tests/test_apply_iam_is_iam_only.py
+++ b/tests/test_apply_iam_is_iam_only.py
@@ -1,0 +1,141 @@
+"""`deploy.sh --apply-iam` applies IAM and NOTHING else (config-I7444).
+
+The measured incident, 2026-08-16. `nousergon-data-PR1400` changed
+`pipeline-watchdog/iam-policy.json`, and `iam-policy-change-guard` (a
+REQUIRED check) went red because the policy was not live. The operator ran
+the exact command the guard printed, from `~/Development/nousergon-data`,
+which was on `main`. Output ended `✓ IAM applied.` Two things had happened,
+neither of them visible:
+
+  1. The policy applied was **main's** — the change lived on an unmerged
+     branch — so `put-role-policy` wrote a document identical to what was
+     already live. A complete no-op that printed success.
+  2. `--apply-iam` did not stop after applying IAM. The script continued into
+     `update-function-code` and **reverted the deployed Lambda to main's
+     code**, undoing a deploy, from a flag named `--apply-iam`.
+
+Two of the thirty-five deploy scripts (`freshness-monitor`,
+`ssm-reachability-probe`) already exited after applying. This module pins
+that property for all of them, so the correct behaviour cannot silently
+diverge again on a thirty-sixth.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+DEPLOY_SCRIPTS = sorted(REPO.glob("infrastructure/lambdas/*/deploy.sh"))
+
+# deploy.sh files that still hand-roll the role/policy apply inline instead of
+# sourcing _shared/apply_iam_policy.sh. Both predate the shared helper and
+# both additionally attach AWSLambdaBasicExecutionRole, which the shared
+# function does not yet support -- folding them in needs that parameter and is
+# tracked separately, so they are grandfathered here rather than rewritten
+# approximately.
+#
+# This list may only ever SHRINK. Adding to it is adding a copy of logic whose
+# duplication already produced one silent failure: `alert-drain-liveness-probe`
+# printed `apply_iam_policy: command not found` behind a `|| echo "expected in
+# CI"` and its IAM auto-apply had never once run (see the header of
+# _shared/apply_iam_policy.sh).
+GRANDFATHERED_INLINE_APPLY = frozenset({
+    "alpha-engine-alerts-forwarder",
+    "changelog-incident-mirror",
+})
+
+
+def _apply_iam_scripts() -> "list[Path]":
+    return [p for p in DEPLOY_SCRIPTS if "APPLY_IAM=false" in p.read_text()]
+
+
+def _apply_iam_block(path: Path) -> str:
+    m = re.search(r"if \$APPLY_IAM; then\n(.*?)\nfi\n", path.read_text(), re.S)
+    assert m, f"{path.parent.name}: no `if $APPLY_IAM; then ... fi` block found"
+    return m.group(1)
+
+
+def test_there_are_apply_iam_scripts_to_check():
+    """A guard that silently matches nothing is not a guard."""
+    assert len(_apply_iam_scripts()) >= 30
+
+
+@pytest.mark.parametrize(
+    "script", _apply_iam_scripts(), ids=lambda p: p.parent.name
+)
+def test_apply_iam_exits_and_never_falls_through_to_a_code_deploy(script: Path):
+    """`--apply-iam` must terminate the script.
+
+    Falling through means an operator applying a GRANT also ships whatever
+    code is in their working tree — which on 2026-08-16 silently reverted a
+    deployed Lambda to an older commit.
+    """
+    body = _apply_iam_block(script)
+    assert re.search(r"^\s*exit 0\s*$", body, re.M), (
+        f"{script.parent.name}/deploy.sh: the --apply-iam block does not exit, "
+        f"so it falls through into the code-deploy path. A flag named "
+        f"--apply-iam must not update function code. Mirror "
+        f"freshness-monitor/deploy.sh."
+    )
+
+
+@pytest.mark.parametrize(
+    "script", _apply_iam_scripts(), ids=lambda p: p.parent.name
+)
+def test_apply_iam_says_that_nothing_else_was_touched(script: Path):
+    """The operator must be able to tell from the output that this did not
+    deploy anything. `✓ IAM applied.` alone does not say that."""
+    body = _apply_iam_block(script)
+    assert "Nothing else was touched" in body, (
+        f"{script.parent.name}/deploy.sh: the --apply-iam block does not state "
+        f"that it touched nothing else. The operator reads this line to know "
+        f"whether a code deploy happened."
+    )
+
+
+@pytest.mark.parametrize(
+    "script", _apply_iam_scripts(), ids=lambda p: p.parent.name
+)
+def test_apply_iam_uses_the_shared_helper(script: Path):
+    """One applier, so the no-op detection added for I7444 reaches every
+    caller. The grandfather list may only shrink."""
+    name = script.parent.name
+    body = _apply_iam_block(script)
+    if name in GRANDFATHERED_INLINE_APPLY:
+        pytest.skip(f"{name} is grandfathered; the list may only shrink")
+    assert "apply_iam_policy " in body, (
+        f"{name}/deploy.sh hand-rolls the IAM apply instead of calling "
+        f"apply_iam_policy from _shared/apply_iam_policy.sh. A second copy "
+        f"does not get the no-op detection, and duplication here has already "
+        f"produced one silent failure."
+    )
+
+
+def test_grandfather_list_names_only_real_scripts():
+    """A stale grandfather entry hides a script that no longer exists, and
+    makes the list look smaller than the debt it represents."""
+    names = {p.parent.name for p in _apply_iam_scripts()}
+    unknown = GRANDFATHERED_INLINE_APPLY - names
+    assert not unknown, (
+        f"grandfather list names scripts that do not exist or no longer "
+        f"support --apply-iam: {sorted(unknown)}"
+    )
+
+
+def test_shared_applier_detects_a_no_op_apply():
+    """The header property: apply_iam_policy compares live against the file
+    and says which, so an apply from the wrong checkout is not silent."""
+    shared = (REPO / "infrastructure" / "lambdas" / "_shared"
+              / "apply_iam_policy.sh").read_text()
+    assert "get-role-policy" in shared, (
+        "apply_iam_policy no longer reads the live policy, so it cannot tell "
+        "a real change from a no-op — the I7444 failure mode is back"
+    )
+    for marker in ("NO-OP", "wrong checkout", "DIFFERS"):
+        assert marker in shared, (
+            f"apply_iam_policy no longer reports {marker!r}; the operator "
+            f"cannot distinguish an applied change from an idempotent rewrite"
+        )


### PR DESCRIPTION
## The incident this fixes, measured 2026-08-16

`nousergon-data-PR1400` changed `pipeline-watchdog/iam-policy.json`, and `iam-policy-change-guard` — a **required** check — went red because the policy was not live. The operator ran the exact command the guard printed, from a checkout on `main`. Output ended `✓ IAM applied.`

Two things had happened, **neither visible in that output**:

1. **The policy applied was `main`'s.** The change lived on an unmerged branch, so `put-role-policy` wrote a document identical to what was already live — a complete no-op that printed success. `put-role-policy` is idempotent, so re-applying an unchanged document succeeds *exactly* like a real change: the command could not be distinguished from a no-op by reading it.
2. **`--apply-iam` did not stop after applying IAM.** The script fell through into `update-function-code` and **reverted the deployed Lambda to `main`'s code** — undoing a deploy, from a flag named `--apply-iam`.

Tracker: `alpha-engine-config-I7444`.

## Fix 1 — the apply says whether it changed anything

`apply_iam_policy` now reads the live inline policy and compares it against the file before writing, then reports which:

```
live policy DIFFERS from <file> — applying the change.
no inline policy <name> on the role yet — first apply.
NOTE: live policy already matches <file> — this apply is a NO-OP.
NOTE: If you expected a change, you are almost certainly running from the
NOTE: wrong checkout: this reads iam-policy.json from the working tree, so
NOTE: a policy edit that lives on an unmerged branch requires running from
NOTE: THAT BRANCH.
```

The no-op notice names the *actual* cause, because running from the wrong checkout is what produces it. Best-effort by design: if the read or the comparison cannot be done it says so and applies anyway — **a diagnostic must never be able to block the apply itself**. One edit in `_shared/apply_iam_policy.sh`, so all 35 callers gain it with zero call-site changes.

## Fix 2 — `--apply-iam` exits

**Two of the thirty-five deploy scripts already did this**, and that is what makes this a sweep rather than an invention:

| | count |
|---|---|
| already exited (`freshness-monitor`, `ssm-reachability-probe`) | **2** |
| canonical block, no exit — rewritten mechanically | **31** |
| hand-rolled inline apply — patched individually | **2** |

The correct behaviour existed in-fleet and 33 scripts diverged from it, so this mirrors the existing pattern (`policy-shared-code`) rather than inventing one. The message is `freshness-monitor`'s, generalised: *"✓ IAM applied. Nothing else was touched — no code, no env, no alarms."*

The two hand-rolled scripts (`alpha-engine-alerts-forwarder`, `changelog-incident-mirror`) additionally attach `AWSLambdaBasicExecutionRole`, which the shared helper does not support. Folding them in needs that parameter, so they were **not** rewritten approximately — they get the `exit 0` and are grandfathered for the helper, tracked below.

## The derived guard

`tests/test_apply_iam_is_iam_only.py`, parameterised over every `deploy.sh` supporting the flag. Each block must: **exit**, **state that nothing else was touched**, and **use the shared helper**.

The two inline appliers sit in a `GRANDFATHERED_INLINE_APPLY` list that **may only shrink** — the same convention `test_no_imperative_alarm_authorship.py` already uses. That list is not cosmetic: a second copy does not get the no-op detection, and duplication here has already produced one silent failure. From the shared file's own header:

> `alert-drain-liveness-probe/deploy.sh` printed `apply_iam_policy: command not found` / `WARN: IAM auto-apply failed (expected in CI — role lacks iam:PutRolePolicy)`. It had never sourced this file. The WARN named a cause that could not have been true, read as benign, and the auto-apply feature had therefore never executed on that lambda.

A further test asserts the grandfather list names only scripts that actually exist, so a stale entry cannot make the debt look smaller than it is.

## Validation

- `tests/test_apply_iam_is_iam_only.py` — **106 passed, 2 skipped** (the grandfathered pair)
- **68 of those assertions fail against the unfixed tree** — verified by stashing `infrastructure/lambdas/` and re-running
- Deploy/IAM suites repo-wide: **660 passed**, 1 pre-existing failure unchanged (`test_bootstrap_clones_private_config_package`, needs a sibling private checkout)
- `bash -n` clean on the shared file and on both rewrite shapes

Rehearsal-exempt: structural

This changes shell control flow and adds a static guard; there is no runtime behaviour a rehearsal could exercise that `bash -n` plus the parameterised guard do not already cover, and the AWS calls are unchanged apart from one added read.

## Out of scope, named and filed

- Folding `alpha-engine-alerts-forwarder` and `changelog-incident-mirror` onto the shared helper needs an optional managed-policy-ARN parameter — filed as `alpha-engine-config-I7447`.

## Related

- `alpha-engine-config-I7440` — the PR whose operator step exposed this
- `nousergon-data-PR1401` (`config-I7443`) is open against the same repo and touches disjoint files; no merge order required

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
