### PR TITLE
fix(fundamentals): a field dead for the whole universe now fails the collector (alpha-engine-config-I7583)

### DIFF
--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -101,6 +101,84 @@ _FUNDAMENTALS_FIELD_SPECS: dict[str, dict] = {
 }
 
 
+# ── Cross-sectional collapse gate (alpha-engine-config-I7583) ────────────────
+#
+# The per-ticker `ok_ratio` gate below asks "did THIS TICKER return anything at
+# all". It cannot see a field that is dead for EVERY ticker: a ticker returning
+# 13 of 14 fields counts as fully populated, so a field absent from the vendor
+# response for the whole universe passes it 903 times over.
+#
+# That is not hypothetical. `capitalSpendingGrowth5Y` and `freeCashFlowTTM` do
+# not exist in Finnhub's `metric=all` response at all; `_pick`'s `default=0.0`
+# turned both into a universe-wide 0.0, and this collector reported `ok` every
+# run for as long as the Finnhub integration has been live. The same shape hit
+# a second way when the percent-point units were wrong: every value exceeded
+# its clip bound, so `gross_margin` and `roe` collapsed onto the ceiling for
+# ~90% of the universe. Both were found by hand, off a question in a chat
+# (alpha-engine-config-I7569); nothing in this file would have raised, and
+# nothing would raise for the next one.
+#
+# This gate is deliberately written over the OUTPUT rather than over the vendor
+# keys, so it catches the class regardless of cause — an absent key defaulting
+# to a constant, a units mismatch saturating a clip bound, a scaling divisor
+# that collapses a range, or a vendor silently switching a field to a fixed
+# value. Any cause that ends in "this column carries no cross-sectional
+# information" is caught by the same predicate.
+#
+# It also sits where `_FUNDAMENTALS_FIELD_SPECS` cannot: that gate runs on
+# values `_clip` has ALREADY bounded to its own bands, so it is structurally
+# incapable of firing on saturation. This one runs on the assembled universe.
+#
+# FAIL is set at 0.99 rather than 1.00 so a single stray ticker cannot mask a
+# dead field. WARN is the observe band: it does not halt, because a legitimately
+# concentrated field (a payout ratio where most of the universe pays nothing) is
+# plausible, and per alpha-engine-config-I7581 a new gate must not go straight
+# to enforcing on a range whose real distribution has not been measured over the
+# full universe. Promote the warn band to fail once a full post-I7569 run has
+# been observed — tracked on I7583.
+_FIELD_COLLAPSE_FAIL_SHARE = 0.99
+_FIELD_COLLAPSE_WARN_SHARE = 0.70
+
+# Below this many fetched tickers the gate does not apply. "Every value is the
+# same" is unremarkable across three tickers and says nothing about whether a
+# field carries cross-sectional information — the statement this gate makes is
+# only meaningful over a real universe. 50 is well under the ~900 production
+# universe and well over any fixture or smoke run, so a narrowed operator run
+# is not falsely failed and a production run is never exempted. Recorded rather
+# than silently skipped: a run below the floor logs that the gate did not
+# apply, because "the check did not fire" and "the check was not run" must not
+# look the same on the log (principles.md §2.7).
+_FIELD_COLLAPSE_MIN_TICKERS = 50
+
+# Fields exempt from the gate, each with the reason it may legitimately
+# collapse. Deliberately by NAME, never by a heuristic: a heuristic that
+# tolerates "few distinct values" would also tolerate the defect.
+_COLLAPSE_EXEMPT: frozenset[str] = frozenset()
+
+
+def _field_collapse_report(records: list[dict]) -> dict[str, tuple[float, object]]:
+    """{field: (modal_share, modal_value)} for every field, over ``records``.
+
+    Callers pass only records that actually came back from the vendor —
+    NEUTRAL rows are fetch failures and are already accounted for by
+    ``ok_ratio``; including them would let a bad fetch day manufacture a
+    collapse that is really an outage.
+    """
+    from collections import Counter
+
+    if not records:
+        return {}
+    fields = sorted({k for r in records for k in r})
+    out: dict[str, tuple[float, object]] = {}
+    for field in fields:
+        if field in _COLLAPSE_EXEMPT:
+            continue
+        counts = Counter(r.get(field) for r in records)
+        value, n = counts.most_common(1)[0]
+        out[field] = (n / len(records), value)
+    return out
+
+
 def _load_fundamentals_block_anomaly_types() -> frozenset[str]:
     """Read ``FUNDAMENTALS_BLOCK_ANOMALY_TYPES`` env var or fall back.
 
@@ -519,6 +597,69 @@ def collect(
         "quality_anomaly_counts": quality_counts_by_type,
         "quality_block_anomaly_types": sorted(block_anomaly_types),
     }
+
+    # ── Cross-sectional collapse gate (alpha-engine-config-I7583) ───────────
+    # Runs BEFORE the ok_ratio gate below and is deliberately independent of
+    # it: ok_ratio answers "did each ticker return anything", this answers
+    # "does each FIELD carry any information across the universe". A field
+    # that is dead for every ticker passes ok_ratio 903 times over — that is
+    # exactly how capitalSpendingGrowth5Y and freeCashFlowTTM went unnoticed
+    # for the life of the Finnhub integration (alpha-engine-config-I7569).
+    _real_records = [r for r in results.values() if r != NEUTRAL]
+    if len(_real_records) < _FIELD_COLLAPSE_MIN_TICKERS:
+        logger.info(
+            "Fundamentals field-collapse gate NOT APPLIED: %d fetched ticker(s) "
+            "is below the %d floor, where 'every value is identical' carries no "
+            "information about cross-sectional coverage.",
+            len(_real_records), _FIELD_COLLAPSE_MIN_TICKERS,
+        )
+        _collapse = {}
+    else:
+        _collapse = _field_collapse_report(_real_records)
+    _collapsed = {
+        f: (share, val) for f, (share, val) in _collapse.items()
+        if share >= _FIELD_COLLAPSE_FAIL_SHARE
+    }
+    _concentrated = {
+        f: (share, val) for f, (share, val) in _collapse.items()
+        if _FIELD_COLLAPSE_WARN_SHARE <= share < _FIELD_COLLAPSE_FAIL_SHARE
+    }
+    if _concentrated:
+        # Observe band — loud, not halting. See the promotion note on
+        # _FIELD_COLLAPSE_WARN_SHARE.
+        logger.error(
+            "Fundamentals field-collapse WARN over %d fetched tickers: %s. "
+            "Each of these carries one value for most of the universe. That is "
+            "plausible for a genuinely concentrated field and is the signature "
+            "of an absent source key or a units/clip mismatch — check before "
+            "the next consumer reads it.",
+            len(_real_records),
+            {f: f"{share:.1%} at {val!r}" for f, (share, val) in sorted(_concentrated.items())},
+        )
+    if _collapsed:
+        msg = (
+            f"field(s) carry a single value for effectively the whole universe "
+            f"over {len(_real_records)} fetched tickers: "
+            + ", ".join(
+                f"{f} ({share:.1%} at {val!r})"
+                for f, (share, val) in sorted(_collapsed.items())
+            )
+            + ". A source key absent from the vendor response, a units mismatch "
+            "saturating a clip bound, or a vendor field switched to a constant "
+            "all land here. Refusing to write a fundamentals snapshot whose "
+            "column(s) would read as fully covered while carrying zero "
+            "cross-sectional information (alpha-engine-config-I7583)."
+        )
+        logger.error("Fundamentals collapse gate: %s", msg)
+        return {
+            "status": "error",
+            "error": msg,
+            "tickers_ok": n_ok,
+            "tickers_error": n_err,
+            "collapsed_fields": {f: share for f, (share, _v) in _collapsed.items()},
+            "concentrated_fields": {f: share for f, (share, _v) in _concentrated.items()},
+            **_quality_fields,
+        }
 
     if ok_ratio < _MIN_OK_RATIO:
         msg = (

--- a/tests/test_fundamentals_field_collapse_gate.py
+++ b/tests/test_fundamentals_field_collapse_gate.py
@@ -1,0 +1,171 @@
+"""A field dead for the whole universe fails the collector (alpha-engine-config-I7583).
+
+The per-ticker `ok_ratio` gate asks "did THIS TICKER return anything at all".
+It cannot see a field that is dead for EVERY ticker: a ticker returning 13 of
+14 fields counts as fully populated, so a field absent from the vendor response
+for the whole universe passes it 903 times over.
+
+That is how `capitalSpendingGrowth5Y` and `freeCashFlowTTM` — neither of which
+exists in Finnhub's `metric=all` response — became a universe-wide 0.0 via
+`_pick`'s `default=0.0`, with this collector reporting `ok` on every run for the
+life of the Finnhub integration. It is also how the percent-point units bug
+collapsed `gross_margin` and `roe` onto their clip ceilings for ~90% of the
+universe. Both were fixed in alpha-engine-config-I7569 — by hand, after someone
+asked a question. Nothing in the collector raised, and nothing would have raised
+for the next one.
+
+`_FUNDAMENTALS_FIELD_SPECS` cannot cover this: it validates values that `_clip`
+has already bounded to its own bands, so it is structurally incapable of firing
+on saturation.
+
+These tests pin the gate that closes the class.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from collectors.fundamentals import (
+    _FIELD_COLLAPSE_FAIL_SHARE,
+    _FIELD_COLLAPSE_MIN_TICKERS,
+    _FIELD_COLLAPSE_WARN_SHARE,
+    _field_collapse_report,
+)
+
+
+def _universe(n: int, **overrides) -> list[dict]:
+    """n records with a healthy spread, minus whatever the caller breaks."""
+    records = []
+    for i in range(n):
+        rec = {
+            "roe": 0.05 + i * 0.001,
+            "gross_margin": 0.20 + i * 0.002,
+            "fcf_yield": 0.01 + i * 0.0005,
+        }
+        rec.update({k: v for k, v in overrides.items()})
+        records.append(rec)
+    return records
+
+
+class TestTheDefectsThatActuallyHappened:
+    def test_an_absent_source_key_defaulting_to_zero_is_caught(self):
+        """capitalSpendingGrowth5Y / freeCashFlowTTM: `_pick` returns 0.0 for
+        every ticker because the vendor never exposes the key."""
+        report = _field_collapse_report(_universe(903, capex_growth_5y=0.0))
+        share, value = report["capex_growth_5y"]
+        assert share == 1.0
+        assert value == 0.0
+        assert share >= _FIELD_COLLAPSE_FAIL_SHARE
+
+    def test_clip_saturation_from_a_units_mismatch_is_caught(self):
+        """Finnhub returns roeTTM=111.66 (percent points). Clipped as a
+        fraction to [-1, 1], ~90% of the universe lands on 1.0 exactly."""
+        records = _universe(900)
+        for i, rec in enumerate(records):
+            rec["roe"] = 1.0 if i < 830 else 0.4 + i * 0.0001
+        share, value = _field_collapse_report(records)["roe"]
+        assert value == 1.0
+        assert _FIELD_COLLAPSE_WARN_SHARE <= share < _FIELD_COLLAPSE_FAIL_SHARE
+
+    def test_a_healthy_field_is_not_flagged(self):
+        share, _ = _field_collapse_report(_universe(903))["gross_margin"]
+        assert share < _FIELD_COLLAPSE_WARN_SHARE
+
+
+class TestPredicateEdges:
+    def test_one_stray_ticker_cannot_mask_a_dead_field(self):
+        """FAIL is 0.99, not 1.00, for exactly this reason."""
+        records = _universe(903, fcf_yield=0.0)
+        records[0]["fcf_yield"] = 0.037
+        share, _ = _field_collapse_report(records)["fcf_yield"]
+        assert share >= _FIELD_COLLAPSE_FAIL_SHARE
+
+    def test_empty_input_reports_nothing_rather_than_dividing_by_zero(self):
+        assert _field_collapse_report([]) == {}
+
+    def test_thresholds_are_ordered(self):
+        assert 0 < _FIELD_COLLAPSE_WARN_SHARE < _FIELD_COLLAPSE_FAIL_SHARE <= 1.0
+
+    def test_a_field_absent_from_some_records_still_reports(self):
+        """A field only some tickers carry must not crash the report — and its
+        absence counts as a value, because `None` for most of the universe is
+        the same defect wearing a different mask."""
+        records = _universe(100)
+        for rec in records[:99]:
+            rec.pop("fcf_yield")
+        share, value = _field_collapse_report(records)["fcf_yield"]
+        assert value is None
+        assert share >= _FIELD_COLLAPSE_FAIL_SHARE
+
+
+class TestGateIsWiredIntoCollect:
+    """Guard-the-guard: the predicate above is only worth anything if collect()
+    actually consults it and actually refuses."""
+
+    @staticmethod
+    def _source() -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[1] / "collectors" / "fundamentals.py"
+        ).read_text(encoding="utf-8")
+
+    def test_collect_calls_the_report(self):
+        assert "_field_collapse_report(_real_records)" in self._source()
+
+    def test_collect_returns_error_status_on_collapse(self):
+        src = self._source()
+        assert "Fundamentals collapse gate" in src
+        assert '"status": "error"' in src
+
+    def test_the_gate_runs_before_the_ok_ratio_gate(self):
+        """ok_ratio cannot see this class, so a collapse must not be masked by
+        an ok_ratio pass that returns first."""
+        src = self._source()
+        assert src.index("_field_collapse_report(_real_records)") < src.index(
+            "if ok_ratio < _MIN_OK_RATIO:"
+        )
+
+    def test_neutral_records_are_excluded(self):
+        """NEUTRAL rows are fetch failures already counted by ok_ratio; folding
+        them in would let an outage manufacture a false collapse."""
+        assert "if r != NEUTRAL" in self._source()
+
+    def test_the_warn_band_does_not_halt(self):
+        """alpha-engine-config-I7581: a new gate does not go straight to
+        enforcing on a range whose real distribution has not been measured."""
+        src = self._source()
+        warn_at = src.index("Fundamentals field-collapse WARN")
+        fail_at = src.index("Fundamentals collapse gate")
+        between = src[warn_at:fail_at]
+        assert '"status": "error"' not in between
+
+
+@pytest.mark.parametrize("field", ["fcf_yield", "capex_growth_5y", "roe", "gross_margin"])
+def test_every_field_i7569_had_to_fix_by_hand_is_now_machine_detectable(field):
+    """The four fields alpha-engine-config-I7569 corrected manually. If this
+    gate had existed, each would have failed the collector on its first run."""
+    report = _field_collapse_report(_universe(903, **{field: 0.0}))
+    share, _ = report[field]
+    assert share >= _FIELD_COLLAPSE_FAIL_SHARE
+
+
+class TestSampleSizeFloor:
+    def test_the_floor_is_below_the_production_universe(self):
+        """~900 tickers in production. The floor must never exempt a real run."""
+        assert _FIELD_COLLAPSE_MIN_TICKERS < 500
+
+    def test_the_floor_is_above_any_fixture(self):
+        """Three identical fixture tickers must not read as a collapsed universe
+        — that false positive broke six existing tests in this file's first
+        draft, which is the evidence the floor is load-bearing rather than
+        defensive."""
+        assert _FIELD_COLLAPSE_MIN_TICKERS >= 20
+
+    def test_a_below_floor_run_is_logged_not_silently_skipped(self):
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parents[1] / "collectors" / "fundamentals.py"
+        ).read_text(encoding="utf-8")
+        assert "field-collapse gate NOT APPLIED" in src


