### PR TITLE
fix(alerts): register two unregistered emitters in playbooks.yaml (alpha-engine-config-I7752)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -847,6 +847,17 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+  - class: research_cuts_leaderboard_alerts
+    # alpha-engine-config-I7752 static-chokepoint registration: the cuts
+    # leaderboard build is observe-only and swallows its own exception
+    # (crucible-research/scoring/leaderboard_producers.py::build_cuts_leaderboard),
+    # so this alert is the ONLY signal that a day's
+    # research/cuts_leaderboard/{date}.json was never written.
+    # publish_observe_alert defaults to severity WARN.
+    source: "research:cuts_leaderboard"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
   - class: research_experiment_record_alerts
     source: "research:experiment_record"
     severities: [warning]
@@ -897,6 +908,15 @@ alert_classes:
   # ── data plane (nousergon-data) ──
   - class: data_constituents_drift
     source: "alpha-engine-data/validators/constituents_drift_check.py"
+    severities: [dynamic]
+    intake: bus
+    response: drain-queue
+  - class: data_stage_output_sweep
+    # alpha-engine-config-I7752 static-chokepoint registration: the per-run
+    # stage-output verdict (validators/stage_output_sweep.py). Severity is
+    # chosen at emit time — `error` when the run has defects, `warn` otherwise
+    # — hence [dynamic], matching its sibling validators above.
+    source: "alpha-engine-data/validators/stage_output_sweep.py"
     severities: [dynamic]
     intake: bus
     response: drain-queue


### PR DESCRIPTION
Tracker: `alpha-engine-config-I7752`. A closing keyword does not work across repositories, so that issue is closed by hand once this merges.

## What was wrong

`Cross-check alert source literals against playbooks.yaml` is RED on `alpha-engine-config` `main` ([run 32299053543](https://github.com/nousergon/alpha-engine-config/actions/runs/32299053543/job/96217158666), 2026-08-19). Two publish source literals have no `alert_classes:` row here:

| source | emitter |
|---|---|
| `research:cuts_leaderboard` | `crucible-research/scoring/leaderboard_producers.py::build_cuts_leaderboard` |
| `alpha-engine-data/validators/stage_output_sweep.py` | `nousergon-data/validators/stage_output_sweep.py` |

An unregistered source is not cosmetic — the drain has no playbook for it, so the alert arrives with no declared response. It matters most for the first: `build_cuts_leaderboard` is observe-only and swallows its own exception, so that alert is the **only** signal that a day's `research/cuts_leaderboard/{date}.json` was never written.

## What changed

Two rows, following the conventions already in the file. Severity follows each emitter rather than a default:

- `research_cuts_leaderboard_alerts` — `severities: [warning]`, because `publish_observe_alert` defaults to WARN (`crucible-research/observe_alerts.py:31`). Matches its sibling `research:*_leaderboard` rows.
- `data_stage_output_sweep` — `severities: [dynamic]`, because the emitter picks `error` when the run has defects and `warn` otherwise (`validators/stage_output_sweep.py:814`). Matches its sibling validator rows.

## Test plan

- `python3 scripts/check_alert_class_registry_drift.py` (from `alpha-engine-config`) against this registry and the local fleet checkouts → **77 alert class patterns loaded, "All publish source literals are registered in alert_classes — no drift."** The same command against `main` reports the two literals above.
- `python3 -m pytest tests/test_overseer_playbook_registry.py tests/test_overseer_arming.py tests/test_groom_cycle_notifications.py -q` → **83 passed**
- `python3 -m pytest tests/ --ignore=tests/live_smoke -q` → 6101 passed, 18 failed. All 18 fail identically on `main` without this diff (verified by reverting `playbooks.yaml` and re-running), and all 18 are laptop-environment gaps — `No module named 'openpyxl'`, `cannot import name 'aws_region' from 'krepis'`. This repo's CI on `main` is green.

## Related

- `alpha-engine-config-PR7753` — the other check red on the same commit, a scope defect rather than a real finding
- `alpha-engine-config-I7749` — the Actions-minutes consolidation that will fold this drift check into a consolidated job, renaming its check context

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)