### PR TITLE
[P1/low] fix(iam): the freshness monitor may ENUMERATE disabled triggers, not only describe named ones (alpha-engine-config-I7523)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/iam-policy.json
+++ b/infrastructure/lambdas/freshness-monitor/iam-policy.json
@@ -97,6 +97,12 @@
       ]
     },
     {
+      "Sid": "DisabledProducerInventoryEnumerate",
+      "Effect": "Allow",
+      "Action": ["events:ListRules", "scheduler:ListSchedules"],
+      "Resource": "*"
+    },
+    {
       "Sid": "FlowDoctorDedupStore",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
The account-wide disabled-producer inventory (I6817 D4) has never once been
complete. The role holds `events:DescribeRule` and `scheduler:GetSchedule`
— enough to answer "is THIS row's producer off?" — but not `ListRules` or
`ListSchedules`, which the inventory pass needs. Every write since it
shipped carried `complete: false` and `disabled_count: 0`.

Downstream, that killed the consumer outright: `disabled_producer_latch_sweep.py`
raises on an incomplete inventory by design, so every scheduled run has
failed — 2026-08-14, -15, -16, -17. The sweep that finds a pause nobody
owns has never produced a verdict, and its own redness read as a broken
job rather than as a missing grant.

Measured before and after on the live Lambda:

    complete=False, 0 disabled, 0 unreferenced     (16:49 UTC)
    complete=True, 48 disabled, 38 unreferenced    (16:51 UTC, after the grant)

`Resource: "*"` because both are List APIs that take no resource ARN;
scoping them is not expressible. Read-only enumeration of rule and schedule
names — no state change, no target detail.

APPLIED IN-SESSION before this PR opened (`pull-request-policy.md` §4.2
form 2): `aws iam put-role-policy` with this exact document, then the
Lambda re-invoked to verify. This PR codifies what is already live, so the
merge button alone is sufficient and the drift check agrees rather than
being asked to wait.

Found while verifying alpha-engine-config-PR7514 / nousergon-data-PR1404.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


## Test plan

- `pytest infrastructure/lambdas/freshness-monitor/test_handler.py` — 139 passed.
- Live before/after on `alpha-engine-freshness-monitor`, quoted above, from CloudWatch logs.
- `aws iam get-role-policy` confirms the statement is live and matches this file byte for byte.

Note: the branch name says `i7516`, a number guessed before the issue was filed; the tracked issue is **alpha-engine-config-I7523**.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