### PR DESCRIPTION
## Why

`nousergon-data#1417` (`alpha-engine-config-I7569`) fixed two instances today — the percent-point units, and two source keys that do not exist in Finnhub's `metric=all` response at all (`capitalSpendingGrowth5Y`, `freeCashFlowTTM`). **Both were found by hand, after someone asked a question.** This PR is the mechanism that hid them, so the next one is caught by a machine.

The per-ticker `ok_ratio` gate asks *"did this ticker return anything at all"*. It cannot see a field that is dead for **every** ticker: a ticker returning 13 of 14 fields counts as fully populated, so a field absent from the vendor response for the whole universe passes it 903 times over.

Measured on `archive/fundamentals/2026-08-14.json`, before I7569 landed:

| field | distinct values | modal value | share | cause |
|---|---:|---:|---:|---|
| `fcf_yield` | 1 | 0.0 | **100.0%** | source key absent |
| `capex_growth_5y` | 1 | 0.0 | **100.0%** | source key absent |
| `roe` | 14 | 1.0 | 92.2% | clip ceiling |
| `gross_margin` | 2 | 1.0 | 87.2% | clip ceiling |
| `revenue_growth_yoy` | 79 | 2.0 | 78.4% | clip ceiling |
| `payout_ratio` | 13 | 2.0 | 73.9% | clip ceiling |
| `dividend_yield` | 34 | 0.2 | 71.5% | clip ceiling |

