### PR TITLE
feat(preopen): an undeployed merge degrades; a changed definition halts (config-I7799)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -392,16 +392,30 @@
           ],
           "Comment": "alpha-engine-config#6615: cf_drift=true without sf_drift=true is CloudFormation stack-state/template drift only \u2014 orchestration metadata, not a trading-correctness failure. sf-pipeline-policy \u00a73 degrades loudly instead of halting: trade on the last verified frozen SHA with a degraded flag + page.",
           "Next": "SetDeployDriftDegradedFlag"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.drift_result.Payload.deploy_stamp_stale",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.drift_result.Payload.deploy_stamp_stale",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "alpha-engine-config-I7799 (Brian ruling 2026-08-20, option b). sf_drift above is now a comparison of the DEPLOYED preopen definition body against the repo's, so it halts only when the orchestration about to run differs from what main describes. deploy_stamp_stale carries what the old SHA-stamp comparison used to say: this repo has merged something it has not deployed. That is still real \u2014 a merged Lambda, collector or script this pipeline INVOKES but does not embed is genuinely undeployed \u2014 so it DEGRADES and pages rather than halting, which is the \u00a73 halt-vs-degrade split applied one layer down from the 2026-08-05/07 CFN case (config-I6615). Evaluated AFTER the cf_drift branch so a cf_drift degrade is not relabelled by it, and before Default. NOT IsPresent-guarded toward failure, deliberately: an absent key means an older predictor Lambda that has not yet shipped I7799, and that Lambda's sf_drift IS the stamp comparison \u2014 so the coverage this branch adds is not lost during a rollout, it is still being enforced one branch up, more strictly.",
