### PR TITLE
feat(freshness): report the suppression gap instead of paging it (I7606)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -1159,6 +1159,90 @@ def _check_one(
 # ── Aggregation + S3 emission ───────────────────────────────────────────────
 
 
+def suppression_coverage(
+    pairs: list[tuple[Any, Any]],
+    producer_trigger_by_id: dict[str, str | list],
+    suppression_by_id: dict[str, dict[str, Any]],
+    inventory: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Which not-fresh rows nothing can explain (alpha-engine-config-I7606).
+
+    Producer suppression only ever fires for a row that DECLARED its
+    ``producer_trigger``. Coverage of that field is therefore the thing
+    standing between "a producer was deliberately switched off" and "Brian
+    gets a CRITICAL page for his own ruling" — and until now the only way to
+    learn a row was missing the declaration was to receive that page.
+
+    Measured 2026-08-18: 13 of 145 rows declared it. Two that did not —
+    ``health_alpha_engine_predictor_health_check`` and
+    ``predictor_drift_detection`` — had been escalating warning->critical on
+    miss-count for producers DISABLED under the 2026-08-07 pause ruling
+    (config-I6617), while six rows that did declare it sat correctly quiet in
+    the same sweep. The mechanism was working; the field was absent. Nothing
+    reported the absence.
+
+    This does not guess. A registry row does not say what produces it, so
+    "undeclared" here means exactly that and never "its producer is off" —
+    the inventory of what IS off is the other half, already written next door,
+    and the two are reported side by side so a human can join them. The number
+    that matters is ``undeclared_not_fresh``: rows that are stale or missing
+    and carry no declaration that could ever explain it.
+    """
+    not_fresh = [
+        spec for spec, result in pairs
+        if getattr(result, "state", None) in ("stale", "missing")
+    ]
+    undeclared = sorted(
+        spec.artifact_id for spec in not_fresh
+        if spec.artifact_id not in producer_trigger_by_id
+    )
+    disabled_rows = [
+        r for r in ((inventory or {}).get("rows") or []) if not r.get("error")
+    ]
+    return {
+        "registry_rows": len(pairs),
+        "rows_declaring_producer_trigger": len(producer_trigger_by_id),
+        "not_fresh": len(not_fresh),
+        "suppressed": len(
+            [v for v in suppression_by_id.values() if v.get("suppressed")]
+        ),
+        "undeclared_not_fresh": len(undeclared),
+        "undeclared_not_fresh_ids": undeclared,
+        # The join a human has to make by hand today: these are switched off
+        # and no registry row names them, so no artifact's page can currently
+        # be explained by them even if one of them is the cause.
+        "disabled_producers_unreferenced": len(
+            [r for r in disabled_rows if not r.get("referenced_by_registry")]
+        ),
+        "inventory_complete": bool((inventory or {}).get("complete")),
+    }
+
+
+def _emit_suppression_coverage_metrics(
+    cw_client: Any, coverage: dict[str, Any]
+) -> None:
+    """Emit coverage to CW on EVERY run, zeros included (config-I7606).
+
+    Zeros included for the reason the execution-loop emitter states: the
+    absence of these datapoints means the emitter is dead, never that coverage
+    is complete. ``UndeclaredNotFreshRows`` is the alarmable one — it is the
+    count of pages that no suppression could ever prevent.
+    """
+    cw_client.put_metric_data(
+        Namespace=CW_NAMESPACE,
+        MetricData=[
+            {"MetricName": "UndeclaredNotFreshRows",
+             "Value": float(coverage["undeclared_not_fresh"]), "Unit": "Count"},
+            {"MetricName": "RowsDeclaringProducerTrigger",
+             "Value": float(coverage["rows_declaring_producer_trigger"]),
+             "Unit": "Count"},
+            {"MetricName": "DisabledProducersUnreferenced",
+             "Value": float(coverage["disabled_producers_unreferenced"]),
+             "Unit": "Count"},
+        ],
+    )
+
+
 def _serialize_check_results(
     pairs: list[tuple[ArtifactSpec, CheckResult]], now: datetime,
     miss_counts: dict[str, int] | None = None,
@@ -1167,6 +1251,7 @@ def _serialize_check_results(
     suppression_by_id: dict[str, dict[str, Any]] | None = None,
     owning_by_id: dict[str, dict[str, Any]] | None = None,
     execution_loop: dict[str, Any] | None = None,
+    coverage: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the ``check_results.json`` payload — one row per spec for
     the dashboard surface (Phase 5). ``miss_counts``/``coerced_ids``
@@ -1259,6 +1344,12 @@ def _serialize_check_results(
         # never has to fetch a second artifact to answer "is this class
         # paging about a component or about an undrained backlog?".
         "execution_loop": execution_loop,
+        # config-I7606 — the coverage of the suppression mechanism itself, on
+        # the same surface as the rows it governs, for the same reason: a
+        # consumer can now tell "quiet because its producer is deliberately
+        # off" from "loud because nothing declared what produces it" without
+        # joining two artifacts by hand.
+        "suppression_coverage": coverage,
         "results": rows,
     }
 
@@ -3178,7 +3269,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # off?", this answers "what is off at all?", including schedules no
     # artifact row names. Written before the probe pass so a pass that raises
     # still leaves the inventory current.
-    write_disabled_producer_inventory(
+    disabled_inventory = write_disabled_producer_inventory(
         s3, now,
         {t for v in producer_trigger_by_id.values() for t in _declared_triggers(v)},
     )
@@ -3223,12 +3314,31 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     )
 
     # Emit dashboard surface + self-heartbeat.
+    # config-I7606: coverage of the suppression mechanism itself, computed
+    # before serialization so the numbers and the rows they describe come out
+    # of the same pass and cannot disagree.
+    coverage = suppression_coverage(
+        pairs, producer_trigger_by_id, suppression_by_id, disabled_inventory,
+    )
+    if coverage["undeclared_not_fresh"]:
+        logger.warning(
+            "SUPPRESSION COVERAGE: %d not-fresh row(s) declare no "
+            "producer_trigger, so no producer pause could ever explain them: "
+            "%s. %d of %d rows declare the field; %d disabled producer(s) are "
+            "named by no registry row (config-I7606).",
+            coverage["undeclared_not_fresh"],
+            coverage["undeclared_not_fresh_ids"],
+            coverage["rows_declaring_producer_trigger"],
+            coverage["registry_rows"],
+            coverage["disabled_producers_unreferenced"],
+        )
     check_results = _serialize_check_results(
         pairs, now, miss_counts=miss_counts, coerced_ids=coerced_ids,
         issue_filed_by_id=issue_filed_by_id,
         suppression_by_id=suppression_by_id,
         owning_by_id=owning_by_id,
         execution_loop=execution_loop,
+        coverage=coverage,
     )
     heartbeat = _serialize_heartbeat(pairs, now, started_at)
 
@@ -3255,6 +3365,18 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
             exc_info=True,
         )
         _emit_cycle_verdict_error("execution_loop_cw_emit")
+
+    # config-I7606 — coverage on CloudWatch, in its own trap for the same
+    # reason as the pair above: a PutMetricData regression must not suppress
+    # the S3 artifact that already carries the same numbers.
+    try:
+        _emit_suppression_coverage_metrics(boto3.client("cloudwatch"), coverage)
+    except Exception as exc:  # noqa: BLE001 — secondary observability; recording surfaces: this ERROR, the CW Stage=suppression_coverage_cw_emit datapoint, and check_results.json's suppression_coverage block (already written above)
+        logger.error(
+            "suppression-coverage CW metric emit failed (non-fatal): %s", exc,
+            exc_info=True,
+        )
+        _emit_cycle_verdict_error("suppression_coverage_cw_emit")
 
     # ── Per-cycle completion rollup (L249 consumer) ─────────────────────
     # Secondary observability hung off the primary probe pass. The artifact

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -3709,3 +3709,119 @@ def test_gha_pause_age_comes_from_githubs_own_switch_off_date(fixed_now):
         _keyed_s3(objects), {"pr_resting_state_trend": trig}, fixed_now)
     assert out["pr_resting_state_trend"]["disabled_since"] == "2026-05-01"
     assert out["pr_resting_state_trend"]["days_disabled"] == 29
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Suppression coverage — the gap that could only be learned by being paged
+# (alpha-engine-config-I7606)
+# ══════════════════════════════════════════════════════════════════════════
+#
+# Producer suppression only ever fires for a row that DECLARED its
+# producer_trigger, so coverage of that field is the whole distance between
+# "a producer was deliberately switched off" and "Brian gets a CRITICAL page
+# for his own ruling". Measured 2026-08-18: 13 of 145 rows declared it, six of
+# them sat correctly quiet, and two that did not declare it —
+# health_alpha_engine_predictor_health_check and predictor_drift_detection —
+# had been escalating warning->critical on miss-count for producers disabled
+# under the 2026-08-07 pause (config-I6617). The mechanism worked. The field
+# was absent. Nothing anywhere reported the absence, so the page was the
+# notification channel for its own coverage gap.
+
+
+class _Spec:
+    def __init__(self, artifact_id):
+        self.artifact_id = artifact_id
+
+
+class _Result:
+    def __init__(self, state):
+        self.state = state
+
+
+def _coverage(pairs, declared, suppression=None, inventory=None):
+    import index
+    return index.suppression_coverage(
+        pairs, declared, suppression or {}, inventory,
+    )
+
+
+def test_coverage_counts_a_not_fresh_row_that_declared_nothing():
+    """The exact 2026-08-18 case: the row is stale, nothing says what produces
+    it, so no producer pause could ever explain the page."""
+    pairs = [
+        (_Spec("predictor_health"), _Result("stale")),
+        (_Spec("fresh_one"), _Result("fresh")),
+    ]
+    out = _coverage(pairs, {})
+    assert out["undeclared_not_fresh"] == 1
+    assert out["undeclared_not_fresh_ids"] == ["predictor_health"]
+    assert out["not_fresh"] == 1
+
+
+def test_a_declared_row_is_not_counted_even_when_it_is_still_stale():
+    """Suppression does not make a stale artifact fresh — the row keeps its
+    true state. What the declaration buys is that the staleness is EXPLAINED,
+    so it must not show up as a coverage gap."""
+    pairs = [(_Spec("daily_heal_summary"), _Result("stale"))]
+    out = _coverage(
+        pairs,
+        {"daily_heal_summary": "events:alpha-engine-daily-heal"},
+        {"daily_heal_summary": {"suppressed": True}},
+    )
+    assert out["undeclared_not_fresh"] == 0
+    assert out["suppressed"] == 1
+
+
+def test_missing_counts_the_same_as_stale():
+    """rag_ingestion_progress was `missing`, not `stale`, for 14 sweeps. A
+    coverage measure that only looked at staleness would have scored the
+    loudest row in the fleet as covered."""
+    pairs = [(_Spec("never_written"), _Result("missing"))]
+    assert _coverage(pairs, {})["undeclared_not_fresh"] == 1
+
+
+def test_coverage_never_guesses_that_a_disabled_producer_owns_a_row():
+    """A registry row does not say what produces it. Reporting the unreferenced
+    disabled producers NEXT TO the undeclared rows lets a human join them;
+    inferring the join here would silence pages on a resemblance."""
+    pairs = [(_Spec("orphan"), _Result("stale"))]
+    inventory = {
+        "complete": True,
+        "rows": [
+            {"trigger": "events:something-off", "referenced_by_registry": False},
+            {"trigger": "events:known", "referenced_by_registry": True},
+        ],
+    }
+    out = _coverage(pairs, {}, None, inventory)
+    assert out["undeclared_not_fresh_ids"] == ["orphan"]
+    assert out["disabled_producers_unreferenced"] == 1
+    # No field claims a link between the two.
+    assert not any("owner" in k or "likely" in k for k in out)
+
+
+def test_an_incomplete_inventory_is_reported_as_incomplete():
+    """enumerate_disabled_schedules records an ERROR row rather than returning
+    a short list. Coverage must carry that forward: an inventory that failed to
+    walk the account must never read as "nothing else is disabled"."""
+    out = _coverage([], {}, None, {"complete": False, "rows": []})
+    assert out["inventory_complete"] is False
+    assert _coverage([], {}, None, None)["inventory_complete"] is False
+
+
+def test_coverage_metrics_emit_zeros_rather_than_nothing():
+    """Zeros included, for the reason the execution-loop emitter states: the
+    absence of these datapoints means the emitter is dead, never that coverage
+    is complete."""
+    import index
+    calls = []
+
+    class _CW:
+        def put_metric_data(self, **kw):
+            calls.append(kw)
+
+    index._emit_suppression_coverage_metrics(_CW(), _coverage([], {}))
+    assert len(calls) == 1
+    names = {m["MetricName"]: m["Value"] for m in calls[0]["MetricData"]}
+    assert names["UndeclaredNotFreshRows"] == 0.0
+    assert names["RowsDeclaringProducerTrigger"] == 0.0
+    assert names["DisabledProducersUnreferenced"] == 0.0


### PR DESCRIPTION
## What and why

Producer suppression (config-I6570) only ever fires for a row that **declared** its `producer_trigger`. Coverage of that field is therefore the entire distance between *"a producer was deliberately switched off"* and *"Brian gets a CRITICAL page for his own ruling"* — and nothing measured it. **The page was the notification channel for its own coverage gap.**

Tracked: alpha-engine-config-I7606 (deliverable 1).

## Measured against the live sweep, 2026-08-18

`s3://alpha-engine-research/_freshness_monitor/check_results.json`, run `2026-08-18T12:00:17Z`: **13 of 145 rows** declared the field.

| | rows | outcome |
|---|---|---|
| declared, producer disabled | 6 | correctly quiet — the mechanism works |
| **undeclared, producer disabled** | **2** | escalated `warning -> critical` on miss-count and paged |

The two were `health_alpha_engine_predictor_health_check` (5 misses) and `predictor_drift_detection` (10), both behind EventBridge rules disabled under the 2026-08-07 pause ruling (config-I6617). The mechanism was working. The field was absent. Nothing anywhere reported the absence.

## The change

`suppression_coverage()`, computed in the same pass that builds the rows so the numbers and the rows they describe cannot disagree. It surfaces in three places:

- **`check_results.json`** — a `suppression_coverage` block beside `results`, so a consumer can tell *"quiet because its producer is deliberately off"* from *"loud because nothing declared what produces it"* without joining two artifacts by hand.
- **CloudWatch** — `UndeclaredNotFreshRows` (the alarmable one: pages no suppression could ever prevent), `RowsDeclaringProducerTrigger`, `DisabledProducersUnreferenced`.
- **A WARNING** naming the offending `artifact_id`s.

## What it deliberately does not do

**It does not guess.** A registry row does not say what produces it, so `undeclared_not_fresh` means exactly *"stale or missing, and nothing declared could ever explain it"* — never *"its producer is off"*. The count of disabled producers no row names is reported **next to** it so a human can make the join. Inferring that join here would silence a page on a resemblance, which is the failure the whole mechanism exists to avoid making. A test asserts no field claims the link.

## Three details that are load-bearing, not stylistic

1. **`missing` counts the same as `stale`.** `rag_ingestion_progress` was *missing*, not stale, for 14 sweeps — a measure that only looked at staleness would have scored the loudest row in the fleet as covered.
2. **A suppressed row is not a coverage gap, even though it is still stale.** Suppression does not make an artifact fresh; the row keeps its true state. What the declaration buys is that the staleness is *explained*.
3. **An inventory that failed to walk the account reports `inventory_complete: false`** rather than reading as *"nothing else is disabled"*.

Metrics emit every run, zeros included — their absence means the emitter is dead, never that coverage is complete — and in their own `try/except` for the same reason as the execution-loop pair: a `PutMetricData` regression must not suppress the S3 artifact carrying the same numbers.

## SOTA and the delta

The institutional shape is that a suppression mechanism publishes its own coverage, so the gap is found on a dashboard rather than in an inbox. That is what this implements. **Delta: it measures the gap, it does not close it** — 13 of 145 rows still carry the field. The backfill is I7606 deliverable 2, deliberately separate: it is per-row research into what produces each artifact, and bundling ~130 judgement calls with the mechanism that reports them would make both harder to review.

## Test plan (run before opening)

- `pytest infrastructure/lambdas/freshness-monitor/test_handler.py -q` → **145 passed** (6 new)
- `pytest tests/ -q` → **6036 passed, 13 skipped**

The two suites cannot share a pytest process — each stubs `boto3` in `sys.modules` — which is why `ci.yml` runs them separately, and why they were verified separately here.

## Post-merge

None. The Lambda deploys through the existing path; the merge button is the last action.

## Related

alpha-engine-config-I7606, -I6570, -I6617, -I3086, -I7515 (no surface reads `alert_suppressed` — this adds the first aggregate one), -I6817.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)