### PR TITLE
fix(features): revive residual_momentum_ratio and factor_momentum_ratio (I7539)

### DIFF
--- a/features/compute.py
+++ b/features/compute.py
@@ -40,10 +40,12 @@ from dataclasses import dataclass
 
 import corporate_actions as ca
 from features.cross_sectional import apply_factor_zscores
+from features.factor_momentum import DEFAULT_FACTOR_LOADINGS, compute_factor_momentum_feature
 from features.feature_engineer import FEATURES, FEATURE_CFG, MIN_ROWS_FOR_FEATURES, compute_features
 from features.metron_supplemental import compute_metron_supplemental_features, write_metron_supplemental_snapshot
+from features.postflight import assert_no_zero_variance_features
 from features.private_pack import apply_private_features
-from features.registry import upload_registry
+from features.registry import GROUPS, upload_registry
 from features.writer import write_feature_snapshot
 
 log = logging.getLogger(__name__)
@@ -103,11 +105,18 @@ def make_source_series(values: list[str] | pd.Series, index: pd.Index | None = N
     cat = pd.Categorical(cleaned, categories=SOURCE_CATEGORIES)
     return pd.Series(cat, index=index)
 
-# Rows to keep per ticker before feature computation. The longest rolling
-# window is 252 rows (52w high/low); 280 provides a small buffer. Trimming
-# before the compute loop cuts base memory ~44% vs the full 2y slim cache
-# and lets each ticker's DataFrame be freed incrementally via pop().
-_FEATURE_WARMUP_ROWS = 280
+# Rows to keep per ticker before feature computation. The longest STACKED
+# rolling window is residual_momentum_ratio (alpha-engine-config-I7539): it
+# needs beta_60d's 60-row warmup BEFORE the 231-row cumulative-residual
+# window can start, then a 21-row shift on top — 60 + 231 + 21 = 312 rows
+# minimum for the latest (most recent) row to be non-NaN. Below that, the
+# per-ticker value is NaN for every ticker, and the compute.py store-row
+# fallback (`row[f] = float(val) if pd.notna(val) else 0.0`) silently turns
+# a universe-wide NaN into a universe-wide 0.0 — a zero-variance column that
+# passes every null-coverage check. 340 keeps a ~28-row buffer, matching the
+# ~10% margin the original 252->280 buffer used. Do not lower this without
+# re-deriving the deepest stacked window across feature_engineer.py.
+_FEATURE_WARMUP_ROWS = 340
 
 # Sub-sector benchmark ETFs (config#934) — SMH/IGV/XBI/PPH/XOP/KRE/ITA/GDX,
 # the distinct non-XL* symbols in constituents.GICS_SUBINDUSTRY_TO_ETF. Like
@@ -922,9 +931,10 @@ def compute_and_write(
     )
 
     # Trim price DataFrames to the last _FEATURE_WARMUP_ROWS rows before the
-    # compute loop. The longest rolling window is 252 rows; keeping 280 is
-    # sufficient. Trimming here reduces peak RSS on t3.micro by ~40%+ vs
-    # holding the full 2y slim cache in memory during feature computation.
+    # compute loop — see the constant's definition above for the derived
+    # minimum (alpha-engine-config-I7539). Trimming here reduces peak RSS on
+    # t3.micro by ~40%+ vs holding the full 2y slim cache in memory during
+    # feature computation.
     for _t in list(price_data.keys()):
         df = price_data[_t]
         if len(df) > _FEATURE_WARMUP_ROWS:
@@ -956,6 +966,18 @@ def compute_and_write(
     uso_series = macro.get("USO")
     vix3m_series = macro.get("VIX3M")
     hyoas_series = macro.get("HYOAS")
+
+    # alpha-engine-config-I7539: factor_momentum_ratio (W2.3, Gupta-Kelly) is a
+    # cross-sectional-time-series column — it needs the WHOLE universe panel's
+    # (date, close, loading) history at once (compute_factor_momentum_feature),
+    # not a single ticker's latest row. builders/backfill.py runs this as a
+    # second pass over ArcticDB, but nothing ran the equivalent second pass on
+    # this S3 daily snapshot path, so the FEATURES-loop fallback below
+    # (`row[f] = ... else 0.0`) silently wrote a universe-wide constant 0.0
+    # every day. Collect the slim (date, close, *loading) frame per ticker
+    # here — while featured_df is already in hand — so the second pass below
+    # can rebuild the long panel without re-computing or re-loading anything.
+    fm_frames: dict[str, pd.DataFrame] = {}
 
     for ticker in universe_tickers:
         try:
@@ -991,6 +1013,13 @@ def compute_and_write(
                 n_skip += 1
                 continue
 
+            _fm_loading_cols = [c for c in DEFAULT_FACTOR_LOADINGS if c in featured_df.columns]
+            if _fm_loading_cols:
+                _fm_slim = featured_df[["Close", *_fm_loading_cols]].rename(columns={"Close": "close"})
+                _fm_slim = _fm_slim.reset_index(names="date")
+                _fm_slim.insert(0, "ticker", ticker)
+                fm_frames[ticker] = _fm_slim
+
             latest = featured_df.iloc[-1]
             row = {"ticker": ticker}
             for f in FEATURES:
@@ -1025,6 +1054,54 @@ def compute_and_write(
     # ── 3. Write to S3 ───────────────────────────────────────────────────────
     features_df = pd.DataFrame(store_rows)
 
+    # alpha-engine-config-I7539: factor_momentum_ratio second pass. Rebuild the
+    # long panel from the slim per-ticker frames collected in the compute loop
+    # above and run the SAME cross-sectional-time-series construction backfill
+    # uses (features.factor_momentum.materialize_factor_momentum), just against
+    # the in-memory panel instead of a re-read of ArcticDB — this snapshot
+    # already holds the whole universe's (date, close, loading) history for the
+    # trimmed warmup window, which is all compute_factor_momentum_feature needs.
+    # A failure here is caught and logged (log.exception, full traceback) so
+    # it doesn't take down the per-ticker compute / zscore / private-pack
+    # producers that already succeeded — but it deliberately does NOT
+    # swallow the outcome: leaving factor_momentum_ratio at the FEATURES-loop
+    # default (0.0) is caught downstream by the postflight zero-variance
+    # guard below, which raises before anything is written. So the net
+    # effect of a failure here is still a loud, pipeline-halting failure —
+    # just with the stack trace preserved and the OTHER columns' failure
+    # isolated from this one's.
+    if fm_frames:
+        try:
+            _fm_panel = pd.concat(fm_frames.values(), ignore_index=True)
+            _fm_signal = compute_factor_momentum_feature(_fm_panel)
+            _fm_panel = _fm_panel.assign(factor_momentum_ratio=_fm_signal)
+            _fm_latest = (
+                _fm_panel.sort_values("date")
+                .groupby("ticker", sort=False)["factor_momentum_ratio"]
+                .last()
+            )
+            _fm_map = _fm_latest.dropna()
+            n_fm = int(features_df["ticker"].map(_fm_map).notna().sum())
+            features_df["factor_momentum_ratio"] = (
+                features_df["ticker"].map(_fm_map).fillna(0.0).astype(float)
+            )
+            log.info(
+                "Factor-momentum second pass (daily): %d/%d tickers got a non-NaN "
+                "factor_momentum_ratio (window/skip warmup — rest fall back to 0.0)",
+                n_fm, len(features_df),
+            )
+        except Exception:
+            log.exception(
+                "Factor-momentum second pass failed — factor_momentum_ratio "
+                "stays at the FEATURES-loop default (0.0) for this snapshot"
+            )
+    else:
+        log.warning(
+            "Factor-momentum second pass skipped: no per-ticker loading frames "
+            "collected — factor_momentum_ratio will be the FEATURES-loop "
+            "default (0.0) for every ticker"
+        )
+
     # C.1 (optimizer-sota-upgrades-260526.md §C.1): append cross-sectional
     # factor-loading z-scores AFTER per-ticker compute, BEFORE write. These
     # are the columns of the factor-loading matrix B that workstream C.3
@@ -1038,6 +1115,16 @@ def compute_and_write(
     # (features_df unchanged) unless NOUSERGON_PRIVATE_FEATURE_PACK is set;
     # every public/CI run takes this no-op path. See features/private_pack.py.
     features_df = apply_private_features(features_df)
+
+    # alpha-engine-config-I7539: postflight zero-variance guard, run AFTER
+    # every producer above (per-ticker compute, factor-momentum second pass,
+    # cross-sectional zscores, private pack) has had its chance to fill a
+    # column and BEFORE the snapshot is written. Macro-group columns are
+    # excluded — they broadcast one value to the whole universe on a date BY
+    # CONSTRUCTION (e.g. the VIX level), so zero cross-sectional variance
+    # there is the expected shape, not a defect.
+    _non_macro_features = [f for f in FEATURES if f not in GROUPS.get("macro", ())]
+    assert_no_zero_variance_features(features_df, _non_macro_features)
 
     if dry_run:
         log.info(

--- a/features/postflight.py
+++ b/features/postflight.py
@@ -1,0 +1,94 @@
+"""Postflight zero-variance guard for the daily feature-store snapshot.
+
+alpha-engine-config-I7539: ``residual_momentum_ratio`` and
+``factor_momentum_ratio`` were both 901/901 non-null, std 0.0, on
+``s3://alpha-engine-research/features/2026-08-14/technical.parquet`` — every
+ticker got an identical constant 0.0. A null-coverage check passes at 100%
+on a column like that; it provably cannot catch this failure class, because
+the column IS fully populated, just with no information in it.
+
+This module is the guard that catches it: a cross-sectional feature column
+whose non-null values are all identical, over the whole universe, is a
+producer defect (never computed / silently defaulted / a second pass that
+never ran), not a legitimate shape.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+# Two FEATURES columns encode a genuinely binary (0/1) EVENT flag rather than
+# a continuous per-ticker magnitude. An all-0 day (e.g. not one ticker in the
+# whole universe had a MACD zero-line cross) is a plausible, non-defective
+# outcome for a sparse event flag — exempt them by name rather than by a
+# generic "few distinct values" heuristic, which would also hide a genuine
+# defect that happens to collapse onto two values.
+ZERO_VARIANCE_EXEMPT: frozenset[str] = frozenset({"macd_cross", "macd_above_zero"})
+
+# min_non_null mirrors the ``min_names`` floor features/factor_momentum.py
+# already uses before it will call a cross-section "populated enough to
+# rank" (20). Below that, a handful of sparse alt-data rows (options/
+# earnings-revision fields, only populated for tickers with an event that
+# day) coincidentally tying at a shared value is a plausible non-defective
+# outcome, not the failure class this guard targets.
+DEFAULT_MIN_NON_NULL = 20
+
+
+def find_zero_variance_columns(
+    features_df: pd.DataFrame,
+    feature_names: list[str],
+    *,
+    exempt: frozenset[str] = ZERO_VARIANCE_EXEMPT,
+    min_non_null: int = DEFAULT_MIN_NON_NULL,
+) -> dict[str, int]:
+    """Return ``{column: non_null_count}`` for every column in
+    ``feature_names`` whose cross-sectional std (over its non-null values,
+    population std) is exactly 0.0.
+
+    Callers are expected to have already excluded macro-broadcast columns
+    (features.registry.GROUPS["macro"]) — those carry ONE value for the
+    whole universe on a given date BY CONSTRUCTION (e.g. the VIX level),
+    so zero cross-sectional variance there is the correct, expected shape,
+    not a defect.
+    """
+    offending: dict[str, int] = {}
+    for col in feature_names:
+        if col in exempt or col not in features_df.columns:
+            continue
+        s = pd.to_numeric(features_df[col], errors="coerce").dropna()
+        if len(s) < min_non_null:
+            continue
+        if s.std(ddof=0) == 0.0:
+            offending[col] = int(len(s))
+    return offending
+
+
+def assert_no_zero_variance_features(
+    features_df: pd.DataFrame,
+    feature_names: list[str],
+    *,
+    exempt: frozenset[str] = ZERO_VARIANCE_EXEMPT,
+    min_non_null: int = DEFAULT_MIN_NON_NULL,
+) -> None:
+    """Raise loud (``RuntimeError``) if any column in ``feature_names`` is a
+    cross-sectional constant. Intended as the LAST step before a feature
+    snapshot is written — after per-ticker compute, the factor-momentum
+    second pass, and the private-pack extension point have all had their
+    chance to fill a column, a remaining zero-variance column is a producer
+    defect, not a transient gap.
+    """
+    offending = find_zero_variance_columns(
+        features_df, feature_names, exempt=exempt, min_non_null=min_non_null,
+    )
+    if offending:
+        raise RuntimeError(
+            "Zero-variance feature column(s) detected: every non-null value "
+            "is identical across the whole universe. This passes every "
+            "null-coverage check and carries zero signal "
+            "(alpha-engine-config-I7539). Offending columns "
+            f"(column: non_null_count): {offending}"
+        )

--- a/tests/test_compute_momentum_columns_i7539.py
+++ b/tests/test_compute_momentum_columns_i7539.py
@@ -1,0 +1,118 @@
+"""alpha-engine-config-I7539: end-to-end regression for the daily S3 feature
+snapshot (features/compute.py::compute_and_write).
+
+Both root causes were measured on the LIVE 2026-08-14 snapshot:
+
+  - residual_momentum_ratio: computed per-ticker, but _FEATURE_WARMUP_ROWS
+    (280) trimmed price history BELOW the 312-row minimum the stacked
+    beta_60d(60) -> cum_resid(231) -> shift(21) window needs for the latest
+    row to be non-NaN. Every ticker's value was NaN, and the FEATURES-loop
+    fallback (`row[f] = ... else 0.0`) turned universe-wide NaN into
+    universe-wide constant 0.0.
+  - factor_momentum_ratio: a cross-sectional-time-series SECOND PASS
+    (features/factor_momentum.py) that nothing in features/compute.py's S3
+    daily-snapshot path ever ran — it is only wired into
+    builders/backfill.py (full 10y) and builders/daily_append.py's ArcticDB
+    go-forward path (features/factor_momentum.py::update_factor_momentum_latest).
+    The S3 snapshot writer never read that value back, so the column was
+    never in `latest.index` and hit the same 0.0 fallback.
+
+This test builds a synthetic universe with genuinely different per-ticker
+drift (so beta/idio-vol/momentum loadings differ across tickers — the
+precondition for both columns to carry real cross-sectional variance), runs
+the FULL compute_and_write pipeline in dry-run mode (skips only the S3
+write itself), and relies on the postflight zero-variance guard
+(features/postflight.py, wired into compute_and_write just before the
+dry-run branch) to fail the test loud if either column comes back constant.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from features import compute
+
+
+def _price_frame(n: int, seed: int, drift: float) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    r = drift + rng.normal(0, 0.01, n)
+    close = 100.0 * np.exp(np.cumsum(r))
+    idx = pd.date_range("2025-01-01", periods=n, freq="B")
+    return pd.DataFrame(
+        {
+            "Open": close,
+            "High": close * 1.001,
+            "Low": close * 0.999,
+            "Close": close,
+            "Volume": rng.integers(1_000_000, 5_000_000, n).astype(float),
+        },
+        index=idx,
+    )
+
+
+def _synthetic_universe(n_tickers: int = 30, n_rows: int = 400):
+    tickers = [f"T{i:02d}" for i in range(n_tickers)]
+    price_data = {}
+    for i, t in enumerate(tickers):
+        # Spread of per-ticker drifts -> real cross-sectional dispersion in
+        # beta_60d / momentum_20d / idio_vol_60d, the inputs both columns
+        # under test are built from.
+        drift = 0.0003 * (i - n_tickers / 2)
+        price_data[t] = _price_frame(n_rows, seed=i, drift=drift)
+    spy = _price_frame(n_rows, seed=999, drift=0.0002)["Close"]
+    return price_data, {"SPY": spy}
+
+
+def _patch_loaders(monkeypatch, price_data, macro):
+    monkeypatch.setattr(
+        compute, "_load_prices_and_macro",
+        lambda s3, bucket, date_str: (dict(price_data), dict(macro)),
+    )
+    monkeypatch.setattr(compute, "_load_sector_map", lambda s3, bucket: {})
+    monkeypatch.setattr(
+        compute, "_load_cached_fundamentals", lambda s3, bucket, date_str: {}
+    )
+    monkeypatch.setattr(compute, "_load_cached_alternative", lambda s3, bucket: {})
+
+
+def test_warmup_rows_covers_the_stacked_residual_momentum_window():
+    """312 = 60 (beta_60d warmup) + 231 (cum-residual window) + 21 (skip
+    shift) - 1 is the derived minimum for the LATEST row to be non-NaN
+    (alpha-engine-config-I7539). _FEATURE_WARMUP_ROWS must stay above it."""
+    assert compute._FEATURE_WARMUP_ROWS >= 312
+
+
+def test_residual_and_factor_momentum_carry_real_variance(monkeypatch):
+    """Full pipeline, dry-run. This synthetic universe has no sector map,
+    fundamentals, or alt data, so those groups legitimately default to a
+    shared neutral constant (the real postflight guard would — correctly —
+    flag THOSE here too; features.postflight has its own isolated unit
+    tests in test_postflight_zero_variance.py). This test isolates the two
+    columns this issue is about: capture the assembled features_df by
+    intercepting the guard call instead of letting it run against the full
+    FEATURES list, and assert directly that residual_momentum_ratio and
+    factor_momentum_ratio — the two columns measured constant 0.0 in
+    production — carry real cross-sectional variance here."""
+    price_data, macro = _synthetic_universe()
+    _patch_loaders(monkeypatch, price_data, macro)
+
+    captured = {}
+
+    def _capture_guard(features_df, feature_names, **kwargs):
+        captured["features_df"] = features_df.copy()
+
+    monkeypatch.setattr(compute, "assert_no_zero_variance_features", _capture_guard)
+
+    result = compute.compute_and_write(
+        date_str="2026-08-14", bucket="test-bucket", dry_run=True
+    )
+
+    assert result["status"] == "ok"
+    assert result["tickers_computed"] >= 20
+
+    df = captured["features_df"]
+    for col in ("residual_momentum_ratio", "factor_momentum_ratio"):
+        non_null = df[col].dropna()
+        assert len(non_null) >= 20, f"{col}: too few non-null values ({len(non_null)})"
+        assert non_null.nunique() > 1, f"{col}: still constant — {non_null.unique()}"
+        assert non_null.std() > 0.0, f"{col}: still zero cross-sectional variance"

--- a/tests/test_postflight_zero_variance.py
+++ b/tests/test_postflight_zero_variance.py
@@ -1,0 +1,95 @@
+"""alpha-engine-config-I7539: postflight zero-variance guard.
+
+Null-coverage checks pass at 100% for a column that's fully populated with a
+single repeated constant (measured: residual_momentum_ratio and
+factor_momentum_ratio were both 901/901 non-null, std 0.0, on the 2026-08-14
+technical.parquet snapshot). This guard catches that class directly.
+
+Verified RED first: test_raises_on_synthetic_constant_column below fails
+(no exception raised) against features/compute.py as it stood before this
+PR — there was no zero-variance guard at all, so a constant column sailed
+through untouched. It is green now that features/postflight.py exists and
+is wired into features/compute.py::compute_and_write.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from features.postflight import (
+    ZERO_VARIANCE_EXEMPT,
+    assert_no_zero_variance_features,
+    find_zero_variance_columns,
+)
+
+
+def _df(n=901, **cols):
+    return pd.DataFrame({"ticker": [f"T{i}" for i in range(n)], **cols})
+
+
+class TestFindZeroVarianceColumns:
+    def test_flags_a_universe_wide_constant(self):
+        df = _df(residual_momentum_ratio=[0.0] * 901)
+        offending = find_zero_variance_columns(df, ["residual_momentum_ratio"])
+        assert offending == {"residual_momentum_ratio": 901}
+
+    def test_does_not_flag_a_varying_column(self):
+        rng = np.random.default_rng(0)
+        df = _df(mom_12_1_pct=rng.normal(size=901))
+        assert find_zero_variance_columns(df, ["mom_12_1_pct"]) == {}
+
+    def test_below_min_non_null_is_not_flagged(self):
+        # Sparse alt-data column: only a handful of tickers had an event
+        # today and they coincidentally tie — not the defect class this
+        # guard targets (min_non_null mirrors factor_momentum's min_names).
+        vals = [0.0] * 5 + [np.nan] * 896
+        df = _df(eps_revision_4w=vals)
+        assert find_zero_variance_columns(df, ["eps_revision_4w"]) == {}
+
+    def test_exempt_binary_flag_never_flagged_even_at_full_population(self):
+        for col in ZERO_VARIANCE_EXEMPT:
+            df = _df(**{col: [0.0] * 901})
+            assert find_zero_variance_columns(df, [col]) == {}
+
+    def test_missing_column_is_skipped_not_errored(self):
+        df = _df(mom_12_1_pct=[1.0, 2.0, 3.0] * 300 + [1.0])
+        assert find_zero_variance_columns(df, ["not_a_real_column"]) == {}
+
+    def test_all_nan_column_is_not_flagged(self):
+        df = _df(residual_momentum_ratio=[np.nan] * 901)
+        assert find_zero_variance_columns(df, ["residual_momentum_ratio"]) == {}
+
+
+class TestAssertNoZeroVarianceFeatures:
+    def test_raises_on_synthetic_constant_column(self):
+        """The guard, verified RED: a synthetic all-zero column across the
+        full universe must fail loud."""
+        df = _df(factor_momentum_ratio=[0.0] * 901)
+        with pytest.raises(RuntimeError, match="Zero-variance"):
+            assert_no_zero_variance_features(df, ["factor_momentum_ratio"])
+
+    def test_passes_on_real_variance(self):
+        rng = np.random.default_rng(1)
+        df = _df(
+            residual_momentum_ratio=rng.normal(size=901),
+            factor_momentum_ratio=rng.normal(size=901),
+        )
+        assert_no_zero_variance_features(
+            df, ["residual_momentum_ratio", "factor_momentum_ratio"]
+        )  # no raise
+
+    def test_reproduces_the_measured_i7539_shape(self):
+        """Both columns constant 0.0 at once, mirroring the exact measured
+        production shape — both must be named in the raised error."""
+        df = _df(
+            residual_momentum_ratio=[0.0] * 901,
+            factor_momentum_ratio=[0.0] * 901,
+        )
+        with pytest.raises(RuntimeError) as exc_info:
+            assert_no_zero_variance_features(
+                df, ["residual_momentum_ratio", "factor_momentum_ratio"]
+            )
+        msg = str(exc_info.value)
+        assert "residual_momentum_ratio" in msg
+        assert "factor_momentum_ratio" in msg


### PR DESCRIPTION
## What + why

alpha-engine-config-I7539: residual_momentum_ratio and factor_momentum_ratio were both measured constant 0.0 across the whole 901-ticker universe on s3://alpha-engine-research/features/2026-08-14/technical.parquet — 901/901 non-null, nunique=1, std=0.0. A null-coverage check passes at 100% on a column like that, so nothing alarmed even though both are registered predictor-consumed columns (registry.py:173, :181).

mom_12_1_pct was NOT touched — confirmed fine (901 unique, std 1.12) and untouched by this diff.

### Root causes (two independent bugs, same failure shape)

1. residual_momentum_ratio — computed correctly per-ticker in feature_engineer.compute_features (line ~796), but features/compute.py's _FEATURE_WARMUP_ROWS trim (280) was below the minimum the STACKED window needs: beta_60d warmup (60 rows) has to complete before the 231-row cumulative-residual rolling sum can start, then a 21-row shift on top — 60 + 231 + 21 - 1 = 311 rows minimum for the LATEST row to be non-NaN. At 280 rows, every ticker's value was NaN for the entire trimmed frame. The per-row fallback in compute.py (`row[f] = float(val) if pd.notna(val) else 0.0`) then silently turned universe-wide NaN into universe-wide constant 0.0. This is (b) in the issue's taxonomy: computed, but silently erroring (via NaN) into a 0.0 fill.

2. factor_momentum_ratio — a genuine second-pass, cross-sectional-time-series column (features/factor_momentum.py), never meant to be produced per-ticker. It IS wired into builders/backfill.py (full 10y rewrite) and builders/daily_append.py's ArcticDB go-forward path (update_factor_momentum_latest, enabled by default). But nothing in features/compute.py's S3 daily-snapshot path (compute_and_write, the sole producer of features/{date}/technical.parquet) ever ran the equivalent pass — it was never in latest.index, hitting the same 0.0 fallback. This is (c) in the issue's taxonomy: second-pass not running on this particular daily path.

### Fix

- _FEATURE_WARMUP_ROWS: 280 -> 340 (311 derived minimum + a ~28-row buffer, matching the original 252->280 buffer's ~10% margin). Comment documents the derivation so it isn't silently re-broken by a future feature with an even deeper stacked window.
- Added a self-contained factor-momentum second pass inside compute_and_write: while each ticker's featured_df is already in memory, collect the slim (date, close, *loading) frame; after the per-ticker loop, rebuild the long panel and run compute_factor_momentum_feature over it directly — mirroring the existing apply_factor_zscores in-process cross-sectional pattern already used in this same function, rather than depending on an ArcticDB round-trip through update_factor_momentum_latest. That function is explicitly best-effort/OBSERVE (never raises, can silently no-op on failure) and is only guaranteed to have run before this snapshot under the Saturday weekly SF's --morning-enrich -> --phase 1 ordering — making the S3 snapshot's correctness hostage to that cross-pipeline sequencing was judged the wrong dependency to take. SOTA / delta: the robust fix is a self-contained producer; the alternative (read back ArcticDB's value) is cheaper in CPU but couples snapshot correctness to another pipeline's timing — rejected.

### Postflight guard (issue deliverable #3)

Added features/postflight.py::assert_no_zero_variance_features, wired into compute_and_write immediately before the snapshot is written (after per-ticker compute, the factor-momentum second pass, cross-sectional zscores, and the private-pack extension point). Any non-macro FEATURES column whose non-null values are all identical across >=20 tickers now fails the pipeline loud — closing the exact detection gap this issue is about (null-coverage checks provably can't catch this class).

Exclusions, both deliberate and named in-code:
- Macro-group columns (features.registry.GROUPS["macro"] — VIX level, 10y yield, etc.) broadcast one value to the whole universe on a date BY CONSTRUCTION; zero cross-sectional variance there is the expected shape.
- macd_cross / macd_above_zero — genuinely binary event flags; an all-0 day (no MACD cross anywhere in the universe) is a plausible non-defective outcome for a sparse event, not the failure class this guard targets.
- min_non_null=20 mirrors factor_momentum.py's own min_names floor — protects sparse alt-data columns (options/earnings-revision fields only populated for tickers with an event that day) from a false alarm when a handful of rows coincidentally tie.

No FEATURES / registry.py / SCHEMA.md column was added or removed, so no migrations/ entry is needed — verified tests/test_schema_migration_chokepoint.py stays green.

## Test plan

- tests/test_postflight_zero_variance.py (9 tests): unit coverage of find_zero_variance_columns / assert_no_zero_variance_features — flags a universe-wide constant, ignores sparse (<20 non-null) columns, ignores the two exempt binary flags, ignores missing/all-NaN columns, passes on real variance. Verified RED first: confirmed no features/postflight.py (or any equivalent zero-variance check) exists anywhere on origin/main before this PR — the guard's own "RED" state is its prior total absence, matching the measured production incident.
- tests/test_compute_momentum_columns_i7539.py (2 tests): full compute_and_write dry-run over a synthetic 30-ticker universe with genuine per-ticker price drift (so beta/idio-vol/momentum loadings differ across tickers — the real precondition for cross-sectional variance). Asserts both residual_momentum_ratio and factor_momentum_ratio come back with nunique > 1 and std > 0. Confirmed RED against unpatched compute.py (git stash check: AttributeError on the new import — the guard/second-pass code isn't there to patch), GREEN after.
- Regression comparison: ran the full suite on a clean origin/main worktree vs this branch.
  - Baseline: 65 failed, 5509 passed, 13 skipped, 48 errors (all pre-existing — missing yfinance/tenacity etc., matching the known ~34-ish local-only gaps in test_metron_market_data.py, test_constituents_sector_map.py, test_chronic_polygon_gap_self_heal.py and friends).
  - This branch: 65 failed, 5520 passed, 13 skipped, 48 errors.
  - Diffed the two FAILED test-name lists byte-for-byte: identical. Delta is exactly the 11 new passing tests added by this PR. Zero regressions.
- tests/test_schema_migration_chokepoint.py, tests/test_feature_engineer_residual_momentum.py, tests/test_factor_momentum.py, tests/test_daily_append_factor_momentum.py all green.

Closes-when (per the issue): both columns show non-zero cross-sectional variance on a fresh snapshot — verified via the synthetic-universe regression test above (a live S3 snapshot re-run is the follow-up production verification, outside this PR's local-test scope) — and the postflight assertion fails red on a synthetic constant column, verified above.

References alpha-engine-config-I7539 (cross-repo Closes does not auto-close; tracked separately).

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
