### PR TITLE
fix(notify): the EOD terminal lands where the RUNNING ping lands (alpha-engine-config-I7573)

### DIFF
--- a/infrastructure/lambdas/_shared/run_handler_tests.sh
+++ b/infrastructure/lambdas/_shared/run_handler_tests.sh
@@ -47,15 +47,52 @@
 #   HANDLER_TEST_PYTHONPATH  extra colon-path appended after the scratch deps dir
 #                            (e.g. the lambdas dir so `import flow_doctor_telegram`
 #                            resolves for tests that don't self-path)
-#   HANDLER_TEST_TARGETS     extra pytest target paths run alongside test_handler.py
-#                            (e.g. sf-telegram-notifier's test_execution_digest.py)
-# Returns pytest's exit code (0 if the lambda has no test_handler.py). Cleans up
-# its own scratch dir; safe under `set -euo pipefail`.
+#   HANDLER_TEST_TARGETS     extra pytest target paths run alongside test_handler.py.
+#                            DEFAULTS to every sibling test_*.py in SCRIPT_DIR.
+#                            Set it explicitly to narrow; set it to " " to run
+#                            test_handler.py alone.
+# Returns non-zero if ANY target failed (0 if the lambda has no test_handler.py).
+# Cleans up its own scratch dir; safe under `set -euo pipefail`.
+#
+# Two invariants this function owns, both earned (alpha-engine-config-I7573):
+#
+#  1. AUTO-DISCOVERY. HANDLER_TEST_TARGETS was set in exactly one place —
+#     sf-telegram-notifier/deploy.sh — and nowhere in ci.yml, whose glob step
+#     passes only the directory. So that lambda's test_execution_digest.py and
+#     test_eod_artifact_verification.py ran at DEPLOY time (post-merge) and
+#     never pre-merge, and its test_flow_doctor_fleet_wiring.py ran in neither.
+#     A test file that no gate runs is not coverage. Defaulting to the sibling
+#     glob makes pre-merge and post-merge see the same set, which is the whole
+#     reason this helper exists.
+#
+#  2. ONE PROCESS PER FILE. They used to share a single pytest invocation, so a
+#     module-scope `sys.modules[...] = <stub>` in one file leaked into every
+#     file collected after it. Live instance: sf-telegram-notifier's
+#     test_handler.py installs a stub of `nousergon_lib.flow_doctor_fleet` that
+#     omits `fleet_telegram_notifier_dicts`, and
+#     test_flow_doctor_fleet_wiring.py — which exists precisely to check the
+#     config against the REAL fleet spec — then fails on import. It passes
+#     alone and fails in a full run, i.e. the result depended on collection
+#     order. Separate processes make each file's answer its own.
 run_handler_tests() {
   local script_dir="$1"; shift
   local test_file="${script_dir}/test_handler.py"
   if [[ ! -f "${test_file}" ]]; then
     return 0
+  fi
+
+  local targets
+  if [[ -n "${HANDLER_TEST_TARGETS+x}" ]]; then
+    # shellcheck disable=SC2206 — intentional word-split on the caller's list.
+    targets=(${HANDLER_TEST_TARGETS})
+  else
+    targets=()
+    local sibling
+    for sibling in "${script_dir}"/test_*.py; do
+      if [[ -f "${sibling}" && "${sibling}" != "${test_file}" ]]; then
+        targets+=("${sibling}")
+      fi
+    done
   fi
 
   local deps_dir
@@ -69,13 +106,20 @@ run_handler_tests() {
   fi
 
   local pypath="${deps_dir}${HANDLER_TEST_PYTHONPATH:+:${HANDLER_TEST_PYTHONPATH}}"
-  echo "Running handler unit tests (${test_file##*/}${HANDLER_TEST_TARGETS:+ + ${HANDLER_TEST_TARGETS}})..." >&2
 
-  local rc=0
-  # ${HANDLER_TEST_TARGETS} intentionally unquoted — space-separated extra targets.
-  PYTHONPATH="${pypath}" \
-  AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}" \
-    python3 -m pytest "${test_file}" ${HANDLER_TEST_TARGETS:-} -q || rc=$?
+  local rc=0 one file_rc
+  # ${targets[@]+...} guard: bash 3.2 (the macOS system bash every deploy.sh
+  # runs under) errors on "${arr[@]}" for an EMPTY array under `set -u`.
+  for one in "${test_file}" ${targets[@]+"${targets[@]}"}; do
+    echo "Running ${one##*/}..." >&2
+    file_rc=0
+    PYTHONPATH="${pypath}" \
+    AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}" \
+      python3 -m pytest "${one}" -q || file_rc=$?
+    if [[ "${file_rc}" -ne 0 ]]; then
+      rc="${file_rc}"
+    fi
+  done
 
   rm -rf "${deps_dir}"
   return "${rc}"

