### PR TITLE
[P1/mid] feat(freshness-monitor): one grouped page per sweep instead of one page per artifact (config-I7713)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -68,6 +68,7 @@ exception path is a CW Logs-level surface.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -2287,12 +2288,23 @@ def _owning_item_body_fragment(owning: dict[str, Any] | None) -> str:
     return frag
 
 
-def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
-                 consecutive_miss_runs: int = 0,
-                 producer_suppression: dict[str, Any] | None = None,
-                 owning: dict[str, Any] | None = None) -> bool:
-    """Route an alert for a non-fresh probe result. Returns True if
-    publish was attempted (OBSERVE-mode short-circuit returns False).
+def _alert_decision(spec: ArtifactSpec, result: CheckResult, now: datetime,
+                    consecutive_miss_runs: int = 0,
+                    producer_suppression: dict[str, Any] | None = None,
+                    owning: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """Decide whether this probe result belongs on the operator page, and
+    return the decision. Returns ``None`` when it does not.
+
+    **This function performs no I/O.** It carries every gate the per-artifact
+    publish path used to apply inline — states, SLA grace, OBSERVE mode,
+    producer suppression, probe-failure coercion, the config-I3086 warning
+    ladder and the §7.4a owning-item escalation basis — and hands the surviving
+    rows to :func:`_publish_digest`, which emits ONE page per sweep covering all
+    of them (config-I7713).
+
+    Splitting the decision from the delivery is what makes the rollup possible
+    at all: while each row published itself, "one page per sweep" could only
+    have been a cooldown, which suppresses facts rather than combining them.
 
     Only fires when:
       - ``result.state ∈ {missing, stale, probe_failed}``
