### PR TITLE
fix(weekly-sf-rerun): reject an incoherent skip-set before dispatch, refuse silent run_date minting (alpha-engine-config-I7443)

### DIFF
--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -95,7 +95,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # sys.path insertion (not a package import) so this resolves identically
@@ -970,6 +970,101 @@ def next_rerun_name(sf, sm_arn: str, run_date: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Skip-coherence pre-flight (alpha-engine-config-I7443, sf-pipeline-policy
+# §2.5: "a skip-set that leaves a downstream JSONPath unresolvable must be
+# rejected by the helper, not discovered as a States.Runtime error thirty
+# seconds into the rerun.")
+# ---------------------------------------------------------------------------
+
+PREDICTOR_MANIFEST_BUCKET = "alpha-engine-research"
+PREDICTOR_MANIFEST_KEY = "predictor/weights/meta/manifest.json"
+
+
+class SkipCoherenceError(Exception):
+    """A derived (or carried-forward) skip_* flag is incoherent with the
+    plan's run_date: the artifact it claims already exists does not, FOR
+    THIS run_date. Raised before any dispatch is spent finding out.
+
+    2026-08-15 recovery of weekly cycle 2026-08-15 burned two full
+    ne-weekly-freshness-pipeline executions (watch-rerun-2026-08-16-1,
+    -2; ~50 minutes) on skip_predictor_training=true paired with a
+    run_date the predictor never trained for — the SF's own
+    ValidatePredictorSkipWeightsFresh / CheckPredictorSkipWeightsFresh gate
+    (infrastructure/step_function.json) caught it correctly, but four hours
+    and two dispatches into the recovery arc instead of at --dry-run. This
+    mirrors that exact predicate here, ahead of --start.
+    """
+
+
+def refuse_fallback_run_date_without_acceptance(plan: "RerunPlan", accept: bool) -> None:
+    """Refuse (SystemExit) a --start whose run_date was MINTED from the
+    source execution's own UTC start time rather than carried from an
+    explicit input or InitializeInput output, unless the operator passed
+    ``--accept-fallback-run-date``. alpha-engine-config-I7443: the printed
+    FALLBACK provenance note went unnoticed/unacted-on for exactly this
+    reason on 2026-08-16, and the resulting rerun burned two dispatches on
+    PredictorSkipWeightsStale."""
+    if not plan.run_date_provenance.startswith("FALLBACK") or accept:
+        return
+    raise SystemExit(
+        f"FATAL: run_date {plan.run_date!r} was MINTED from the source "
+        f"execution's own UTC start time ([{plan.run_date_provenance}]), "
+        "not carried from an explicit input or InitializeInput output — "
+        "refusing to --start on it. If this really is a pre-workload "
+        "failure (the source never reached InitializeInput) and "
+        f"{plan.run_date!r} is correct, re-run with "
+        "--accept-fallback-run-date. Otherwise pass --execution-arn to "
+        "point at the right source, or pass the cycle's ORIGINAL "
+        "run_date by hand-crafting the input (alpha-engine-config-I7443)."
+    )
+
+
+def check_predictor_skip_freshness(s3, run_date: str, skip_flags: dict) -> None:
+    """Mirror ValidatePredictorSkipWeightsFresh: if skip_predictor_training
+    is set, HeadObject the live weights manifest and require its
+    LastModified DATE >= run_date (lexicographic YYYY-MM-DD compare, same as
+    the SF's CheckPredictorSkipWeightsFresh Choice state). Raises
+    SkipCoherenceError rather than emitting an input the SF will only reject
+    after a dispatch is already spent.
+
+    Any S3 error (missing manifest, AccessDenied, throttling exhausted) is
+    treated the same as the SF's own Catch on ValidatePredictorSkipWeightsFresh
+    — fail loud rather than silently trust an unverifiable freshness claim.
+    """
+    if not skip_flags.get("skip_predictor_training"):
+        return
+    try:
+        head = s3.head_object(Bucket=PREDICTOR_MANIFEST_BUCKET, Key=PREDICTOR_MANIFEST_KEY)
+    except Exception as exc:  # noqa: BLE001 — cannot PROVE freshness on any S3 error; fail loud, mirrors the SF's own Catch
+        raise SkipCoherenceError(
+            f"skip_predictor_training=true but HeadObject on "
+            f"s3://{PREDICTOR_MANIFEST_BUCKET}/{PREDICTOR_MANIFEST_KEY} "
+            f"failed ({exc!r}) — cannot verify weights freshness for "
+            f"run_date {run_date}. Refusing to emit a plan the SF's own "
+            "ValidatePredictorSkipWeightsFresh would also reject. Re-run "
+            "WITHOUT skip_predictor_training, or investigate the manifest."
+        ) from exc
+    last_modified = head["LastModified"]
+    if hasattr(last_modified, "astimezone"):
+        manifest_date = last_modified.astimezone(timezone.utc).date().isoformat()
+    else:
+        manifest_date = str(last_modified).split("T", 1)[0]
+    if manifest_date < run_date:
+        raise SkipCoherenceError(
+            f"skip_predictor_training=true but "
+            f"s3://{PREDICTOR_MANIFEST_BUCKET}/{PREDICTOR_MANIFEST_KEY} "
+            f"LastModified date {manifest_date} < run_date {run_date} — no "
+            "completed predictor training for this run_date; refusing to "
+            "launch onto stale weights (same predicate as the SF's own "
+            "ValidatePredictorSkipWeightsFresh / PredictorSkipWeightsStale — "
+            "checked here BEFORE a dispatch, not after one; "
+            "alpha-engine-config-I7443). Either re-run WITHOUT "
+            "skip_predictor_training, or pass the ORIGINAL run_date "
+            "explicitly if this is a cross-UTC-midnight recovery rerun."
+        )
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -997,7 +1092,13 @@ def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str,
         print(f"WARN : {w}", file=sys.stderr)
     print("\nStartExecution input:")
     print(json.dumps(_emitted, indent=2, sort_keys=True))
-    print("\nequivalent CLI:")
+    print(
+        "\nequivalent CLI (name and input.run_date are DERIVED TOGETHER — "
+        "alpha-engine-config-I7443: watch-rerun-{run_date}-N must never "
+        "carry a different run_date. Do not hand-edit the JSON below "
+        "without also renaming; re-run this script with --execution-arn "
+        "instead):"
+    )
     print(
         f"aws stepfunctions start-execution --state-machine-arn {sm_arn} "
         f"--name {name} --input '{json.dumps(_emitted, sort_keys=True)}'"
@@ -1011,6 +1112,17 @@ def main(argv: list | None = None) -> int:
     mode = ap.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", action="store_true", help="derive + print only (default)")
     mode.add_argument("--start", action="store_true", help="run pre-start guards, steal stale mutex item if safe, StartExecution")
+    ap.add_argument(
+        "--accept-fallback-run-date", action="store_true",
+        help=(
+            "required to --start when run_date could not be resolved from "
+            "an explicit input or InitializeInput output and fell back to "
+            "the source execution's own UTC start date (provenance "
+            "'FALLBACK: ...'). Without it, --start refuses rather than "
+            "silently minting a run_date that may not match the cycle "
+            "being recovered (alpha-engine-config-I7443)."
+        ),
+    )
     ap.add_argument("--region", default="us-east-1")
     args = ap.parse_args(argv)
 
@@ -1018,6 +1130,7 @@ def main(argv: list | None = None) -> int:
 
     sf = boto3.client("stepfunctions", region_name=args.region)
     ddb = boto3.client("dynamodb", region_name=args.region)
+    s3 = boto3.client("s3", region_name=args.region)
 
     if args.execution_arn:
         desc = sf.describe_execution(executionArn=args.execution_arn)
@@ -1041,6 +1154,16 @@ def main(argv: list | None = None) -> int:
     name = next_rerun_name(sf, args.state_machine_arn, plan.run_date)
     sm_name = args.state_machine_arn.rsplit(":", 1)[-1]
     source_role = execution_input(events).get("pipeline_role")
+
+    # Skip-coherence pre-flight (alpha-engine-config-I7443): reject an
+    # incoherent skip-set BEFORE any mutex work or dispatch, not after one —
+    # sf-pipeline-policy §2.5. Checked ahead of the mutex inspection below so
+    # a doomed plan never touches DynamoDB or prints a false "OK" mutex line.
+    try:
+        check_predictor_skip_freshness(s3, plan.run_date, plan.skip_flags)
+    except SkipCoherenceError as exc:
+        _print_plan(plan, source_arn, source_status, name, args.state_machine_arn)
+        raise SystemExit(f"\nFATAL (skip-coherence, alpha-engine-config-I7443): {exc}")
 
     # Mutex inspection (read-only here; delete only under --start).
     decision = None
@@ -1097,6 +1220,14 @@ def main(argv: list | None = None) -> int:
     if not args.start:
         print("\n(dry-run — nothing mutated; re-run with --start to execute)")
         return 0
+
+    # A FALLBACK-provenance run_date was MINTED from the source execution's
+    # own start time, not carried from an explicit input or InitializeInput
+    # output — never let --start launch on one silently (alpha-engine-
+    # config-I7443: the printed provenance line went unnoticed/unacted-on
+    # for exactly this reason on 2026-08-16). --dry-run always shows it
+    # above; --start additionally refuses unless explicitly acknowledged.
+    refuse_fallback_run_date_without_acceptance(plan, args.accept_fallback_run_date)
 
     # --- pre-start guards ---------------------------------------------------
     running = list_all_executions(sf, args.state_machine_arn, status_filter="RUNNING")

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -879,3 +879,158 @@ class TestHistoricalWorkStateNames:
                 f"in step_function.json — remove the alias or the rename is "
                 f"not complete"
             )
+
+
+# ---------------------------------------------------------------------------
+# alpha-engine-config-I7443: a rerun must carry the cycle's run_date, never
+# mint one across a UTC-midnight boundary, and a skip_predictor_training
+# whose weights are stale for that run_date must be rejected BEFORE a
+# dispatch is spent (sf-pipeline-policy §2.5).
+# ---------------------------------------------------------------------------
+
+def _history(*, explicit_run_date=None, init_run_date=None, extra_input=None):
+    """Build a minimal synthetic execution-history events list."""
+    inp = {"pipeline_role": "watch-rerun"}
+    if extra_input:
+        inp.update(extra_input)
+    if explicit_run_date is not None:
+        inp["run_date"] = explicit_run_date
+    events = [{
+        "type": "ExecutionStarted",
+        "executionStartedEventDetails": {"input": json.dumps(inp)},
+    }]
+    if init_run_date is not None:
+        out = dict(inp)
+        out["run_date"] = init_run_date
+        events.append({
+            "type": "PassStateExited",
+            "stateExitedEventDetails": {
+                "name": "InitializeInput",
+                "output": json.dumps(out),
+            },
+        })
+    return events
+
+
+class TestRunDateCarriedAcrossUTCMidnight:
+    """derive_run_date must carry the ORIGINAL cycle's run_date, never mint
+    one from wall-clock/start-time, whenever the source execution's own
+    input or InitializeInput output actually resolves one — regardless of
+    what UTC calendar date the rerun happens to be launched on.
+
+    Regression for alpha-engine-config-I7443: watch-rerun-2026-08-16-1/-2
+    carried run_date=2026-08-16 though the recovered cycle was 2026-08-15;
+    a start_time that has already crossed UTC midnight relative to the
+    source's own explicit/InitializeInput run_date must NOT leak in.
+    """
+
+    def test_explicit_input_run_date_wins_over_a_later_start_time(self, mod):
+        events = _history(explicit_run_date="2026-08-15")
+        # start_time is AFTER UTC midnight relative to the cycle's own date —
+        # exactly the shape of the real 2026-08-15/16 incident.
+        late_start = datetime(2026, 8, 16, 1, 51, 10, tzinfo=timezone.utc)
+        run_date, provenance = mod.derive_run_date(events, late_start)
+        assert run_date == "2026-08-15"
+        assert "explicit" in provenance
+        assert "2026-08-16" not in provenance
+
+    def test_initialize_input_run_date_wins_over_a_later_start_time(self, mod):
+        events = _history(init_run_date="2026-08-15")
+        late_start = datetime(2026, 8, 16, 1, 51, 10, tzinfo=timezone.utc)
+        run_date, provenance = mod.derive_run_date(events, late_start)
+        assert run_date == "2026-08-15"
+        assert "InitializeInput" in provenance
+
+    def test_only_a_genuine_pre_workload_failure_falls_back_to_start_time(self, mod):
+        """No explicit run_date, no InitializeInput output at all (the
+        source never reached it) — the ONLY case where start_time is used,
+        and it must be labeled FALLBACK so --start refuses it by default."""
+        events = _history()
+        start = datetime(2026, 8, 16, 1, 51, 10, tzinfo=timezone.utc)
+        run_date, provenance = mod.derive_run_date(events, start)
+        assert run_date == "2026-08-16"
+        assert provenance.startswith("FALLBACK")
+
+    def test_start_refuses_a_fallback_run_date_without_explicit_acceptance(self, mod):
+        """--start must not launch on a FALLBACK-provenance run_date unless
+        the operator passes --accept-fallback-run-date (alpha-engine-
+        config-I7443: the printed FALLBACK note went unnoticed on
+        2026-08-16 and the operator's rerun launched anyway)."""
+        plan = mod.RerunPlan(
+            run_date="2026-08-16",
+            run_date_provenance="FALLBACK: UTC date of the failed execution's start time",
+            original_input={},
+        )
+        with pytest.raises(SystemExit) as exc:
+            mod.refuse_fallback_run_date_without_acceptance(plan, accept=False)
+        assert "FALLBACK" in str(exc.value)
+        assert "--accept-fallback-run-date" in str(exc.value)
+        # explicit acceptance lets it through
+        mod.refuse_fallback_run_date_without_acceptance(plan, accept=True)
+
+    def test_non_fallback_provenance_never_refused(self, mod):
+        plan = mod.RerunPlan(
+            run_date="2026-08-15",
+            run_date_provenance="explicit run_date in the failed execution's input",
+            original_input={},
+        )
+        mod.refuse_fallback_run_date_without_acceptance(plan, accept=False)  # does not raise
+
+    def test_accept_fallback_flag_is_wired_into_the_cli(self, mod, capsys):
+        with pytest.raises(SystemExit) as exc:
+            mod.main(["--help"])
+        assert exc.value.code == 0
+        assert "--accept-fallback-run-date" in capsys.readouterr().out
+
+
+class TestPredictorSkipFreshness:
+    """check_predictor_skip_freshness mirrors the SF's own
+    ValidatePredictorSkipWeightsFresh / CheckPredictorSkipWeightsFresh
+    predicate (infrastructure/step_function.json): HeadObject the live
+    weights manifest and require LastModified's DATE >= run_date. Checked
+    here BEFORE any dispatch — alpha-engine-config-I7443."""
+
+    class _FakeS3:
+        def __init__(self, *, last_modified=None, error=None):
+            self._last_modified = last_modified
+            self._error = error
+
+        def head_object(self, **kwargs):
+            if self._error is not None:
+                raise self._error
+            return {"LastModified": self._last_modified}
+
+    def test_noop_when_skip_predictor_training_not_set(self, mod):
+        s3 = self._FakeS3(error=RuntimeError("must not be called"))
+        mod.check_predictor_skip_freshness(s3, "2026-08-16", {})
+        mod.check_predictor_skip_freshness(
+            s3, "2026-08-16", {"skip_predictor_training": False}
+        )
+
+    def test_fresh_manifest_passes(self, mod):
+        s3 = self._FakeS3(
+            last_modified=datetime(2026, 8, 16, 3, 0, 0, tzinfo=timezone.utc)
+        )
+        mod.check_predictor_skip_freshness(
+            s3, "2026-08-16", {"skip_predictor_training": True}
+        )  # does not raise
+
+    def test_manifest_older_than_run_date_is_rejected(self, mod):
+        """The real 2026-08-15/16 incident shape: manifest last written
+        2026-08-15, skip claimed for run_date 2026-08-16."""
+        s3 = self._FakeS3(
+            last_modified=datetime(2026, 8, 15, 20, 0, 0, tzinfo=timezone.utc)
+        )
+        with pytest.raises(mod.SkipCoherenceError) as exc:
+            mod.check_predictor_skip_freshness(
+                s3, "2026-08-16", {"skip_predictor_training": True}
+            )
+        assert "2026-08-15" in str(exc.value)
+        assert "2026-08-16" in str(exc.value)
+
+    def test_s3_error_is_rejected_not_silently_trusted(self, mod):
+        s3 = self._FakeS3(error=RuntimeError("boom"))
+        with pytest.raises(mod.SkipCoherenceError):
+            mod.check_predictor_skip_freshness(
+                s3, "2026-08-16", {"skip_predictor_training": True}
+            )


### PR DESCRIPTION
## Summary

alpha-engine-config-I7443: recovering weekly cycle 2026-08-15 took six rerun executions; two were pure waste because the recovery input carried `run_date: 2026-08-16` (minted across UTC midnight) paired with `skip_predictor_training=true`, and the predictor refused onto stale weights (`PredictorSkipWeightsStale`) — correctly, but ~4 hours into the recovery arc instead of at plan time. sf-pipeline-policy §2.5 target: 1 operator action per recovery; observed 6.

## Investigation finding (stated up front, per the issue's "verify first")

`derive_run_date`'s existing precedence (explicit input `run_date` > `InitializeInput` merged output > FALLBACK to the source execution's own UTC start date) already resolves the real 2026-08-15/16 incident's most plausible source execution (`watch-rerun-2026-08-15-2`, FAILED 2026-08-15T23:28:43Z with explicit `run_date=2026-08-15` in both its input and its `InitializeInput` output) correctly — reproduced locally against the real captured execution history (`aws stepfunctions get-execution-history`), current `main`:

```
derived: 2026-08-15  explicit run_date in the failed execution's input
```

So the wall-clock-minting defect could not be reproduced against current `main`'s `derive_run_date` logic itself. Separately, CloudTrail/S3 evidence shows `watch-rerun-2026-08-16-3` and `-4` carried `run_date=2026-08-15` in their **input** while named with the `-16-` prefix — impossible from a single invocation of this script (name and input `run_date` are both drawn from the same `plan.run_date` in one call), which points at the printed "equivalent CLI" convenience command being hand-copied and partially edited outside the script's own `--start` path.

Given that, this PR closes the two concrete gaps that are real and load-bearing regardless of the exact prior operator sequence:

1. **A rerun must be rejected before it's dispatched, not after.** `check_predictor_skip_freshness()` mirrors the SF's own `ValidatePredictorSkipWeightsFresh`/`CheckPredictorSkipWeightsFresh` predicate (HeadObject `s3://alpha-engine-research/predictor/weights/meta/manifest.json`, require `LastModified` date `>= run_date`) and refuses at `--dry-run`/`--start` time, before any dispatch — the exact check that would have caught both wasted 2026-08-16 executions at plan time instead of ~25 minutes into each.
2. **A FALLBACK-minted run_date can no longer silently launch.** `refuse_fallback_run_date_without_acceptance()` makes `--start` hard-refuse when `run_date` was derived from the source execution's own start time (the only tier that ever "mints" rather than carries) unless `--accept-fallback-run-date` is passed explicitly. The printed `FALLBACK: ...` provenance note existed before this PR but was easy to miss in a wall of stdout; this makes it a hard stop.
3. **The name/input divergence footgun is called out.** The printed "equivalent CLI" now warns against hand-editing the JSON without also updating `--name` — the two are derived together and must never disagree (observed divergence: `watch-rerun-2026-08-16-3`/`-4`).

## Changes

- `scripts/weekly_sf_rerun.py`:
  - `check_predictor_skip_freshness(s3, run_date, skip_flags)` + `SkipCoherenceError`, wired into `main()` right after plan derivation, before mutex inspection or dispatch.
  - `refuse_fallback_run_date_without_acceptance(plan, accept)`, wired into the `--start` path; new `--accept-fallback-run-date` CLI flag.
  - `_print_plan`'s "equivalent CLI" text warns against hand-editing.
- `tests/test_weekly_sf_rerun.py`: regression tests for run_date carried across a UTC-midnight-crossing start_time (explicit + InitializeInput tiers), the FALLBACK-only case and its refusal, and the predictor-skip-freshness check (fresh/stale/S3-error).

## Verification

- `pytest tests/test_weekly_sf_rerun.py -q` — 55 passed (was 47 before this PR's new tests).
- Full suite: `pytest -q` — 5804 passed, 12 skipped (baseline 5797 passed).
- Read-only AWS evidence gathered via `aws stepfunctions describe-execution`/`get-execution-history` against the live 2026-08-15/16 executions (no execution launched).

## Not touched

`infrastructure/step_function.json` was not modified by this PR — the in-pipeline `ValidatePredictorSkipWeightsFresh` gate is unchanged; this PR adds an equivalent pre-flight check in the operator-facing helper only.

## Merge order

Standalone — no other repo's PR depends on this one.

Closes #7443

---
Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_weekly_sf_rerun.py