### PR TITLE
fix(eod): the self-heal's replay must sync the executor checkout (alpha-engine-config-I7586)

### DIFF
--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1923,7 +1923,7 @@
     },
     "HealDispatchReplay": {
       "Type": "Task",
-      "Comment": "config-I2702 deliverable #3(c): auto-start the reconcile-only replay execution, reusing I2700's PROVEN input shape EXACTLY (pipeline_role=operator-replay + skip_post_market_data=true + skip_capture_snapshot=true \u2014 the shape that ran successfully as 'operator-replay-eodreconcile-2026-07-15' and its 2026-07-13 precedent). Deliberately a SEPARATE execution rather than looping this one back through CaptureSnapshot: CaptureSnapshot already ran ONCE earlier in THIS execution (it sits upstream of the precondition probe in the pipeline order), so re-entering the data-spot phase in-place would re-trigger a second live-IB snapshot capture \u2014 exactly what I2700's skip_capture_snapshot flag exists to avoid. skip_refresh_executor_deploy=true because RefreshExecutorDeploy already ran at the top of THIS execution and re-froze .frozen_executor_sha \u2014 the box is already known-fresh. Fire-and-forget (non-.sync): this execution's own terminal state does not wait for the replay's outcome \u2014 the replay's own SUCCEEDED/FAILED status is independently observable (execution name eod-heal-replay-{run_date}-*) and IS the 'convergence notification' this issue's closes-when criteria describes.",
+      "Comment": "config-I2702 deliverable #3(c): auto-start the reconcile-only replay execution, reusing I2700's PROVEN input shape (pipeline_role=operator-replay + skip_post_market_data=true + skip_capture_snapshot=true). Deliberately a SEPARATE execution rather than looping this one back through CaptureSnapshot: CaptureSnapshot already ran ONCE earlier in THIS execution (it sits upstream of the precondition probe in the pipeline order), so re-entering the data-spot phase in-place would re-trigger a second live-IB snapshot capture \u2014 exactly what I2700's skip_capture_snapshot flag exists to avoid. Fire-and-forget (non-.sync): this execution's own terminal state does not wait for the replay's outcome \u2014 the replay's own SUCCEEDED/FAILED status is independently observable (execution name eod-heal-replay-{run_date}-*). \u2014 alpha-engine-config-I7586: skip_refresh_executor_deploy was REMOVED from this Input. It was justified as 'RefreshExecutorDeploy already ran at the top of THIS execution and re-froze .frozen_executor_sha \u2014 the box is already known-fresh'. That premise holds for the PARENT and not for the CHILD, because this state's own successors are HealConvergedNotify \u2192 StopTradingInstance: the parent stops the trading box out from under the fire-and-forget replay it just started, the replay's own StartTradingInstance boots it again, and a rebooted box is not on the SHA the parent froze. Reproduced by hand 2026-08-17 with this exact input shape \u2014 the replay reached EODReconcile and died in executor/preflight.py::check_deploy_drift ('checkout is on dfbab49b7b06 but this run pinned EXPECTED_EXECUTOR_SHA=1ea15df6ce83'), terminal EODPipelineFailure. Re-running the identical input WITHOUT the flag succeeded first try. The drift guard is correct; the replay was handing it a box nobody synced. THE OTHER TWO FLAGS ARE CORRECT and must not be swept along with it: skip_capture_snapshot (the parent genuinely already captured, and a second live-IB capture is the thing it exists to avoid) and skip_post_market_data (the heal loop just ran it). Only the deploy-refresh flag has a premise a box restart invalidates. The replay's own RefreshExecutorDeploy is cheap relative to a failed reconcile, and it is the only thing that makes the child's freshness gate meaningful.",
       "Resource": "arn:aws:states:::states:startExecution",
       "Parameters": {
         "StateMachineArn.$": "$$.StateMachine.Id",
@@ -1935,8 +1935,7 @@
           "triggered_by": "eod-self-heal",
           "pipeline_role": "operator-replay",
           "skip_post_market_data": true,
-          "skip_capture_snapshot": true,
-          "skip_refresh_executor_deploy": true
+          "skip_capture_snapshot": true
         }
       },
       "TimeoutSeconds": 30,
