### PR TITLE
fix(features): an uncomputed factor momentum is absent, not zero (config-I7539)

### DIFF
--- a/features/compute.py
+++ b/features/compute.py
@@ -44,7 +44,9 @@ from features.factor_momentum import DEFAULT_FACTOR_LOADINGS, compute_factor_mom
 from features.feature_engineer import FEATURES, FEATURE_CFG, MIN_ROWS_FOR_FEATURES, compute_features
 from features.metron_supplemental import compute_metron_supplemental_features, write_metron_supplemental_snapshot
 from features.postflight import (
-    assert_no_zero_variance_features,
+    ZERO_VARIANCE_EXEMPT,
+    assert_no_dead_feature_columns,
+    find_all_null_columns,
     find_zero_variance_columns,
 )
 from features.private_pack import apply_private_features
@@ -1201,18 +1203,34 @@ def compute_and_write(
             )
             _fm_map = _fm_latest.dropna()
             n_fm = int(features_df["ticker"].map(_fm_map).notna().sum())
+            # NOT `.fillna(0.0)` (alpha-engine-config-I7539). 0.0 is a LEGAL
+            # factor-momentum reading, so back-filling it makes an uncomputed
+            # ticker indistinguishable from one whose tilt really is zero —
+            # and when the pass produced nothing at all, the whole column read
+            # as a plausible universe-wide zero. Measured 2026-08-18: this
+            # snapshot carried 0.0 for all 901 tickers while ArcticDB's daily
+            # second pass (builders/daily_append.update_factor_momentum_latest)
+            # held real values for the same date (AAPL -0.049, MSFT +0.069,
+            # XOM -0.101). Two stores disagreeing about one registered column,
+            # with the S3 side fabricating the disagreement.
+            #
+            # NaN is the honest state: absent, recoverable, and visible to the
+            # postflight guard below, which now reports an entirely-empty
+            # column as loudly as a constant one.
             features_df["factor_momentum_ratio"] = (
-                features_df["ticker"].map(_fm_map).fillna(0.0).astype(float)
+                features_df["ticker"].map(_fm_map).astype(float)
             )
             log.info(
                 "Factor-momentum second pass (daily): %d/%d tickers got a non-NaN "
-                "factor_momentum_ratio (window/skip warmup — rest fall back to 0.0)",
+                "factor_momentum_ratio (window/skip warmup — the rest stay NaN, "
+                "never a fabricated 0.0)",
                 n_fm, len(features_df),
             )
         except Exception:
             log.exception(
                 "Factor-momentum second pass failed — factor_momentum_ratio "
-                "stays at the FEATURES-loop default (0.0) for this snapshot"
+                "is left as the FEATURES-loop default for this snapshot and "
+                "the postflight guard below reports it"
             )
     else:
         log.warning(
@@ -1244,12 +1262,24 @@ def compute_and_write(
     # there is the expected shape, not a defect.
     _non_macro_features = [f for f in FEATURES if f not in GROUPS.get("macro", ())]
     if zero_variance_fatal:
-        assert_no_zero_variance_features(features_df, _non_macro_features)
+        assert_no_dead_feature_columns(features_df, _non_macro_features)
         _zero_variance: dict[str, int] = {}
+        _all_null: list[str] = []
     else:
         # Same columns, same predicate — only the consequence differs. See the
         # zero_variance_fatal note in this function's docstring.
         _zero_variance = find_zero_variance_columns(features_df, _non_macro_features)
+        _all_null = [c for c in find_all_null_columns(features_df, _non_macro_features)
+                     if c not in ZERO_VARIANCE_EXEMPT]
+        if _all_null:
+            log.error(
+                "EMPTY feature column(s) on the daily path: zero non-null values "
+                "over the whole universe — a producer that ran and wrote nothing "
+                "(alpha-engine-config-I7539). The snapshot IS still written and "
+                "this run is reported DEGRADED, not failed, matching the "
+                "zero-variance verdict's blast radius (I7572). Columns: %s",
+                _all_null,
+            )
         if _zero_variance:
             log.error(
                 "ZERO-VARIANCE feature column(s) detected on the daily path: every "
@@ -1339,8 +1369,11 @@ def compute_and_write(
         # A distinct status rather than "ok" so no caller can read a run whose
         # feature store carries a dead column as a fully clean one
         # (alpha-engine-config-I7572).
-        "status": "degraded" if _zero_variance else "ok",
+        "status": "degraded" if (_zero_variance or _all_null) else "ok",
         "zero_variance_columns": _zero_variance,
+        # Separate key, not folded into the one above: "constant" and "empty"
+        # send the reader to different producer questions.
+        "all_null_columns": _all_null,
         "date": date_str,
         "tickers_computed": n_ok,
         "tickers_skipped": n_skip,

--- a/features/postflight.py
+++ b/features/postflight.py
@@ -67,6 +67,74 @@ def find_zero_variance_columns(
     return offending
 
 
+def find_all_null_columns(
+    features_df: pd.DataFrame,
+    feature_names: list[str],
+) -> list[str]:
+    """Registered columns present in the frame with ZERO non-null values.
+
+    The companion to :func:`find_zero_variance_columns`, and the reason it
+    needs one: that function skips any column with fewer than
+    ``min_non_null`` values, deliberately, so a genuinely sparse alt-data
+    field is not reported as a constant. A column the producer never filled
+    has zero values and falls straight through that floor.
+
+    The hole opens the moment a producer stops back-filling an uncomputed
+    column with a fabricated default: it goes from LOUDLY constant to
+    SILENTLY absent (alpha-engine-config-I7539). A missing VALUE is the
+    honest state; a column that is missing EVERY value is a dead producer,
+    and both must be visible.
+
+    Sparse-but-present is NOT reported here — that is a coverage question
+    with its own surfaces. A column absent from the frame entirely is not
+    reported either: that is a schema failure, and naming it here would send
+    the reader to the wrong producer.
+    """
+    return [
+        col for col in feature_names
+        if col in features_df.columns
+        and int(pd.to_numeric(features_df[col], errors="coerce").notna().sum()) == 0
+    ]
+
+
+def assert_no_dead_feature_columns(
+    features_df: pd.DataFrame,
+    feature_names: list[str],
+    *,
+    exempt: frozenset[str] = ZERO_VARIANCE_EXEMPT,
+    min_non_null: int = DEFAULT_MIN_NON_NULL,
+) -> None:
+    """Raise loud (``RuntimeError``) if any registered column is dead in
+    EITHER sense: a cross-sectional constant, or entirely empty.
+
+    One entry point for the two halves of one question — "did this column's
+    producer actually produce anything?" — so a caller cannot wire up the
+    half that existed first and leave the other unchecked.
+    """
+    constant = find_zero_variance_columns(
+        features_df, feature_names, exempt=exempt, min_non_null=min_non_null,
+    )
+    empty = [c for c in find_all_null_columns(features_df, feature_names)
+             if c not in exempt]
+    if not constant and not empty:
+        return
+    parts = []
+    if constant:
+        parts.append(
+            "cross-sectional CONSTANT (every non-null value identical, so the "
+            f"column passes every null-coverage check and carries zero signal): {constant}"
+        )
+    if empty:
+        parts.append(
+            "entirely EMPTY (zero non-null values over the whole universe — a "
+            f"producer that ran and wrote nothing): {sorted(empty)}"
+        )
+    raise RuntimeError(
+        "Dead feature column(s) detected (alpha-engine-config-I7539). "
+        + " | ".join(parts)
+    )
+
+
 def assert_no_zero_variance_features(
     features_df: pd.DataFrame,
     feature_names: list[str],

--- a/tests/test_compute_momentum_columns_i7539.py
+++ b/tests/test_compute_momentum_columns_i7539.py
@@ -102,7 +102,9 @@ def test_residual_and_factor_momentum_carry_real_variance(monkeypatch):
     def _capture_guard(features_df, feature_names, **kwargs):
         captured["features_df"] = features_df.copy()
 
-    monkeypatch.setattr(compute, "assert_no_zero_variance_features", _capture_guard)
+    # Renamed when the guard grew its all-null half (I7539, second
+    # part): one entry point now covers "constant" AND "empty".
+    monkeypatch.setattr(compute, "assert_no_dead_feature_columns", _capture_guard)
 
     result = compute.compute_and_write(
         date_str="2026-08-14", bucket="test-bucket", dry_run=True
@@ -117,3 +119,41 @@ def test_residual_and_factor_momentum_carry_real_variance(monkeypatch):
         assert len(non_null) >= 20, f"{col}: too few non-null values ({len(non_null)})"
         assert non_null.nunique() > 1, f"{col}: still constant — {non_null.unique()}"
         assert non_null.std() > 0.0, f"{col}: still zero cross-sectional variance"
+
+
+def test_an_uncomputed_factor_momentum_stays_nan_never_a_fabricated_zero(monkeypatch):
+    """0.0 is a LEGAL factor-momentum reading, so back-filling it makes an
+    uncomputed ticker indistinguishable from one whose tilt really is zero
+    (alpha-engine-config-I7539).
+
+    Measured 2026-08-18: `features/2026-08-18/technical.parquet` carried 0.0
+    for all 901 tickers while ArcticDB's daily second pass held real values
+    for the same date (AAPL -0.049, MSFT +0.069, XOM -0.101). Two stores
+    disagreeing about one registered column, with the S3 side fabricating the
+    disagreement.
+
+    RED before this change: the `.fillna(0.0)` made every unmapped ticker 0.0.
+    """
+    price_data, macro = _synthetic_universe()
+    _patch_loaders(monkeypatch, price_data, macro)
+
+    captured = {}
+
+    def _capture_guard(features_df, feature_names, **kwargs):
+        captured["features_df"] = features_df.copy()
+
+    monkeypatch.setattr(compute, "assert_no_dead_feature_columns", _capture_guard)
+    # An empty signal map: the pass ran and resolved nothing, which is the
+    # live shape this issue is about.
+    monkeypatch.setattr(
+        compute, "compute_factor_momentum_feature",
+        lambda panel: pd.Series([float("nan")] * len(panel), index=panel.index),
+    )
+
+    compute.compute_and_write(date_str="2026-08-14", bucket="test-bucket", dry_run=True)
+
+    col = captured["features_df"]["factor_momentum_ratio"]
+    assert col.isna().all(), (
+        "an uncomputed factor_momentum_ratio must be absent, not 0.0 — a "
+        f"fabricated zero is unfalsifiable downstream. Got: {col.dropna().unique()[:5]}"
+    )

--- a/tests/test_postflight_all_null.py
+++ b/tests/test_postflight_all_null.py
@@ -1,0 +1,94 @@
+"""An entirely-empty registered column is a producer defect too
+(alpha-engine-config-I7539, second half).
+
+`find_zero_variance_columns` skips any column with fewer than
+`DEFAULT_MIN_NON_NULL` (20) non-null values — deliberately, so a genuinely
+sparse alt-data field is not reported as a constant. That skip leaves a hole
+exactly where this issue lives: a column the producer never filled has ZERO
+non-null values and is therefore invisible to the guard.
+
+That hole is not hypothetical, and it opens the moment
+`factor_momentum_ratio` stops being back-filled with a fabricated 0.0
+(same PR): the column goes from LOUDLY constant to SILENTLY absent, which is
+the detection blindness this fleet treats as outranking the defect it hides.
+
+Measured on `features/2026-08-18/technical.parquet` (901 rows, 49 columns)
+before the change: zero all-null columns and zero columns with fewer than 20
+non-null values — so this guard has no false positive to answer for on the
+live shape it will run against.
+
+RED on 6f9b0b4d: `find_all_null_columns` does not exist.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from features.postflight import (
+    assert_no_dead_feature_columns,
+    find_all_null_columns,
+    find_zero_variance_columns,
+)
+
+
+def _df(n=901, **cols):
+    return pd.DataFrame({"ticker": [f"T{i}" for i in range(n)], **cols})
+
+
+class TestFindAllNullColumns:
+    def test_flags_a_column_the_producer_never_filled(self):
+        df = _df(factor_momentum_ratio=[np.nan] * 901)
+        assert find_all_null_columns(df, ["factor_momentum_ratio"]) == ["factor_momentum_ratio"]
+
+    def test_does_not_flag_a_sparse_but_present_column(self):
+        """Sparse is a coverage question, not a producer defect — the same
+        reason `find_zero_variance_columns` has a `min_non_null` floor."""
+        vals = [np.nan] * 900 + [1.5]
+        assert find_all_null_columns(_df(earnings_revision_ratio=vals),
+                                     ["earnings_revision_ratio"]) == []
+
+    def test_does_not_flag_a_populated_column(self):
+        rng = np.random.default_rng(0)
+        assert find_all_null_columns(_df(mom_12_1_pct=rng.normal(size=901)),
+                                     ["mom_12_1_pct"]) == []
+
+    def test_a_column_absent_from_the_frame_is_not_reported_here(self):
+        """A missing column is a schema failure with its own contract test;
+        reporting it as 'all null' would send the reader to the wrong producer."""
+        assert find_all_null_columns(_df(), ["never_emitted"]) == []
+
+    def test_the_all_null_case_is_invisible_to_the_zero_variance_guard(self):
+        """The reason this function has to exist, asserted rather than
+        described: the older guard's `min_non_null` floor skips it."""
+        df = _df(factor_momentum_ratio=[np.nan] * 901)
+        assert find_zero_variance_columns(df, ["factor_momentum_ratio"]) == {}
+        assert find_all_null_columns(df, ["factor_momentum_ratio"]) != []
+
+
+class TestAssertNoDeadFeatureColumns:
+    def test_raises_on_either_failure_mode(self):
+        constant = _df(residual_momentum_ratio=[0.0] * 901)
+        empty = _df(factor_momentum_ratio=[np.nan] * 901)
+        for df, col in ((constant, "residual_momentum_ratio"),
+                        (empty, "factor_momentum_ratio")):
+            with pytest.raises(RuntimeError, match=col):
+                assert_no_dead_feature_columns(df, [col])
+
+    def test_silent_on_a_healthy_frame(self):
+        rng = np.random.default_rng(1)
+        assert_no_dead_feature_columns(_df(mom_12_1_pct=rng.normal(size=901)),
+                                       ["mom_12_1_pct"])
+
+    def test_the_message_names_both_kinds_when_both_are_present(self):
+        rng = np.random.default_rng(2)
+        df = _df(mom_12_1_pct=rng.normal(size=901),
+                 residual_momentum_ratio=[0.0] * 901,
+                 factor_momentum_ratio=[np.nan] * 901)
+        with pytest.raises(RuntimeError) as exc:
+            assert_no_dead_feature_columns(
+                df, ["mom_12_1_pct", "residual_momentum_ratio", "factor_momentum_ratio"])
+        msg = str(exc.value)
+        assert "residual_momentum_ratio" in msg and "factor_momentum_ratio" in msg
+        assert "mom_12_1_pct" not in msg

--- a/tests/test_sub_sector_wiring_i7569.py
+++ b/tests/test_sub_sector_wiring_i7569.py
@@ -116,7 +116,8 @@ def test_sub_sector_vs_benchmark_carries_real_variance(monkeypatch):
     def _capture_guard(features_df, feature_names, **kwargs):
         captured["features_df"] = features_df.copy()
 
-    monkeypatch.setattr(compute, "assert_no_zero_variance_features", _capture_guard)
+    # Renamed when the guard grew its all-null half (I7539).
+    monkeypatch.setattr(compute, "assert_no_dead_feature_columns", _capture_guard)
 
     result = compute.compute_and_write(
         date_str="2026-08-14", bucket="test-bucket", dry_run=True


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7539`, second half. The factor-momentum second pass in `features/compute.py` ended in `.fillna(0.0)`.

**0.0 is a legal factor-momentum reading.** Back-filling it makes a ticker the pass could not compute indistinguishable from one whose tilt really is zero — and when the pass resolves nothing, the whole column reads as a plausible universe-wide zero.

Measured 2026-08-18, same date, same universe:

| store | value |
|---|---|
| `features/2026-08-18/technical.parquet` | `0.0` for all 901 tickers |
| ArcticDB universe lib (2026-08-17 row) | AAPL `-0.049`, MSFT `+0.069`, JPM `-0.059`, XOM `-0.101`, GD `-0.065` |

Two stores disagreeing about one registered column, with the S3 side fabricating the disagreement. `builders/daily_append.update_factor_momentum_latest` writes real values every day; only the snapshot path invented zeros. `crucible-predictor/training/meta_trainer.py:1289` already treats an absent value as NaN and imputes to neutral — NaN is the convention the consumer expects.

## Why the fillna could not be removed on its own

`find_zero_variance_columns` skips any column with fewer than `DEFAULT_MIN_NON_NULL` (20) non-null values — deliberately, so a sparse alt-data field is not reported as a constant. An all-NaN column falls straight through that floor. Dropping the fillna alone would have taken `factor_momentum_ratio` from **loudly constant** to **silently absent**, which is the detection blindness this fleet treats as outranking the defect it hides.

So the guard grew its missing half:

- **`find_all_null_columns`** — registered columns present in the frame with zero non-null values. Sparse-but-present is not reported (coverage, and the reason the older floor exists). A column absent from the frame is not reported either (schema — naming it here sends the reader to the wrong producer).
- **`assert_no_dead_feature_columns`** — one entry point for both halves of *"did this column's producer produce anything?"*, so a caller cannot wire up the half that existed first and leave the other unchecked.
- The **daily path** reports empty columns at ERROR and marks the run DEGRADED — the same blast radius `I7572` established for the constant verdict, not a return to fail-the-pipeline. The summary carries `all_null_columns` as its own key: "constant" and "empty" send the reader to different producer questions.

**Measured against the live shape before adding it:** 2026-08-18's snapshot (901 rows × 49 columns) has zero all-null columns and zero columns with fewer than 20 non-null values. This guard has no false positive to answer for on the frame it will actually run against.

## What this does NOT fix

Why the in-memory panel rebuild yields nothing while the ArcticDB pass on the same day yields real values. That diagnosis needs the box's EOD log and stays open on `I7539` deliverable 1. This PR makes the artifact honest about it — after this, an uncomputed column says so instead of asserting a number.

## Test plan

`tests/test_postflight_all_null.py` — **9 new tests**, RED on `6f9b0b4d` (`find_all_null_columns` does not exist): the empty case, sparse-not-flagged, populated-not-flagged, absent-column-not-flagged, the explicit assertion that the older guard *cannot* see the all-null case, and the combined entry point's behaviour on each failure mode and on a healthy frame.

`tests/test_compute_momentum_columns_i7539.py` — extended with `test_an_uncomputed_factor_momentum_stays_nan_never_a_fabricated_zero`, RED before this change.

Two existing tests patched `compute.assert_no_zero_variance_features` by name and follow the rename.

**Full local suite: 67 failed / 5796 passed / 48 errors — failure set IDENTICAL to the merge base** (`6f9b0b4d`: 67 failed / 5787 passed / 48 errors), diffed name by name. Every failure pre-exists this branch; the delta is +9 passing tests. `ruff` clean on `features/postflight.py` and the new test (the 9 pre-existing `features/` lint findings are unchanged and untouched).

## Deployable by the merge button alone

No post-merge step. The next daily feature build writes NaN instead of a fabricated 0.0 and reports the column in `all_null_columns` until its producer is fixed.

Tracker: `alpha-engine-config-I7539`

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)