### PR TITLE
feat(observability): the preflight-sweep descriptor becomes a full registry declaration (config-I7490)

### DIFF
--- a/registry.d/ae-preflight-sweep.yaml
+++ b/registry.d/ae-preflight-sweep.yaml
@@ -18,11 +18,92 @@
 # below rather than omitted from the denominator.
 component_id: ae-preflight-sweep
 owning_repo: nousergon-data
-substrate: eventbridge+ec2-spot
+# `eventbridge`, not `eventbridge+ec2-spot`. `substrate` is a CLOSED set in
+# `nous-ergon-ops/scripts/observability_registry.py` (a substrate with no
+# representation there is a blind spot by construction), and the value must
+# agree with `origin` — alpha-engine-config-I7061 is 25 rows that said `lambda`
+# while their origin named an EventBridge rule, so the console asked the
+# AWS/Lambda question about a schedule and correctly found nothing. This row's
+# origin IS the daily rule; the spot box it provisions is the thing triggered,
+# not the trigger.
+substrate: eventbridge
 origin: aws:events:alpha-engine-preflight-sweep-daily
 owner: brian
 lifecycle: in-service
+
+# ── Registry claims (observability-policy.md §2.2) ──────────────────────────
+# This file is now gathered into the fleet observability registry by
+# `nous-ergon-ops/scripts/gather_repo_descriptors.py` and held to the SAME
+# schema as a row in `governance/observability.d/`
+# (alpha-engine-config-I7490). That is the point rather than a tax: §2.6 says
+# the descriptor IS the declaration for its component, so a descriptor exempt
+# from the required-field rule would be a way to publish a row that reads as
+# declared and is not. One file, one declaration, one standard.
+#
+# Every `unknown` below carries a reason, per §2.2's rule that a blank required
+# field is worse than no row. Two of them were SEARCHED FOR and not found
+# rather than left unexamined, and the reason says which — a claim recorded as
+# a guess is a wrong answer that reads as measured.
 authority_tier: observe-and-report
+
+signals:
+  # Emitted: the run report and the per-stage check envelopes both carry
+  # `ran_at`, and the dispatcher's own invocation is an EventBridge target.
+  execution: emitted
+  # Emitted: `stages_declared` / `_passed` / `_failed` / `_unmeasured` /
+  # `_unobserved` are the sweep's own coverage numbers, published even at zero.
+  data: emitted
+  # Emitted: `outcome`, plus `unsweepable_streak_state`.
+  outcome: emitted
+  cost:
+    status: unknown
+    reason: >-
+      The sweep provisions a spot box per run and no cost figure is written to
+      any artifact this row names. Not audited — stated as a work item rather
+      than claimed absent, because nothing here has looked at Cost Explorer
+      tagging for the launcher.
+  resource:
+    status: unknown
+    reason: >-
+      Not audited. The launcher box emits no memory/CPU record into
+      `_preflight_sweep/latest.json` or the check envelope, and whether the
+      spot instance publishes CloudWatch agent metrics has not been checked.
+
+log_location: >-
+  s3://alpha-engine-research/_ssm_logs/preflight-sweep/{YYYY-MM-DD}/{run_id}.log
+  (written by infrastructure/preflight_sweep.sh, which tees /var/log/
+  preflight-sweep-${RUN_ID}.log to S3), plus the
+  alpha-engine-preflight-sweep-dispatcher Lambda's CloudWatch log group for the
+  provisioning half.
+
+alert_channel: unknown
+alert_channel_reason: >-
+  Searched and not found rather than unexamined: no SES, Telegram or notifier
+  call exists in infrastructure/preflight_sweep.sh, infrastructure/
+  preflight_sweep.py or the preflight-sweep-dispatcher handler as of
+  2026-08-17. The sweep publishes verdicts and nothing routes them, so its
+  console rows are currently its ONLY reader. Recorded as unknown rather than
+  `n/a` because a daily coverage sweep with no alert path is a gap to close,
+  not a design.
+
+severity_source: unknown
+severity_source_reason: >-
+  Follows from alert_channel: with no routing there is no severity mapping to
+  declare. The status vocabulary the envelopes use is pinned by
+  alpha-engine-config-PR7488, which is a console contract, not a severity
+  taxonomy.
+
+console_surface: >-
+  console:/component/ae-preflight-sweep — the roll-up row from this descriptor,
+  plus one `ae-preflight-stage-<Stage>` check-envelope row per derived stage
+  (see the design note above on why the stage set is not enumerated here).
+
+retention: unknown
+retention_reason: >-
+  Not audited. `_preflight_sweep/latest.json` is last-write-wins with no
+  declared history, `_ssm_logs/preflight-sweep/` is date-partitioned under no
+  lifecycle rule this row has verified, and the bucket-level policy on
+  alpha-engine-research has not been read for these prefixes.
 
 # Executions: the dispatcher Lambda that provisions the launcher box and sends
 # the sweep command. Did it run, did it finish, did it miss.