@@ -1977,12 +1976,12 @@
     },
     "HealConvergedNotify": {
       "Type": "Task",
-      "Comment": "config-I2702 closes-when 'convergence notification': informational (non-paging) \u2014 the self-heal succeeded without any operator action; the replay execution named here does the actual EODReconcile.",
+      "Comment": "config-I2702 closes-when 'convergence notification': informational (non-paging) \u2014 the self-heal re-dispatched the missing workload(s) and the replay execution named here does the actual EODReconcile. alpha-engine-config-I7586: this used to assert 'No operator action required' on the strength of a DISPATCH. Under the deploy-refresh defect that claim was false in every case this state could be reached, and it is a claim this state structurally cannot make \u2014 the dispatch is fire-and-forget, so the convergence signal belongs to the replay's own terminal, independently observable by execution name.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
-        "Subject": "Alpha Engine EOD Self-Heal \u2014 CONVERGED (replay dispatched, no operator action needed)",
-        "Message.$": "States.Format('EOD self-heal for {} converged after {} attempt(s): the missing data-spot workload(s) were re-dispatched, SPY close is now verified present in ArcticDB, and a reconcile-only replay execution has been started automatically ({}). No operator action required.', $.run_date, States.MathAdd($.heal_loop.attempts, 1), States.JsonToString($.heal_replay_dispatch))"
+        "Subject": "Alpha Engine EOD Self-Heal \u2014 replay dispatched (convergence pending)",
+        "Message.$": "States.Format('EOD self-heal for {} re-dispatched the missing data-spot workload(s) after {} attempt(s); SPY close is now verified present in ArcticDB and a reconcile-only replay execution has been started ({}). The replay\\'s OWN terminal is the convergence signal \u2014 this message reports a dispatch, not an outcome.', $.run_date, States.MathAdd($.heal_loop.attempts, 1), States.JsonToString($.heal_replay_dispatch))"
       },
       "ResultPath": "$.heal_converged_notify",
       "TimeoutSeconds": 60,

