### PR TITLE
[P1/mid] fix(freshness-monitor): prefix membership is not the never-written question (config-I7622)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -1167,39 +1167,87 @@ def _is_confirmed_miss(result: CheckResult) -> bool:
 _NEVER_WRITTEN_PROBE_MAX = int(os.environ.get("NEVER_WRITTEN_PROBE_MAX", "25"))
 
 
+_NEVER_WRITTEN_SCAN_PAGES = int(os.environ.get("NEVER_WRITTEN_SCAN_PAGES", "5"))
+
+
 def _prefix_has_ever_been_written(
     s3_client: Any, spec: ArtifactSpec, result: CheckResult
 ) -> bool | None:
-    """Has ANY instance of this artifact ever existed?
+    """Has ANY instance of THIS artifact ever existed?
 
     Returns True/False, or None when the question could not be answered — which
-    is NOT the same as False and must never be rendered as "never written".
-    An unanswerable probe leaves the row on the normal page path, because the
-    failure toward which this must lean is paging about a real absence, never
-    silencing one.
+    is NOT the same as False and must never be rendered as "never written". An
+    unanswerable probe leaves the row on the normal page path, because the
+    direction this must never fail in is silencing a real absence.
 
     The recency scan that produced ``missing`` is bounded by a cadence-derived
-    window. This asks the unbounded question, over the key's own prefix, with
-    ``MaxKeys=1`` — one cheap LIST, and only for rows already in ``missing``
-    (three of 146 in the measured sweep).
+    window; this asks the unbounded question, and only for rows already in
+    ``missing`` (three of 146 in the measured sweep).
+
+    **Prefix alone is not the question (config-I7622 follow-up).** A
+    date-templated key like ``research/{date}/self_test.json`` has the fixed head
+    ``research/`` — a shared top-level prefix with thousands of unrelated objects
+    under it. Measured 2026-08-19: ``research_self_test`` resolved
+    ``never_written=False`` on a populated ``research/`` prefix while
+    ``aws s3 ls s3://alpha-engine-research/research/ --recursive | grep
+    self_test.json`` returned NOTHING — the artifact has never once been written
+    and the probe could not see it. ``backtest_contribution_lift`` sits under
+    ``backtest/`` with the same shape. So the trailing fixed segment of the
+    template is matched too, and the answer is only ``False`` when a key actually
+    bearing that suffix is found.
+
+    The scan is bounded at :data:`_NEVER_WRITTEN_SCAN_PAGES` pages of 1000. Hitting
+    the cap returns None — not False. A prefix too large to search is a question
+    left unanswered, and answering it "never written" on the strength of having
+    given up is the failure this whole function is shaped to avoid.
     """
-    key = result.canonical_key or spec.s3_key_template
-    # The template's fixed leading segment: everything before the first
-    # placeholder, trimmed to a directory boundary. For a fixed key this is the
-    # key itself, which LISTs exactly one object if it exists.
     template = spec.s3_key_template
     head = template.split("{", 1)[0]
-    prefix = head if head.endswith("/") else head.rsplit("/", 1)[0] + "/" if "/" in head else head
+    if head.endswith("/"):
+        prefix = head
+    elif "/" in head:
+        prefix = head.rsplit("/", 1)[0] + "/"
+    else:
+        prefix = head
     if not prefix:
-        prefix = key
+        prefix = result.canonical_key or template
+
+    # Everything after the LAST placeholder — e.g. "/self_test.json" for
+    # `research/{date}/self_test.json`. A template ending at a directory
+    # boundary (`groom/{date}/`) has no distinguishing trailing segment, so
+    # prefix membership IS the question there and the cheap MaxKeys=1 path is
+    # the right one.
+    suffix = template.rsplit("}", 1)[-1] if "{" in template else ""
+    if not suffix.strip("/"):
+        suffix = ""
+
     try:
-        resp = s3_client.list_objects_v2(
-            Bucket=spec.s3_bucket, Prefix=prefix, MaxKeys=1
+        if not suffix:
+            resp = s3_client.list_objects_v2(
+                Bucket=spec.s3_bucket, Prefix=prefix, MaxKeys=1
+            )
+            return int(resp["KeyCount"]) > 0
+
+        token = None
+        for _ in range(_NEVER_WRITTEN_SCAN_PAGES):
+            kwargs = {"Bucket": spec.s3_bucket, "Prefix": prefix, "MaxKeys": 1000}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = s3_client.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents") or []:
+                if str(obj.get("Key", "")).endswith(suffix):
+                    return True
+            if not resp.get("IsTruncated"):
+                return False
+            token = resp.get("NextContinuationToken")
+            if not token:
+                return False
+        logger.info(
+            "never-written probe for %s gave up after %d page(s) under %r — "
+            "recorded as UNKNOWN, so the row keeps the normal page path",
+            spec.artifact_id, _NEVER_WRITTEN_SCAN_PAGES, prefix,
         )
-        # A response that does not carry an integer KeyCount has not answered
-        # the question. Coercing it would turn "I could not tell" into "never
-        # written", which is the one direction this must never fail in.
-        return int(resp["KeyCount"]) > 0
+        return None
     except Exception as exc:  # noqa: BLE001 — unanswerable, so the row keeps the page path; this WARNING and never_written=None on the row are the recording surfaces
         logger.warning(
             "never-written probe for %s could not run (prefix=%r) — the row "

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -4094,16 +4094,23 @@ def test_handler_still_writes_check_results_when_the_digest_cannot_be_sent(
 
 
 class _ListStub:
-    """Minimal S3 double for the never-written probe."""
+    """Minimal S3 double for the never-written probe.
 