+          "Next": "SetDeployDriftDegradedFlag"
         }
       ],
       "Default": "TradingDayGate"
     },
     "SetDeployDriftDegradedFlag": {
       "Type": "Pass",
-      "Comment": "alpha-engine-config#6615 (sf-pipeline-policy \u00a73, Brian's 2026-08-09 ruling): DeployDriftGate found cf_drift=true (CloudFormation stack terminal-state or template drift) WITHOUT sf_drift=true \u2014 orchestration metadata, not a trading-correctness failure. Sets $.degraded_summary the same way SetDaemonDegradedFlag/SetDataSpotDegradedFlag do (alpha-engine-config#6692 Option-A parity) so CheckDegradedOutcome later routes this execution's terminal to WriteCompletionMarkerDegraded/DegradedRun instead of a plain SUCCEEDED marker. Does NOT change the run's continuation \u2014 Next is PublishDeployDriftDegraded then straight on to TradingDayGate, exactly the path a clean drift check would take. If a later stage (data-spot fail-open, daemon restart failure) also degrades, that state's write to $.degraded_summary simply wins as the most-recent cause \u2014 degraded=true is preserved either way (same last-write-wins convention SetDaemonDegradedFlag documents).",
+      "Comment": "alpha-engine-config#6615 + I7799. The NON-HALTING branch of DeployDriftGate: the deployed preopen DEFINITION matches main (sf_drift=false), and at least one condition that is real but not trading-correctness-critical is true \u2014 cf_drift (CloudFormation stack terminal-state or template drift, orchestration metadata) and/or deploy_stamp_stale (this repo has merged something it has not deployed, which reaches a Lambda/collector/script the pipeline INVOKES but does not embed). Both degrade rather than halt per sf-pipeline-policy \u00a73, and WHICH one fired is carried in $.drift_result.Payload rather than in this state's static reason \u2014 a Choice cannot format a message per-branch, and a second state pair would have to be registered in nousergon_lib.pipeline_status before it could render. Sets $.degraded_summary the same way SetDaemonDegradedFlag/SetDataSpotDegradedFlag do (config#6692 Option-A parity) so CheckDegradedOutcome routes this execution's terminal to WriteCompletionMarkerDegraded/DegradedRun instead of a plain SUCCEEDED marker. Does NOT change the run's continuation \u2014 Next is PublishDeployDriftDegraded then straight on to TradingDayGate, exactly the path a clean drift check would take. If a later stage also degrades, that state's write to $.degraded_summary wins as the most-recent cause; degraded=true is preserved either way.",
       "Parameters": {
         "degraded": true,
-        "reason": "deploy_drift_metadata",
+        "reason": "deploy_drift_nonhalting",
         "run_date.$": "$.run_date",
         "stage_error.$": "$.drift_result.Payload"
       },
@@ -410,12 +424,12 @@
     },
     "PublishDeployDriftDegraded": {
       "Type": "Task",
-      "Comment": "alpha-engine-config#6615: best-effort SNS alert that DeployDriftGate found CloudFormation/stack-state drift (cf_drift=true) WITHOUT an SF-definition drift (sf_drift=false) \u2014 per sf-pipeline-policy \u00a73 this is orchestration metadata, so the pipeline degrades loudly and proceeds to TradingDayGate on the last verified frozen SHA rather than halting. Its own Catch also routes to TradingDayGate so even an SNS failure cannot halt the run (mirrors PublishDataSpotFailureImmediate's fail-open-on-notify-failure convention \u2014 config#1767).",
+      "Comment": "config#6615 + I7799: best-effort SNS alert that DeployDriftGate degraded the run WITHOUT halting it \u2014 the deployed preopen definition matches main, so trading proceeds, but a non-halting condition (cf_drift and/or deploy_stamp_stale) is true and must not pass silently. The message names which, from the probe payload, rather than asserting a cause it cannot know: \u00a72.3's rule that the notification carries the ACTUAL condition is what made the old CloudFormation-only wording wrong the moment a second condition could route here. Its own Catch also routes to TradingDayGate so even an SNS failure cannot halt the run (mirrors PublishDataSpotFailureImmediate \u2014 config#1767). The message interpolates ONLY fields both the pre- and post-I7799 probe emit (cf_drift_reason, sf_drift_reason) and carries deploy_stamp_stale inside the JsonToString payload instead: a States.Format on an absent path raises States.Runtime, and this state's Catch would then swallow the alert into TradingDayGate \u2014 the notification would be lost precisely during the rollout window where an old predictor Lambda is still answering.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekday Pipeline \u2014 DEGRADED (CloudFormation/stack drift, trading proceeds on frozen SHA)",
-        "Message.$": "States.Format('DeployDriftGate found CloudFormation/stack-state drift (cf_drift=true) WITHOUT an SF-definition drift (sf_drift=false) \u2014 orchestration metadata only, per sf-pipeline-policy \u00a73 (alpha-engine-config#6615). Trading proceeds on the last verified frozen SHA; this execution will complete DEGRADED, not SUCCEEDED. Detail: {}', States.JsonToString($.drift_result.Payload))"
+        "Subject": "Alpha Engine Weekday Pipeline \u2014 DEGRADED (deploy drift, non-halting; trading proceeds)",
+        "Message.$": "States.Format('DeployDriftGate degraded this run WITHOUT halting it: the deployed preopen DEFINITION matches main (sf_drift=false), so orchestration semantics are known and trading proceeds on the last verified frozen SHA. At least one non-halting condition is true \u2014 cf_drift (CloudFormation stack state/template) and/or deploy_stamp_stale (nousergon-data has merged something it has not deployed, reaching code this pipeline invokes but does not embed). Both are sf-pipeline-policy \u00a73 degrade-and-proceed conditions (config#6615, I7799). This execution will complete DEGRADED, not SUCCEEDED. cf_drift_reason={}, sf_drift_reason={}. Full probe (carries deploy_stamp_stale): {}', $.drift_result.Payload.cf_drift_reason, $.drift_result.Payload.sf_drift_reason, States.JsonToString($.drift_result.Payload))"
       },
       "ResultPath": "$.deploy_drift_degraded_notify",
       "TimeoutSeconds": 60,

--- a/tests/test_sf_drift_gate_families.py
+++ b/tests/test_sf_drift_gate_families.py
@@ -33,6 +33,24 @@ These tests pin:
   6. Clean payload (both false) still reaches TradingDayGate via Default.
   7. The notify state fails open (its own Catch also leads to TradingDayGate)
      so an SNS outage cannot turn a degrade into a halt.
