### PR TITLE
[P1/mid] fix(freshness-monitor): spend the owning-item budget where it can page (config-I7730)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -3488,8 +3488,43 @@ def _run_probe_pass(
         # `owning_item=unknown` and the page still fires. Recording
         # surfaces: the WARNING below, `owning_item_lookup_degraded_reason`
         # on the check_results row, and the OwningItemLookupDegraded metric.
+        # config-I7622 — only `missing` rows can be "never written", and only
+        # a handful are missing in any sweep (3 of 146, measured 2026-08-19), so
+        # this costs one bounded LIST each rather than a scan. Runs BEFORE the
+        # owning-item join (config-I7730) because that join's budget gate reads
+        # this answer — a never-written row cannot page, so it must not spend a
+        # GitHub query.
+        never_written: bool | None = None
+        if result.state == "missing" and len(never_written_by_id) < _NEVER_WRITTEN_PROBE_MAX:
+            never_written = _prefix_has_ever_been_written(s3_client, spec, result)
+            if never_written is not None:
+                never_written = not never_written
+            never_written_by_id[spec.artifact_id] = never_written
+
         owning: dict[str, Any] | None = None
-        if _is_confirmed_miss(result):
+        # config-I7730 — spend the budget where it can change an outcome.
+        # `_resolve_owning_item` ran for EVERY confirmed miss at 2+ GitHub
+        # searches each, against a 24-query cap. MEASURED 2026-08-19T17:02Z: 12
+        # confirmed misses, of which 9 could not page under ANY owning-item
+        # answer — 7 producer-suppressed, 2 never-written — so the cap was spent
+        # on them and the ONE row that did page carried
+        # `owning_item_lookup=degraded owning_item_lookup_reason=
+        # 'lookup_budget_exhausted'` onto Brian's Telegram page. The join that
+        # exists to explain a page was starved by rows that cannot produce one.
+        #
+        # These two gates are exactly `_alert_decision`'s own early returns,
+        # BOTH of which sit above every use of `owning`, so skipping the lookup
+        # for them cannot change any verdict — it only stops paying for an
+        # answer nothing reads. The row still reaches check_results.json with
+        # its true state; what it loses is an owning-item block on a page it was
+        # never going to appear on.
+        _suppressed = (suppression_by_id or {}).get(spec.artifact_id)
+        _cannot_page = (
+            (_suppressed and _suppressed.get("suppressed"))
+            or never_written_by_id.get(spec.artifact_id) is True
+            or suppress_page
+        )
+        if _is_confirmed_miss(result) and not _cannot_page:
             try:
                 owning = _resolve_owning_item(
                     spec.artifact_id, result.canonical_key,
@@ -3512,16 +3547,6 @@ def _run_probe_pass(
         # keeps its exact meaning (this row is on the operator page), so the
         # execution-loop records, the drain-candidate gate and the `alerted`
         # count below are unchanged; only the number of MESSAGES changed.
-        # config-I7622 — only `missing` rows can be "never written", and only
-        # a handful are missing in any sweep (3 of 146, measured 2026-08-19), so
-        # this costs one MaxKeys=1 LIST each rather than a scan.
-        never_written: bool | None = None
-        if result.state == "missing" and len(never_written_by_id) < _NEVER_WRITTEN_PROBE_MAX:
-            never_written = _prefix_has_ever_been_written(s3_client, spec, result)
-            if never_written is not None:
-                never_written = not never_written
-            never_written_by_id[spec.artifact_id] = never_written
-
         decision = None
         if not suppress_page:
             decision = _alert_decision(

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -4368,3 +4368,90 @@ def test_a_prefix_shaped_template_still_uses_membership(monkeypatch):
     stub = _ListStub(0)
     assert index._prefix_has_ever_been_written(stub, spec, result) is False
     assert stub.calls[0]["MaxKeys"] == 1
+
+
+# ── config-I7730: the owning-item budget must be spent where it pages ────────
+#
+# MEASURED 2026-08-19T17:02:08Z, on Brian's Telegram page: the one paging row
+# carried `owning_item_lookup=degraded owning_item_lookup_reason=
+# 'lookup_budget_exhausted'`. The sweep had 12 confirmed misses, of which NINE
+# could not page under any owning-item answer — 7 producer-suppressed
+# (config-I6570) and 2 never-written (config-I7622) — and the 24-query cap was
+# spent on them first. The join that exists to EXPLAIN a page was starved by
+# rows that cannot produce one.
+#
+# Both gates below are exactly `_alert_decision`'s own early returns, and both
+# sit above every use of `owning`, so skipping the lookup cannot change a
+# verdict — it only stops paying for an answer nothing reads.
+
+
+def _lookup_calls(index_mod, monkeypatch):
+    """Record which artifact_ids the owning-item join is actually spent on."""
+    spent: list[str] = []
+
+    def fake(artifact_id, canonical_key, known, now, state):
+        spent.append(artifact_id)
+        return {"resolved": True, "degraded": False, "degraded_reason": None,
+                "owning_item": None, "members": [], "n_candidates": 0}
+
+    monkeypatch.setattr(index_mod, "_resolve_owning_item", fake)
+    return spent
+
+
+def test_a_suppressed_row_does_not_spend_a_github_query(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = yaml_registry_body
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock(return_value=mock.Mock(dedup_skipped=False)))
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    spent = _lookup_calls(index, monkeypatch)
+
+    # Every not-fresh row reports as producer-suppressed.
+    monkeypatch.setattr(index, "apply_producer_suppression", lambda *a, **kw: {
+        aid: {"suppressed": True, "reason": "producer disabled",
+              "disabled_since": "2026-08-07", "days_disabled": 12,
+              "trigger": "scheduler:x", "pause_owner": None, "pause_owner_url": None}
+        for aid in ("probe_missing", "probe_heartbeat", "probe_fresh")
+    })
+    index.handler({}, None)
+    assert spent == [], f"budget spent on rows that cannot page: {spent}"
+
+
+def test_a_never_written_row_does_not_spend_a_github_query(monkeypatch, fixed_now):
+    """The gate reads the never-written answer, so the probe must run FIRST."""
+    import importlib
+    import index
+    importlib.reload(index)
+    # The ordering is the contract: if the probe moved back below the join, the
+    # gate would read an unpopulated dict and silently stop working.
+    src = __import__("pathlib").Path(index.__file__).read_text()
+    probe_at = src.index("never_written_by_id[spec.artifact_id] = never_written")
+    join_at = src.index("_cannot_page = (")
+    assert probe_at < join_at, (
+        "the never-written probe must run BEFORE the owning-item budget gate "
+        "that reads its answer (config-I7730)"
+    )
+
+
+def test_an_unsuppressed_paging_row_still_gets_its_lookup(
+    monkeypatch, yaml_registry_body, fake_s3, fixed_now
+):
+    """The point is not fewer lookups — it is that the row on the page gets one."""
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    fake_s3._registry_body = yaml_registry_body
+    import importlib
+    import index
+    importlib.reload(index)
+    _patch_now(monkeypatch, fixed_now)
+    monkeypatch.setattr(index, "boto3", mock.Mock(client=lambda *a, **kw: fake_s3))
+    monkeypatch.setattr(index, "publish", mock.Mock(return_value=mock.Mock(dedup_skipped=False)))
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    spent = _lookup_calls(index, monkeypatch)
+    index.handler({}, None)
+    assert "probe_missing" in spent


### PR DESCRIPTION
## What & why

Brian's Telegram page at **2026-08-19T17:02:08Z** — the first digest emitted after the `config-I7713` rollout. One message, grouped by cause, never-written reported separately: that part is working. But the one paging row read:

```
owning_item=unknown owning_item_lookup=degraded
owning_item_lookup_reason='lookup_budget_exhausted'
```

That sweep had **12 confirmed misses**, of which **nine could not page under any owning-item answer** — 7 producer-suppressed (`config-I6570`, Brian's 2026-08-07 and 2026-08-12 pauses) and 2 never-written (`config-I7622`). `_resolve_owning_item` ran for every confirmed miss at 2+ GitHub searches each against a 24-query cap, so the cap was spent on the nine that cannot page and the one that did got nothing.

**The join that exists to explain a page was starved by rows that cannot produce one.**

Tracked: `alpha-engine-config-I7730`.

### This is the query cap, not the wall clock

The wall-clock half was a *different* defect, fixed in #1442 — the 25s budget started when the lookup state was constructed, ahead of a 68.5s probe loop, so it was ~40s over before the first query could run. That fix worked: the page now says `lookup_budget_exhausted` rather than `lookup_time_budget_exhausted`.

## How

The lookup is skipped for rows that cannot page:

| gate | source |
|---|---|
| `producer_suppression.suppressed` | config-I6570 |
| `never_written is True` | config-I7622 |
| `recovery.mode == "dispatch"` already suppressed the page | config#1240 |

All three are **exactly `_alert_decision`'s own early returns**, and all three sit *above every use of `owning`* — so skipping the lookup cannot change a verdict. It only stops paying for an answer nothing reads. The row still reaches `check_results.json` with its true state; what it loses is an owning-item block on a page it was never going to appear on.

The never-written probe moves **above** the owning-item join, because the gate reads its answer. A test pins that ordering — if the probe drifts back below, the gate would read an unpopulated dict and silently stop working, which is the failure mode where a guard keeps passing while checking nothing.

## Not raising the cap

GitHub's search API allows 30 authenticated requests/minute and `OWNING_ITEM_LOOKUP_MAX_QUERIES` is 24 for that reason. Raising it to cover rows that cannot page buys nothing and moves the function toward a rate limit. Spending the existing budget correctly is strictly better than spending more of it. Per-group resolution stays the next lever if this binds again (named in `config-I7713`).

## Test plan (run before opening)

- `pytest tests/ -q` → **6092 passed, 13 skipped**
- `pytest infrastructure/lambdas/freshness-monitor/test_handler.py -q` → **172 passed**

3 new tests: a suppressed row spends zero queries · a never-written row spends zero · **a paging row still gets its lookup** — the point is not fewer lookups, it is that the row on the page gets one — plus the probe-ordering pin.

## Deploy

`deploy-freshness-monitor.yml` auto-deploys on merge. No post-merge step.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)