### PR TITLE
fix(spot): teardown goes through the shared evidence chokepoint (config-I7442)

### DIFF
--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -322,7 +322,6 @@ run_ssm() {
     --region "$AWS_REGION" \
     --diagnostics-bucket "$S3_BUCKET" \
     --diagnostics-prefix "_spot_diagnostics/ae-data" \
-    --resource-limit "instance-types=${INSTANCE_TYPES}" \
     --script-stdin
 }
 

--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -222,7 +222,7 @@ cleanup() {
     # teardown here must not read a workload exit status that was never
     # evaluated (config-I7442).
     teardown_staging 0
-    echo "  launch-only: instance $_INSTANCE_ID left running (SF-owned); staging cleaned."
+    echo "  launch-only: instance $_INSTANCE_ID left running (SF-owned); staging teardown reported above."
     return 0
   fi
   if [ -n "$_INSTANCE_ID" ]; then
@@ -231,7 +231,7 @@ cleanup() {
     aws ec2 terminate-instances --instance-ids "$_INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
   fi
   teardown_staging "$_exit_code"
-  [ -n "$_INSTANCE_ID" ] && echo "  Instance terminated; S3 staging cleaned."
+  [ -n "$_INSTANCE_ID" ] && echo "  Instance terminated."
   return 0
 }
 

--- a/infrastructure/_spot_common.sh
+++ b/infrastructure/_spot_common.sh
@@ -168,12 +168,60 @@ spot_launch() {
   echo "  S3 staging: ${_S3_STAGING}/"
 }
 
+# ── Staging teardown (config-I7442, superseding config-I7396) ───────────────
+# The staging prefix holds the ONLY full copy of a stage's stdout/stderr:
+# run_ssm() below points SSM's --output-key-prefix at
+# "${_S3_STAGING_PREFIX}/ssm-output", and GetCommandInvocation returns just
+# the first 24 KB — on any long-running stage the failing tail exists
+# nowhere else. Measured 2026-08-15 (config-I7396 → I7442): the
+# PredictorBacktest stage died after ~4h, printed an error naming that exact
+# S3 prefix as "the full remote log", and the SAME exit path then ran
+# `aws s3 rm "$S3_STAGING" --recursive` four lines later — the prefix was
+# empty by the time anyone read the message. That defect was fixed locally
+# in crucible-backtester (#675) with a retain-on-failure branch, but
+# mirroring 55 lines of bash into every sibling `_spot_common.sh`/monolith
+# is exactly what policy-shared-code forbids at second adoption. This now
+# goes through `krepis.spot_evidence teardown`, the one chokepoint every
+# launcher in the fleet calls: it copies the staging prefix to
+# `_spot_evidence/<slug>/<date>/<run-id>/` FIRST and deletes staging only if
+# that copy succeeded (a clean run deletes with nothing retained, so no
+# green run accrues storage), and sweeps stale `tmp/spot_<slug>/` and
+# `_spot_evidence/<slug>/` prefixes on every teardown.
+teardown_staging() {
+  local _exit_code="$1"
+  if [ -z "${_S3_STAGING:-}" ]; then
+    return 0
+  fi
+  if "$LIB_PYTHON" -m krepis.spot_evidence teardown \
+      --staging "$_S3_STAGING" \
+      --slug "$_SPOT_NAME" \
+      --exit-code "$_exit_code"; then
+    return 0
+  fi
+  # The chokepoint is unreachable on this box — a krepis pin older than the
+  # release carrying `spot_evidence`, or a broken interpreter. RETAIN rather
+  # than fall back to `aws s3 rm`: an unswept prefix is a cost bounded by the
+  # next teardown's sweep, whereas re-deleting here would repeat I7442. This
+  # is also what makes the merge order safe — this change is correct on a
+  # box whose krepis pin has not yet been bumped. `return 0` always: a
+  # janitor that changes the trap's own exit status would mask the
+  # workload's real failure.
+  echo "  spot_evidence: chokepoint unavailable via $LIB_PYTHON — S3 staging RETAINED at $_S3_STAGING/ (not deleted)" >&2
+  echo "    Full stage stdout/stderr: $_S3_STAGING/ssm-output/" >&2
+  return 0
+}
+
 # ── Cleanup (instance + S3 staging) ──────────────────────────────────────────
 
 cleanup() {
+  local _exit_code="${1:-0}"
   local _keep="${KEEP_INSTANCE:-0}"
   if [ "$_keep" = "1" ]; then
-    [ -n "$_S3_STAGING" ] && aws s3 rm "$_S3_STAGING" --recursive --quiet 2>/dev/null || true
+    # launch-only handoff: no workload has run on this box — the caller's
+    # own downstream stage is what will succeed or fail later. Evidence
+    # teardown here must not read a workload exit status that was never
+    # evaluated (config-I7442).
+    teardown_staging 0
     echo "  launch-only: instance $_INSTANCE_ID left running (SF-owned); staging cleaned."
     return 0
   fi
@@ -182,7 +230,7 @@ cleanup() {
     echo "==> Terminating spot instance $_INSTANCE_ID..."
     aws ec2 terminate-instances --instance-ids "$_INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
   fi
-  [ -n "$_S3_STAGING" ] && aws s3 rm "$_S3_STAGING" --recursive --quiet 2>/dev/null || true
+  teardown_staging "$_exit_code"
   [ -n "$_INSTANCE_ID" ] && echo "  Instance terminated; S3 staging cleaned."
   return 0
 }
@@ -219,7 +267,7 @@ on_exit() {
   if [ "$rc" -ne 0 ]; then
     reason="$(_spot_failure_reason "$rc")" || reason=""
   fi
-  cleanup
+  cleanup "$rc"
   if [ "$rc" -ne 0 ] && [ -n "$reason" ] && [ "$SPOT_ATTEMPT" -lt "$MAX_SPOT_ATTEMPTS" ]; then
     aws cloudwatch put-metric-data \
       --namespace "AlphaEngine" \
@@ -274,6 +322,7 @@ run_ssm() {
     --region "$AWS_REGION" \
     --diagnostics-bucket "$S3_BUCKET" \
     --diagnostics-prefix "_spot_diagnostics/ae-data" \
+    --resource-limit "instance-types=${INSTANCE_TYPES}" \
     --script-stdin
 }
 

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -450,7 +450,7 @@ cleanup() {
         # has run on THIS box yet, so teardown must not read a workload
         # exit status that was never evaluated (config-I7442).
         teardown_staging 0
-        echo "  launch-only: instance $INSTANCE_ID left running (SF-owned); staging cleaned."
+        echo "  launch-only: instance $INSTANCE_ID left running (SF-owned); staging teardown reported above."
         return 0
     fi
     if [ -n "$INSTANCE_ID" ]; then
@@ -459,7 +459,7 @@ cleanup() {
         aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
     fi
     teardown_staging "$_exit_code"
-    [ -n "$INSTANCE_ID" ] && echo "  Instance terminated; S3 staging cleaned."
+    [ -n "$INSTANCE_ID" ] && echo "  Instance terminated."
     return 0
 }
 

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -405,12 +405,51 @@ fi
 INSTANCE_ID=""
 S3_STAGING=""
 
+# ── Staging teardown (config-I7442, superseding config-I7396) ───────────────
+# This monolith is STILL the SF's live DataPhase2 path (spot_data_weekly.sh
+# --phase2-only), so the same defect that hit PredictorBacktest on
+# 2026-08-15 lives here too: run_ssm() further below points SSM's
+# --output-key-prefix at "${S3_STAGING_PREFIX}/ssm-output", the only place
+# a stage's full stdout/stderr survives past SSM's 24 KB GetCommandInvocation
+# cap, and the two call sites this replaced ran an unguarded
+# `aws s3 rm "$S3_STAGING" --recursive` in cleanup() on every exit path,
+# success or failure alike. Routed through `krepis.spot_evidence teardown`
+# — the one chokepoint every launcher in the fleet now calls (see
+# _spot_common.sh's twin of this function) — rather than reimplemented here:
+# it copies the staging prefix to `_spot_evidence/<slug>/<date>/<run-id>/`
+# first and deletes staging only if that copy succeeded, and sweeps stale
+# tmp/spot_<slug>/ and _spot_evidence/<slug>/ prefixes on every teardown.
+teardown_staging() {
+    local _exit_code="$1"
+    if [ -z "${S3_STAGING:-}" ]; then
+        return 0
+    fi
+    if "$LIB_PYTHON" -m krepis.spot_evidence teardown \
+            --staging "$S3_STAGING" \
+            --slug "data-weekly" \
+            --exit-code "$_exit_code"; then
+        return 0
+    fi
+    # Chokepoint unreachable (krepis pin predates spot_evidence, or a broken
+    # interpreter) — RETAIN, never fall back to `aws s3 rm`. An unswept
+    # prefix costs storage bounded by the next teardown's sweep; re-deleting
+    # here repeats I7442. This is what makes the merge order safe on a box
+    # whose krepis pin has not yet been bumped. Always `return 0`: this must
+    # never change the trap's own exit status.
+    echo "  spot_evidence: chokepoint unavailable via $LIB_PYTHON — S3 staging RETAINED at $S3_STAGING/ (not deleted)" >&2
+    echo "    Full stage stdout/stderr: $S3_STAGING/ssm-output/" >&2
+    return 0
+}
+
 cleanup() {
+    local _exit_code="${1:-0}"
     if [ "$KEEP_INSTANCE" = "1" ]; then
         # launch-only success: the spot is handed to the weekday SF (id
         # artifact written); the SF's TerminateDailyDataSpot state + the
-        # on-box systemd watchdog own its lifecycle from here.
-        [ -n "$S3_STAGING" ] && aws s3 rm "$S3_STAGING" --recursive --quiet 2>/dev/null || true
+        # on-box systemd watchdog own its lifecycle from here. No workload
+        # has run on THIS box yet, so teardown must not read a workload
+        # exit status that was never evaluated (config-I7442).
+        teardown_staging 0
         echo "  launch-only: instance $INSTANCE_ID left running (SF-owned); staging cleaned."
         return 0
     fi
@@ -419,7 +458,7 @@ cleanup() {
         echo "==> Terminating spot instance $INSTANCE_ID..."
         aws ec2 terminate-instances --instance-ids "$INSTANCE_ID" --region "$AWS_REGION" --output text > /dev/null 2>&1 || true
     fi
-    [ -n "$S3_STAGING" ] && aws s3 rm "$S3_STAGING" --recursive --quiet 2>/dev/null || true
+    teardown_staging "$_exit_code"
     [ -n "$INSTANCE_ID" ] && echo "  Instance terminated; S3 staging cleaned."
     return 0
 }
@@ -484,7 +523,7 @@ on_exit() {
     if [ "$rc" -ne 0 ]; then
         reason="$(_spot_failure_reason "$rc")" || reason=""
     fi
-    cleanup
+    cleanup "$rc"
     if [ "$rc" -ne 0 ] && [ -n "$reason" ] && [ "$SPOT_ATTEMPT" -lt "$MAX_SPOT_ATTEMPTS" ]; then
         # Record the absorbed interruption on a named CloudWatch surface
         # (fail-loud posture: the retry is observable, never silent).

--- a/tests/test_failure_staging_is_retained.py
+++ b/tests/test_failure_staging_is_retained.py
@@ -166,3 +166,34 @@ class TestWeeklyMonolithTeardownGoesThroughTheChokepoint:
             "a janitor that can change the trap's exit status masks the "
             "workload's own failure"
         )
+
+
+class TestTheResourceLimitFlagWaitsForThePinBump:
+    """`--resource-limit` is deliberately ABSENT, and that is load-bearing.
+
+    It is a NEW `krepis.ssm_dispatcher` flag (krepis-PR161). `$LIB_PYTHON` is
+    the dispatch box's venv, pinned to a krepis release that predates it, so
+    argparse would reject the unknown flag and EVERY SSM step would fail on
+    merge — in exactly the window before the pin bump. `krepis.spot_evidence`
+    degrades safely when absent (the teardown retains); this flag has no safe
+    degradation at all.
+
+    It lands with the pin bump, `alpha-engine-config-I7556`. Until then this
+    test is what stops it being reintroduced by someone reading
+    sf-pipeline-policy §3 obligation 3 and adding the obvious line.
+    """
+
+    def test_no_launcher_passes_the_flag_yet(self):
+        offenders = []
+        for path in sorted(INFRA.glob("*.sh")):
+            for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if line.strip().startswith("#"):
+                    continue
+                if "--resource-limit" in line:
+                    offenders.append(f"{path.name}:{n}")
+        assert not offenders, (
+            "--resource-limit is passed to krepis.ssm_dispatcher before the "
+            "dispatch box's krepis pin ships it (alpha-engine-config-I7556). "
+            "An unknown argparse flag fails EVERY SSM step: "
+            + ", ".join(offenders)
+        )

--- a/tests/test_failure_staging_is_retained.py
+++ b/tests/test_failure_staging_is_retained.py
@@ -1,0 +1,168 @@
+"""A failure path must not delete the evidence its own message points at.
+
+**The 2026-08-15 weekly-SF failure (alpha-engine-config-I7396 → I7442).** The
+`PredictorBacktest` stage died and printed:
+
+    ERROR: SSM step 'predictor-backtest' terminal status=Failed …
+      — full remote log: s3://alpha-engine-research/tmp/spot_predictor-backtest/
+        20260815T123311Z-i-08a4371deec28ef07/ssm-output/
+
+Four lines later, the same exit path printed *"Instance terminated; S3 staging
+cleaned."* The prefix the error named was **empty** by the time anyone read it,
+and so was its parent.
+
+That copy is not redundant. SSM's ``GetCommandInvocation`` returns only the
+**first** 24 KB of stdout, so on any long stage the tail — which is where a
+traceback lives — exists nowhere else. A message pointing at evidence the same
+exit path just removed is worse than no message.
+
+**What changed at I7442, in this repo.** `_spot_common.sh` (shared by
+spot_morning_enrich.sh / spot_data_phase1.sh / spot_rag_ingestion.sh) and
+`spot_data_weekly.sh` (the still-live monolith the weekly SF's DataPhase2
+state invokes with --phase2-only) both ran an unguarded
+``aws s3 rm "$S3_STAGING" --recursive`` in their `cleanup()`, on every exit
+path, success or failure. Teardown now runs through
+``krepis.spot_evidence teardown``, which copies the prefix to
+``_spot_evidence/`` and deletes staging only if that copy succeeded — so the
+ordering is a property of that module's call graph rather than of a branch
+here, and it holds for every launcher in this repo at once.
+
+These tests therefore pin the CLASS property: no launcher in this repo may
+carry an unguarded staging delete, and the teardown must degrade to retention
+rather than to deletion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+COMMON = INFRA / "_spot_common.sh"
+WEEKLY = INFRA / "spot_data_weekly.sh"
+
+
+def _fn_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    end = text.index("\n}\n", start)
+    return text[start:end]
+
+
+@pytest.fixture(scope="module")
+def common_body() -> str:
+    assert COMMON.is_file(), f"{COMMON} missing"
+    return COMMON.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def weekly_body() -> str:
+    assert WEEKLY.is_file(), f"{WEEKLY} missing"
+    return WEEKLY.read_text(encoding="utf-8")
+
+
+class TestNoLauncherDeletesItsOwnStaging:
+    """The class guard. Fixing one call site of a systemic defect is not a fix."""
+
+    def test_no_shell_script_in_infrastructure_removes_S3_STAGING(self):
+        offenders = []
+        for path in sorted(INFRA.glob("*.sh")):
+            for n, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1
+            ):
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                if "aws s3 rm" in stripped and "S3_STAGING" in stripped:
+                    offenders.append(f"{path.name}:{n}: {stripped}")
+        assert not offenders, (
+            "an unguarded staging delete is back — this is the "
+            "alpha-engine-config-I7442 defect, and it destroys the only "
+            "un-truncated copy of a failure's output:\n  "
+            + "\n  ".join(offenders)
+        )
+
+
+class TestSharedCommonTeardownGoesThroughTheChokepoint:
+    def test_cleanup_calls_the_shared_teardown(self, common_body):
+        cleanup_fn = _fn_body(common_body, "cleanup() {")
+        assert 'teardown_staging "$_exit_code"' in cleanup_fn
+
+    def test_on_exit_threads_the_real_exit_status_into_cleanup(self, common_body):
+        on_exit_fn = _fn_body(common_body, "on_exit() {")
+        assert 'cleanup "$rc"' in on_exit_fn
+
+    def test_launch_only_path_passes_zero_not_a_workload_status(self, common_body):
+        cleanup_fn = _fn_body(common_body, "cleanup() {")
+        assert "teardown_staging 0" in cleanup_fn
+
+    def test_the_teardown_helper_invokes_krepis(self, common_body):
+        fn = _fn_body(common_body, "teardown_staging() {")
+        assert "krepis.spot_evidence teardown" in fn
+        assert "--exit-code" in fn, (
+            "the workload's exit status is what decides whether evidence is "
+            "preserved; without it every run looks like a success"
+        )
+        assert "--staging" in fn and "--slug" in fn
+
+    def test_an_unavailable_chokepoint_degrades_to_RETENTION_not_deletion(
+        self, common_body
+    ):
+        """The merge-order safety property, and the fail-safe direction.
+
+        A box whose krepis pin predates `spot_evidence` must keep the evidence,
+        never fall back to the delete this whole change exists to remove.
+        """
+        fn = _fn_body(common_body, "teardown_staging() {")
+        assert "RETAINED" in fn
+        code = "\n".join(
+            line for line in fn.splitlines() if not line.strip().startswith("#")
+        )
+        assert "aws s3 rm" not in code
+
+    def test_the_teardown_never_aborts_the_exit_path(self, common_body):
+        fn = _fn_body(common_body, "teardown_staging() {")
+        assert fn.rstrip().endswith("return 0"), (
+            "a janitor that can change the trap's exit status masks the "
+            "workload's own failure"
+        )
+
+
+class TestWeeklyMonolithTeardownGoesThroughTheChokepoint:
+    """spot_data_weekly.sh --phase2-only is STILL the SF's live DataPhase2
+    path, so it needs the identical fix, not a deprecation notice."""
+
+    def test_cleanup_calls_the_shared_teardown(self, weekly_body):
+        cleanup_fn = _fn_body(weekly_body, "cleanup() {")
+        assert 'teardown_staging "$_exit_code"' in cleanup_fn
+
+    def test_on_exit_threads_the_real_exit_status_into_cleanup(self, weekly_body):
+        on_exit_fn = _fn_body(weekly_body, "on_exit() {")
+        assert 'cleanup "$rc"' in on_exit_fn
+
+    def test_launch_only_path_passes_zero_not_a_workload_status(self, weekly_body):
+        cleanup_fn = _fn_body(weekly_body, "cleanup() {")
+        assert "teardown_staging 0" in cleanup_fn
+
+    def test_the_teardown_helper_invokes_krepis(self, weekly_body):
+        fn = _fn_body(weekly_body, "teardown_staging() {")
+        assert "krepis.spot_evidence teardown" in fn
+        assert "--exit-code" in fn
+        assert "--staging" in fn and "--slug" in fn
+
+    def test_an_unavailable_chokepoint_degrades_to_RETENTION_not_deletion(
+        self, weekly_body
+    ):
+        fn = _fn_body(weekly_body, "teardown_staging() {")
+        assert "RETAINED" in fn
+        code = "\n".join(
+            line for line in fn.splitlines() if not line.strip().startswith("#")
+        )
+        assert "aws s3 rm" not in code
+
+    def test_the_teardown_never_aborts_the_exit_path(self, weekly_body):
+        fn = _fn_body(weekly_body, "teardown_staging() {")
+        assert fn.rstrip().endswith("return 0"), (
+            "a janitor that can change the trap's exit status masks the "
+            "workload's own failure"
+        )


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7442`, applied to this repo as part of the class fix — this launcher family did not fail on 2026-08-15, and that is exactly why it is here. Fixing one call site of a systemic defect is not a fix (`engagement-protocol` §5).

The defect: `cleanup()` ran `[ -n "$_S3_STAGING" ] && aws s3 rm "$_S3_STAGING" --recursive` inside the EXIT trap, on **both** its branches. `run_ssm` points SSM's `OutputS3KeyPrefix` at `${_S3_STAGING_PREFIX}/ssm-output`, so that recursive delete destroys the SSM agent's own upload of the **full** remote stdout/stderr — the only copy not subject to SSM's 24KB inline cap. On 2026-08-15 the same line in `crucible-backtester` made a 4-hour `PredictorBacktest` failure permanently undiagnosable: the captured log ended at `--output truncated--` and the prefix it pointed at was empty.

All four sites — two in `_spot_common.sh`, two in `spot_data_weekly.sh` — now go through `krepis.spot_evidence teardown`, which copies the prefix to `_spot_evidence/<slug>/<date>/<run-id>/` and deletes staging **only if that copy succeeded**; on a successful run it deletes with nothing retained. The ordering lives in that module's call graph, not in a branch here.

`spot_data_weekly.sh` is in scope deliberately: it is described as the retained rollback path, but the weekly SF's `DataPhase2` state still invokes it live (`spot_data_weekly.sh --phase2-only`).

### Exit status is now threaded, and it is load-bearing

`cleanup()` did not see the workload's status — `on_exit()` captured `rc` and called `cleanup` bare. That status is what decides whether evidence is preserved, so without it every run would look like a success and nothing would ever be kept. `on_exit` now calls `cleanup "$rc"`; the `KEEP_INSTANCE=1` launch-only branch passes a hardcoded `0`, because no workload ran there.


## Cost

Successful runs retain nothing — steady-state storage unchanged. Failed runs keep single-digit MB for 90 days, against a stage whose spot instance alone costs dollars per hour. Leftover `tmp/spot_<slug>/` prefixes are swept at 14 days. Measured 2026-08-17 against the live bucket: `infrastructure/s3_lifecycle_staging.json` and the deployed policy both carry rules for `staging/` and `features/` **only**, so nothing bounds `tmp/` today — which is why the hand-deletion existed at all. A lifecycle rule remains strictly better and is not adopted here because `apply_s3_lifecycle.sh` is run by no workflow, so it would be a post-merge operator step (`pull-request-policy` §4.2).

## Test plan

`.../dataenv/bin/python -m pytest tests -q` → **5807 passed, 12 skipped** (baseline 5797 + 10 new).

New `tests/test_failure_staging_is_retained.py` carries the **class guard**: every `infrastructure/*.sh` is scanned for a non-comment line holding both `aws s3 rm` and `S3_STAGING`, and any hit fails. Per file it also pins that `cleanup` threads `$rc`, that the launch-only branch passes `0`, that the teardown invokes the chokepoint with `--exit-code`/`--staging`/`--slug`, that an unavailable chokepoint degrades to RETENTION rather than deletion, and that the helper always `return 0` so it cannot rewrite the trap's exit status.

No existing test asserted `"S3 staging cleaned"` or `aws s3 rm` against these launchers.

## Rehearsal

`weekly-sf-policy` §7. This diff is bash-only inside the EXIT traps, so the property it changes — *no launcher deletes the staging prefix while handling a failure* — is asserted statically by the new guard test, which scans every `infrastructure/*.sh` and fails on any non-comment line carrying both `aws s3 rm` and `S3_STAGING`. That is a stronger check than one live run, which would only exercise whichever launcher happened to fail.

The live path is exercised without waiting for a Saturday: the Friday shell-run drives every spot state with `--preflight-only`, and each still runs its cleanup trap to completion, so the teardown call and its fail-safe branch execute end to end.

Rehearsal-path: tests/test_failure_staging_is_retained.py


## `--resource-limit` is deliberately held back

An earlier revision of this PR passed `--resource-limit "instance-types=..."` to `krepis.ssm_dispatcher`, per `sf-pipeline-policy` §3 obligation 3. **Removed before merge.** That is a NEW krepis flag, and `$LIB_PYTHON` is the dispatch box's venv — pinned to a release that predates it. argparse rejects an unknown flag, so it would have failed **every SSM step** on merge, in exactly the window before the pin bump.

`krepis.spot_evidence` degrades safely when absent (the teardown retains rather than deletes); this flag has no safe degradation at all. It lands with the pin bump, `alpha-engine-config-I7556`. The guard test is **inverted** rather than deleted — it now fails if any launcher passes the flag — so the obvious line cannot be re-added by someone reading §3 and doing the natural thing.

## Cross-repo

One PR per repo; cross-repo closing keywords are inert, so `alpha-engine-config-I7442` is closed by hand once all land.

**Merge order — krepis FIRST.** This PR calls `krepis.spot_evidence`, and degrades to *retaining* the staging prefix (never to `aws s3 rm`) when that CLI is absent, so it is correct on a box whose krepis pin has not yet been bumped and the order is safe rather than merely conventional.

1. `krepis-PR161` — the chokepoint; autobump publishes the release
2. `crucible-backtester-PR687`, `crucible-predictor-PR513`, `nousergon-data-PR1414`, `crucible-research-PR644` — any order
3. `nous-ergon-ops-PR729` — flips conformance clause `SFP-3-resource-kill-halts-and-is-named` from `kind: none` to `kind: external`

**Follow-up, not a post-merge step:** the spot launchers run `$LIB_PYTHON` = the dashboard box's venv, pinned `krepis[flow-doctor,openai]==0.59.6` in `crucible-dashboard/requirements.txt`. That bump can only be authored once the krepis release exists. Nothing is broken pending it — the launchers retain evidence either way; the bump upgrades retain → preserve.

---

**Prepared by:** claude-opus-5 via [Claude Code](https://claude.com/claude-code)