+
+alpha-engine-config-I7799 (Brian ruling 2026-08-20) adds a FIFTH branch and
+renames the degrade reason. `sf_drift` is now a comparison of the deployed
+preopen DEFINITION against the repo's, so it halts only when the orchestration
+about to run differs from what main describes. What the old SHA-stamp
+comparison used to say survives as `deploy_stamp_stale` — this repo merged
+something it has not deployed, reaching code the pipeline invokes but does not
+embed — which DEGRADES rather than halting. Two conditions can now reach the
+one degrade path, so its `reason` is `deploy_drift_nonhalting` and the notify
+message names which fired from the probe payload rather than asserting
+CloudFormation.
+
+  8. deploy_stamp_stale=true degrades, is evaluated after the cf_drift branch
+     and before Default, and is IsPresent-guarded toward PROCEEDING — an absent
+     key means an older predictor Lambda whose sf_drift IS the stamp
+     comparison, so the coverage is still enforced one branch up, more
+     strictly.
+  9. The notify message interpolates only fields both probe versions emit.
 """
 from __future__ import annotations
 
@@ -66,9 +84,10 @@ def _guard_pairs(choice):
     return guard, comparison
 
 
-def test_gate_is_a_choice_with_four_branches_and_a_default(gate):
+def test_gate_is_a_choice_with_five_branches_and_a_default(gate):
+    # Four since config#6615; the fifth is deploy_stamp_stale (config-I7799).
     assert gate["Type"] == "Choice"
-    assert len(gate["Choices"]) == 4
+    assert len(gate["Choices"]) == 5
     assert gate["Default"] == "TradingDayGate"
 
 
@@ -145,6 +164,45 @@ def test_no_branch_routes_cf_drift_true_to_handle_failure(gate):
             assert not_clause.get("IsPresent") is True
 
 
+def test_deploy_stamp_stale_degrades_and_is_ordered_after_cf_drift(gate):
+    """config-I7799: the fifth branch. Ordered after cf_drift so a cf_drift
+    degrade is not relabelled by it, and before Default."""
+    c = gate["Choices"][4]
+    guard, comparison = _guard_pairs(c)
+    assert guard == {
+        "Variable": "$.drift_result.Payload.deploy_stamp_stale",
+        "IsPresent": True,
+    }
+    assert comparison["Variable"] == "$.drift_result.Payload.deploy_stamp_stale"
+    assert comparison["BooleanEquals"] is True
+    assert c["Next"] == "SetDeployDriftDegradedFlag"
+    assert c["Next"] != "HandleFailure"
+
+
+def test_absent_deploy_stamp_stale_does_not_halt(gate):
+    """During a rollout the predictor Lambda may not emit the field yet. No
+    branch may route its ABSENCE anywhere — Default must carry it, because the
+    old Lambda's sf_drift is the stamp comparison and already halts on it."""
+    for c in gate["Choices"]:
+        not_clause = c.get("Not") or {}
+        assert not_clause.get("Variable") != "$.drift_result.Payload.deploy_stamp_stale", (
+            "an absent deploy_stamp_stale must fall through to Default, not "
+            "be branched on — see the branch Comment (config-I7799)"
+        )
+
+
+def test_degrade_notify_only_interpolates_fields_both_probe_versions_emit(states):
+    """A States.Format on an absent path raises States.Runtime, and this
+    state's Catch would swallow the alert into TradingDayGate — losing the
+    notification precisely during the rollout window it matters in."""
+    msg = states["PublishDeployDriftDegraded"]["Parameters"]["Message.$"]
+    assert "$.drift_result.Payload.deploy_stamp_stale" not in msg, (
+        "deploy_stamp_stale must ride inside the JsonToString payload, never "
+        "as its own States.Format argument (config-I7799)"
+    )
+    assert "States.JsonToString($.drift_result.Payload)" in msg
+
+
 def test_clean_payload_reaches_trading_day_gate_via_default(gate):
     assert gate["Default"] == "TradingDayGate"
 