@@ -2309,7 +2321,7 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
     how many 15min probes have already fired in this window.
     """
     if result.state not in _ALERTING_STATES:
-        return False
+        return None
 
     # config-I6570 — the producing trigger is live-confirmed DISABLED, so this
     # miss is a deliberate switch-off rather than a producer failure. Placed
@@ -2327,20 +2339,20 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
             producer_suppression["disabled_since"],
             producer_suppression["days_disabled"],
         )
-        return False
+        return None
 
     # Substrate already filters fresh/grace; the SLA-grace filter
     # mirrors the substrate's clip-at-zero arithmetic for
     # missing/stale. probe_failed has no SLA — fire immediately.
     if result.state in ("missing", "stale") and result.sla_violated_by_minutes == 0:
-        return False
+        return None
 
     if not ALERTS_ENABLED:
         logger.info(
             "OBSERVE-mode: would alert on %s state=%s reason=%r",
             spec.artifact_id, result.state, result.reason,
         )
-        return False
+        return None
 
     # Probe failures route to critical (the monitor itself is broken);
     # missing/stale respect the spec's severity. Plan §3 invariant 6.
@@ -2391,10 +2403,13 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
             "check_results.json, no SNS/Telegram",
             spec.artifact_id, result.state,
         )
-        return False
+        return None
 
-    # Compose the alert body.
-    body = (
+    # The per-artifact detail line. Identical field-for-field to the body the
+    # per-artifact page used to send, so nothing an operator or a log grep
+    # relied on lost its shape — it is now one line of a grouped page rather
+    # than a page of its own.
+    line = (
         f"artifact_id={spec.artifact_id} "
         f"owner_repo={spec.owner_repo} "
         f"state={result.state} "
@@ -2403,38 +2418,192 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
         f"reason={result.reason}"
     )
     if escalated:
-        body += (
+        line += (
             f" escalated_from=warning escalation_basis={escalation_basis}"
             f" after_consecutive_miss_runs={consecutive_miss_runs}"
         )
-    body += " " + _owning_item_body_fragment(owning)
-    dedup_key = resolve_dedup_key(spec, now)
+    line += " " + _owning_item_body_fragment(owning)
 
-    # config-I6796: `publish()` is the only channel here whose dedup actually
-    # matches the artifact's own cadence (dedup_window_min=None + a
-    # cycle-scoped dedup_key ⇒ exactly one send per cadence window). Flow-doctor's
-    # Telegram dedup is a fleet-wide 1-minute DynamoDB cooldown
-    # (flow_doctor_telegram.build_flow_doctor_config) completely decoupled from
-    # cadence — any artifact re-evaluated more than 1 minute apart (every 30-min
-    # intraday tick, or the daily vs. historical cron) re-pages Telegram even
-    # though `dedup_key` is unchanged. Gating the Telegram send on `publish()`'s
-    # own dedup verdict makes the already-correct cadence-window dedup the single
-    # source of truth for BOTH channels, instead of letting Telegram ignore it.
+    return {
+        "artifact_id": spec.artifact_id,
+        "owner_repo": spec.owner_repo,
+        "cadence": spec.cadence,
+        "alert_class": _alert_class(spec),
+        "state": result.state,
+        "canonical_key": result.canonical_key,
+        "sla_violated_by_minutes": result.sla_violated_by_minutes,
+        "severity": severity,
+        "escalated": escalated,
+        "escalation_basis": escalation_basis,
+        "consecutive_miss_runs": consecutive_miss_runs,
+        "group_key": _cause_group_key(spec),
+        "owning": owning,
+        "owning_item": owning_item,
+        "line": line,
+    }
+
+
+def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
+                 consecutive_miss_runs: int = 0,
+                 producer_suppression: dict[str, Any] | None = None,
+                 owning: dict[str, Any] | None = None) -> bool:
+    """Whether this row belongs on the sweep's page.
+
+    Retained as the boolean face of :func:`_alert_decision` — it is the gate
+    predicate the drain lane, the execution-loop records and a long tail of
+    tests are written against, and that predicate did not change. What changed
+    is that it no longer SENDS: since config-I7713 a sweep emits one grouped
+    page via :func:`_publish_digest` rather than one message per artifact.
+    """
+    return _alert_decision(
+        spec, result, now,
+        consecutive_miss_runs=consecutive_miss_runs,
+        producer_suppression=producer_suppression,
+        owning=owning,
+    ) is not None
+
+
+# ── Digest rollup (config-I7713) ────────────────────────────────────────────
+#
+# Brian, 2026-08-19: "I should only get one if it points to a singular issue,
+# instead i'm getting ~20. The single error should encompass all errors
+# currently triggering."
+#
+# The monitor used to publish once per artifact per cadence window. That dedup
+# is correct at the artifact level and useless at the operator level: on
+# 2026-08-19T12:03:13Z a single sweep emitted 17 pages, and all 17 were one
+# cause (78 registry rows carrying a weekday cadence over a once-weekly
+# producer — alpha-engine-config-I7709). Seventeen true statements about one
+# fact is not seventeen findings.
+#
+# So: ONE page per sweep, grouped by CAUSE. The grouping key is derived from
+# what the registry already declares about a row's producer, in this order:
+#
+#   1. `produced_by` — the pipeline(s) that write it. Rows that go stale
+#      together because one pipeline did not run share this key exactly.
+#   2. `producer_trigger` — the schedule/rule/workflow, for rows with no
+#      pipeline (the `continuous` tier).
+#   3. `owner_repo` — the last resort, so a row with neither declaration still
+#      lands in a named group rather than in a nameless remainder.
+#
+# Dedup is on the SET, not the artifact: the page re-fires when the set of
+# alerting artifacts CHANGES (something joined or recovered) or when the UTC
+# day rolls over, and stays quiet while the same condition persists. A cooldown
+# would have suppressed the 17th page; this suppresses nothing and says the 17
+# things once.
+
+
+def _cause_group_key(spec: ArtifactSpec) -> str:
+    """The cause this row's absence belongs to — see the module note above.
+
+    Derived, never hand-kept: every input is already declared on the row, and a
+    second copy of "what produces this" is the drift shape the registry's own
+    cadence coupling exists to prevent.
+    """
+    pipelines = sorted(
+        {
+            entry.get("pipeline")
+            for entry in (getattr(spec, "produced_by", None) or [])
+            if isinstance(entry, dict) and entry.get("pipeline")
+        }
+    )
+    if pipelines:
+        return "pipeline:" + "+".join(pipelines)
+    declared = getattr(spec, "producer_trigger", None)
+    triggers = _declared_triggers(declared) if declared else ()
+    if triggers:
+        return "trigger:" + "+".join(sorted(triggers))
+    return f"owner_repo:{spec.owner_repo}"
+
+
+def _digest_dedup_key(decisions: list[dict[str, Any]], now: datetime) -> str:
+    """One key per (distinct set of alerting artifacts, UTC day).
+
+    Hashing the SET is the whole point: an unchanged condition stays quiet, and
+    an artifact joining or recovering changes the key and re-pages, because the
+    situation genuinely changed. A time-based cooldown could not tell those
+    apart and would have to drop the new one.
+    """
+    ids = ",".join(sorted(d["artifact_id"] for d in decisions))
+    fingerprint = hashlib.sha256(ids.encode("utf-8")).hexdigest()[:16]
+    return f"freshness_digest_{now.date().isoformat()}_{fingerprint}"
+
+
+def _compose_digest(decisions: list[dict[str, Any]], now: datetime) -> str:
+    """The single page body: a one-line verdict, then one block per cause.
+
+    Ordering is deterministic (critical groups first, then by group size, then
+    by key) so the same condition renders the same way every time and a
+    diff between two pages means something.
+    """
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for decision in decisions:
+        groups[decision["group_key"]].append(decision)
+
+    n_critical = sum(1 for d in decisions if d["severity"] == "critical")
+    header = (
+        f"{len(decisions)} artifact(s) past SLA across {len(groups)} cause(s) "
+        f"({n_critical} critical) — freshness sweep {now.isoformat()}"
+    )
+
+    def _group_rank(item: tuple[str, list[dict[str, Any]]]) -> tuple:
+        key, members = item
+        has_critical = any(m["severity"] == "critical" for m in members)
+        return (0 if has_critical else 1, -len(members), key)
+
+    blocks = [header]
+    for key, members in sorted(groups.items(), key=_group_rank):
+        members.sort(key=lambda m: (m["severity"] != "critical", m["artifact_id"]))
+        worst = max(m["sla_violated_by_minutes"] for m in members)
+        # The owning item is a property of the CAUSE, so it is named once for
+        # the group rather than repeated on every member line.
+        owning_fragment = _owning_item_body_fragment(
+            next((m["owning"] for m in members if (m["owning"] or {}).get("owning_item")),
+                 members[0]["owning"])
+        )
+        blocks.append(
+            f"\n[{key}] {len(members)} artifact(s), worst "
+            f"sla_violated_by_minutes={worst}\n  {owning_fragment}"
+        )
+        for member in members:
+            blocks.append(f"  - {member['line']}")
+    return "\n".join(blocks)
+
+
+def _publish_digest(decisions: list[dict[str, Any]], now: datetime) -> int:
+    """Emit the sweep's single page. Returns the number of artifacts it covers
+    (0 when there is nothing to say, which is silence by absence of condition —
+    never by suppression).
+
+    Severity is the MAX over the covered rows: a digest containing one critical
+    row is a critical page, so grouping can never demote an alert. That is the
+    invariant that makes the rollup safe — it changes how many messages are
+    sent, never which conditions are reportable.
+    """
+    if not decisions:
+        return 0
+
+    severity = "critical" if any(
+        d["severity"] == "critical" for d in decisions
+    ) else "warning"
+    body = _compose_digest(decisions, now)
+    dedup_key = _digest_dedup_key(decisions, now)
+
     publish_result = publish(
         body,
         severity=severity,
         source="freshness-monitor",
         dedup_key=dedup_key,
-        dedup_window_min=None,  # one alert per cadence window — substrate handles cycle bucketing
+        dedup_window_min=None,
         telegram=False,
     )
     if publish_result.dedup_skipped:
         logger.info(
-            "telegram suppressed (config-I6796): %s state=%s already paged "
-            "this cadence window (%s)",
-            spec.artifact_id, result.state, publish_result.dedup_reason,
+            "digest suppressed: the same %d-artifact condition set already "
+            "paged today (%s)",
+            len(decisions), publish_result.dedup_reason,
         )
-        return True
+        return len(decisions)
 
     notify_via_flow_doctor(
         body,
@@ -2446,15 +2615,13 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
         topics=_FRESHNESS_TELEGRAM_TOPICS,
         db_basename=_DB_BASENAME,
         context={
-            "artifact_id": spec.artifact_id,
-            "state": result.state,
-            "owner_repo": spec.owner_repo,
-            "owning_item": (owning_item or {}).get("number"),
-            "owning_item_age_days": (owning_item or {}).get("age_days"),
-            "escalation_basis": escalation_basis,
+            "n_artifacts": len(decisions),
+            "n_groups": len({d["group_key"] for d in decisions}),
+            "artifact_ids": sorted(d["artifact_id"] for d in decisions),
+            "group_keys": sorted({d["group_key"] for d in decisions}),
         },
     )
-    return True
+    return len(decisions)
 
 
 # ── Key-deliverable extended-staleness escalation (config#2055 Gap 2) ───────
@@ -3058,6 +3225,7 @@ def _run_probe_pass(
     """
     pairs: list[tuple[ArtifactSpec, CheckResult]] = []
     alerted = 0