--- a/tests/test_heal_replay_deploy_refresh_i7586.py
+++ b/tests/test_heal_replay_deploy_refresh_i7586.py
@@ -1,0 +1,116 @@
+"""The self-heal's replay must sync the executor checkout (alpha-engine-config-I7586).
+
+`HealDispatchReplay` carried `skip_refresh_executor_deploy: true`, justified in
+its own comment as:
+
+    RefreshExecutorDeploy already ran at the top of THIS execution and re-froze
+    .frozen_executor_sha — the box is already known-fresh.
+
+That premise holds for the PARENT and not for the CHILD. This state's own
+successors are `HealConvergedNotify` -> `StopTradingInstance`: the parent stops
+the trading box out from under the fire-and-forget replay it just started, the
+replay's `StartTradingInstance` boots it again, and a rebooted box is not on
+the SHA the parent froze.
+
+Reproduced by hand on 2026-08-17 with this exact input shape — the replay
+reached `EODReconcile` and died in `executor/preflight.py::check_deploy_drift`:
+
+    RuntimeError: Deploy drift: executor checkout at /home/ec2-user/alpha-engine
+    is on dfbab49b7b06 but this run pinned EXPECTED_EXECUTOR_SHA=1ea15df6ce83 at
+    its freshness gate.
+
+Terminal `EODPipelineFailure`. Re-running the identical input WITHOUT the flag
+succeeded first try.
+
+Consequence, and the reason this is a P1 rather than a note: the self-heal
+loop's entire convergence path ends in `HealDispatchReplay`. If the loop ever
+converges, the replay it dispatches fails this way — so **the convergence path
+has never worked**. On 2026-08-17 the loop reached `HealNonConvergent` instead,
+so the flag was never exercised in production. That is luck, not coverage.
+
+The flag reads as a harmless optimisation and will be re-added by anyone
+reasoning from the parent's state alone. Hence a test rather than a comment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+SF = json.loads(
+    (
+        Path(__file__).resolve().parents[1] / "infrastructure" / "step_function_eod.json"
+    ).read_text(encoding="utf-8")
+)
+STATES = SF["States"]
+REPLAY_INPUT = STATES["HealDispatchReplay"]["Parameters"]["Input"]
+
+
+def test_the_replay_does_not_skip_the_deploy_refresh():
+    assert "skip_refresh_executor_deploy" not in REPLAY_INPUT, (
+        "HealDispatchReplay must not skip RefreshExecutorDeploy: the parent stops "
+        "the box (StopTradingInstance) right after dispatching this replay, so the "
+        "child boots a box that is no longer on the frozen SHA and dies in "
+        "check_deploy_drift. See alpha-engine-config-I7586."
+    )
+
+
+@pytest.mark.parametrize("flag", ["skip_post_market_data", "skip_capture_snapshot"])
+def test_the_other_two_skip_flags_are_retained(flag):
+    """Guard against an over-broad fix. Only the deploy-refresh flag has a
+    premise a box restart invalidates.
+
+    `skip_capture_snapshot` is correct — the parent genuinely already captured,
+    and a second live-IB capture is precisely what it exists to avoid.
+    `skip_post_market_data` is correct — the heal loop just ran it.
+    """
+    assert REPLAY_INPUT.get(flag) is True
+
+
+def test_the_parent_still_stops_the_box_after_dispatching():
+    """The pin on WHY the flag is wrong. If this ordering ever changes, the
+    premise behind the original flag becomes true again and this whole test
+    module should be revisited rather than silently kept.
+    """
+    assert STATES["HealDispatchReplay"]["Next"] == "HealConvergedNotify"
+    assert STATES["HealConvergedNotify"]["Next"] == "StopTradingInstance"
+
+
+def test_the_dispatch_is_still_fire_and_forget():
+    """Non-`.sync` startExecution. If it became `.sync` the parent would wait,
+    the box would not be stopped underneath the child, and the reasoning above
+    would change."""
+    assert STATES["HealDispatchReplay"]["Resource"] == "arn:aws:states:::states:startExecution"
+
+
+class TestConvergenceNotificationDoesNotOverclaim:
+    """`HealConvergedNotify` fires on a DISPATCH, not on an outcome."""
+
+    MSG = STATES["HealConvergedNotify"]["Parameters"]["Message.$"]
+    SUBJECT = STATES["HealConvergedNotify"]["Parameters"]["Subject"]
+
+    def test_it_does_not_assert_no_operator_action_required(self):
+        """Under the I7586 defect that claim was false in every case this state
+        could be reached — and it is a claim this state structurally cannot make,
+        because the dispatch is fire-and-forget."""
+        combined = (self.MSG + self.SUBJECT).lower()
+        assert "no operator action required" not in combined
+
+    def test_it_names_the_replay_execution(self):
+        """The convergence signal belongs to the replay's own terminal, so the
+        message has to point at it."""
+        assert "heal_replay_dispatch" in self.MSG
+
+    def test_it_says_what_it_is_reporting(self):
+        assert "dispatch" in (self.MSG + self.SUBJECT).lower()
+
+
+def test_replay_input_carries_the_identifiers_the_child_needs():
+    """Guard-the-guard: the assertions above are about what is ABSENT, so also
+    assert the input is still a usable execution input."""
+    for key in ("trading_instance_id.$", "ec2_instance_id.$", "run_date.$"):
+        assert key in REPLAY_INPUT
+    assert REPLAY_INPUT["pipeline_role"] == "operator-replay"
+    assert REPLAY_INPUT["triggered_by"] == "eod-self-heal"

--- a/tests/test_sf_eod_precondition_probe_wiring.py
+++ b/tests/test_sf_eod_precondition_probe_wiring.py
@@ -443,8 +443,14 @@ class TestHealOutcomeNotifications:
     standalone dashboard-box systemd timer, so these now route to
     StopTradingInstance directly."""
 
+    # alpha-engine-config-I7586: HealConvergedNotify's expected substring moved
+    # from "CONVERGED" to "replay dispatched". Not a test bent to fit the code —
+    # the state fires on a fire-and-forget DISPATCH and cannot know whether the
+    # replay converged, and under the deploy-refresh defect it never had. The
+    # property this parametrization actually protects (three heal-outcome
+    # notifications, three distinct subjects) is unchanged and still asserted.
     @pytest.mark.parametrize("state_name,subject_substr", [
-        ("HealConvergedNotify", "CONVERGED"),
+        ("HealConvergedNotify", "replay dispatched"),
         ("HealReplayDispatchFailed", "REPLAY DISPATCH FAILED"),
         ("HealNonConvergent", "DID NOT CONVERGE"),
     ])