--- a/infrastructure/lambdas/flow_doctor_telegram.py
+++ b/infrastructure/lambdas/flow_doctor_telegram.py
@@ -38,6 +38,7 @@ def build_flow_doctor_config(
     db_basename: str,
     repo: str = "nousergon/nousergon-data",
     notifier_overrides: Optional[Dict[str, Any]] = None,
+    rate_limit_exempt_severities: Optional[Sequence[str]] = None,
 ) -> dict:
     """Build a flow-doctor config for ``topics``.
 
@@ -78,7 +79,32 @@ def build_flow_doctor_config(
         # Lambda's own iam-policy.json FlowDoctorDedupStore statement.
         "store": {"type": "dynamodb", "table_name": "flow-doctor-store", "region": "us-east-1"},
         "dedup_cooldown_minutes": 1,
-        "rate_limits": {"max_alerts_per_day": 100},
+        # `max_alerts_per_day` is counted by flow-doctor's RateLimiter as
+        # `store.count_actions_today("telegram_alert")` — against the SHARED
+        # DynamoDB store above, so the 100/day budget is a FLEET-WIDE counter,
+        # not a per-flow one. Every consumer writing to `flow-doctor-store`
+        # spends from the same pool, and terminal notifications are by
+        # construction the last events of the day, so they are the ones the
+        # budget reaches first (flow_doctor/core/rate_limiter.py's own docstring
+        # records the 2026-07-28 incident where exactly this dropped 12 of 13
+        # terminal pipeline notifications).
+        #
+        # `rate_limit_exempt_severities` is flow-doctor's mechanism for taking a
+        # class of traffic out of that blunt daily cap; it defaults to
+        # critical+error, so `info` (a SUCCEEDED terminal) and `warning` (a
+        # FAILED or DegradedRun terminal) are both droppable by default.
+        # Callers that are BOUNDED producers — a lifecycle mirror of a fixed
+        # set of state machines cannot storm, and repeats of one signature are
+        # already handled by signature dedup + `dedup_cooldown_minutes` — pass
+        # their own list. Unset is byte-identical to before.
+        "rate_limits": (
+            {"max_alerts_per_day": 100}
+            if rate_limit_exempt_severities is None
+            else {
+                "max_alerts_per_day": 100,
+                "rate_limit_exempt_severities": list(rate_limit_exempt_severities),
+            }
+        ),
     }
 
 
@@ -88,6 +114,7 @@ def get_flow_doctor(
     *,
     db_basename: str,
     notifier_overrides: Optional[Dict[str, Any]] = None,
+    rate_limit_exempt_severities: Optional[Sequence[str]] = None,
 ) -> Any | None:
     # NOTE: the cache is keyed on flow_name alone, so a caller applying
     # notifier_overrides MUST use a distinct flow_name (the groom cycle flow
@@ -109,6 +136,7 @@ def get_flow_doctor(
         cfg = build_flow_doctor_config(
             flow_name, topics, db_basename=db_basename,
             notifier_overrides=notifier_overrides,
+            rate_limit_exempt_severities=rate_limit_exempt_severities,
         )
         path = Path(f"/tmp/flow_doctor_{db_basename}.yaml")
         path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
@@ -186,7 +214,9 @@ def notify_via_flow_doctor(
     source: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
     silent_topic: Any | None = None,
+    guaranteed_topic: Any | None = None,
     notifier_overrides: Optional[Dict[str, Any]] = None,
+    rate_limit_exempt_severities: Optional[Sequence[str]] = None,
 ) -> bool:
     """Route ``text`` through flow-doctor forum topics; fallback to ``send_message``.
     Args:
