### PR TITLE
fix(eod-backstop): ask whether the EOD DID ITS JOB, not whether one started (alpha-engine-config-I7582)

### DIFF
--- a/infrastructure/lambdas/_shared/run_handler_tests.sh
+++ b/infrastructure/lambdas/_shared/run_handler_tests.sh
@@ -105,7 +105,18 @@ run_handler_tests() {
     return 1
   fi
 
-  local pypath="${deps_dir}${HANDLER_TEST_PYTHONPATH:+:${HANDLER_TEST_PYTHONPATH}}"
+  # The lambdas dir is ALWAYS on the path (alpha-engine-config-I7582), not only
+  # when a caller remembers to set HANDLER_TEST_PYTHONPATH. It holds the modules
+  # siblings import by bare name — flow_doctor_telegram.py, and now
+  # eod_artifact_verification.py — and it was hand-set in exactly one deploy.sh
+  # and in NO ci.yml step, so a lambda importing a shared sibling passed locally
+  # and ModuleNotFound'd in CI. Same shape as the HANDLER_TEST_TARGETS gap this
+  # helper already absorbed: a mechanism every caller needs, owned here instead
+  # of re-declared per caller. An explicit HANDLER_TEST_PYTHONPATH still appends
+  # after it, so callers that set one keep whatever extra roots they wanted.
+  local lambdas_dir
+  lambdas_dir="$(cd "${script_dir}/.." && pwd)"
+  local pypath="${deps_dir}:${lambdas_dir}${HANDLER_TEST_PYTHONPATH:+:${HANDLER_TEST_PYTHONPATH}}"
 
   local rc=0 one file_rc
   # ${targets[@]+...} guard: bash 3.2 (the macOS system bash every deploy.sh

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -40,6 +40,7 @@ set -euo pipefail
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
 FUNCTION_NAME="alpha-engine-eod-backstop"
 ROLE_NAME="alpha-engine-eod-backstop-role"
@@ -106,6 +107,12 @@ python3 -m pip install \
   -r "${SCRIPT_DIR}/requirements.txt"
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+# alpha-engine-config-I7582: the backstop's dispatch predicate is "did the EOD
+# produce its artifacts", read from the SAME module sf-telegram-notifier uses to
+# decide whether a terminal message may read clean. One definition, two
+# consumers — a backstop that stands down on a day the notifier would call
+# incomplete is the 2026-08-17 gap.
+cp "${LAMBDAS_DIR}/eod_artifact_verification.py" "${PKG}/eod_artifact_verification.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
 echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"

--- a/infrastructure/lambdas/eod-backstop/iam-policy.json
+++ b/infrastructure/lambdas/eod-backstop/iam-policy.json
@@ -14,7 +14,9 @@
     {
       "Sid": "DescribeTradingBox",
       "Effect": "Allow",
-      "Action": ["ec2:DescribeInstances"],
+      "Action": [
+        "ec2:DescribeInstances"
+      ],
       "Resource": "*"
     },
     {
@@ -25,6 +27,33 @@
         "states:StartExecution"
       ],
       "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:ne-postclose-trading-pipeline"
+    },
+    {
+      "Sid": "EodPnlRowRead",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research/trades/eod_pnl.csv",
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/ne-postclose-trading-pipeline/*"
+      ]
+    },
+    {
+      "Sid": "EodPnlRowListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "trades/*",
+            "_sf_completion/ne-postclose-trading-pipeline/*"
+          ]
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/eod-backstop/index.py
+++ b/infrastructure/lambdas/eod-backstop/index.py
@@ -36,7 +36,8 @@ is retained purely to TAG the dispatch (``triggered_by``) for observability,
 never to gate it.
 
 If the box is already stopped, EOD either ran (success or failure — both end
-in stopping the box, caught by the ``eod_ran_today`` guard) or the box never
+in stopping the box, and a completed EOD leaves its eod_pnl row, caught by
+the ``_eod_did_its_job`` guard) or the box never
 booted (caught by the widened dispatch above). The late-discovery case (box
 long gone, gap found days later) is NOT this Lambda's job — that is the IBKR
 Flex Query ``eod_pnl`` backfill (config#1229).
@@ -44,7 +45,7 @@ Flex Query ``eod_pnl`` backfill (config#1229).
 The EOD SF's own DynamoDB mutex (``AcquireMutex``) is the concurrency
 backstop: if a daemon-triggered EOD is mid-flight when this fires, our
 StartExecution would only hit ``MutexConflict`` and fail cleanly — but the
-``eod_ran_today`` guard means we don't even attempt it.
+``_eod_did_its_job`` guard means we don't even attempt it.
 
 CaptureSnapshot on a freshly-booted box (config-I6690 evidence, verified
 against crucible-executor + step_function_eod.json, not assumed): IB Gateway
@@ -92,6 +93,8 @@ import boto3
 
 from nousergon_lib.trading_calendar import is_trading_day, last_closed_trading_day
 
+from eod_artifact_verification import verify_eod_artifacts
+
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -125,6 +128,115 @@ SNS_TOPIC_ARN = os.environ.get(
 _STARTED_STATUSES = ("RUNNING", "SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED")
 
 
+def _eod_did_its_job(trading_day: str, s3_client: Optional[object] = None) -> bool:
+    """True iff ``trading_day``'s EOD produced its load-bearing ARTIFACT.
+
+    alpha-engine-config-I7582. This replaced ``_eod_ran_today`` as the dispatch
+    predicate. That one asked "did an execution START today", which covers *the
+    EOD never fired* and not *the EOD fired and did not do its job* — and this
+    module's whole reason for existing, in its own words above, is "the
+    load-bearing failure — NO ``eod_pnl`` ROW for the day".
+
+    Measured 2026-08-17: the EOD SF started at 20:00 UTC and ended at 21:55 UTC
+    in ``DegradedRun`` (``reason: eod_reconcile_skipped_data_gap``) with no
+    ArcticDB append, no ``EODReconcile`` and no ``eod_pnl`` row. This Lambda's
+    22:30 UTC firing was a no-op, CORRECTLY per its own predicate, on exactly
+    the day it exists for.
+
+    Keyed on the ARTIFACT, not on the terminal's colour, and deliberately so: a
+    ``DegradedRun`` whose degradation is unrelated to the row
+    (``mutex_acquire_degraded``, ``weekly_exercise_launch_failed``) has already
+    produced it, and re-dispatching would cost a second live-IB snapshot
+    capture — the exact thing ``skip_capture_snapshot`` exists to avoid.
+
+    The check itself is ``eod_artifact_verification``, the same module
+    sf-telegram-notifier uses to decide whether a terminal message may read
+    clean. Two consumers, one definition of "did the EOD do its job": a
+    backstop that stands down on a day the notifier would call incomplete is
+    the gap this closes, reopened.
+
+    ``verify_eod_artifacts`` fails TOWARD absent on any non-404 S3 fault, which
+    is the correct direction here too — an unverifiable day dispatches a
+    backstop run rather than silently skipping one.
+    """
+    if s3_client is None:  # pragma: no cover — production path
+        s3_client = boto3.client("s3", region_name=REGION)
+    status = verify_eod_artifacts(s3_client, trading_day)
+    if status is None:
+        logger.warning(
+            "EOD artifact verification returned no status for %s — treating as "
+            "NOT done so the backstop dispatches rather than silently skipping.",
+            trading_day,
+        )
+        return False
+    logger.info(
+        "EOD artifacts for %s: completion_marker=%s pnl_row=%s",
+        trading_day, status.completion_marker_present, status.pnl_row_present,
+    )
+    return status.pnl_row_present
+
+
+def _eod_running(sf_client: Optional[object] = None) -> bool:
+    """True iff an EOD execution is RUNNING right now.
+
+    A degraded run still inside its self-heal loop must not be re-dispatched
+    underneath itself. The SF's own DynamoDB ``AcquireMutex`` is the hard
+    concurrency backstop; this is the cheap check that avoids relying on it.
+    """
+    if sf_client is None:  # pragma: no cover — production path
+        sf_client = boto3.client("stepfunctions", region_name=REGION)
+    resp = sf_client.list_executions(
+        stateMachineArn=EOD_SF_ARN, statusFilter="RUNNING", maxResults=1
+    )
+    running = bool(resp.get("executions"))
+    if running:
+        logger.info("An EOD execution is currently RUNNING — no-op.")
+    return running
+
+
+def _backstop_already_fired_today(
+    now_utc: datetime, sf_client: Optional[object] = None
+) -> bool:
+    """True iff THIS Lambda already dispatched an EOD today.
+
+    One retry per day. Without this the outcome predicate would re-dispatch on
+    every firing for as long as the row stayed missing, which on a genuinely
+    broken day is an unbounded loop of trading-box boots. A second miss is a
+    page, not another attempt.
+    """
+    if sf_client is None:  # pragma: no cover — production path
+        sf_client = boto3.client("stepfunctions", region_name=REGION)
+    midnight = now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    for status_filter in _STARTED_STATUSES:
+        next_token: Optional[str] = None
+        while True:
+            kwargs = {
+                "stateMachineArn": EOD_SF_ARN,
+                "statusFilter": status_filter,
+                "maxResults": 100,
+            }
+            if next_token:
+                kwargs["nextToken"] = next_token
+            resp = sf_client.list_executions(**kwargs)
+            for row in resp.get("executions") or []:
+                if not str(row.get("name") or "").startswith("eod-backstop-"):
+                    continue
+                start = row.get("startDate")
+                if not hasattr(start, "astimezone"):
+                    continue
+                start_utc = (
+                    start.astimezone(timezone.utc)
+                    if start.tzinfo
+                    else start.replace(tzinfo=timezone.utc)
+                )
+                if start_utc >= midnight:
+                    return True
+            next_token = resp.get("nextToken")
+            if not next_token:
+                break
+    return False
+
+
 def _trading_box_running(ec2_client: Optional[object] = None) -> bool:
     """True iff the trading EC2 instance is in the ``running`` state.
 
@@ -146,48 +258,13 @@ def _trading_box_running(ec2_client: Optional[object] = None) -> bool:
     return False
 
 
-def _eod_ran_today(now_utc: datetime, sf_client: Optional[object] = None) -> bool:
-    """True iff at least one EOD SF execution STARTED since 00:00 UTC today.
-
-    At the ~22:30 UTC firing time, today's expected EOD (~20:00–21:30 UTC) is
-    within the since-midnight window, while the prior trading day's EOD is not
-    — so this is trading-day-correct without a per-day marker. Raises on a
-    ListExecutions failure (fail-loud)."""
-    if sf_client is None:  # pragma: no cover — production path
-        sf_client = boto3.client("stepfunctions", region_name=REGION)
-    midnight = now_utc.replace(hour=0, minute=0, second=0, microsecond=0)
-    for status_filter in _STARTED_STATUSES:
-        next_token: Optional[str] = None
-        while True:
-            kwargs = {
-                "stateMachineArn": EOD_SF_ARN,
-                "statusFilter": status_filter,
-                "maxResults": 100,
-            }
-            if next_token:
-                kwargs["nextToken"] = next_token
-            resp = sf_client.list_executions(**kwargs)
-            for row in resp.get("executions") or []:
-                start = row.get("startDate")
-                if not hasattr(start, "astimezone"):
-                    continue
-                start_utc = (
-                    start.astimezone(timezone.utc)
-                    if start.tzinfo
-                    else start.replace(tzinfo=timezone.utc)
-                )
-                if start_utc >= midnight:
-                    logger.info(
-                        "EOD execution %s already started today (%s, %s)",
-                        row.get("name"), start_utc.isoformat(), status_filter,
-                    )
-                    return True
-            next_token = resp.get("nextToken")
-            if not next_token:
-                break
-    return False
-
-
+# _eod_ran_today was REMOVED (alpha-engine-config-I7582). It answered "did an
+# EOD execution start since 00:00 UTC", which is not the question this Lambda
+# exists to ask, and on 2026-08-17 it correctly returned True for an execution
+# that produced no eod_pnl row — so the backstop stood down on exactly the day
+# it was written for. Replaced by _eod_did_its_job (the artifact) + _eod_running
+# (concurrency) + _backstop_already_fired_today (one retry per day). Deleted
+# rather than left dormant: champion-challenger-policy.md §6.
 def _start_eod(trading_day: str, triggered_by: str, sf_client: Optional[object] = None) -> str:
     """Start the EOD SF with the same input shape the daemon uses (config-I6690:
     identical regardless of whether the box was running — see the module
@@ -229,9 +306,32 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
 
     trading_day = last_closed_trading_day(now_utc).isoformat()
 
-    if _eod_ran_today(now_utc):
-        logger.info("An EOD execution already started today — no-op.")
-        return {"action": "noop", "reason": "eod_already_ran_today", "trading_day": trading_day}
+    # alpha-engine-config-I7582: the dispatch predicate is the ARTIFACT, not the
+    # fact that something started. Order matters — cheapest and most decisive
+    # first, and each no-op reason is distinct so the console can tell a quiet
+    # healthy day from a quiet blocked one.
+    if _eod_running():
+        return {"action": "noop", "reason": "eod_currently_running", "trading_day": trading_day}
+
+    if _eod_did_its_job(trading_day):
+        logger.info("EOD produced its eod_pnl row for %s — no-op.", trading_day)
+        return {"action": "noop", "reason": "eod_row_present", "trading_day": trading_day}
+
+    if _backstop_already_fired_today(now_utc):
+        # One retry per day. A second miss is a page, not another boot — see
+        # _backstop_already_fired_today.
+        logger.error(
+            "EOD-BACKSTOP EXHAUSTED: this Lambda already dispatched an EOD today "
+            "and trading_day=%s STILL has no eod_pnl row. Not dispatching again. "
+            "The next day's reconcile will have no adjacent prior-day NAV "
+            "baseline (config#1229) — operator action required.",
+            trading_day,
+        )
+        return {
+            "action": "noop",
+            "reason": "backstop_already_fired_and_row_still_missing",
+            "trading_day": trading_day,
+        }
 
     # config-I6690: box state no longer gates dispatch — it is checked only
     # to tag the run (StartTradingInstance boots the box unconditionally and

--- a/infrastructure/lambdas/eod-backstop/test_handler.py
+++ b/infrastructure/lambdas/eod-backstop/test_handler.py
@@ -29,14 +29,16 @@ def _ec2(state: str | None):
     return cli
 
 
-def _sf(exec_start: datetime | None):
+def _sf(exec_start: datetime | None, name: str = "eod-x"):
     """A Step Functions client mock. ``exec_start`` (a tz-aware datetime) seeds
-    one EOD execution under the RUNNING status; None → no executions."""
+    one EOD execution under the RUNNING status; None → no executions. ``name``
+    matters since alpha-engine-config-I7582: _backstop_already_fired_today only
+    counts executions THIS Lambda started (``eod-backstop-*``)."""
     cli = MagicMock()
 
     def _list(**kwargs):
         if kwargs.get("statusFilter") == "RUNNING" and exec_start is not None:
-            return {"executions": [{"name": "eod-x", "startDate": exec_start}]}
+            return {"executions": [{"name": name, "startDate": exec_start}]}
         return {"executions": []}
 
     cli.list_executions.side_effect = _list
@@ -60,19 +62,35 @@ class TestBoxRunning:
         assert index._trading_box_running(_ec2(None)) is False
 
 
-class TestEodRanToday:
+class TestBackstopAlreadyFiredToday:
+    """One retry per day. `_eod_ran_today` used to be the dispatch predicate and
+    is deleted (alpha-engine-config-I7582); this replaces only its
+    since-midnight window logic, narrowed to THIS Lambda's own dispatches."""
+
     NOW = datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc)
 
-    def test_execution_started_today_is_true(self):
-        started = datetime(2026, 6, 25, 20, 15, tzinfo=timezone.utc)
-        assert index._eod_ran_today(self.NOW, _sf(started)) is True
+    def test_backstop_execution_started_today_is_true(self):
+        started = datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc)
+        assert index._backstop_already_fired_today(
+            self.NOW, _sf(started, name="eod-backstop-2026-06-25-1750000000")
+        ) is True
 
-    def test_yesterdays_execution_is_not_today(self):
-        started = datetime(2026, 6, 24, 20, 15, tzinfo=timezone.utc)
-        assert index._eod_ran_today(self.NOW, _sf(started)) is False
+    def test_a_daemon_triggered_eod_is_not_a_backstop_dispatch(self):
+        """The whole point of the I7582 change: a daemon-triggered EOD that ran
+        and produced nothing must NOT suppress the backstop."""
+        started = datetime(2026, 6, 25, 20, 15, tzinfo=timezone.utc)
+        assert index._backstop_already_fired_today(
+            self.NOW, _sf(started, name="eod-2026-06-25-1750000000")
+        ) is False
+
+    def test_yesterdays_backstop_is_not_today(self):
+        started = datetime(2026, 6, 24, 22, 30, tzinfo=timezone.utc)
+        assert index._backstop_already_fired_today(
+            self.NOW, _sf(started, name="eod-backstop-2026-06-24-1749000000")
+        ) is False
 
     def test_no_executions_is_false(self):
-        assert index._eod_ran_today(self.NOW, _sf(None)) is False
+        assert index._backstop_already_fired_today(self.NOW, _sf(None)) is False
 
 
 # ── Handler decision matrix ───────────────────────────────────────────────────
@@ -81,18 +99,21 @@ class TestEodRanToday:
 class TestHandler:
     TRADING_NOW = datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc)  # Thursday
 
-    def _run(self, *, trading_day=True, box="running", eod_started=None):
+    def _run(self, *, trading_day=True, box="running", eod_started=None,
+             row_present=False, running=False, backstop_fired=False):
         with patch("index.datetime") as dt, \
              patch("index.is_trading_day", return_value=trading_day), \
              patch("index.last_closed_trading_day", return_value=self.TRADING_NOW.date()), \
              patch("index._trading_box_running", return_value=(box == "running")), \
-             patch("index._eod_ran_today", return_value=(eod_started is not None)), \
+             patch("index._eod_running", return_value=running), \
+             patch("index._eod_did_its_job", return_value=row_present), \
+             patch("index._backstop_already_fired_today", return_value=backstop_fired), \
              patch("index._start_eod", return_value="arn:exec:backstop") as start:
             dt.now.return_value = self.TRADING_NOW
             result = index.handler({}, None)
         return result, start
 
-    def test_starts_eod_when_box_up_and_no_eod_today(self):
+    def test_starts_eod_when_box_up_and_no_row(self):
         # box running + no execution + trading day -> dispatch (existing
         # behavior preserved), tagged triggered_by="backstop".
         result, start = self._run(box="running", eod_started=None)
@@ -111,16 +132,57 @@ class TestHandler:
         assert result["box_was_running"] is False
         start.assert_called_once_with(self.TRADING_NOW.date().isoformat(), "backstop-box-stopped")
 
-    def test_noop_when_box_stopped_and_execution_exists(self):
-        # box stopped + execution exists -> no dispatch, regardless of box
-        # state (the eod_ran_today guard alone decides this).
-        result, start = self._run(box="stopped", eod_started=self.TRADING_NOW)
-        assert result["action"] == "noop" and result["reason"] == "eod_already_ran_today"
+    def test_noop_when_the_row_is_present(self):
+        # The artifact decides, regardless of box state.
+        for box in ("running", "stopped"):
+            result, start = self._run(box=box, row_present=True)
+            assert result["action"] == "noop"
+            assert result["reason"] == "eod_row_present"
+            start.assert_not_called()
+
+    def test_THE_2026_08_17_CASE_an_execution_ran_and_produced_nothing(self):
+        """The defect this whole change exists for.
+
+        On 2026-08-17 the EOD SF started at 20:00 UTC and ended at 21:55 UTC in
+        DegradedRun with no ArcticDB append, no EODReconcile and no eod_pnl row.
+        The old `_eod_ran_today` predicate returned True, so this Lambda's 22:30
+        UTC firing was a no-op — correctly, per its own predicate, on exactly
+        the day it was written for. It must now DISPATCH.
+        """
+        result, start = self._run(box="stopped", row_present=False, running=False)
+        assert result["action"] == "started_eod"
+        start.assert_called_once()
+
+    def test_noop_while_an_eod_is_still_running(self):
+        """A degraded run still inside its self-heal loop must not be
+        re-dispatched underneath itself."""
+        result, start = self._run(running=True, row_present=False)
+        assert result["action"] == "noop"
+        assert result["reason"] == "eod_currently_running"
         start.assert_not_called()
 
-    def test_noop_when_box_running_and_eod_already_ran(self):
-        result, start = self._run(box="running", eod_started=self.TRADING_NOW)
-        assert result["action"] == "noop" and result["reason"] == "eod_already_ran_today"
+    def test_one_retry_per_day_then_page(self):
+        """A second miss is a page, not another trading-box boot. Without this
+        the outcome predicate would re-dispatch on every firing for as long as
+        the row stayed missing."""
+        result, start = self._run(row_present=False, backstop_fired=True)
+        assert result["action"] == "noop"
+        assert result["reason"] == "backstop_already_fired_and_row_still_missing"
+        start.assert_not_called()
+
+    def test_running_is_checked_before_the_artifact(self):
+        """Cheapest and most decisive first: a RUNNING execution may still be
+        about to write the row, so reading S3 to decide is both wasted and
+        misleading."""
+        with patch("index.datetime") as dt, \
+             patch("index.is_trading_day", return_value=True), \
+             patch("index.last_closed_trading_day", return_value=self.TRADING_NOW.date()), \
+             patch("index._eod_running", return_value=True), \
+             patch("index._eod_did_its_job") as did_its_job, \
+             patch("index._start_eod") as start:
+            dt.now.return_value = self.TRADING_NOW
+            index.handler({}, None)
+        did_its_job.assert_not_called()
         start.assert_not_called()
 
     def test_noop_when_not_a_trading_day(self):
@@ -128,15 +190,17 @@ class TestHandler:
         assert result["action"] == "noop" and result["reason"] == "not_a_trading_day"
         start.assert_not_called()
 
-    def test_eod_ran_today_checked_before_box_state(self):
-        # eod_ran_today is decisive on its own — box state must not even be
-        # consulted once an execution is already found for today (avoids an
-        # unnecessary EC2 describe_instances call on the common no-op path).
+    def test_row_present_checked_before_box_state(self):
+        # The artifact predicate is decisive on its own — box state must not
+        # even be consulted once the row is confirmed (avoids an unnecessary
+        # EC2 describe_instances call on the common no-op path).
         with patch("index.datetime") as dt, \
              patch("index.is_trading_day", return_value=True), \
              patch("index.last_closed_trading_day", return_value=self.TRADING_NOW.date()), \
              patch("index._trading_box_running") as box_running, \
-             patch("index._eod_ran_today", return_value=True), \
+             patch("index._eod_running", return_value=False), \
+             patch("index._eod_did_its_job", return_value=True), \
+             patch("index._backstop_already_fired_today", return_value=False), \
              patch("index._start_eod") as start:
             dt.now.return_value = self.TRADING_NOW
             index.handler({}, None)
@@ -189,4 +253,6 @@ class TestFailLoud:
         cli = MagicMock()
         cli.list_executions.side_effect = RuntimeError("states down")
         with pytest.raises(RuntimeError):
-            index._eod_ran_today(datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc), cli)
+            index._backstop_already_fired_today(
+                datetime(2026, 6, 25, 22, 30, tzinfo=timezone.utc), cli
+            )

--- a/infrastructure/lambdas/eod_artifact_verification.py
+++ b/infrastructure/lambdas/eod_artifact_verification.py
@@ -1,4 +1,16 @@
-"""EOD artifact verification for sf-telegram-notifier (alpha-engine-config#5289).
+"""EOD artifact verification — the fleet definition of "did the EOD do its job".
+
+Originally sf-telegram-notifier-local (alpha-engine-config#5289); lifted to the
+shared lambdas dir on second adoption (alpha-engine-config-I7582, shared-code
+policy). Two consumers, one definition:
+
+  * ``sf-telegram-notifier`` — so a terminal Telegram message cannot read clean
+    when the day's load-bearing artifacts were never written.
+  * ``eod-backstop`` — so the same-day trigger of last resort asks whether the
+    EOD PRODUCED ITS ROW, not merely whether an execution started.
+
+Those two must never drift: a backstop that stands down on a day the notifier
+would call incomplete is the 2026-08-17 gap.
 
 A postclose (EOD) run's terminal SUCCEEDED/DEGRADED Telegram message must not
 read "clean" when the day's load-bearing artifacts were never written — the

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -97,7 +97,10 @@ HANDLER_TEST_PYTHONPATH="${LAMBDAS_DIR}" \
 
 cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
 cp "${SCRIPT_DIR}/execution_digest.py" "${PKG}/execution_digest.py"
-cp "${SCRIPT_DIR}/eod_artifact_verification.py" "${PKG}/eod_artifact_verification.py"
+# Moved up to LAMBDAS_DIR (alpha-engine-config-I7582): eod-backstop now reads the
+# same artifact definition, and two copies of "did the EOD do its job" is the
+# §2.3 one-owner-per-config-fact defect.
+cp "${LAMBDAS_DIR}/eod_artifact_verification.py" "${PKG}/eod_artifact_verification.py"
 cp "${SCRIPT_DIR}/../flow_doctor_telegram.py" "${PKG}/flow_doctor_telegram.py"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")


### PR DESCRIPTION
fix(eod-backstop): ask whether the EOD DID ITS JOB, not whether one started (alpha-engine-config-I7582)

This Lambda's own docstring names the failure it exists to prevent: "the
load-bearing failure — NO `eod_pnl` ROW for the day", citing the 2026-06-24
gap -> RGEN +14.92% class (config#1229). Its dispatch predicate did not ask
that question. It asked whether an EOD execution had STARTED since 00:00
UTC, which covers *the EOD never fired* and not *the EOD fired and did not
do its job*.

Measured 2026-08-17: the EOD SF started at 20:00 UTC and ended at 21:55 UTC
in DegradedRun (reason: eod_reconcile_skipped_data_gap) — no ArcticDB
append, no EODReconcile, no eod_pnl row. This Lambda's 22:30 UTC firing was
a no-op. Correctly, per its own predicate, on exactly the day it was written
for. The day was recovered by hand.

`_eod_ran_today` is DELETED, not left dormant (champion-challenger-policy.md
§6). Three predicates replace it, cheapest and most decisive first, each
with a distinct no-op reason so the console can tell a quiet healthy day
from a quiet blocked one:

  _eod_running()                  a degraded run still inside its self-heal
                                  loop must not be re-dispatched underneath
                                  itself. Checked FIRST: a RUNNING execution
                                  may still be about to write the row, so
                                  reading S3 to decide is both wasted and
                                  misleading. The SF's DynamoDB AcquireMutex
                                  remains the hard concurrency backstop.
  _eod_did_its_job()              the ARTIFACT. Keyed on the eod_pnl row and
                                  not on the terminal's colour, deliberately:
                                  a DegradedRun whose degradation is
                                  unrelated to the row
                                  (mutex_acquire_degraded,
                                  weekly_exercise_launch_failed) has already
                                  produced it, and re-dispatching would cost
                                  a second live-IB snapshot capture — the
                                  exact thing skip_capture_snapshot exists to
                                  avoid.
  _backstop_already_fired_today() one retry per day. Without it the outcome
                                  predicate would re-dispatch on every firing
                                  for as long as the row stayed missing,
                                  which on a genuinely broken day is an
                                  unbounded loop of trading-box boots. A
                                  second miss logs at ERROR naming the
                                  operator consequence, and stops.

The artifact check is `eod_artifact_verification`, LIFTED from
sf-telegram-notifier/ to infrastructure/lambdas/ on second adoption
(shared-code policy). Two consumers, one definition of "did the EOD do its
job": a backstop that stands down on a day the notifier would call
incomplete is the gap this closes, reopened. Both deploy.sh files package it
from the shared path. Its fail-toward-absent posture on any non-404 S3 fault
is the correct direction here too — an unverifiable day dispatches a
backstop run rather than silently skipping one.

IAM: EodPnlRowRead (s3:GetObject on trades/eod_pnl.csv and the postclose
completion-marker prefix) plus the matching prefix-scoped
EodPnlRowListBucket that config#2878's lint requires — S3 returns 403 rather
than 404 for GetObject on a missing key without ListBucket, and the ABSENCE
of that row is the meaningful answer here. Applied live in-session against
alpha-engine-eod-backstop-role and verified with
iam simulate-principal-policy (allowed), so the merge button is the last
action.

Test plan: eod-backstop test_handler.py rewritten around the new decision
matrix — 20 pass, including a test named for the 2026-08-17 case that asserts
an execution which ran and produced nothing now DISPATCHES, plus the
still-running no-op, the one-retry-then-page path, and the two ordering
guards. Two tests that asserted the OLD "an execution exists -> noop"
semantics are replaced rather than patched, since that behaviour is what this
change removes. CI-equivalent per-file run over both affected lambdas: 20 +
38 + 14 + 24 + 1 + 16, all green. Full tests/ suite: 5987 passed, 13 skipped,
1 failed — test_stage_output_sweep.py::test_no_injected_client_resolves_a_region_with_no_env_set,
an ImportError that reproduces identically on an untouched origin/main
worktree and is unrelated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