@@ -154,7 +212,7 @@ def test_degraded_flag_state_shape(states):
     assert st["Type"] == "Pass"
     assert st["ResultPath"] == "$.degraded_summary"
     assert st["Parameters"]["degraded"] is True
-    assert st["Parameters"]["reason"] == "deploy_drift_metadata"
+    assert st["Parameters"]["reason"] == "deploy_drift_nonhalting"
     assert st["Parameters"]["run_date.$"] == "$.run_date"
     # Mirrors SetDaemonDegradedFlag/SetDataSpotDegradedFlag's stage_error
     # convention — carries the probe's own diagnostic payload (cf_drift_reason,


### PR DESCRIPTION
## Ruling

Brian, 2026-08-20, option **(b)** on `alpha-engine-config-I7799`. Consumer half of `crucible-predictor-PR528`.

## Why

`sf_drift` was a comparison of the deployed `[git:<sha>]` **stamp** against `nousergon-data@main` HEAD, so **any** merge that had not deployed halted preopen. On 2026-08-20 three merges had not deployed — an illegal ASL escape in the **weekly** definition was failing the all-or-nothing deploy preflight — and none of them touched the preopen definition. The live preopen orchestration was byte-identical to what `main` describes, and correct. `DeployDriftGate` halted anyway; the session went unmanaged.

PR528 makes `sf_drift` a comparison of the preopen definition **body**, and keeps the stamp verdict under its own name, `deploy_stamp_stale`. This PR consumes it.

## Changes

**A fifth branch on `DeployDriftGate`:** `deploy_stamp_stale=true` → `SetDeployDriftDegradedFlag`.

- Ordered **after** the `cf_drift` branch so a `cf_drift` degrade is not relabelled by it, and before `Default`.
- `IsPresent`-guarded toward **proceeding**, deliberately: an absent key means an older predictor Lambda whose `sf_drift` *is* the stamp comparison — so the coverage is not lost during a rollout, it is still enforced one branch up, more strictly.

**The degrade path now names its actual cause.** Two conditions can reach it, so the static `reason` becomes `deploy_drift_nonhalting` and the SNS message reports which fired from the probe payload rather than asserting CloudFormation. §2.3 requires the notification to carry the actual condition; the CloudFormation-only wording became wrong the moment a second condition could route there.

**The message interpolates only fields both probe versions emit** (`cf_drift_reason`, `sf_drift_reason`), carrying `deploy_stamp_stale` inside the `JsonToString` payload. A `States.Format` on an absent path raises `States.Runtime`, and this state's `Catch` would then swallow the alert into `TradingDayGate` — losing the notification precisely during the rollout window where an old Lambda is still answering.

`step_function_eod.json` is untouched: the postclose pipeline has no `DeployDriftGate`. PR528's postclose path mapping is forward-looking.

## Test plan

- `tests/test_sf_drift_gate_families.py` — **16 passed**, including three new tests: the branch's ordering and degrade target, that an **absent** `deploy_stamp_stale` is branched on nowhere, and that the notify message never formats the new field directly.
- `aws stepfunctions validate-state-machine-definition` — `OK` for all four definitions.
- Full SF-touching set: 2791 passed. The 2 failures in `test_pipeline_status_registry_source_check.py` are a stale local venv (`nousergon-lib` 0.124.70 against the repo's 0.124.74 pin), not this change.

Rehearsal-path: tests/test_sf_drift_gate_families.py — this is a Choice-topology change, validated against the real AWS API and pinned structurally; no live trading morning is involved.

Verified-when: the next preopen execution's `DeployDriftCheck` payload carries `deploy_stamp_stale`, and a run with a stale stamp and an unchanged definition reaches `TradingDayGate` with `degraded_summary.reason=deploy_drift_nonhalting` rather than `HandleFailure`.

## Cross-repo

`crucible-predictor-PR528` — the probe. **Merge that first**; this Choice reads a field only the new probe emits. Until then the branch is simply never taken, which is inert.

Tracked: `alpha-engine-config-I7799`. Incident chain: `nousergon-data-PR1453`, `nousergon-data-PR1454`, `nous-ergon-ops-PR773`, `alpha-engine-config-I7798`, `I7800`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
