### PR TITLE
[P1/mid] fix(universe_returns): a bar that has not published yet is not a collector failure (config-I7714)

### DIFF
--- a/collectors/universe_returns.py
+++ b/collectors/universe_returns.py
@@ -36,6 +36,7 @@ from pathlib import Path
 import boto3
 import pandas as pd
 from nousergon_lib.trading_calendar import add_trading_days as _add_trading_days
+from polygon_client import PolygonForbiddenError
 
 logger = logging.getLogger(__name__)
 
@@ -487,6 +488,60 @@ def _insert_rows(db_path: str, rows: list[dict]) -> int:
 
 # -- Row building (polygon.io) -----------------------------------------------
 
+# -- "not yet published" is not a collector failure (config-I7714) ------------
+#
+# Polygon returns 403 `"Attempted to request today's data before end of day"`
+# for a grouped-daily bar on the CURRENT session before its plan-tier EOD
+# publication. `polygon_client._get` raises `PolygonForbiddenError` on every 403
+# — deliberately, since data#4496: swallowing 403s once masked the 2026-04-17 to
+# 2026-04-23 VWAP outage by letting `daily_closes.collect` fall through to
+# yfinance and write VWAP=None for every stock. That raise stays.
+#
+# But this collector walks FORWARD dates from each eval_date, so it asks about
+# the current session by construction, and the request is simply early. Measured
+# 2026-08-18 (`watch-rerun-2026-08-18-3`): DataPhase1 ran to completion in 2723s
+# and then exited 1 because this collector raised, `weekly_collector.py` marked
+# the phase `partial`, and the weekly pipeline halted. It had not succeeded
+# since 2026-08-15 as a result, which is why every artifact downstream of the
+# weekly graph was four days old.
+#
+# So: exactly one 403 shape, for exactly one date range, is treated as "not yet
+# available" and yields no bars for that date. Every other 403 — an invalid key,
+# a revoked plan, an entitlement the account does not hold — still raises, which
+# is the failure mode the raise exists for. Narrowing on BOTH the message and
+# the date is what keeps this from becoming the swallow it replaces.
+
+_BEFORE_EOD_MARKER = "before end of day"
+
+
+def _grouped_daily_or_empty(polygon_client, date_str: str, *, today: date) -> dict:
+    """`get_grouped_daily`, tolerating only the before-EOD 403 for a session
+    that has not closed yet.
+
+    A 403 on a PAST date is re-raised: that session is over, so "before end of
+    day" cannot be the true explanation, and reading it as absent data would
+    silently drop returns the run needs.
+    """
+    try:
+        return polygon_client.get_grouped_daily(date_str)
+    except PolygonForbiddenError as exc:
+        if _BEFORE_EOD_MARKER not in str(exc).lower():
+            raise
+        try:
+            requested = date.fromisoformat(date_str)
+        except ValueError:
+            raise exc from None
+        if requested < today:
+            raise
+        logger.info(
+            "universe_returns: %s has not published yet (polygon 403 "
+            "'%s') — no bars for that date this run, not a collector failure "
+            "(config-I7714)",
+            date_str, _BEFORE_EOD_MARKER,
+        )
+        return {}
+
+
 def _build_rows_for_date(
     eval_date: str,
     polygon_client,
@@ -520,22 +575,31 @@ def _build_rows_for_date(
     has_90d = fwd_90d < today
 
     # Fetch grouped-daily prices for eval_date and forward dates
-    prices_t0 = polygon_client.get_grouped_daily(eval_date)
-    prices_1d = polygon_client.get_grouped_daily(str(fwd_1d)) if has_1d else {}
-    prices_3d = polygon_client.get_grouped_daily(str(fwd_3d)) if has_3d else {}
-    prices_5d = polygon_client.get_grouped_daily(str(fwd_5d))
-    prices_10d = polygon_client.get_grouped_daily(str(fwd_10d)) if has_10d else {}
-    prices_15d = polygon_client.get_grouped_daily(str(fwd_15d)) if has_15d else {}
-    prices_21d = polygon_client.get_grouped_daily(str(fwd_21d)) if has_21d else {}
-    prices_30d = polygon_client.get_grouped_daily(str(fwd_30d)) if has_30d else {}
-    prices_60d = polygon_client.get_grouped_daily(str(fwd_60d)) if has_60d else {}
-    prices_90d = polygon_client.get_grouped_daily(str(fwd_90d)) if has_90d else {}
+    prices_t0 = _grouped_daily_or_empty(polygon_client, eval_date, today=today)
+    prices_1d = _grouped_daily_or_empty(polygon_client, str(fwd_1d), today=today) if has_1d else {}
+    prices_3d = _grouped_daily_or_empty(polygon_client, str(fwd_3d), today=today) if has_3d else {}
+    prices_5d = _grouped_daily_or_empty(polygon_client, str(fwd_5d), today=today)
+    prices_10d = _grouped_daily_or_empty(polygon_client, str(fwd_10d), today=today) if has_10d else {}
+    prices_15d = _grouped_daily_or_empty(polygon_client, str(fwd_15d), today=today) if has_15d else {}
+    prices_21d = _grouped_daily_or_empty(polygon_client, str(fwd_21d), today=today) if has_21d else {}
+    prices_30d = _grouped_daily_or_empty(polygon_client, str(fwd_30d), today=today) if has_30d else {}
+    prices_60d = _grouped_daily_or_empty(polygon_client, str(fwd_60d), today=today) if has_60d else {}
+    prices_90d = _grouped_daily_or_empty(polygon_client, str(fwd_90d), today=today) if has_90d else {}
 
     if not prices_t0:
         logger.warning("No prices for eval_date %s — may be a non-trading day", eval_date)
         # Try next business day
         next_day = _add_trading_days(eval_dt, 1)
-        prices_t0 = polygon_client.get_grouped_daily(str(next_day))
+        # config-I7714 — this fallback was the one grouped-daily call with no
+        # `< today` guard at all, so on a run whose eval_date is the last closed
+        # session it asked polygon for the CURRENT one.
+        if next_day >= today:
+            logger.debug(
+                "Skipping %s: next trading day %s has not closed yet",
+                eval_date, next_day,
+            )
+            return []
+        prices_t0 = _grouped_daily_or_empty(polygon_client, str(next_day), today=today)
         if not prices_t0:
             return []
 

--- a/tests/test_universe_returns_before_eod.py
+++ b/tests/test_universe_returns_before_eod.py
@@ -1,0 +1,106 @@
+"""The before-EOD 403 must not halt the weekly pipeline (config-I7714).
+
+MEASURED 2026-08-18, weekly execution `watch-rerun-2026-08-18-3`: DataPhase1 ran
+to completion in 2723s and then exited 1 because `universe_returns` raised on a
+polygon 403 — `"Attempted to request today's data before end of day"` on the
+grouped-daily endpoint for 2026-08-18. `weekly_collector.py` marks any non-ok
+collector `partial` and deliberately exits 1, so the pipeline halted. It had not
+succeeded since 2026-08-15, which is why every artifact downstream of the weekly
+graph was four days stale and the freshness monitor had something real to say
+underneath the cadence noise.
+
+The collector walks FORWARD dates from each eval_date, so it asks about the
+current session by construction. The request is early, not wrong.
+
+These tests pin BOTH halves: the tolerated shape, and — more importantly — every
+403 that must still raise. `polygon_client._get` raises on all 403s deliberately
+(data#4496: swallowing them masked the 2026-04-17 to 2026-04-23 VWAP outage by
+letting `daily_closes.collect` fall through to yfinance and write VWAP=None for
+every stock). This narrowing must not become that swallow.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from collectors.universe_returns import _grouped_daily_or_empty
+from polygon_client import PolygonForbiddenError
+
+_TODAY = date(2026, 8, 18)
+_BEFORE_EOD = PolygonForbiddenError(
+    "Polygon 403 on /v2/aggs/grouped/locale/us/market/stocks/2026-08-18: "
+    "Attempted to request today's data before end of day"
+)
+
+
+class _Client:
+    def __init__(self, outcome):
+        self.outcome = outcome
+        self.calls = []
+
+    def get_grouped_daily(self, date_str):
+        self.calls.append(date_str)
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return self.outcome
+
+
+def test_before_eod_on_the_current_session_yields_no_bars():
+    """The tolerated shape: today's bar has not published yet."""
+    client = _Client(_BEFORE_EOD)
+    assert _grouped_daily_or_empty(client, "2026-08-18", today=_TODAY) == {}
+
+
+def test_before_eod_on_a_future_date_yields_no_bars():
+    """A forward date beyond today is the same condition, further out."""
+    client = _Client(_BEFORE_EOD)
+    assert _grouped_daily_or_empty(client, "2026-08-25", today=_TODAY) == {}
+
+
+def test_before_eod_on_a_PAST_date_still_raises():
+    """The session is over, so 'before end of day' cannot be the true
+    explanation — something else is wrong and must not read as absent data."""
+    client = _Client(_BEFORE_EOD)
+    with pytest.raises(PolygonForbiddenError):
+        _grouped_daily_or_empty(client, "2026-08-11", today=_TODAY)
+
+
+@pytest.mark.parametrize("message", [
+    "Polygon 403 on /v2/aggs/grouped/...: Not authorized",
+    "Polygon 403 on /v2/aggs/grouped/...: Unknown API Key",
+    "Polygon 403 on /v2/aggs/grouped/...: Your plan does not include this data",
+])
+def test_every_other_403_still_raises(message):
+    """An invalid key, a revoked plan, or an entitlement the account does not
+    hold are exactly the failures the raise exists for."""
+    client = _Client(PolygonForbiddenError(message))
+    with pytest.raises(PolygonForbiddenError):
+        _grouped_daily_or_empty(client, "2026-08-18", today=_TODAY)
+
+
+def test_a_malformed_date_string_raises_rather_than_being_tolerated():
+    """If the date cannot be parsed, the 'has it closed yet' question cannot be
+    answered, so the 403 stands."""
+    client = _Client(_BEFORE_EOD)
+    with pytest.raises(PolygonForbiddenError):
+        _grouped_daily_or_empty(client, "not-a-date", today=_TODAY)
+
+
+def test_a_successful_call_is_passed_straight_through():
+    client = _Client({"SPY": {"close": 500.0}})
+    assert _grouped_daily_or_empty(client, "2026-08-11", today=_TODAY) == {
+        "SPY": {"close": 500.0}
+    }
+    assert client.calls == ["2026-08-11"]
+
+
+def test_non_403_errors_are_not_caught():
+    """Only PolygonForbiddenError is in scope; a transport or 5xx failure keeps
+    its own handling."""
+    class _Boom(Exception):
+        pass
+
+    client = _Client(_Boom("connection reset"))
+    with pytest.raises(_Boom):
+        _grouped_daily_or_empty(client, "2026-08-18", today=_TODAY)


### PR DESCRIPTION
## What & why

**The weekly pipeline has not succeeded since 2026-08-15.** This is why every artifact downstream of the weekly graph is four days old — the real finding underneath the cadence noise that `config-I7708` / `I7709` removed.

Three reruns failed on 2026-08-18. The third, `watch-rerun-2026-08-18-3`, ran DataPhase1 to **full completion (2723s)** and then exited 1 because `universe_returns` raised on a polygon 403:

```
Attempted to request today's data before end of day
```

on the grouped-daily endpoint for `2026-08-18`. `weekly_collector.py` marks any non-ok collector `partial` and deliberately `exit 1`s, so the pipeline halted. Verified live:

```json
// s3://alpha-engine-research/health/data_phase1.json
{"phase": 1, "date": "2026-08-18", "status": "partial", "completed_at": "2026-08-19T01:13:26Z"}
```

Tracked: `alpha-engine-config-I7714`.

### It is not a spot reclaim

The SF failure text — `DataPhase1 failed (last output: Instance terminated.)` — is emitted whenever the launcher's cleanup trap tears the instance down for **any** terminal exit, and it misleads toward the 2026-08-13 reclaim class. The launcher's own classifier (`krepis.ec2_spot.classify_termination` via `infrastructure/spot_data_weekly.sh`) evaluated `describe-spot-instance-requests` plus `describe-instances` and returned `{"classification": "other", "reason": "not-reclaim:other", "relaunch": false}` — correctly refusing to blind-retry an application-level failure. No spot capacity event correlates with any of the three failures. **No provisioning change is indicated.**

The other two failures were preflight gates and have both since self-cleared: `LibPinDriftGate` on a co-install parity mismatch (all four repos now on `v0.124.70`), and `WeeklyPreflightGate.sf_iam_reachability` (the role's inline policy now includes `alpha-engine-weekly-run-scope*`).

## How

This collector walks **forward** dates from each `eval_date`, so it asks about the current session by construction. The request is early, not wrong.

`_grouped_daily_or_empty()` tolerates exactly one 403 shape for exactly one date range — the message must contain `"before end of day"` **and** the requested date must not have closed yet. Everything else still raises:

| case | behaviour |
|---|---|
| before-EOD 403, date ≥ today | `{}` — not yet published |
| before-EOD 403, date **in the past** | **raises** — the session is over, so that cannot be the true explanation |
| `Not authorized` / `Unknown API Key` / plan-not-included 403 | **raises** |
| malformed date string | **raises** |
| any non-403 exception | **propagates** |

`polygon_client._get` raising on all 403s stays exactly as it is. Narrowing on **both** the message and the date is what keeps this from becoming the swallow it replaces — `data#4496`: swallowing 403s once masked the 2026-04-17 → 2026-04-23 VWAP outage by letting `daily_closes.collect` fall through to yfinance and write `VWAP=None` for every stock.

Also: the `prices_t0` next-trading-day fallback was the one grouped-daily call in the function with **no `< today` guard at all**, so on a run whose `eval_date` is the last closed session it asked polygon for the current one. Guarded.

## Test plan (run before opening)

- `pytest tests/ -q` → **6092 passed, 13 skipped**

9 new tests, and the ones that matter are the negatives: a before-EOD 403 on a past date, three other 403 messages, a malformed date, and a non-403 exception all still raise.

## Note on ruff

`ruff check collectors/universe_returns.py` reports 3 findings (`F401` unused `tempfile` / `Path`, one more). **Identical on `main`** — pre-existing, untouched by this diff, and this repo carries 297 repo-wide, so its CI does not gate on a clean run. Not fixed here to keep the diff to one purpose.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)