+    digest_decisions: list[dict[str, Any]] = []
     dispatched = 0
     per_spec_exceptions = 0
     prev_miss_counts = prev_miss_counts or {}
@@ -3143,14 +3311,22 @@ def _run_probe_pass(
             )
             owning_by_id[spec.artifact_id] = owning
 
-        paged = False
-        if not suppress_page and _maybe_alert(
+        # config-I7713 — decide here, deliver ONCE after the loop. `paged`
+        # keeps its exact meaning (this row is on the operator page), so the
+        # execution-loop records, the drain-candidate gate and the `alerted`
+        # count below are unchanged; only the number of MESSAGES changed.
+        decision = None
+        if not suppress_page:
+            decision = _alert_decision(
                 spec, result, now, consecutive_miss_runs=miss_runs,
                 producer_suppression=(suppression_by_id or {}).get(
                     spec.artifact_id),
-                owning=owning):
+                owning=owning,
+            )
+        paged = decision is not None
+        if paged:
+            digest_decisions.append(decision)
             alerted += 1
-            paged = True
 
         if paged:
             owning_item = (owning or {}).get("owning_item")
@@ -3178,6 +3354,21 @@ def _run_probe_pass(
             and remediation_by_id.get(spec.artifact_id) != "operator"
         ):
             drain_candidates.append(spec.artifact_id)
