### PR TITLE
fix(fundamentals): an absent vendor key fails the collector BY NAME (alpha-engine-config-I7583)

### DIFF
--- a/collectors/fundamentals.py
+++ b/collectors/fundamentals.py
@@ -330,6 +330,70 @@ NEUTRAL = {
 }
 
 
+# ── Source-key declaration + absent-source gate (alpha-engine-config-I7583) ──
+#
+# The vendor keys each output field reads, in fallback order. SINGLE OWNER:
+# _fetch_single_ticker picks through this map instead of repeating the key
+# lists inline, so the absence check cannot drift from what is actually read.
+#
+# Why this exists, and why it is separate from the collapse gate below:
+# `_pick` returns 0.0 for a key absent from the response, and nothing
+# distinguished that from a genuine zero. `capitalSpendingGrowth5Y` and
+# `freeCashFlowTTM` do not exist in Finnhub's `metric=all` response AT ALL, so
+# both read as a universe-wide 0.0 for the life of the integration with this
+# collector reporting `ok` every run. They were found by hand off a question in
+# a chat (alpha-engine-config-I7569), not by any check.
+#
+# The collapse gate catches that class by its SYMPTOM (a field carrying one
+# value across the universe). This gate catches it at the CAUSE, before any
+# default has been applied, which buys two things the symptom check cannot:
+# the error names the missing vendor keys instead of the constant they
+# produced, and it still fires when an absent field's default happens to VARY.
+_FIELD_SOURCE_KEYS: dict[str, tuple[str, ...]] = {
+    "pe_ratio": ("peTTM", "peExclExtraTTM", "peNormalizedAnnual"),
+    "pb_ratio": ("pbAnnual", "pbQuarterly"),
+    "debt_to_equity": ("totalDebt/totalEquityAnnual", "totalDebt/totalEquityQuarterly"),
+    "revenue_growth_yoy": (
+        "revenueGrowthTTMYoy", "revenueGrowthQuarterlyYoy", "revenueGrowth5Y",
+    ),
+    "gross_margin": ("grossMarginTTM", "grossMarginAnnual", "grossMargin5Y"),
+    "roe": ("roeTTM", "roeRfy"),
+    "current_ratio": ("currentRatioAnnual", "currentRatioQuarterly"),
+    "revenue_growth_3y": ("revenueGrowth3Y", "revenueGrowth5Y"),
+    "eps_growth_3y": ("epsGrowth3Y", "epsBasicExclExtraItemsAnnual5Y", "epsGrowth5Y"),
+    "payout_ratio": ("payoutRatioTTM", "payoutRatioAnnual"),
+    "dividend_yield": ("dividendYieldIndicatedAnnual", "currentDividendYieldTTM"),
+    "capex_growth_5y": ("capexCagr5Y",),
+    # fcf_yield is DERIVED (1 / P-FCF-per-share), not read directly; these are
+    # the keys whose absence makes it underivable.
+    "fcf_yield": ("pfcfShareTTM", "pfcfShareAnnual"),
+    "market_cap_raw": ("marketCapitalization",),
+}
+
+# A field absent for MORE than this fraction of the fetched universe is not
+# per-ticker sparsity (newer listings, ADRs, funds without the metric) — it is
+# the vendor not exposing the key. Set well above realistic sparsity and below
+# 1.0 so it fires before the field is fully dead rather than only at the extreme.
+_SOURCE_ABSENCE_FAIL_SHARE = 0.95
+
+# Transport-only key on the per-ticker record. Popped in collect() before the
+# snapshot is assembled — never written to S3, never seen by a consumer.
+_ABSENT_KEY = "__absent_source_fields__"
+
+
+def _absent_source_fields(metrics: dict) -> set[str]:
+    """Output fields for which NONE of the declared vendor keys is present.
+
+    A property of the RESPONSE, read before any default is applied — the one
+    point where "the vendor did not send this" and "the value is zero" are
+    still distinguishable.
+    """
+    return {
+        field for field, keys in _FIELD_SOURCE_KEYS.items()
+        if not any(k in metrics and metrics[k] is not None for k in keys)
+    }
+
+
 def _fetch_single_ticker(ticker: str) -> dict:
     """Fetch and normalize fundamental data for a single ticker via Finnhub.
 
@@ -345,35 +409,29 @@ def _fetch_single_ticker(ticker: str) -> dict:
     if not isinstance(metrics, dict) or not metrics:
         return NEUTRAL.copy()
 
+    # Recorded BEFORE any default is applied (alpha-engine-config-I7583).
+    _absent = _absent_source_fields(metrics)
+
     # P/E: TTM preferred; peExclExtraTTM smooths special-item noise; annual fallback
-    pe_raw = _pick(metrics, "peTTM", "peExclExtraTTM", "peNormalizedAnnual")
+    pe_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["pe_ratio"])
 
     # P/B: annual is the canonical book-value reference; quarterly fallback for newly-listed
-    pb_raw = _pick(metrics, "pbAnnual", "pbQuarterly")
+    pb_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["pb_ratio"])
 
     # D/E: Finnhub uses literal slash in field name. Quarterly fallback when annual missing.
-    de_raw = _pick(
-        metrics,
-        "totalDebt/totalEquityAnnual",
-        "totalDebt/totalEquityQuarterly",
-    )
+    de_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["debt_to_equity"])
 
     # Revenue growth: TTM YoY preferred; quarterly YoY fallback; 5Y last (smooths cycles).
-    revenue_growth_raw = _pick(
-        metrics,
-        "revenueGrowthTTMYoy",
-        "revenueGrowthQuarterlyYoy",
-        "revenueGrowth5Y",
-    )
+    revenue_growth_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["revenue_growth_yoy"])
 
     # Gross margin: TTM preferred; annual fallback; 5Y last.
-    gross_margin_raw = _pick(metrics, "grossMarginTTM", "grossMarginAnnual", "grossMargin5Y")
+    gross_margin_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["gross_margin"])
 
     # ROE: TTM preferred; Rfy (rolling fiscal year) fallback.
-    roe_raw = _pick(metrics, "roeTTM", "roeRfy")
+    roe_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["roe"])
 
     # Current ratio: annual; quarterly fallback.
-    current_ratio_raw = _pick(metrics, "currentRatioAnnual", "currentRatioQuarterly")
+    current_ratio_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["current_ratio"])
 
     # FCF yield: ``freeCashFlowTTM``/``freeCashFlowAnnual`` were assumed
     # present by analogy with the old FMP integration but are absent from
@@ -384,8 +442,8 @@ def _fetch_single_ticker(ticker: str) -> dict:
     # ratio inverted: FCF yield = 1 / (P/FCF). Fall back to NEUTRAL (0.0)
     # when the ratio is missing or non-positive — inverting a non-positive
     # P/FCF would silently emit a meaningless (or sign-flipped) yield.
-    market_cap = _pick(metrics, "marketCapitalization")
-    pfcf_share = _pick(metrics, "pfcfShareTTM", "pfcfShareAnnual")
+    market_cap = _pick(metrics, *_FIELD_SOURCE_KEYS["market_cap_raw"])
+    pfcf_share = _pick(metrics, *_FIELD_SOURCE_KEYS["fcf_yield"])
     if pfcf_share and pfcf_share > 0:
         fcf_yield_raw = 1.0 / pfcf_share
     else:
@@ -406,10 +464,8 @@ def _fetch_single_ticker(ticker: str) -> dict:
     # composite ranking (base-effect noise + single-quarter anomalies
     # average out). Annual fallbacks for newer listings without a full
     # 3y history.
-    revenue_growth_3y_raw = _pick(metrics, "revenueGrowth3Y", "revenueGrowth5Y")
-    eps_growth_3y_raw = _pick(
-        metrics, "epsGrowth3Y", "epsBasicExclExtraItemsAnnual5Y", "epsGrowth5Y",
-    )
+    revenue_growth_3y_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["revenue_growth_3y"])
+    eps_growth_3y_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["eps_growth_3y"])
 
     # ── Stewardship pillar substrate (Phase 3a) ──
     # Payout ratio + dividend yield + capex growth proxy. Insider ownership
@@ -420,14 +476,12 @@ def _fetch_single_ticker(ticker: str) -> dict:
     # discipline" axis: payout (return-of-capital intensity), dividend
     # yield (vs. payout, identifies low-yield + low-payout = buyback-
     # heavy retainers), and capex growth (reinvestment intensity).
-    payout_ratio_raw = _pick(metrics, "payoutRatioTTM", "payoutRatioAnnual")
-    dividend_yield_raw = _pick(
-        metrics, "dividendYieldIndicatedAnnual", "currentDividendYieldTTM",
-    )
+    payout_ratio_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["payout_ratio"])
+    dividend_yield_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["dividend_yield"])
     # capitalSpendingGrowth5Y does not exist in Finnhub's response (same
     # absent-field problem as freeCashFlowTTM above); the real 5y CAPEX CAGR
     # field is capexCagr5Y (alpha-engine-config-I7569).
-    capex_growth_5y_raw = _pick(metrics, "capexCagr5Y")
+    capex_growth_5y_raw = _pick(metrics, *_FIELD_SOURCE_KEYS["capex_growth_5y"])
 
     # Finnhub reports growth/margin/return/payout/yield metrics as PERCENT
     # POINTS (e.g. ``grossMarginTTM: 48.65`` means 48.65%, ``roeTTM: 137.18``
@@ -465,6 +519,7 @@ def _fetch_single_ticker(ticker: str) -> dict:
         # SIZE loading's log + cross-sectional z-score downstream tames the
         # scale; clipping here would corrupt the absolute units.
         "market_cap_raw": market_cap_raw,
+        _ABSENT_KEY: _absent,
     }
 
 
@@ -510,9 +565,19 @@ def collect(
     quality_counts_by_type: dict[str, int] = {}
     quality_blocked_details: list[str] = []  # "TICKER.type" per block
 
+    absent_counts: dict[str, int] = {}
+    n_fetched = 0
+
     for ticker in tickers:
         try:
             data = _fetch_single_ticker(ticker)
+            # I7583: strip the transport-only absence set before ANY consumer
+            # (the value-range gate, NEUTRAL comparison, the snapshot) sees it.
+            _absent = data.pop(_ABSENT_KEY, None)
+            if _absent is not None:
+                n_fetched += 1
+                for _f in _absent:
+                    absent_counts[_f] = absent_counts.get(_f, 0) + 1
             # ── Write-time value-range gate ─────────────────────────────
             # Runs on the fully-shaped (clipped) per-ticker dict before it
             # is queued for the S3 snapshot. block → drop the corrupt row
@@ -605,6 +670,48 @@ def collect(
     # that is dead for every ticker passes ok_ratio 903 times over — that is
     # exactly how capitalSpendingGrowth5Y and freeCashFlowTTM went unnoticed
     # for the life of the Finnhub integration (alpha-engine-config-I7569).
+    # ── Absent-source gate (alpha-engine-config-I7583) ──────────────────────
+    # The CAUSE-side check, run before the collapse gate below, which is the
+    # SYMPTOM-side one. Both are kept: this names the missing vendor keys and
+    # fires even when an absent field's default varies; the collapse gate
+    # catches every other route to a dead column (units saturation, a scaling
+    # divisor, a vendor pinning a value) without needing to know the cause.
+    _absent_everywhere = {
+        f: n for f, n in absent_counts.items()
+        if n_fetched and (n / n_fetched) >= _SOURCE_ABSENCE_FAIL_SHARE
+    }
+    if _absent_everywhere and n_fetched >= _FIELD_COLLAPSE_MIN_TICKERS:
+        msg = (
+            "source key(s) absent from the vendor response for effectively the "
+            f"whole universe over {n_fetched} fetched tickers: "
+            + ", ".join(
+                f"{f} ({n}/{n_fetched}, reads {list(_FIELD_SOURCE_KEYS[f])})"
+                for f, n in sorted(_absent_everywhere.items())
+            )
+            + ". Each is currently being written as a default value a consumer "
+            "cannot distinguish from real data. Refusing to write the snapshot."
+        )
+        logger.error("Fundamentals absent-source gate: %s", msg)
+        return {
+            "status": "error",
+            "error": msg,
+            "tickers_ok": n_ok,
+            "tickers_error": n_err,
+            "absent_source_fields": _absent_everywhere,
+            **_quality_fields,
+        }
+    if absent_counts:
+        # Below the fail share this is ordinary per-ticker sparsity, but it is
+        # RECORDED rather than dropped: a field drifting from 5% to 60% absent
+        # is the shape of a vendor deprecating a key, and it should be visible
+        # before it crosses the threshold, not at the moment it halts a run.
+        logger.info(
+            "Fundamentals source-key coverage over %d fetched tickers "
+            "(absent counts, below the %.0f%% fail share): %s",
+            n_fetched, _SOURCE_ABSENCE_FAIL_SHARE * 100,
+            dict(sorted(absent_counts.items())),
+        )
+
     _real_records = [r for r in results.values() if r != NEUTRAL]
     if len(_real_records) < _FIELD_COLLAPSE_MIN_TICKERS:
         logger.info(

--- a/tests/test_fundamentals_absent_source_gate.py
+++ b/tests/test_fundamentals_absent_source_gate.py
@@ -1,0 +1,150 @@
+"""An absent vendor key fails the collector by NAME (alpha-engine-config-I7583).
+
+`_pick(metrics, *keys, default=0.0)` returns 0.0 when the response carries none
+of the requested keys, and nothing distinguished that from a genuine zero.
+`capitalSpendingGrowth5Y` and `freeCashFlowTTM` do not exist in Finnhub's
+`metric=all` response AT ALL, so `capex_growth_5y` and `fcf_yield` read as a
+universe-wide 0.0 for the life of the integration — with this collector
+reporting `ok` on every run. They were found by hand off a question in a chat
+(alpha-engine-config-I7569), not by any check.
+
+The collapse gate (`test_fundamentals_field_collapse_gate.py`) catches that
+class by its SYMPTOM. This one catches it at the CAUSE, and the two are kept
+deliberately, because each sees something the other cannot:
+
+  cause-side  names the missing VENDOR KEYS, not the constant they produced,
+              and still fires when an absent field's default happens to VARY.
+  symptom-side catches every other route to a dead column — units saturation,
+              a scaling divisor, a vendor pinning a field to a constant —
+              without needing to know the cause.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from collectors.fundamentals import (
+    _FIELD_SOURCE_KEYS,
+    _SOURCE_ABSENCE_FAIL_SHARE,
+    NEUTRAL,
+    _absent_source_fields,
+)
+
+
+def _full_response() -> dict:
+    """One vendor key present for every declared field."""
+    return {keys[0]: 1.0 for keys in _FIELD_SOURCE_KEYS.values()}
+
+
+class TestAbsenceDetection:
+    def test_a_complete_response_has_nothing_absent(self):
+        assert _absent_source_fields(_full_response()) == set()
+
+    def test_the_two_keys_finnhub_never_exposed(self):
+        """The measured instance. Neither `capitalSpendingGrowth5Y` nor
+        `freeCashFlowTTM` exists in the response, so both fields' whole key
+        lists are missing."""
+        metrics = _full_response()
+        for field in ("capex_growth_5y", "fcf_yield"):
+            for key in _FIELD_SOURCE_KEYS[field]:
+                metrics.pop(key, None)
+        assert _absent_source_fields(metrics) == {"capex_growth_5y", "fcf_yield"}
+
+    def test_a_fallback_key_still_counts_as_present(self):
+        """Absence means NONE of the fallbacks landed — a field served by its
+        second choice is covered, not missing."""
+        metrics = _full_response()
+        keys = _FIELD_SOURCE_KEYS["pe_ratio"]
+        assert len(keys) > 1
+        metrics.pop(keys[0])
+        metrics[keys[1]] = 12.0
+        assert "pe_ratio" not in _absent_source_fields(metrics)
+
+    def test_an_explicit_null_is_absent_not_present(self):
+        """Finnhub returns the key with a `null` value for fields it does not
+        carry for a given ticker; `_pick` skips those, so the gate must too."""
+        metrics = _full_response()
+        for key in _FIELD_SOURCE_KEYS["roe"]:
+            metrics[key] = None
+        assert "roe" in _absent_source_fields(metrics)
+
+    def test_an_empty_response_is_entirely_absent(self):
+        assert _absent_source_fields({}) == set(_FIELD_SOURCE_KEYS)
+
+
+class TestDeclarationIsTheSingleOwner:
+    def test_every_declared_field_is_a_real_output_field(self):
+        """The declaration must describe fields the collector actually emits —
+        otherwise the gate guards names nothing reads."""
+        unknown = set(_FIELD_SOURCE_KEYS) - set(NEUTRAL)
+        assert not unknown, f"declared but not emitted: {sorted(unknown)}"
+
+    def test_every_vendor_sourced_output_field_is_declared(self):
+        """Guard-the-guard, and the property that actually matters: a field
+        added to the collector without an entry here is a field the gate is
+        blind to — exactly the state that let two dead columns ship."""
+        undeclared = set(NEUTRAL) - set(_FIELD_SOURCE_KEYS)
+        assert not undeclared, (
+            f"emitted but not declared: {sorted(undeclared)} — add its vendor "
+            "keys to _FIELD_SOURCE_KEYS or the absent-source gate cannot see it."
+        )
+
+    def test_the_picks_go_through_the_declaration(self):
+        """One owner. If a call site re-inlines its key list the declaration can
+        drift from what is actually read, and the gate silently checks the wrong
+        keys."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parents[1] / "collectors" / "fundamentals.py"
+        ).read_text(encoding="utf-8")
+        body = src.split("def _fetch_single_ticker", 1)[1]
+        # Every _pick call inside the fetch must unpack the declaration.
+        for line in body.splitlines():
+            if "_pick(metrics" in line:
+                assert "_FIELD_SOURCE_KEYS[" in line or line.rstrip().endswith("_pick("), (
+                    f"_pick call site does not read the declaration: {line.strip()}"
+                )
+
+
+class TestGateWiring:
+    @staticmethod
+    def _source() -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[1] / "collectors" / "fundamentals.py"
+        ).read_text(encoding="utf-8")
+
+    def test_the_transport_key_never_reaches_a_consumer(self):
+        """It rides on the per-ticker record only to get out of the fetch; if it
+        survived it would break the `!= NEUTRAL` comparison, the value-range
+        gate, and the S3 snapshot's shape."""
+        src = self._source()
+        assert "data.pop(_ABSENT_KEY, None)" in src
+
+    def test_the_gate_returns_error_status(self):
+        assert "Fundamentals absent-source gate" in self._source()
+
+    def test_the_gate_runs_before_the_collapse_gate(self):
+        src = self._source()
+        assert src.index("Fundamentals absent-source gate") < src.index(
+            "Fundamentals collapse gate"
+        )
+
+    def test_sub_threshold_absence_is_recorded_not_dropped(self):
+        """A field drifting from 5% to 60% absent is a vendor deprecating a key.
+        It should be visible before it crosses the threshold, not at the moment
+        it halts a run."""
+        assert "Fundamentals source-key coverage over" in self._source()
+
+    def test_the_fail_share_leaves_room_for_real_sparsity(self):
+        assert 0.5 < _SOURCE_ABSENCE_FAIL_SHARE < 1.0
+
+
+@pytest.mark.parametrize("field", ["capex_growth_5y", "fcf_yield"])
+def test_both_i7569_fields_would_have_been_caught_on_day_one(field):
+    metrics = _full_response()
+    for key in _FIELD_SOURCE_KEYS[field]:
+        metrics.pop(key, None)
+    assert field in _absent_source_fields(metrics)