-    def __init__(self, key_count):
+    `key_count` drives the fixed-key path; `pages` drives the suffix-matching
+    path (config-I7622 follow-up) as a list of `list_objects_v2` responses.
+    """
+
+    def __init__(self, key_count=None, pages=None):
         self.key_count = key_count
+        self.pages = list(pages or [])
         self.calls = []
 
     def list_objects_v2(self, **kw):
         self.calls.append(kw)
         if isinstance(self.key_count, Exception):
             raise self.key_count
+        if self.pages:
+            return self.pages.pop(0)
         return {"KeyCount": self.key_count}
 
 
@@ -4177,10 +4184,9 @@ def test_probe_prefix_is_the_templates_fixed_head(monkeypatch):
     result = CheckResult(state="missing", sla_violated_by_minutes=300,
                          canonical_key="backtest/2026-08-18/contribution_lift.json",
                          reason="no instance found")
-    stub = _ListStub(0)
+    stub = _ListStub(pages=[{"Contents": [], "IsTruncated": False}])
     index._prefix_has_ever_been_written(stub, spec, result)
     assert stub.calls[0]["Prefix"] == "backtest/"
-    assert stub.calls[0]["MaxKeys"] == 1
 
 
 def test_never_written_rows_are_reported_in_the_digest_not_silenced(monkeypatch, fixed_now):
@@ -4245,3 +4251,120 @@ def test_owning_item_wall_clock_starts_at_the_first_lookup(monkeypatch):
         "the clock must not start at construction — that is the probe loop's "
         "duration, not the lookup phase's"
     )
+
+
+# ── config-I7622 follow-up: prefix membership is not the question ────────────
+#
+# MEASURED 2026-08-19: `research_self_test` (`research/{date}/self_test.json`)
+# resolved never_written=False because the `research/` prefix is populated with
+# thousands of unrelated objects — while
+# `aws s3 ls s3://alpha-engine-research/research/ --recursive | grep self_test.json`
+# returned NOTHING. The artifact has never once been written and the probe could
+# not see it. `backtest_contribution_lift` sits under `backtest/` with the same
+# shape. A shared top-level prefix answers a different question than the one
+# being asked.
+
+
+def _dated_spec(index_mod):
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+    spec = ArtifactSpec(
+        artifact_id="research_self_test", s3_bucket="alpha-engine-research",
+        s3_key_template="research/{date}/self_test.json", cadence="weekday_sf",
+        sla_minutes_after_cron=2880, severity="warning",
+        owner_repo="crucible-research", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="missing", sla_violated_by_minutes=100,
+                         canonical_key="research/2026-08-19/self_test.json",
+                         reason="no instance found")
+    return spec, result
+
+
+def test_a_populated_prefix_without_the_suffix_is_never_written(monkeypatch):
+    """The regression: `research/` is full, and not one object is a self_test."""
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _dated_spec(index)
+    stub = _ListStub(pages=[{
+        "Contents": [{"Key": "research/2026-08-19/signals.json"},
+                     {"Key": "research/2026-08-19/rationale.json"}],
+        "IsTruncated": False,
+    }])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is False
+
+
+def test_one_matching_key_anywhere_in_the_prefix_is_enough(monkeypatch):
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _dated_spec(index)
+    stub = _ListStub(pages=[{
+        "Contents": [{"Key": "research/2026-01-02/other.json"},
+                     {"Key": "research/2026-03-04/self_test.json"}],
+        "IsTruncated": False,
+    }])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is True
+
+
+def test_the_match_can_be_on_a_later_page(monkeypatch):
+    """A match beyond the first page must still count — S3 lists lexically, so
+    the newest keys are frequently in the tail."""
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _dated_spec(index)
+    stub = _ListStub(pages=[
+        {"Contents": [{"Key": "research/2026-01-02/other.json"}],
+         "IsTruncated": True, "NextContinuationToken": "t1"},
+        {"Contents": [{"Key": "research/2026-08-14/self_test.json"}],
+         "IsTruncated": False},
+    ])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is True
+    assert stub.calls[1]["ContinuationToken"] == "t1"
+
+
+def test_giving_up_at_the_page_cap_reports_unknown_not_never_written(monkeypatch):
+    """A prefix too large to search is a question left UNANSWERED. Answering it
+    'never written' on the strength of having given up is precisely the failure
+    this function is shaped to avoid — the row keeps its page path."""
+    monkeypatch.setenv("NEVER_WRITTEN_SCAN_PAGES", "2")
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _dated_spec(index)
+    stub = _ListStub(pages=[
+        {"Contents": [{"Key": f"research/x{i}/other.json"}], "IsTruncated": True,
+         "NextContinuationToken": f"t{i}"}
+        for i in range(4)
+    ])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is None
+    assert len(stub.calls) == 2, "the cap must actually bound the scan"
+
+
+def test_a_truncated_page_with_no_token_stops_rather_than_looping(monkeypatch):
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _dated_spec(index)
+    stub = _ListStub(pages=[{"Contents": [], "IsTruncated": True}])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is False
+
+
+def test_a_prefix_shaped_template_still_uses_membership(monkeypatch):
+    """`groom/{date}/` has no trailing fixed segment, so prefix membership IS
+    the question and the cheap MaxKeys=1 path is correct."""
+    import importlib
+    import index
+    importlib.reload(index)
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+    spec = ArtifactSpec(
+        artifact_id="groom_run_artifacts", s3_bucket="alpha-engine-research",
+        s3_key_template="groom/{date}/", cadence="continuous",
+        interval_minutes=1440, sla_minutes_after_cron=60, severity="warning",
+        owner_repo="alpha-engine-config", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(state="missing", sla_violated_by_minutes=10,
+                         canonical_key="groom/2026-08-19/", reason="absent")
+    stub = _ListStub(0)
+    assert index._prefix_has_ever_been_written(stub, spec, result) is False
+    assert stub.calls[0]["MaxKeys"] == 1


### PR DESCRIPTION
## What & why

Follow-up to #1442, found by the live sweep that shipped it.

**Measured 2026-08-19T16:17:15Z:** `research_self_test` resolved `never_written=False` — so it kept the page path — while

```
aws s3 ls s3://alpha-engine-research/research/ --recursive | grep self_test.json
```

returns **nothing**. The artifact has never once been written and the probe could not see it.

The cause: `research/{date}/self_test.json` has the fixed head `research/` — a shared top-level prefix with thousands of unrelated objects under it. *"Is this prefix non-empty"* answers a different question than *"has THIS artifact ever existed."* `backtest_contribution_lift` under `backtest/` and `predictor_self_test` under `predictor/` have the same shape. This is the class, not one row.

## How

- The template's **trailing fixed segment** is matched too, so the answer is `False` only when a key actually bearing that suffix is found. A template ending at a directory boundary (`groom/{date}/`) has no distinguishing segment — prefix membership genuinely *is* the question there, so the cheap `MaxKeys=1` path stays.
- The scan is bounded at `NEVER_WRITTEN_SCAN_PAGES` (default 5) pages of 1000. **Hitting the cap returns `None`, not `False`.** A prefix too large to search is a question left unanswered; answering it "never written" on the strength of having given up is exactly the failure this function is shaped to avoid, and the row keeps its page path.
- A truncated page carrying no continuation token stops rather than looping.

## Test plan (run before opening)

- `pytest tests/ -q` → **6083 passed, 13 skipped**
- `pytest infrastructure/lambdas/freshness-monitor/test_handler.py -q` → **169 passed**

6 new tests: a populated prefix with no matching suffix reads never-written · one matching key anywhere counts · **a match on a later page counts** (S3 lists lexically, so the newest keys are frequently in the tail — the same bug class as the 8000-object scan cap that once named a stale key the freshest) · the page cap reports `None` *and* actually bounds the scan · a tokenless truncated page terminates · a prefix-shaped template still uses membership.

## Cross-repo

Independent of `nousergon-data-PR1443` (the `universe_returns` before-EOD fix). Either order.

## Deploy

`deploy-freshness-monitor.yml` auto-deploys on merge. No post-merge step.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)