@@ -204,6 +234,16 @@ def notify_via_flow_doctor(
             krepis behavior).
         context: Arbitrary key-value metadata.
         silent_topic: Optional topic for silent notifications when ``silent`` is True.
+        guaranteed_topic: Optional topic that MUST receive ``text`` even when
+            flow-doctor suppresses the alert. On any suppression other than
+            dedup (rate_limited, severity_filtered, category_filtered,
+            delivery_failed, no_notifiers) the message is delivered raw to this
+            topic's notifier, bypassing the shared daily budget. For a
+            once-per-day lifecycle terminal, "suppressed" and "the pipeline
+            never ran" look identical to the operator, and the second is the
+            one worth interrupting them for.
+        rate_limit_exempt_severities: Severities this flow takes out of the
+            fleet-shared daily alert budget — see ``build_flow_doctor_config``.
         notifier_overrides: Per-flow delivery-posture override merged into every
             notifier dict — see ``build_flow_doctor_config``. Requires a
             flow_name unique to that posture (the config cache is keyed on it).
@@ -220,6 +260,7 @@ def notify_via_flow_doctor(
         fd = get_flow_doctor(
             flow_name, topics, db_basename=db_basename,
             notifier_overrides=notifier_overrides,
+            rate_limit_exempt_severities=rate_limit_exempt_severities,
         )
         if fd is None:
             return send_message(text, disable_notification=silent)
@@ -231,11 +272,49 @@ def notify_via_flow_doctor(
             if notifier is not None:
                 return notifier.send_raw(text, disable_notification=True) is not None
 
-        report_id = fd.notify_event(
+        fd.notify_event(
             subject,
             body=None,
             severity=severity,
             context=context or {},
             dedup_key=dedup_key,
         )
-        return report_id is not None
+        # NOT `report_id is not None`. flow-doctor returns a report id for
+        # `severity_filtered` / `category_filtered` / `rate_limited` /
+        # `delivery_failed` / `no_notifiers` too — "seen and evaluated", not
+        # "delivered" — so the old expression reported `telegram_sent: True`
+        # on every suppressed alert. `last_dispatched()` is the library's own
+        # answer to exactly this question (>=1 notifier reached).
+        dispatched = bool(fd.last_dispatched())
+        if dispatched or guaranteed_topic is None:
+            return dispatched
+
+        # Guaranteed delivery. `dedup` is deliberately NOT overridden: a repeat
+        # of the same signature inside the cooldown is a message the operator
+        # has already been shown, and re-sending it raw would defeat the one
+        # suppression that exists to protect them. Every OTHER suppression
+        # reason means the operator was shown nothing, which for a
+        # once-per-day lifecycle terminal is indistinguishable from the
+        # pipeline never having run (principles.md §2.7).
+        reason = fd.last_dispatch_reason()
+        if reason == "deduped":
+            logger.info(
+                "notify_via_flow_doctor: %s suppressed as a duplicate — not "
+                "re-sending raw (flow=%s)", dedup_key, flow_name,
+            )
+            return False
+        notifier = topic_telegram_notifier(fd, guaranteed_topic)
+        if notifier is None:
+            logger.warning(
+                "notify_via_flow_doctor: %r suppressed (reason=%s) and no "
+                "notifier is configured for guaranteed_topic=%r — the message "
+                "reached nobody (flow=%s)",
+                dedup_key, reason, guaranteed_topic, flow_name,
+            )
+            return False
+        logger.warning(
+            "notify_via_flow_doctor: %r suppressed by flow-doctor (reason=%s) "
+            "— delivering raw to guaranteed_topic=%r (flow=%s)",
+            dedup_key, reason, guaranteed_topic, flow_name,
+        )
+        return notifier.send_raw(text, disable_notification=silent) is not None

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -93,7 +93,6 @@ bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements
 # means no linux/amd64 wheel is imported, so the old Darwin skip is obsolete.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
 HANDLER_TEST_PYTHONPATH="${LAMBDAS_DIR}" \
-HANDLER_TEST_TARGETS="${SCRIPT_DIR}/test_execution_digest.py ${SCRIPT_DIR}/test_eod_artifact_verification.py" \
   run_handler_tests "${SCRIPT_DIR}" boto3
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"

--- a/infrastructure/lambdas/sf-telegram-notifier/index.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/index.py
@@ -76,6 +76,14 @@ _STATUS_EMOJI: dict[str, str] = {
 # must also not read as a generic failure). Distinct emoji, distinct label.
 _DEGRADED_EMOJI = "\U0001f7e0"  # 🟠
 
+# Every severity this notifier can emit is exempt from the fleet-shared daily
+# alert budget. Justified by the producer being BOUNDED, not by the traffic
+# being important: this Lambda mirrors the lifecycle of a fixed set of state
+# machines, so its event count per day is bounded by SF transitions and it
+# cannot storm. Repeats of one signature are still suppressed by signature
+# dedup + `dedup_cooldown_minutes: 1`. See the ruling note in `handler`.
+_RATE_LIMIT_EXEMPT_SEVERITIES: tuple[str, ...] = ("critical", "error", "warning", "info")
+
 _CAUSE_MAX_CHARS = 280
 _TERMINAL_STATUSES = frozenset({"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"})
 
@@ -86,6 +94,7 @@ def build_flow_doctor_config_for_tests() -> dict:
         _FLOW_NAME,
         PIPELINE_OBSERVER_TELEGRAM_TOPICS,
         db_basename=_DB_BASENAME,
+        rate_limit_exempt_severities=_RATE_LIMIT_EXEMPT_SEVERITIES,
     )
 
 
@@ -339,6 +348,26 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001
         flow_name=_FLOW_NAME,
         topics=PIPELINE_OBSERVER_TELEGRAM_TOPICS,
         db_basename=_DB_BASENAME,
+        # Brian's ruling, 2026-08-17: "eod outcome should land in the same
+        # place as 'Post-close Trading SF — RUNNING'". Those two messages take
+        # DIFFERENT delivery paths, which is why they had different
+        # reliability. RUNNING goes out via the `silent_topic` branch's
+        # `send_raw`, which never touches flow-doctor's alert pipeline and so
+        # always arrives. The terminal goes through `notify_event`, where the
+        # fleet-shared daily budget can drop it — measured on the postclose SF:
+        # 2026-08-03, -04 and -07 all reached SUCCEEDED and all three reports
+        # were recorded `reason=rate_limited`, delivered nowhere, while that
+        # morning's RUNNING ping landed normally. Three of the last eight
+        # trading days had a green EOD that was indistinguishable, on the
+        # thread the operator actually reads, from a pipeline that never ran.
+        #
+        # Two changes make the ruling structurally true rather than probable:
+        # the exemption below takes this bounded lifecycle mirror out of the
+        # shared budget so the ordinary path fires, and `guaranteed_topic` is
+        # the belt — any FUTURE suppression that is not dedup still lands the
+        # message in PIPELINE, the same thread RUNNING goes to.
+        rate_limit_exempt_severities=_RATE_LIMIT_EXEMPT_SEVERITIES,
+        guaranteed_topic=FleetTelegramTopic.PIPELINE,
         context={
             "state_machine": sm_name,
             "execution": detail.get("name"),

--- a/infrastructure/lambdas/sf-telegram-notifier/test_terminal_delivery_guarantee.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_terminal_delivery_guarantee.py
@@ -1,0 +1,215 @@
+"""The EOD terminal lands where the RUNNING ping lands (alpha-engine-config-I7573).
+
+Brian's ruling, 2026-08-17: "eod outcome should land in the same place as
+'Post-close Trading SF — RUNNING'".
+
+They were not landing in the same place, and the reason was that they take
+different delivery paths inside ``notify_via_flow_doctor``:
+
+* RUNNING is ``silent=True``, so it takes the ``silent_topic`` branch and is
+  written straight to the PIPELINE thread with ``send_raw`` — flow-doctor's
+  dedup, severity filter and rate limiter are never consulted, so it always
+  arrives.
+* The terminal goes through ``fd.notify_event``, where the fleet-shared daily
+  alert budget applies. ``rate_limit_exempt_severities`` defaults to
+  critical+error, and a terminal is ``info`` (SUCCEEDED) or ``warning``
+  (FAILED / DegradedRun) — neither exempt.
+
+Measured on ne-postclose-trading-pipeline: 2026-08-03, -04 and -07 all reached
+SUCCEEDED and all three reports were recorded ``reason=rate_limited``, i.e.
+delivered to nobody, while each of those mornings' RUNNING pings landed
+normally.
+
+These tests pin both halves of the fix: the exemption that stops the drop, and
+the ``guaranteed_topic`` belt that catches any future suppression which is not
+dedup.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import flow_doctor_telegram  # noqa: E402
+
+
+class _Notifier:
+    def __init__(self):
+        self.sent: list[tuple[str, bool]] = []
+
+    def send_raw(self, text, disable_notification=False):
+        self.sent.append((text, disable_notification))
+        return "message-id"
+
+
+class _FlowDoctor:
+    """Minimal stand-in for the bits of FlowDoctor this module touches."""
+
+    def __init__(self, reason: str):
+        self._reason = reason
+        self.events: list[dict] = []
+
+    def notify_event(self, subject, body=None, *, severity, context, dedup_key):
+        self.events.append({"subject": subject, "severity": severity})
+        # A report id is returned for EVERY outcome, including suppressed ones.
+        return "report-id"
+
+    def last_dispatched(self) -> bool:
+        return self._reason == "fired"
+
+    def last_dispatch_reason(self) -> str:
+        return self._reason
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Patch get_flow_doctor / topic_telegram_notifier and hand back the doubles."""
+
+    def _wire(reason: str, *, notifier: _Notifier | None = None):
+        fd = _FlowDoctor(reason)
+        found = _Notifier() if notifier is None else notifier
+        monkeypatch.setattr(flow_doctor_telegram, "get_flow_doctor", lambda *a, **k: fd)
+        monkeypatch.setattr(
+            flow_doctor_telegram, "topic_telegram_notifier", lambda _fd, _topic: found
+        )
+        return fd, found
+
+    return _wire
+
+
+def _call(**overrides):
+    kwargs = dict(
+        text="Post-close Trading SF — SUCCEEDED",
+        silent=False,
+        severity="info",
+        dedup_key="k",
+        flow_name="sf-telegram-notifier",
+        topics=(),
+        db_basename="db",
+    )
+    kwargs.update(overrides)
+    return flow_doctor_telegram.notify_via_flow_doctor(**kwargs)
+
+
+class TestHonestReturnValue:
+    def test_a_rate_limited_alert_is_not_reported_as_sent(self, wired):
+        """The old expression was `report_id is not None`, and flow-doctor
+        returns a report id for a rate-limited alert too — so `telegram_sent`
+        was True on every drop."""
+        wired("rate_limited")
+        assert _call() is False
+
+    def test_a_delivered_alert_is_reported_as_sent(self, wired):
+        wired("fired")
+        assert _call() is True
+
+
+class TestGuaranteedTopic:
+    def test_rate_limited_terminal_still_reaches_the_pipeline_thread(self, wired):
+        _fd, notifier = wired("rate_limited")
+        assert _call(guaranteed_topic="PIPELINE") is True
+        assert notifier.sent == [("Post-close Trading SF — SUCCEEDED", False)]
+
+    @pytest.mark.parametrize(
+        "reason",
+        ["rate_limited", "severity_filtered", "category_filtered",
+         "delivery_failed", "no_notifiers"],
+    )
+    def test_every_non_dedup_suppression_falls_back(self, wired, reason):
+        _fd, notifier = wired(reason)
+        assert _call(guaranteed_topic="PIPELINE") is True
+        assert len(notifier.sent) == 1
+
+    def test_dedup_is_respected_not_bypassed(self, wired):
+        """A repeat inside the cooldown is a message the operator has already
+        been shown. Re-sending it raw would defeat the one suppression that
+        exists to protect them."""
+        _fd, notifier = wired("deduped")
+        assert _call(guaranteed_topic="PIPELINE") is False
+        assert notifier.sent == []
+
+    def test_a_delivered_alert_is_not_sent_twice(self, wired):
+        _fd, notifier = wired("fired")
+        assert _call(guaranteed_topic="PIPELINE") is True
+        assert notifier.sent == []
+
+    def test_without_a_guaranteed_topic_nothing_changes(self, wired):
+        _fd, notifier = wired("rate_limited")
+        assert _call() is False
+        assert notifier.sent == []
+
+    def test_missing_notifier_returns_false_rather_than_claiming_delivery(
+        self, monkeypatch
+    ):
+        fd = _FlowDoctor("rate_limited")
+        monkeypatch.setattr(flow_doctor_telegram, "get_flow_doctor", lambda *a, **k: fd)
+        monkeypatch.setattr(
+            flow_doctor_telegram, "topic_telegram_notifier", lambda _fd, _topic: None
+        )
+        assert _call(guaranteed_topic="PIPELINE") is False
+
+
+@pytest.fixture
+def fleet_module():
+    """A `nousergon_lib.flow_doctor_fleet` that has `fleet_telegram_notifier_dicts`.
+
+    ``test_handler.py`` installs a module-scope stub of that package into
+    ``sys.modules`` and never removes it, and the stub omits this function — so
+    whether ``build_flow_doctor_config`` is importable at all depends on
+    pytest's collection order. That order-dependence is a pre-existing defect
+    in this directory's suite (it is why
+    ``test_flow_doctor_fleet_wiring.py::test_build_flow_doctor_config_matches_pipeline_observer_topics``
+    passes alone and fails in a full run, on `main` as well as on this branch);
+    it is filed separately rather than patched over here. This fixture only
+    stops THESE tests from inheriting it.
+    """
+    import sys as _sys
+
+    mod = _sys.modules.get("nousergon_lib.flow_doctor_fleet")
+    if mod is not None and not hasattr(mod, "fleet_telegram_notifier_dicts"):
+        mod.fleet_telegram_notifier_dicts = lambda topics: [
+            {"type": "telegram", "topic": t} for t in topics
+        ]
+    return mod
+
+
+@pytest.mark.usefixtures("fleet_module")
+class TestRateLimitExemption:
+    def test_default_config_is_unchanged(self):
+        cfg = flow_doctor_telegram.build_flow_doctor_config(
+            "f", (), db_basename="db"
+        )
+        assert cfg["rate_limits"] == {"max_alerts_per_day": 100}
+
+    def test_exemption_is_emitted_when_requested(self):
+        cfg = flow_doctor_telegram.build_flow_doctor_config(
+            "f", (), db_basename="db",
+            rate_limit_exempt_severities=("critical", "error", "warning", "info"),
+        )
+        assert cfg["rate_limits"]["rate_limit_exempt_severities"] == [
+            "critical", "error", "warning", "info",
+        ]
+
+    def test_the_sf_notifier_exempts_both_terminal_severities(self):
+        """`info` is a SUCCEEDED terminal and `warning` is a FAILED or
+        DegradedRun terminal. Missing either one puts that outcome back inside
+        the shared budget that dropped it."""
+        import index
+
+        cfg = index.build_flow_doctor_config_for_tests()
+        exempt = cfg["rate_limits"]["rate_limit_exempt_severities"]
+        assert "info" in exempt
+        assert "warning" in exempt
+
+
+def test_module_imports_without_boto(monkeypatch):
+    """Guard the guard: these tests assert on a real module, not a stub that
+    would make every assertion above vacuous."""
+    assert isinstance(flow_doctor_telegram, types.ModuleType)
+    assert hasattr(flow_doctor_telegram, "notify_via_flow_doctor")


### PR DESCRIPTION
## Ruling

Brian, 2026-08-17: *"eod outcome should land in the same place as 'Post-close Trading SF — RUNNING'"*.

## Why they did not

The two messages take **different delivery paths** inside `notify_via_flow_doctor`:

| Message | Path | Suppressible? |
|---|---|---|
| `RUNNING` | `silent=True` → `silent_topic` branch → `notifier.send_raw` | No — dedup, severity filter and rate limiter are never consulted |
| terminal | `fd.notify_event` | Yes — the daily alert budget applies |

flow-doctor counts that budget as `store.count_actions_today("telegram_alert")` against the **shared** DynamoDB store, so `max_alerts_per_day: 100` is a fleet-wide counter. `rate_limit_exempt_severities` defaults to critical+error; a SUCCEEDED terminal is `info` and a FAILED/DegradedRun terminal is `warning`. Terminals are by construction the last events of the day, so they are what the budget reaches first.

## Measured

`/aws/lambda/alpha-engine-sf-telegram-notifier`, correlating each postclose terminal with its flow-doctor decision:

| Date | Terminal | Decision |
|---|---|---|
| 2026-08-03 | SUCCEEDED | `rate_limited` — delivered nowhere |
| 2026-08-04 | SUCCEEDED | `rate_limited` — delivered nowhere |
| 2026-08-07 | SUCCEEDED | `rate_limited` — delivered nowhere |
| 2026-08-10 … -14 | SUCCEEDED | `fired` → thread 231 |

Each of those three mornings' RUNNING pings landed normally. Three of the last eight trading days had a green EOD that was indistinguishable, on the thread the operator reads, from a pipeline that never ran — `principles.md` §2.7. `flow_doctor/core/rate_limiter.py`'s own docstring records the same shape from 2026-07-28, when it dropped 12 of 13 terminal pipeline notifications.

## Changes

1. **`rate_limit_exempt_severities`** on `build_flow_doctor_config` (unset ⇒ byte-identical to before); the SF notifier passes all four. Justified by the producer being **bounded** — a lifecycle mirror of a fixed set of state machines cannot storm — not by its traffic being important. Signature dedup and `dedup_cooldown_minutes: 1` still suppress repeats.
2. **`guaranteed_topic`** is the belt: on any suppression that is *not* dedup, the message is delivered raw to that topic, so the ruling holds against future suppression reasons too. Dedup is deliberately honoured — a repeat inside the cooldown is a message the operator has already been shown.
3. **Honest return value.** `notify_via_flow_doctor` returned `report_id is not None`, and flow-doctor returns a report id for `severity_filtered` / `category_filtered` / `rate_limited` / `delivery_failed` / `no_notifiers` too. `telegram_sent: True` was reported on every drop, including all three above. Now `fd.last_dispatched()`.

## The tests would not have run anywhere

`ci.yml`'s glob passes only a directory to `run_handler_tests`, which runs `test_handler.py` plus `HANDLER_TEST_TARGETS` — set in exactly one place, `sf-telegram-notifier/deploy.sh`. So this lambda's `test_execution_digest.py` and `test_eod_artifact_verification.py` ran at **deploy** time only, never pre-merge, and `test_flow_doctor_fleet_wiring.py` ran in neither.

The helper now defaults its target list to every sibling `test_*.py`, and the deploy.sh override that narrowed it is removed — pre-merge and post-merge see the same set.

Each target now runs in its **own pytest process**. They shared one invocation, so a module-scope `sys.modules` stub in one file leaked into every file collected after it: `test_handler.py` stubs `nousergon_lib.flow_doctor_fleet` without `fleet_telegram_notifier_dicts`, and `test_flow_doctor_fleet_wiring.py` — which exists to check the config against the *real* fleet spec — failed on import. It passed alone and failed in a full run, **on `main` as well as here**. Separate processes make each file's answer its own; it now passes in both.

## Test plan (run before opening)

Helper end-to-end over this lambda, each file its own process:

```
Running test_handler.py...                       38 passed
Running test_eod_artifact_verification.py...     14 passed
Running test_execution_digest.py...              24 passed
Running test_flow_doctor_fleet_wiring.py...       1 passed
Running test_terminal_delivery_guarantee.py...   16 passed
```

The two other dirs auto-discovery newly reaches run green per-file: `expense-collector` (`test_balance_depletion.py` 23), `scheduled-groom-dispatcher` (`test_attended_window_gate.py` 10).

`tests/` — 5916 passed, 13 skipped, 1 failed: `test_stage_output_sweep.py::TestExecutionContext::test_no_injected_client_resolves_a_region_with_no_env_set`, an ImportError that reproduces identically on an untouched `origin/main` worktree and is unrelated to this change.

## Post-merge

None. The Lambda redeploys from its own `deploy.sh` on the normal cadence; nothing here needs a command run after the merge.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)