### PR DESCRIPTION
fix(fundamentals): an absent vendor key fails the collector BY NAME (alpha-engine-config-I7583)

The remainder of I7583, on top of #1423's collapse gate. #1423 catches a dead
column by its SYMPTOM — one value across the universe. This catches it at the
CAUSE, before any default has been applied.

`_pick(metrics, *keys, default=0.0)` returns 0.0 when the response carries none
of the requested keys, and nothing distinguished that from a genuine zero.
`capitalSpendingGrowth5Y` and `freeCashFlowTTM` do not exist in Finnhub's
`metric=all` response AT ALL, so `capex_growth_5y` and `fcf_yield` read as a
universe-wide 0.0 for the life of the integration, with this collector
reporting `ok` on every run. Both were found by hand off a question in a chat
(alpha-engine-config-I7569), not by any check.

Both gates are kept, because each sees something the other cannot:

  cause-side (here)  names the missing VENDOR KEYS rather than the constant
                     they produced, and still fires when an absent field's
                     default happens to VARY.
  symptom-side       catches every other route to a dead column — units
                     saturation, a scaling divisor, a vendor pinning a field —
                     without needing to know the cause.

`_FIELD_SOURCE_KEYS` is the single owner of "which vendor keys feed which
output field". `_fetch_single_ticker` now picks THROUGH it rather than
repeating the key lists inline, so the gate cannot check keys the collector no
longer reads. A test walks the fetch body and fails any `_pick` call site that
re-inlines its own list.

Absence is recorded per ticker before defaults are applied and carried out on a
transport-only dunder key that collect() pops immediately — it never reaches
the value-range gate, the `!= NEUTRAL` comparison, or the S3 snapshot. A field
absent for >= 95% of the fetched universe returns status="error" naming the
field, the count, and the vendor keys it reads. Below that share the counts are
LOGGED rather than dropped: a field drifting from 5% to 60% absent is a vendor
deprecating a key, and that should be visible before it crosses the threshold,
not at the moment it halts a run.

The gate is bounded by the same >= 50 fetched-ticker floor #1423 established,
for the same reason: absence across three fixture tickers says nothing.

Test plan: tests/test_fundamentals_absent_source_gate.py, 15 tests — the two
measured defect instances, fallback-key and explicit-null handling, the
declaration being the single owner in both directions (a field emitted but not
declared is a field the gate is blind to, which is the state that let the two
dead columns ship), and five wiring assertions. tests/ 6021 passed, 13 skipped,
1 failed — test_stage_output_sweep.py::test_no_injected_client_resolves_a_region_with_no_env_set,
an ImportError reproducing identically on an untouched origin/main worktree,
unrelated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