`_FUNDAMENTALS_FIELD_SPECS` could not have caught the saturated ones: it validates values `_clip` has **already** bounded to those same bands, so it is structurally incapable of firing on saturation. Its own comment says it exists to catch "a gross outlier if a future refactor drops a `_clip`" — it cannot.

## The gate

Written over the **output**, not over the vendor keys, so it catches the class regardless of cause: an absent key defaulting to a constant, a units mismatch saturating a clip bound, a scaling divisor that collapses a range, or a vendor silently pinning a field. Anything ending in *"this column carries no cross-sectional information"* trips the same predicate — the modal share of each field across the fetched universe.

| band | behaviour |
|---|---|
| ≥ 0.99 | `status="error"`, phase fails, no snapshot written. 0.99 not 1.00 so one stray ticker cannot mask a dead field. |
| ≥ 0.70 | logged at ERROR, **does not halt**. A genuinely concentrated field is plausible, and per `alpha-engine-config-I7581` a new gate must not go straight to enforcing on a range whose real distribution has not been measured over the full universe. Promotion tracked on I7583. |
| < 50 fetched tickers | gate does not apply, and **says so in the log**. "Every value is the same" is unremarkable across three tickers. |

Runs **before** the `ok_ratio` gate, since `ok_ratio` structurally cannot see this class and returning first would mask it. `NEUTRAL` records are excluded — fetch failures already counted by `ok_ratio`, and folding them in would let an outage manufacture a false collapse.

The sample-size floor is not defensive padding: without it the first draft turned **six existing tests** in `tests/test_fundamentals_finnhub.py` red, because their two- and three-ticker fixtures legitimately share every value. That false positive is what established the floor, and a test pins it.

## Test plan (run before opening)

`tests/test_fundamentals_field_collapse_gate.py` — 19 tests: the two defect shapes that actually happened, the predicate edges, the sample-size floor, and five guard-the-guard assertions that `collect()` calls the report, refuses on collapse, runs before `ok_ratio`, excludes `NEUTRAL`, and does not halt in the warn band. All pass.

Full `tests/` suite: **5987 passed, 13 skipped, 1 failed** — `test_stage_output_sweep.py::TestExecutionContext::test_no_injected_client_resolves_a_region_with_no_env_set`, an ImportError that reproduces identically on an untouched `origin/main` worktree and is unrelated to this change.

Related: `nousergon-data-PR1422` (the EOD blast-radius fix) merges independently; no ordering constraint between them.

## Post-merge

None.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)