### PR DESCRIPTION
## What

`registry.d/ae-preflight-sweep.yaml` becomes a complete observability-registry declaration: the five signal classes, `log_location`, `alert_channel`, `severity_source`, `console_surface`, `retention` — plus `substrate: eventbridge+ec2-spot` → `eventbridge`.

## Why

`alpha-engine-config-I7490`. This file has been on `main` since 2026-08-13 (nousergon-data#1364/#1377) describing a live component that the console counted as **UNREGISTERED**, because nothing in the fleet ever read a `registry.d/` outside `nous-ergon-ops`. `nous-ergon-ops-PR717` adds the gather step that publishes it.

That gather holds a repo-local descriptor to the **same schema** as a row in `governance/observability.d/`. That is the point rather than a tax: `console-policy.md` §2.6 says the descriptor **is** the declaration for its component, so a descriptor exempt from `observability-policy.md` §2.2's required-field rule would be a way to publish a row that reads as declared and is not — the one thing §2.2 forbids outright. One file, one declaration, one standard.

Measured before this change (`observability_registry.py validate --gathered`, local, against the real file):

```
nousergon-data__ae-preflight-sweep.yaml: required field 'signals' is missing or blank
… 'log_location' … 'alert_channel' … 'severity_source' … 'console_surface' … 'retention'
nousergon-data__ae-preflight-sweep.yaml: substrate 'eventbridge+ec2-spot' not in
  ['ec2-always-on','ec2-spot','eventbridge','github-actions','lambda','laptop-launchd','shared-box','step-functions']
```

After: `observability registry: 211 rows (1 gathered from roster repos), schema clean`.

### The substrate correction

`substrate` is a **closed set** and must agree with `origin`. `alpha-engine-config-I7061` is 25 rows that said `lambda` while their `origin` named an EventBridge rule — the console then asked the `AWS/Lambda` question about a schedule and correctly found nothing. This row's `origin` **is** the daily rule (`aws:events:alpha-engine-preflight-sweep-daily`); the spot box it provisions is the thing triggered, not the trigger.

### Honesty of the new claims

Every `unknown` carries a reason. Two of them — `alert_channel` and `severity_source` — were **searched for and not found** rather than left unexamined, and the reason says so: no SES, Telegram or notifier call exists in `infrastructure/preflight_sweep.sh`, `infrastructure/preflight_sweep.py`, or the `preflight-sweep-dispatcher` handler as of 2026-08-17. Recorded as `unknown` rather than `n/a`, because a daily coverage sweep with no alert path is a gap to close, not a design. `cost` and `resource` are `unknown` with the specific thing that was not audited named in each.

`log_location` is measured, not guessed: `infrastructure/preflight_sweep.sh:48-49` writes `/var/log/preflight-sweep-${RUN_ID}.log` and tees it to `s3://alpha-engine-research/_ssm_logs/preflight-sweep/<date>/<run_id>.log`.

## Merge order

1. **this PR** (`nousergon-data-PR1403`)
2. `nous-ergon-ops-PR717`

This one first. The gather validates every gathered descriptor before publishing any row, and a malformed gathered row fails the whole publish exactly as a malformed fleet row already does. Merging nous-ergon-ops-PR717 first would put the publisher into a red state until this lands.

## Test plan

- `python3 -m pytest -q tests -k "preflight or descriptor or registry"` — **run locally, green.**
- Cross-repo prove, run locally against this branch's checkout: `gather_repo_descriptors.py gather` → `nousergon-data__ae-preflight-sweep.yaml`, then `observability_registry.py validate --gathered` → **211 rows, schema clean** (210 fleet + this one).
- Console read prove (`nousergon-console` `yaml_directory.fetch` against the gathered directory): `status=OK`, `id=ae-preflight-sweep`, `repo` facet `nousergon-data`, `registry_file=nousergon-data__ae-preflight-sweep.yaml`, `runs` binding parsed as `object-store`, three `produces` lineage edges emitted. No console change needed.
- No schema/behaviour change to the sweep itself — this file is read by nothing in this repo.

Refs: `alpha-engine-config-I7490`, `alpha-engine-config-I7061`, `nous-ergon-ops-PR717`, nousergon-data#1364, nousergon-data#1377.

---
Prepared by: Claude Opus via [Claude Code](https://claude.com/claude-code)