### PR DESCRIPTION
fix(eod): the self-heal's replay must sync the executor checkout (alpha-engine-config-I7586)

HealDispatchReplay carried skip_refresh_executor_deploy: true, justified in
its own comment as "RefreshExecutorDeploy already ran at the top of THIS
execution and re-froze .frozen_executor_sha — the box is already
known-fresh."

That premise holds for the PARENT and not for the CHILD. This state's own
successors are HealConvergedNotify -> StopTradingInstance: the parent stops
the trading box out from under the fire-and-forget replay it just started,
the replay's StartTradingInstance boots it again, and a rebooted box is not
on the SHA the parent froze.

Reproduced by hand 2026-08-17 with this exact input shape. The replay reached
EODReconcile and died in executor/preflight.py::check_deploy_drift:

  RuntimeError: Deploy drift: executor checkout at /home/ec2-user/alpha-engine
  is on dfbab49b7b06 but this run pinned EXPECTED_EXECUTOR_SHA=1ea15df6ce83 at
  its freshness gate.

Terminal EODPipelineFailure. Re-running the identical input WITHOUT the flag
succeeded first try. The drift guard is correct — it is the 2026-04-20
stale-code class it was written for. The replay was handing it a box nobody
synced.

Why this is a P1 and not a note: the self-heal loop's entire convergence path
ends in HealDispatchReplay. If the loop ever converges, the replay it
dispatches fails this way — so the convergence path has NEVER worked. On
2026-08-17 the loop reached HealNonConvergent instead, so the flag was never
exercised in production. That is luck, not coverage.

HealConvergedNotify is re-worded with it. It asserted "No operator action
required" on the strength of a DISPATCH — false in every case this state could
be reached under the defect, and a claim the state structurally cannot make,
since the dispatch is fire-and-forget. It now reports that a replay was
started and names it; the convergence signal belongs to the replay's own
terminal, independently observable by execution name.

The other two flags are RETAINED and a test pins them, guarding against an
over-broad fix: skip_capture_snapshot is correct (the parent genuinely already
captured, and a second live-IB capture is the thing it exists to avoid) and
skip_post_market_data is correct (the heal loop just ran it). Only the
deploy-refresh flag has a premise a box restart invalidates.

tests/test_heal_replay_deploy_refresh_i7586.py also pins the ORDERING that
makes the flag wrong (HealDispatchReplay -> HealConvergedNotify ->
StopTradingInstance) and that the dispatch is still non-.sync, so if either
ever changes the premise is re-examined rather than the test silently kept.

One existing assertion changed: test_sf_eod_precondition_probe_wiring.py
expected "CONVERGED" in HealConvergedNotify's subject. Not a test bent to fit
the code — the state cannot know whether the replay converged. The property
that parametrization protects (three heal-outcome notifications, three
distinct subjects) is unchanged and still asserted.

No post-merge step: the EOD SF definition is auto-deployed on every merge to
main by deploy-infrastructure.yml (config#1173).

Test plan: 9 new tests pass; tests/ 5996 passed, 13 skipped, 1 failed —
test_stage_output_sweep.py::test_no_injected_client_resolves_a_region_with_no_env_set,
an ImportError reproducing identically on an untouched origin/main worktree,
unrelated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)


---

## Rehearsal

This change was rehearsed LIVE before the PR was opened, not only in tests.

`operator-replay-eodreconcile-2026-08-17` was started with `HealDispatchReplay`'s
pre-fix input shape verbatim and reproduced the defect — `EODReconcile` reached
`executor/preflight.py::check_deploy_drift` and raised
`Deploy drift: … is on dfbab49b7b06 but this run pinned EXPECTED_EXECUTOR_SHA=1ea15df6ce83`,
terminal `EODPipelineFailure`.

`operator-replay-eodreconcile-2026-08-17-refresh` was then started with the
identical input MINUS `skip_refresh_executor_deploy` — i.e. exactly what this
diff makes `HealDispatchReplay` send — and reached `SUCCEEDED` on the first
attempt, writing both `trades/eod_pnl.csv`'s `2026-08-17` row and
`_sf_completion/ne-postclose-trading-pipeline/2026-08-17.json`.

So both the failure and the fix are observed on the live state machine, on the
real trading box, with the real deploy-drift guard.

Rehearsal-path: tests/test_heal_replay_deploy_refresh_i7586.py