+
+    # config-I7713 — the sweep's SINGLE page, covering every row that decided
+    # to alert above. Trapped like every other side effect: a delivery failure
+    # must not sink check_results.json or the heartbeat, which are the durable
+    # record this page is only a notification of.
+    try:
+        _publish_digest(digest_decisions, now)
+    except Exception as digest_exc:  # noqa: BLE001 — the page is a notification; the durable record is check_results.json, and this ERROR is the recording surface for its loss
+        logger.error(
+            "FRESHNESS_DIGEST_PUBLISH_FAILED for %d artifact(s) %s "
+            "(non-fatal): %s",
+            len(digest_decisions),
+            sorted(d["artifact_id"] for d in digest_decisions),
+            digest_exc, exc_info=True,
+        )
 
     # One aggregated event-time drain per pass (config-I3282), trapped so a
     # dispatch failure can never sink the pass's primary deliverables. The

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -568,11 +568,15 @@ def test_handler_alerts_enabled_fires_with_dedup_key(
     assert publish_mock.called
     assert notify_mock.called
 
-    # Inspect the publish calls — dedup keys should be unique per-artifact
-    # and reflect the cycle window.
-    dedup_keys = [c.kwargs["dedup_key"] for c in publish_mock.call_args_list]
-    # probe_missing is saturday_sf in W22 → "freshness_probe_missing_2026-W22"
-    assert "freshness_probe_missing_2026-W22" in dedup_keys
+    # config-I7713 — a sweep emits exactly ONE page, whose dedup key identifies
+    # the condition SET and the day. The per-artifact key this used to assert
+    # ("freshness_probe_missing_2026-W22") deduped correctly per artifact and
+    # was the reason 17 true statements about one cause arrived as 17 pages on
+    # 2026-08-19. The artifact is still named — in the body, not in the key.
+    assert publish_mock.call_count == 1, publish_mock.call_args_list
+    dedup_key = publish_mock.call_args.kwargs["dedup_key"]
+    assert dedup_key.startswith("freshness_digest_2026-05-30_")
+    assert "artifact_id=probe_missing" in publish_mock.call_args.args[0]
 
 
 def test_handler_warning_severity_console_only_no_alert(
@@ -767,6 +771,22 @@ def test_handler_observe_to_production_cutover_via_env_flip(
     assert publish_mock2.call_count >= 1
 
 
+# ── config-I7713: decide-then-deliver ───────────────────────────────────────
+#
+# A sweep now emits ONE grouped page instead of one message per artifact, so
+# `_maybe_alert` decides and `_publish_digest` delivers. `_page` runs both, which
+# is what the per-artifact tests below were always really asserting: given this
+# spec and result, does a page go out and what does it say? The single-decision
+# case is deliberately covered by the same assertions as before — grouping must
+# not change severity, and must not drop a field from the body.
+def _page(index_mod, spec, result, now, **kwargs) -> bool:
+    decision = index_mod._alert_decision(spec, result, now, **kwargs)
+    if decision is None:
+        return False
+    index_mod._publish_digest([decision], now)
+    return True
+
+
 # ── _maybe_alert direct unit coverage ───────────────────────────────────────
 
 
@@ -786,7 +806,7 @@ def test_maybe_alert_skips_fresh_state(monkeypatch, fixed_now):
     result = CheckResult(state="fresh")
     publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
     monkeypatch.setattr(index, "publish", publish_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is False
+    assert _page(index, spec, result, fixed_now) is False
     assert publish_mock.call_count == 0
 
 
@@ -807,7 +827,7 @@ def test_maybe_alert_skips_missing_within_sla_grace(monkeypatch, fixed_now):
     result = CheckResult(state="missing", sla_violated_by_minutes=0)
     publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
     monkeypatch.setattr(index, "publish", publish_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is False
+    assert _page(index, spec, result, fixed_now) is False
     assert publish_mock.call_count == 0
 
 
@@ -837,15 +857,18 @@ def test_maybe_alert_fires_missing_past_sla(monkeypatch, fixed_now):
     notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is True
+    assert _page(index, spec, result, fixed_now) is True
     publish_mock.assert_called_once()
     call = publish_mock.call_args
     assert "artifact_id=x" in call.args[0]
     assert call.kwargs["severity"] == "critical"  # spec severity, not bumped
     assert call.kwargs["telegram"] is False
-    assert call.kwargs["dedup_key"] == "freshness_x_2026-W22"
+    # config-I7713: the key now identifies the CONDITION SET, not one artifact —
+# that is what lets an unchanged situation stay quiet while a new artifact
+# joining it re-pages. A per-artifact key could not express either.
+    assert call.kwargs["dedup_key"].startswith("freshness_digest_2026-05-30_")
     notify_mock.assert_called_once()
-    assert notify_mock.call_args.kwargs["dedup_key"] == "freshness_x_2026-W22"
+    assert notify_mock.call_args.kwargs["dedup_key"] == call.kwargs["dedup_key"]
 
 
 def test_maybe_alert_telegram_suppressed_when_publish_dedup_skipped(monkeypatch, fixed_now):
@@ -882,7 +905,7 @@ def test_maybe_alert_telegram_suppressed_when_publish_dedup_skipped(monkeypatch,
     notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is True
+    assert _page(index, spec, result, fixed_now) is True
     publish_mock.assert_called_once()
     notify_mock.assert_not_called()
 
@@ -916,7 +939,7 @@ def test_maybe_alert_telegram_path_carries_freshness_monitor_source(monkeypatch,
     notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is True
+    assert _page(index, spec, result, fixed_now) is True
 
     publish_mock.assert_called_once()
     assert publish_mock.call_args.kwargs["source"] == "freshness-monitor"
@@ -953,7 +976,7 @@ def test_maybe_alert_warning_missing_console_only(monkeypatch, fixed_now):
     notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is False
+    assert _page(index, spec, result, fixed_now) is False
     publish_mock.assert_not_called()
     notify_mock.assert_not_called()
 
@@ -977,7 +1000,7 @@ def test_maybe_alert_probe_failed_uses_critical_severity(monkeypatch, fixed_now)
     notify_mock = mock.Mock(return_value=True)
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
-    assert index._maybe_alert(spec, result, fixed_now) is True
+    assert _page(index, spec, result, fixed_now) is True
     publish_mock.assert_called_once()
     assert publish_mock.call_args.kwargs["severity"] == "critical"
     assert publish_mock.call_args.kwargs["telegram"] is False
@@ -1934,7 +1957,7 @@ def test_maybe_alert_warning_escalates_after_threshold(monkeypatch, fixed_now):
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
     spec, result = _warning_spec_and_missing_result(index)
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now,
         consecutive_miss_runs=index.WARNING_ESCALATION_RUNS) is True
     body = publish_mock.call_args.args[0]
@@ -1951,7 +1974,7 @@ def test_maybe_alert_warning_below_threshold_stays_console_only(
     publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
     monkeypatch.setattr(index, "publish", publish_mock)
     spec, result = _warning_spec_and_missing_result(index)
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now,
         consecutive_miss_runs=index.WARNING_ESCALATION_RUNS - 1) is False
     publish_mock.assert_not_called()
@@ -2682,12 +2705,12 @@ def test_maybe_alert_suppressed_when_producer_disabled(monkeypatch, fixed_now):
         "trigger": "events:r", "reason": "EventBridge rule r is DISABLED",
         "disabled_since": "2026-05-29", "days_disabled": 1, "suppressed": True,
     }
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now, producer_suppression=suppression) is False
     assert publish_mock.call_count == 0
 
     # Same critical row, same miss — suppression lapsed ⇒ it pages.
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now,
         producer_suppression={**suppression, "suppressed": False}) is True
     assert publish_mock.call_count == 1
@@ -2947,7 +2970,7 @@ def test_page_names_the_already_open_owning_item(monkeypatch, fixed_now):
     monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
     spec, result = _critical_spec_and_missing_result(index)
 
-    assert index._maybe_alert(spec, result, fixed_now,
+    assert _page(index, spec, result, fixed_now,
                               owning=_owning()) is True
     body = publish_mock.call_args.args[0]
     assert "owning_item=#6562" in body
@@ -2970,7 +2993,7 @@ def test_page_lists_the_other_items_describing_the_same_condition(
     spec, result = _critical_spec_and_missing_result(index)
     members = [{"number": n} for n in (6155, 6345, 6747)]
 
-    assert index._maybe_alert(spec, result, fixed_now,
+    assert _page(index, spec, result, fixed_now,
                               owning=_owning(members=members)) is True
     body = publish_mock.call_args.args[0]
     assert "owning_item=#6562" in body
@@ -2993,7 +3016,7 @@ def test_degraded_owning_item_search_still_pages_and_says_so(
     monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
     spec, result = _critical_spec_and_missing_result(index)
 
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now,
         owning=index._unresolved("api.github.com: URLError: timed out"),
     ) is True
@@ -3016,7 +3039,7 @@ def test_no_open_item_says_none_not_unknown(monkeypatch, fixed_now):
     empty = {"resolved": True, "degraded": False, "degraded_reason": None,
              "owning_item": None, "members": [], "n_candidates": 0}
 
-    assert index._maybe_alert(spec, result, fixed_now, owning=empty) is True
+    assert _page(index, spec, result, fixed_now, owning=empty) is True
     body = publish_mock.call_args.args[0]
     assert "owning_item=none owning_item_lookup=ok" in body
 
@@ -3038,7 +3061,7 @@ def test_owning_item_age_drives_escalation_not_the_miss_count(
     monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
     spec, result = _warning_spec_and_missing_result(index)
 
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now, consecutive_miss_runs=0,
         owning=_owning(age_days=9.0, sla_days=3),
     ) is True
@@ -3063,7 +3086,7 @@ def test_young_owning_item_does_not_escalate_but_is_still_recorded(
     spec, result = _warning_spec_and_missing_result(index)
     owning = _owning(age_days=0.5, sla_days=3)
 
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now, consecutive_miss_runs=13, owning=owning,
     ) is False
     publish_mock.assert_not_called()
@@ -3094,7 +3117,7 @@ def test_miss_count_ladder_still_governs_an_undiagnosed_condition(
     empty = {"resolved": True, "degraded": False, "degraded_reason": None,
              "owning_item": None, "members": [], "n_candidates": 0}
 
-    assert index._maybe_alert(
+    assert _page(index, 
         spec, result, fixed_now,
         consecutive_miss_runs=index.WARNING_ESCALATION_RUNS, owning=empty,
     ) is True
@@ -3413,8 +3436,8 @@ def test_owning_item_resolution_never_widens_a_grace_window(monkeypatch, fixed_n
     monkeypatch.setattr(index, "publish", publish_mock)
     monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
     spec, result = _critical_spec_and_missing_result(index)
-    assert index._maybe_alert(spec, result, fixed_now, owning=_owning()) is True
-    assert index._maybe_alert(
+    assert _page(index, spec, result, fixed_now, owning=_owning()) is True
+    assert _page(index, 
         spec, result.__class__(state="stale", reason="in grace",
                                canonical_key=result.canonical_key,
                                sla_violated_by_minutes=0),
@@ -3825,3 +3848,235 @@ def test_coverage_metrics_emit_zeros_rather_than_nothing():
     assert names["UndeclaredNotFreshRows"] == 0.0
     assert names["RowsDeclaringProducerTrigger"] == 0.0
     assert names["DisabledProducersUnreferenced"] == 0.0
+
+
+# ── config-I7713: one page per sweep, grouped by cause ──────────────────────
+#
+# Brian, 2026-08-19: "I should only get one if it points to a singular issue,
+# instead i'm getting ~20. The single error should encompass all errors
+# currently triggering."
+#
+# The measured condition these tests reconstruct: the 2026-08-19T12:03:13Z
+# sweep emitted 17 pages and all 17 shared one cause (78 registry rows on a
+# weekday cadence over a once-weekly producer — alpha-engine-config-I7709).
+
+
+def _weekly_spec(index_mod, artifact_id, *, severity="critical", pipeline="ne-weekly-freshness-pipeline"):
+    from nousergon_lib.artifact_freshness import ArtifactSpec
+    spec = ArtifactSpec(
+        artifact_id=artifact_id, s3_bucket="b",
+        s3_key_template=f"{artifact_id}/{{date}}.json",
+        cadence="saturday_sf", sla_minutes_after_cron=60,
+        severity=severity, owner_repo="ae-test", created_at=date(2025, 1, 1),
+    )
+    object.__setattr__(spec, "produced_by", [{"pipeline": pipeline, "stage": "S"}])
+    return spec
+
+
+def _missing(index_mod, key):
+    from nousergon_lib.artifact_freshness import CheckResult
+    return CheckResult(state="missing", sla_violated_by_minutes=300,
+                       canonical_key=key, reason="absent")
+
+
+def _decide_all(index_mod, specs, now):
+    return [index_mod._alert_decision(s, _missing(index_mod, f"{s.artifact_id}/k"), now)
+            for s in specs]
+
+
+def test_seventeen_artifacts_one_cause_produce_exactly_one_page(monkeypatch, fixed_now):
+    """The regression itself, at the measured scale."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    notify_mock = mock.Mock(return_value=True)
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
+
+    specs = [_weekly_spec(index, f"backtest_{i}") for i in range(17)]
+    covered = index._publish_digest(_decide_all(index, specs, fixed_now), fixed_now)
+
+    assert covered == 17
+    publish_mock.assert_called_once()
+    notify_mock.assert_called_once()
+    body = publish_mock.call_args.args[0]
+    # Nothing is dropped: every artifact still appears, with its own reason.
+    for spec in specs:
+        assert f"artifact_id={spec.artifact_id}" in body
+    assert "17 artifact(s) past SLA across 1 cause(s)" in body
+
+
+def test_distinct_causes_are_separate_blocks_in_the_same_page(monkeypatch, fixed_now):
+    """Grouping must not merge unrelated conditions into one undifferentiated
+    wall — one page, but the causes stay legible and separately counted."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+
+    specs = [
+        _weekly_spec(index, "weekly_a"),
+        _weekly_spec(index, "weekly_b"),
+        _weekly_spec(index, "preopen_a", pipeline="ne-preopen-trading-pipeline"),
+    ]
+    index._publish_digest(_decide_all(index, specs, fixed_now), fixed_now)
+
+    body = publish_mock.call_args.args[0]
+    assert "across 2 cause(s)" in body
+    assert "[pipeline:ne-weekly-freshness-pipeline] 2 artifact(s)" in body
+    assert "[pipeline:ne-preopen-trading-pipeline] 1 artifact(s)" in body
+
+
+def test_one_critical_row_makes_the_whole_digest_critical(monkeypatch, fixed_now):
+    """The invariant that makes the rollup safe: grouping changes how many
+    messages are sent, never which conditions are reportable. A digest that
+    took its severity from the majority could demote a critical page by
+    surrounding it with warnings."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+
+    decisions = [
+        index._alert_decision(_weekly_spec(index, "crit"), _missing(index, "k"), fixed_now),
+        # A warning row only reaches the page via the escalation ladder, which
+        # is exactly how a mixed-severity digest arises in production.
+        index._alert_decision(
+            _weekly_spec(index, "warn", severity="warning"), _missing(index, "k"),
+            fixed_now, consecutive_miss_runs=index.WARNING_ESCALATION_RUNS),
+    ]
+    index._publish_digest([d for d in decisions if d], fixed_now)
+    assert publish_mock.call_args.kwargs["severity"] == "critical"
+
+
+def test_nothing_alerting_sends_nothing(monkeypatch, fixed_now):
+    """Silence by absence of condition. A healthy sweep must not emit an empty
+    page — check_results.json and the heartbeat are the surfaces that prove the
+    monitor ran (observability-policy §9.2a)."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    notify_mock = mock.Mock(return_value=True)
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
+
+    assert index._publish_digest([], fixed_now) == 0
+    publish_mock.assert_not_called()
+    notify_mock.assert_not_called()
+
+
+def test_dedup_key_tracks_the_condition_set_not_the_clock(monkeypatch, fixed_now):
+    """An unchanged set stays quiet; an artifact joining or recovering re-pages.
+    A time-based cooldown cannot tell those apart — it would have to drop the
+    new one, which is suppressing a fact rather than combining facts."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+
+    two = _decide_all(index, [_weekly_spec(index, "a"), _weekly_spec(index, "b")], fixed_now)
+    three = _decide_all(
+        index, [_weekly_spec(index, "a"), _weekly_spec(index, "b"), _weekly_spec(index, "c")],
+        fixed_now)
+
+    assert index._digest_dedup_key(two, fixed_now) == index._digest_dedup_key(
+        list(reversed(two)), fixed_now), "order must not change the key"
+    assert index._digest_dedup_key(two, fixed_now) != index._digest_dedup_key(three, fixed_now)
+
+
+def test_publish_dedup_skip_does_not_double_send_telegram(monkeypatch, fixed_now):
+    """config-I6796's invariant, preserved through the rollup: publish()'s dedup
+    verdict is the single source of truth for BOTH channels."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    notify_mock = mock.Mock(return_value=True)
+    monkeypatch.setattr(index, "publish", mock.Mock(
+        return_value=mock.Mock(dedup_skipped=True, dedup_reason="already-sent")))
+    monkeypatch.setattr(index, "notify_via_flow_doctor", notify_mock)
+
+    covered = index._publish_digest(
+        _decide_all(index, [_weekly_spec(index, "a")], fixed_now), fixed_now)
+    assert covered == 1  # still counted as covered — it IS on the operator page
+    notify_mock.assert_not_called()
+
+
+def test_group_key_falls_back_through_trigger_to_owner_repo(monkeypatch):
+    """Every alerting row lands in a NAMED group. A nameless remainder bucket
+    would recreate the wall this rollup exists to remove."""
+    import importlib
+    import index
+    importlib.reload(index)
+    from nousergon_lib.artifact_freshness import ArtifactSpec
+
+    base = dict(s3_bucket="b", s3_key_template="k/{date}", cadence="continuous",
+                interval_minutes=15, sla_minutes_after_cron=30, severity="warning",
+                owner_repo="nousergon-data", created_at=date(2025, 1, 1))
+    bare = ArtifactSpec(artifact_id="bare", **base)
+    assert index._cause_group_key(bare) == "owner_repo:nousergon-data"
+
+    triggered = ArtifactSpec(artifact_id="trig", **base)
+    object.__setattr__(triggered, "producer_trigger", ("scheduler:x-15min",))
+    assert index._cause_group_key(triggered) == "trigger:scheduler:x-15min"
+
+    # produced_by wins over producer_trigger — the pipeline is the closer cause.
+    both = ArtifactSpec(artifact_id="both", **base)
+    object.__setattr__(both, "producer_trigger", ("scheduler:x-15min",))
+    object.__setattr__(both, "produced_by", [{"pipeline": "ne-weekly-freshness-pipeline"}])
+    assert index._cause_group_key(both) == "pipeline:ne-weekly-freshness-pipeline"
+
+
+def test_digest_publish_failure_does_not_sink_the_sweep(monkeypatch, fixed_now):
+    """The page is a notification; check_results.json is the record. A delivery
+    failure must be loud and must not cost the durable surface."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    monkeypatch.setattr(index, "publish", mock.Mock(side_effect=RuntimeError("sns down")))
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+
+    with pytest.raises(RuntimeError):
+        index._publish_digest(
+            _decide_all(index, [_weekly_spec(index, "a")], fixed_now), fixed_now)
+
+
+def test_handler_still_writes_check_results_when_the_digest_cannot_be_sent(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """The other half of the above, through the real handler: delivery raising
+    must not cost the durable record. `_publish_digest` raises for the whole
+    sweep now rather than for one artifact, so the trap around it carries more
+    weight than the per-artifact one it replaced — hence this test."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = yaml_registry_body
+    cycle_tick = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc)
+    fake_s3._head_returns["path/2026-05-30/fresh.json"] = {
+        "LastModified": cycle_tick.replace(hour=12),
+    }
+
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock(side_effect=RuntimeError("sns down")))
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+
+    result = index.handler({}, None)
+
+    assert result["alerts_enabled"] is True
+    written = {k for (_, k, _) in fake_s3._put_calls}
+    assert "_freshness_monitor/check_results.json" in written
+    assert "_freshness_monitor/heartbeat.json" in written

--- a/tests/test_severity_taxonomy_chokepoint.py
+++ b/tests/test_severity_taxonomy_chokepoint.py
@@ -168,12 +168,18 @@ _REGISTRY: dict[str, dict[str, list[dict]]] = {
         ],
     },
     "infrastructure/lambdas/freshness-monitor/index.py": {
-        "_maybe_alert": [
+        # config-I7713 — the send moved from `_maybe_alert` (one message per
+        # artifact) to `_publish_digest` (ONE grouped message per sweep).
+        # `_maybe_alert` now only decides. Severity is the MAX over the covered
+        # rows, so grouping can never demote a critical artifact into a warning
+        # page; the per-artifact severities it was computed from are still on
+        # each detail line in the body.
+        "_publish_digest": [
             {
-                "event_class": "Artifact SLA miss",
-                "severity": "per-artifact spec.severity from ARTIFACT_REGISTRY.yaml (warning or critical; dynamically coerced for champion-arm)",
+                "event_class": "Artifact SLA miss (sweep digest, grouped by cause)",
+                "severity": "max over covered rows of spec.severity from ARTIFACT_REGISTRY.yaml (warning or critical; dynamically coerced for champion-arm)",
                 "silent": False,
-                "citation": "severity_taxonomy.md row: index.py:358-392,967-978",
+                "citation": "severity_taxonomy.md row: index.py:358-392,967-978; call site relocated by config-I7713 (2026-08-19)",
             },
         ],
     },


### PR DESCRIPTION
## What & why

Brian, 2026-08-19: *"I should only get one if it points to a singular issue, instead i'm getting ~20. The single error should encompass all errors currently triggering."*

The monitor published **once per artifact per cadence window**. That dedup is correct at the artifact level and useless at the operator level. Measured 2026-08-19T12:03:13Z (`_freshness_monitor/check_results.json`, `execution_loop.classes["freshness-monitor.all"]`): **17 pages in one sweep, all 17 one cause** — 78 registry rows on a weekday cadence over a once-weekly producer (`alpha-engine-config-I7709`).

Same sweep, `pages_with_degraded_lookup: 15` of 17. The §7.4a owning-item join runs per artifact over 69 not-fresh rows at 2+ GitHub searches each against a 25s / 24-query budget, so it exhausts and every later page reads `owning_item_lookup_reason='lookup_time_budget_exhausted'`. The flood starves the join that would have explained the flood.

Tracked: `alpha-engine-config-I7713`.

## How

| | |
|---|---|
| `_alert_decision()` | every existing gate (states, SLA grace, OBSERVE mode, producer suppression, probe-failure coercion, the config-I3086 miss ladder, the §7.4a escalation basis) — **no I/O** |
| `_maybe_alert()` | retained as the boolean face of the above; the drain lane and execution-loop records are written against that predicate and it did not change |
| `_publish_digest()` | ONE page per sweep, grouped by cause |
| group key | derived from `produced_by[].pipeline` → `producer_trigger` → `owner_repo`. Never a hand-kept mapping |
| dedup key | `freshness_digest_{utc_date}_{sha256(sorted ids)[:16]}` — the condition **set**, not the artifact |
| severity | **max** over covered rows |

**Why set-based dedup and not a cooldown.** An unchanged situation stays quiet; an artifact joining or recovering re-pages, because the situation genuinely changed. A cooldown cannot distinguish those and would have to drop the new one — that is suppressing a fact, where this combines facts.

**The invariant that makes grouping safe:** severity is the max over covered rows, so a digest containing one critical row is a critical page. Grouping changes how many messages are sent, never which conditions are reportable. Every artifact's detail line is preserved verbatim as one line of the body, so nothing an operator or a log grep relied on changed shape.

Delivery is trapped at the sweep's call site — `check_results.json` and the heartbeat are the durable record; the page is only a notification of it.

`tests/test_severity_taxonomy_chokepoint.py` caught the relocated `notify_via_flow_doctor` call site and both its assertions (new-site-unregistered, stale-entry) fired. Registry updated with the new entry — the chokepoint doing exactly its job.

## Test plan (run before opening)

- `pytest infrastructure/lambdas/freshness-monitor/test_handler.py -q` → **154 passed**
- `pytest tests/ -q` → **6083 passed, 13 skipped** (`.venv` interpreter; the bare worktree lacks `yfinance`)

Eight new tests drive the rollup itself:

- 17 artifacts, one cause → exactly one `publish()` and one `notify_via_flow_doctor()`, with all 17 `artifact_id=` still in the body — the measured regression at its measured scale;
- distinct causes stay separately labelled and counted inside the one page;
- one critical row makes the whole digest critical;
- nothing alerting sends nothing (silence by absence of condition, not by suppression);
- the dedup key is order-invariant over the set and changes when the set does;
- `publish()` reporting `dedup_skipped` does not double-send Telegram (config-I6796's invariant, preserved);
- the group key falls through trigger to owner_repo so no row lands in a nameless remainder;
- the handler still writes `check_results.json` and the heartbeat when delivery raises.

## Cross-repo

`alpha-engine-config-PR7712` fixes the registry cadence that produced today's 17 pages. **Independent — either may merge first.** This PR fixes the shape (any single pipeline failure makes everything downstream miss at once); that one fixes today's instance.

## Not in scope

Reducing the owning-item lookup's per-artifact cost. With the flood removed the 25s / 24-query budget is no longer binding; if it binds again, resolving once per **group** rather than per artifact is the follow-up and is strictly cheaper. Named in `alpha-engine-config-I7713`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)