### PR TITLE
feat(preopen): the scanner forms its cuts weekly, not every weekday (config-I7811)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1355,7 +1355,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckSkipScanner"
+          "Next": "CheckSkipPredictorInference"
         }
       ],
       "Default": "InitMorningEnrichRetryCounter"
@@ -1369,96 +1369,6 @@
       },
       "ResultPath": "$.morning_enrich_retry",
       "Next": "LaunchMorningEnrichSpot"
-    },
-    "CheckSkipScanner": {
-      "Type": "Choice",
-      "Comment": "Skip-gate (alpha-engine-config-I6494). {\"skip_scanner\": true} bypasses the weekday Scanner Lambda and jumps straight to CheckSkipPredictorInference \u2014 Scanner's own success and Catch edges converge there, so skipping it is behaviorally identical to a Scanner run that did nothing. Defaults to running (Default: Scanner) so scheduled Mon\u2013Fri preopen runs and any rerun that has not explicitly set the flag are unaffected. Same entrypoint as the Saturday SF Scanner state (alpha-engine-research-scanner:live); this is the daily cadence of ONE Scanner, not a second implementation. Distinct from I5489 (weekday exercise of the FULL weekly SF).",
-      "Choices": [
-        {
-          "And": [
-            {
-              "Variable": "$.skip_scanner",
-              "IsPresent": true
-            },
-            {
-              "Variable": "$.skip_scanner",
-              "BooleanEquals": true
-            }
-          ],
-          "Next": "CheckSkipPredictorInference"
-        }
-      ],
-      "Default": "Scanner"
-    },
-    "Scanner": {
-      "Type": "Task",
-      "Comment": "Weekday invoke of the SAME standalone scanner Lambda the Saturday SF runs (alpha-engine-research-scanner:live \u2014 ROADMAP L1995 / alpha-engine-config-I6494). Placed AFTER MorningArcticAppend so ArcticDB technicals for the trading day are present, and BEFORE PredictorInference so universe_membership/{date} + factor profiles (+ provenance) are fresh for the membership consumer (I6495). Features are daily-capable (I5360 / research-PR545; SCANNER_FEATURE_SOURCE default arcticdb). Status contract OK / ERROR \u2014 Catch is non-blocking at the SF layer (mirrors Saturday): Catch and Next converge on CheckSkipPredictorInference; a missing/stale membership surfaces at the predictor's own age gate rather than hard-failing preopen. dry_run_llm omitted \u2014 weekday cadence has no Friday-Preflight research_dry shell path. alpha-engine-config-I6855: 600 -> 440. The SF budget must sit BELOW the function timeout or it can never bind \u2014 on 2026-08-11 this state declared 600s while alpha-engine-research-scanner carried 300s, so both preopen invocations died at 300s with Sandbox.Timedout and the 600 described nothing. The function is now 450s (crucible-research-PR601, p95 x 1.5); 440 keeps the SF the effective budget, so a scanner overrun surfaces as States.Timeout naming this state rather than as an opaque Lambda error.",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName": "alpha-engine-research-scanner:live",
-        "Payload": {
-          "run_date.$": "$.run_date"
-        }
-      },
-      "TimeoutSeconds": 440,
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.TooManyRequestsException",
-            "States.TaskFailed"
-          ],
-          "MaxAttempts": 1,
-          "IntervalSeconds": 60,
-          "BackoffRate": 1.0
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "Comment": "Scanner failure must NOT halt the weekday pipeline at the SF layer (mirrors Saturday Catch \u2192 CheckSkipRegimeSubstrate). Catch routes through SetScannerDegradedFlag then converges on CheckSkipPredictorInference so daemon start still happens; membership freshness is an independent consumer concern. alpha-engine-config#6722: PredictorInference's own downstream freshness/age gate mitigates the trading-safety risk, but the terminal notify previously said nothing about the miss at all \u2014 now Option-A parity (SetDataSpotDegradedFlag shape) threads it into $.degraded_summary.",
-          "Next": "SetScannerDegradedFlag",
-          "ResultPath": "$.scanner_error"
-        }
-      ],
-      "ResultPath": "$.scanner_result",
-      "Next": "CheckSkipPredictorInference"
-    },
-    "SetScannerDegradedFlag": {
-      "Type": "Pass",
-      "Comment": "alpha-engine-config#6722 (Option-A parity with SetDataSpotDegradedFlag/SetMutexAcquireDegradedFlag, config#6692 shape): threads $.degraded_summary onto the weekday Scanner fail-open path WITHOUT changing its continuation \u2014 Next still leads to CheckSkipPredictorInference exactly as before. Last-write-wins if a later stage also degrades. Does not clobber $.scanner_error (set by Scanner's own Catch ResultPath).",
-      "Parameters": {
-        "degraded": true,
-        "reason": "daily_scanner_fail_open",
-        "run_date.$": "$.run_date",
-        "stage_error.$": "$.scanner_error"
-      },
-      "ResultPath": "$.degraded_summary",
-      "Next": "PublishScannerFailureImmediate"
-    },
-    "PublishScannerFailureImmediate": {
-      "Type": "Task",
-      "Comment": "alpha-engine-config-I6903: best-effort SNS alert that the Scanner failed \u2014 surfaces the miss at the MOMENT it happens, WITHOUT blocking the trading chain. The Scanner fail-open was the only one of the five degraded paths in this definition with no Publish state, so on 2026-08-11 there were 37 minutes of silence between the second Scanner timeout (05:32 PT) and the terminal (06:09 PT) \u2014 inside the window where an operator could still have rerun it before the 06:30 open. sf-pipeline-policy.md \u00a75 requires weekday fail-opens to set the degraded flag AND page immediately; this is the missing half. Mirrors PublishDataSpotFailureImmediate exactly, including the Catch: an SNS failure must not hard-fail a pipeline that deliberately continued.",
-      "Resource": "arn:aws:states:::sns:publish",
-      "Parameters": {
-        "TopicArn.$": "$.sns_topic_arn",
-        "Subject": "Alpha Engine Weekday Scanner \u2014 FAILED (fail-open, pipeline continues)",
-        "Message.$": "States.Format('Weekday Scanner failed but the pipeline continued to predictor inference and daemon start (fail-open, config#6722). Today candidates may be stale and the universe board, membership and leaderboard were not written \u2014 the optimizer runs without per-name ADV (config-I6902). Detail: {}', States.JsonToString($.scanner_error))"
-      },
-      "ResultPath": "$.scanner_failure_notify",
-      "TimeoutSeconds": 60,
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "ResultPath": null,
-          "Next": "CheckSkipPredictorInference"
-        }
-      ],
-      "Next": "CheckSkipPredictorInference"
     },
     "CheckSkipPredictorInference": {
       "Type": "Choice",
@@ -1605,7 +1515,7 @@
           "Next": "ExtractDataSpotError"
         }
       ],
-      "Default": "CheckSkipScanner"
+      "Default": "CheckSkipPredictorInference"
     },
     "PollMorningEnrichSpot": {
       "Type": "Task",
@@ -1757,7 +1667,7 @@
     },
     "CheckMorningArcticAppendSpotLaunched": {
       "Type": "Choice",
-      "Comment": "launched:true -> poll; launched:false kill-switch -> continue.",
+      "Comment": "launched:true -> poll; launched:false kill-switch -> continue. alpha-engine-config-I7811 (Brian ruling 2026-08-20): the Scanner state and its CheckSkipScanner / SetScannerDegradedFlag / PublishScannerFailureImmediate siblings were REMOVED from this pipeline \u2014 the scanner forms its two cuts WEEKLY, on step_function.json's ResearchPredictorParallel/Scanner, and those feed research and the predictor for the week. Next is now CheckSkipPredictorInference directly. The predictor is unaffected: inference/stages/load_universe.py walks back MEMBERSHIP_MAX_AGE_DAYS=10 for universe_membership, and a weekly cut is at most 7 days old. I6494 Ruling A put the Scanner here on 2026-08-04 to satisfy that same freshness gate, which it never needed to.",
       "Choices": [
         {
           "And": [
@@ -1782,7 +1692,7 @@
           "Next": "ExtractDataSpotError"
         }
       ],
-      "Default": "CheckSkipScanner"
+      "Default": "CheckSkipPredictorInference"
     },
     "PollMorningArcticAppendSpot": {
       "Type": "Task",
@@ -1838,7 +1748,7 @@
         {
           "Variable": "$.arctic_append_poll.Status",
           "StringEquals": "Success",
-          "Next": "CheckSkipScanner"
+          "Next": "CheckSkipPredictorInference"
         },
         {
           "Variable": "$.arctic_append_poll.Status",
@@ -1924,10 +1834,10 @@
             "States.ALL"
           ],
           "ResultPath": null,
-          "Next": "CheckSkipScanner"
+          "Next": "CheckSkipPredictorInference"
         }
       ],
-      "Next": "CheckSkipScanner"
+      "Next": "CheckSkipPredictorInference"
     }
   }
 }

--- a/scripts/weekday_sf_rerun.py
+++ b/scripts/weekday_sf_rerun.py
@@ -5,7 +5,7 @@ Second adoption of the config#2277 idiom ``scripts/weekly_sf_rerun.py``
 established, covering the two weekday pipelines instead of the Saturday one:
 
 - ``ne-preopen-trading-pipeline`` ("daily") — skip gates: ``skip_morning_
-  enrich``, ``skip_scanner``, ``skip_predictor_inference``,
+  enrich``, ``skip_predictor_inference``,
   ``skip_morning_planner``, ``skip_run_daemon`` (infrastructure/
   step_function_daily.json). These gates test ONLY the flag itself — no
   pipeline_role conjunction, matching the weekly SF's shape.
@@ -145,11 +145,15 @@ class Pipeline:
 
 
 DAILY_STAGES: tuple[Stage, ...] = (
+    # alpha-engine-config-I7811 (Brian ruling 2026-08-20): the `scanner` stage
+    # was REMOVED from this pipeline — the scanner forms its two cuts WEEKLY, on
+    # the Saturday pipeline, and those feed research and the predictor for the
+    # week. morning_enrich's witness therefore moved from CheckSkipScanner to
+    # CheckSkipPredictorInference. A stage table that still named `scanner`
+    # would emit `skip_scanner` into a definition with no gate to read it, and
+    # the helper's own coherence check would reject its own output.
     Stage("morning_enrich", "skip_morning_enrich",
           "CheckSkipMorningEnrich", "LaunchMorningEnrichSpot",
-          frozenset({"CheckSkipScanner"})),
-    Stage("scanner", "skip_scanner",
-          "CheckSkipScanner", "Scanner",
           frozenset({"CheckSkipPredictorInference"})),
     Stage("predictor_inference", "skip_predictor_inference",
           "CheckSkipPredictorInference", "PredictorInference",

--- a/tests/test_sf_chronic_gap_heal_wiring.py
+++ b/tests/test_sf_chronic_gap_heal_wiring.py
@@ -18,7 +18,7 @@ liveness-poll quintet (``InitChronicGapPoll``/``WaitForChronicGap``/
 and its skip-gate (``CheckSkipChronicGapHeal``) are now DELETED from
 ``step_function_daily.json`` — 7 states removed in total. The 5 states that
 used to route into ``CheckSkipChronicGapHeal`` now route to
-``CheckSkipScanner`` (alpha-engine-config-I6494 — weekday Scanner before
+``CheckSkipPredictorInference`` (alpha-engine-config-I6494 — weekday Scanner before
 PredictorInference): ``CheckSkipMorningEnrich``,
 ``CheckMorningEnrichSpotLaunched``, ``CheckMorningArcticAppendSpotLaunched``,
 ``CheckMorningArcticAppendSpotStatus`` (its "Success" choice), and
@@ -30,7 +30,7 @@ This test catches regressions like:
   to this SF instead of the standalone daily-heal job — reopening the exact
   preopen poll-budget risk I2717 exists to close.
 - Someone leaves a dangling reference to one of the removed state names.
-- The 5 rewired predecessors drifting off ``CheckSkipScanner``.
+- The rewired predecessors drifting off ``CheckSkipPredictorInference``.
 - ``ForceStopUnresponsiveInstance`` (SHARED with the code-freshness-gate and
   morning-planner liveness loops) getting accidentally deleted along with the
   chronic-gap quintet it used to also serve.
@@ -111,22 +111,22 @@ class TestChronicGapHealQuintetRemoved:
 
 class TestRewiredPredecessorsRouteToScannerGate:
     """The 5 states that used to enter CheckSkipChronicGapHeal now enter
-    CheckSkipScanner (alpha-engine-config-I6494 — weekday Scanner sits
+    CheckSkipPredictorInference (I7811 removed the weekday Scanner; under I6494 it sat
     between the data-phase continue path and PredictorInference)."""
 
     def test_check_skip_morning_enrich_skip_edge(self, states):
         choices = states["CheckSkipMorningEnrich"]["Choices"]
         assert len(choices) == 1
-        assert choices[0]["Next"] == "CheckSkipScanner"
+        assert choices[0]["Next"] == "CheckSkipPredictorInference"
 
     def test_morning_enrich_spot_launched_default(self, states):
         assert states["CheckMorningEnrichSpotLaunched"]["Default"] == (
-            "CheckSkipScanner"
+            "CheckSkipPredictorInference"
         )
 
     def test_arctic_append_spot_launched_default(self, states):
         assert states["CheckMorningArcticAppendSpotLaunched"]["Default"] == (
-            "CheckSkipScanner"
+            "CheckSkipPredictorInference"
         )
 
     def test_arctic_append_spot_status_success_edge(self, states):
@@ -135,12 +135,12 @@ class TestRewiredPredecessorsRouteToScannerGate:
             for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
             if c.get("StringEquals") == "Success"
         ]
-        assert success == ["CheckSkipScanner"]
+        assert success == ["CheckSkipPredictorInference"]
 
     def test_publish_data_spot_failure_immediate_routes_forward(self, states):
         st = states["PublishDataSpotFailureImmediate"]
-        assert st["Next"] == "CheckSkipScanner"
-        assert st["Catch"][0]["Next"] == "CheckSkipScanner"
+        assert st["Next"] == "CheckSkipPredictorInference"
+        assert st["Catch"][0]["Next"] == "CheckSkipPredictorInference"
 
 
 class TestPredictorInferenceGateUnchanged:

--- a/tests/test_sf_completion_marker_wiring_daily.py
+++ b/tests/test_sf_completion_marker_wiring_daily.py
@@ -9,7 +9,7 @@ skip-gate edge (CheckSkipRunDaemon) all now converge on CheckDegradedOutcome
 rather than going straight to WriteCompletionMarker. The data-spot fail-open
 path (ExtractDataSpotError) threads a $.degraded_summary flag via
 SetDataSpotDegradedFlag WITHOUT changing its own fail-open continuation
-(still proceeds to PublishDataSpotFailureImmediate -> CheckSkipScanner).
+(still proceeds to PublishDataSpotFailureImmediate -> CheckSkipPredictorInference).
 CheckDegradedOutcome is the one place deciding the terminal: Default ->
 WriteCompletionMarker (unchanged normal marker, -> PipelineComplete);
 degraded -> WriteCompletionMarkerDegraded (-> DegradedRun, Type: Fail) so
@@ -92,7 +92,7 @@ def test_data_spot_fail_open_threads_degraded_flag_without_changing_continuation
     daily_states,
 ):
     """ExtractDataSpotError/PublishDataSpotFailureImmediate must keep their
-    fail-open continuation to CheckSkipScanner (Scanner etc. still run) —
+    fail-open continuation to CheckSkipPredictorInference (I7811: the weekday Scanner is gone) —
     SetDataSpotDegradedFlag only adds the flag in between."""
     extract = daily_states["ExtractDataSpotError"]
     assert extract["Next"] == "SetDataSpotDegradedFlag"
@@ -104,9 +104,9 @@ def test_data_spot_fail_open_threads_degraded_flag_without_changing_continuation
     assert flag["Next"] == "PublishDataSpotFailureImmediate"
 
     publish = daily_states["PublishDataSpotFailureImmediate"]
-    assert publish["Next"] == "CheckSkipScanner"
+    assert publish["Next"] == "CheckSkipPredictorInference"
     (publish_catch,) = publish["Catch"]
-    assert publish_catch["Next"] == "CheckSkipScanner"
+    assert publish_catch["Next"] == "CheckSkipPredictorInference"
 
 
 def test_check_degraded_outcome_routes_through_markers(daily_states):

--- a/tests/test_sf_daily_scanner_wiring.py
+++ b/tests/test_sf_daily_scanner_wiring.py
@@ -1,21 +1,34 @@
-"""Pins the weekday Scanner wiring in ``step_function_daily.json``.
+"""The Scanner is NOT in the weekday pipeline — it forms its cuts WEEKLY.
 
-alpha-engine-config-I6494 (Brian ruled option A, 2026-08-04): enable a daily
-Scanner schedule so ``universe_membership/{date}`` + factor profiles (+
-provenance) refresh on trading days without requiring the full Saturday
-weekly SF.
+**Brian ruling 2026-08-20 (`alpha-engine-config-I7811`):** *"the scanner should
+be running weekly, generating the two groups, and then this should be what gets
+passed into research and/or predictor - on a weekly basis."*
 
-SOTA: ONE Scanner entrypoint (``alpha-engine-research-scanner:live``), TWO
-cadences:
+This file used to pin the opposite. `alpha-engine-config-I6494` Ruling A put a
+Scanner state on the preopen pipeline on 2026-08-04, and its stated reason was:
 
-  * Saturday — ``ne-weekly-freshness-pipeline`` Branch A ``Scanner`` state
-    (pinned by ``test_sf_scanner_wiring.py``)
-  * Weekday  — ``ne-preopen-trading-pipeline`` ``Scanner`` state (this file),
-    after MorningArcticAppend and before PredictorInference, riding the
-    existing America/Los_Angeles ``cron(15 5) MON-FRI`` preopen schedule
-    (TradingDayGate already skips NYSE holidays)
+    "Predictor daily inference still depends on `universe_membership` freshness
+    (`MEMBERSHIP_MAX_AGE_DAYS`); a weekday-stale cut is the failure mode I4818
+    was opened for."
 
-Distinct from I5489 (weekday exercise of the FULL weekly SF).
+Measured 2026-08-20 against the tree: `crucible-predictor/inference/stages/
+load_universe.py:113` sets `MEMBERSHIP_MAX_AGE_DAYS = 10` and walks back that
+far. **A weekly cut is at most 7 days old and never trips the gate that
+justified daily formation.** The cadence was set by a threshold, and the
+threshold permits weekly.
+
+The second reason is what it cost. Daily formation is what put the Scanner on
+the 06:30-market-open critical path at all, and on 2026-08-20 it hit its 450s
+Lambda ceiling there and degraded the preopen run — after the 2026-08-17 scoring
+merges took its dominant read from ~(tens of symbols x 107 days) to ~(904
+symbols x 569 days). Second ceiling collision in nine days
+(`alpha-engine-config-I7812`).
+
+So this file is now a RETIREMENT GUARD, in the shape `I7817` asks for: it fails
+if the Scanner comes back to the weekday pipeline without a ruling, and it
+checks that the weekly one is still there — a removal that also lost the weekly
+formation would satisfy "not in the daily pipeline" while silently ending
+scanning altogether.
 """
 
 from __future__ import annotations
@@ -29,137 +42,97 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
 _WEEKLY_SF_PATH = _REPO_ROOT / "infrastructure" / "step_function.json"
 
+# The states I7811 removed from the weekday pipeline.
+_RETIRED_WEEKDAY_STATES = (
+    "Scanner",
+    "CheckSkipScanner",
+    "SetScannerDegradedFlag",
+    "PublishScannerFailureImmediate",
+)
+
 
 @pytest.fixture(scope="module")
-def states() -> dict:
-    return json.loads(_SF_PATH.read_text())["States"]
-
-
-@pytest.fixture(scope="module")
-def sf() -> dict:
+def daily() -> dict:
     return json.loads(_SF_PATH.read_text())
 
 
 @pytest.fixture(scope="module")
-def weekly_scanner() -> dict:
-    weekly = json.loads(_WEEKLY_SF_PATH.read_text())
-    flat: dict = dict(weekly["States"])
-    for st in weekly["States"].values():
-        if st.get("Type") == "Parallel":
-            for branch in st["Branches"]:
-                flat.update(branch["States"])
-    return flat["Scanner"]
+def weekly() -> dict:
+    return json.loads(_WEEKLY_SF_PATH.read_text())
 
 
-class TestStatesPresent:
-    def test_scanner_state_exists(self, states):
-        assert "Scanner" in states
-        assert states["Scanner"]["Type"] == "Task"
+def _walk(states: dict):
+    """Every state in a definition, including inside Parallel branches and Map
+    processors — a state re-added inside a branch is still re-added."""
+    for name, body in states.items():
+        yield name, body
+        for branch in body.get("Branches", []) or []:
+            yield from _walk(branch.get("States", {}))
+        for key in ("ItemProcessor", "Iterator"):
+            proc = body.get(key)
+            if isinstance(proc, dict) and "States" in proc:
+                yield from _walk(proc["States"])
 
-    def test_skip_gate_defaults_to_running(self, states):
-        assert states["CheckSkipScanner"]["Type"] == "Choice"
-        assert states["CheckSkipScanner"]["Default"] == "Scanner"
-        skip = states["CheckSkipScanner"]["Choices"][0]
-        assert skip["Next"] == "CheckSkipPredictorInference"
-        variables = {c["Variable"] for c in skip["And"]}
-        assert variables == {"$.skip_scanner"}
 
+class TestScannerIsGoneFromTheWeekdayPipeline:
+    @pytest.mark.parametrize("name", _RETIRED_WEEKDAY_STATES)
+    def test_the_state_does_not_exist(self, daily, name):
+        present = {n for n, _ in _walk(daily["States"])}
+        assert name not in present, (
+            f"{name} is back in step_function_daily.json. The scanner forms its "
+            f"cuts WEEKLY (Brian ruling 2026-08-20, alpha-engine-config-I7811); "
+            f"re-adding it to the market-open critical path is a ruling, not a "
+            f"wiring change."
+        )
 
-class TestSameEntrypointAsWeekly:
-    def test_lambda_function_matches_weekly(self, states, weekly_scanner):
+    def test_nothing_routes_to_a_removed_state(self, daily):
+        """A dangling `Next` is a `States.Runtime` at execution time, not a
+        parse error — AWS accepts the definition and the run dies mid-flight."""
+        dangling = []
+        for name, body in _walk(daily["States"]):
+            targets = [body.get("Next"), body.get("Default")]
+            targets += [c.get("Next") for c in body.get("Choices", []) or []]
+            targets += [c.get("Next") for c in body.get("Catch", []) or []]
+            for t in targets:
+                if t in _RETIRED_WEEKDAY_STATES:
+                    dangling.append(f"{name} -> {t}")
+        assert not dangling, f"routes into removed scanner states: {dangling}"
+
+    def test_the_data_phase_now_reaches_the_predictor_gate_directly(self, daily):
+        """The three edges that used to converge on `CheckSkipScanner` must now
+        converge on `CheckSkipPredictorInference` — not on nothing, and not on
+        some other stage that happens to parse."""
+        states = dict(_walk(daily["States"]))
+        for name in (
+            "CheckMorningEnrichSpotLaunched",
+            "CheckMorningArcticAppendSpotLaunched",
+        ):
+            assert states[name]["Default"] == "CheckSkipPredictorInference", (
+                f"{name} must fall through to the predictor gate now that the "
+                f"scanner gate is gone"
+            )
         assert (
-            states["Scanner"]["Parameters"]["FunctionName"]
-            == weekly_scanner["Parameters"]["FunctionName"]
-            == "alpha-engine-research-scanner:live"
-        )
-        assert states["Scanner"]["Resource"] == weekly_scanner["Resource"] == (
-            "arn:aws:states:::lambda:invoke"
+            states["PublishDataSpotFailureImmediate"]["Next"]
+            == "CheckSkipPredictorInference"
         )
 
-    def test_timeout_matches_weekly(self, states, weekly_scanner):
-        # 600 -> 440 (alpha-engine-config-I6855). 600 could never bind: the
-        # function's own timeout was 300s, so both 2026-08-11 preopen
-        # invocations died at 300.00s with Sandbox.Timedout and the pipeline
-        # terminated DEGRADED. The function is now 450s (p95 x 1.5,
-        # crucible-research-PR601) and the SF budget sits below it, so an
-        # overrun surfaces as States.Timeout naming this state.
-        # Ordering guard: tests/test_sf_lambda_timeout_ordering.py.
-        assert states["Scanner"]["TimeoutSeconds"] == weekly_scanner["TimeoutSeconds"] == 440
 
+class TestTheWeeklyScannerSurvives:
+    """The other half of the ruling. A change that removed the weekday Scanner
+    AND the weekly one would pass every assertion above while ending scanning
+    altogether — the cut would simply stop being formed, and the predictor's
+    10-day age walk would hide it for a week and a half."""
 
-class TestPayloadAndRunDate:
-    def test_payload_threads_run_date(self, states):
-        payload = states["Scanner"]["Parameters"]["Payload"]
-        assert payload["run_date.$"] == "$.run_date"
-
-    def test_initialize_input_seeds_run_date(self, states):
-        merged = states["InitializeInput"]["Parameters"]["merged.$"]
-        assert "run_date" in merged
-        assert "$$.Execution.StartTime" in merged
-        assert "States.Format" in merged
-
-
-class TestEdges:
-    def test_arctic_append_success_enters_scanner_gate(self, states):
-        success = [
-            c["Next"]
-            for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
-        ]
-        assert success == ["CheckSkipScanner"]
-
-    def test_data_phase_continue_paths_enter_scanner_gate(self, states):
-        assert states["CheckSkipMorningEnrich"]["Choices"][0]["Next"] == (
-            "CheckSkipScanner"
-        )
-        assert states["CheckMorningEnrichSpotLaunched"]["Default"] == (
-            "CheckSkipScanner"
-        )
-        assert states["CheckMorningArcticAppendSpotLaunched"]["Default"] == (
-            "CheckSkipScanner"
-        )
-        pub = states["PublishDataSpotFailureImmediate"]
-        assert pub["Next"] == "CheckSkipScanner"
-        assert pub["Catch"][0]["Next"] == "CheckSkipScanner"
-
-    def test_scanner_success_and_catch_converge_on_predictor_gate(self, states):
-        assert states["Scanner"]["Next"] == "CheckSkipPredictorInference"
-        catches = states["Scanner"]["Catch"]
-        # alpha-engine-config#6722: the Catch now routes through
-        # SetScannerDegradedFlag before converging on
-        # CheckSkipPredictorInference exactly as before.
-        assert any(
-            c["Next"] == "SetScannerDegradedFlag"
-            and "States.ALL" in c["ErrorEquals"]
-            for c in catches
-        )
-        # config-I6903: PublishScannerFailureImmediate now sits between the
-        # flag and the gate. The edge that matters is CONVERGENCE — both the
-        # success and the fail-open path reach CheckSkipPredictorInference —
-        # and it survives inserting the notification the fail-open was missing.
-        assert states["SetScannerDegradedFlag"]["Next"] == "PublishScannerFailureImmediate"
-        publish = states["PublishScannerFailureImmediate"]
-        assert publish["Next"] == "CheckSkipPredictorInference"
-        assert publish["Catch"][0]["Next"] == "CheckSkipPredictorInference", (
-            "an SNS failure must not abort a pipeline that deliberately continued"
+    def test_the_weekly_pipeline_still_has_a_scanner(self, weekly):
+        present = {n for n, _ in _walk(weekly["States"])}
+        assert "Scanner" in present, (
+            "step_function.json lost its Scanner state — the weekly pipeline is "
+            "now the ONLY place the two cuts are formed (I7811)"
         )
 
-    def test_no_direct_edge_from_arctic_to_predictor_bypassing_scanner(self, states):
-        """Regression: Arctic success must not skip the new Scanner gate."""
-        success = [
-            c["Next"]
-            for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
-            if c.get("StringEquals") == "Success"
-        ]
-        assert "CheckSkipPredictorInference" not in success
-
-
-class TestResultPaths:
-    def test_success_result_lands_under_scanner_result(self, states):
-        assert states["Scanner"]["ResultPath"] == "$.scanner_result"
-
-    def test_failure_result_lands_under_scanner_error(self, states):
-        catch_all = next(
-            c for c in states["Scanner"]["Catch"] if "States.ALL" in c["ErrorEquals"]
+    def test_the_weekly_scanner_invokes_the_scanner_lambda(self, weekly):
+        scanner = dict(_walk(weekly["States"]))["Scanner"]
+        payload = json.dumps(scanner.get("Parameters", {}))
+        assert "alpha-engine-research-scanner" in payload, (
+            "the weekly Scanner must still invoke the scanner Lambda"
         )
-        assert catch_all["ResultPath"] == "$.scanner_error"

--- a/tests/test_sf_data_spot_relocation_wiring.py
+++ b/tests/test_sf_data_spot_relocation_wiring.py
@@ -149,8 +149,8 @@ class TestWeekdayFailureIsolation:
     # alpha-engine-config-I2717 (2026-07-16): the continue path used to be the
     # CheckSkipChronicGapHeal gate; that gate (and the heal behind it) was
     # removed entirely. alpha-engine-config-I6494: the continue path now
-    # rejoins at CheckSkipScanner (weekday Scanner before PredictorInference).
-    _CONTINUE = "CheckSkipScanner"
+    # rejoins at CheckSkipPredictorInference (I7811 removed the weekday Scanner).
+    _CONTINUE = "CheckSkipPredictorInference"
 
     def test_launch_catch_is_fail_open(self, daily):
         for name in ("LaunchMorningEnrichSpot", "LaunchMorningArcticAppendSpot"):

--- a/tests/test_sf_drift_gate_families.py
+++ b/tests/test_sf_drift_gate_families.py
@@ -235,6 +235,9 @@ def test_resultpath_threading_survives_to_check_degraded_outcome(sf, states):
     # alpha-engine-config#6722 added SetMutexAcquireDegradedFlag (mutex
     # acquire infra-error fail-open) and SetScannerDegradedFlag (weekday
     # Scanner fail-open) as two more Option-A-shaped setters.
+    # I7811 (Brian ruling 2026-08-20) removed SetScannerDegradedFlag with the
+    # weekday Scanner — the scanner forms its cuts WEEKLY now, so there is no
+    # weekday scanner failure left to fail open.
     overwriters = {
         name
         for name, st in states.items()
@@ -245,7 +248,6 @@ def test_resultpath_threading_survives_to_check_degraded_outcome(sf, states):
         "SetDaemonDegradedFlag",
         "SetDataSpotDegradedFlag",
         "SetMutexAcquireDegradedFlag",
-        "SetScannerDegradedFlag",
     }
 
 

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -251,10 +251,10 @@ _WEEKDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # payload so the spot box carries per-run identity tags for cost attribution.
     "LaunchMorningEnrichSpot": frozenset({"workload", "force_on_demand.$", "execution_id.$"}),
     "LaunchMorningArcticAppendSpot": frozenset({"workload", "force_on_demand.$", "execution_id.$"}),
-    # alpha-engine-config-I6494: weekday Scanner — same Lambda as Saturday SF
-    # Scanner, payload is run_date only (no research_dry / dry_run_llm on the
-    # weekday cadence).
-    "Scanner": frozenset({"run_date.$"}),
+    # alpha-engine-config-I7811 (Brian ruling 2026-08-20): the weekday Scanner
+    # entry was REMOVED with the state. The scanner forms its two cuts WEEKLY,
+    # on the Saturday pipeline, whose own "Scanner" payload registry entry above
+    # is unaffected.
 }
 
 

--- a/tests/test_sf_weekday_skipgate_wiring.py
+++ b/tests/test_sf_weekday_skipgate_wiring.py
@@ -36,7 +36,7 @@ alpha-engine-config-I2717/I2722 (2026-07-16): the CheckSkipChronicGapHeal gate
 + ChronicGapSelfHeal (and its liveness-poll quintet) were REMOVED entirely —
 the heal moved to a standalone EventBridge-triggered daily job, off this SF's
 critical path. alpha-engine-config-I6494: CheckSkipMorningEnrich's skip edge
-and the data-phase spot success edges now route to CheckSkipScanner (weekday
+and the data-phase spot success edges now route to CheckSkipPredictorInference (the weekday
 Scanner before PredictorInference). Likewise PredictorHealthCheck +
 PredictorDriftCheck were REMOVED and re-homed onto their own direct
 EventBridge triggers — CoverageGapChoice and FinalCoverageGate (the
@@ -68,11 +68,13 @@ _SF_PATH = _REPO_ROOT / "infrastructure" / "step_function_daily.json"
 # (gate, task, skip_flag, next_gate) in pipeline order.
 # alpha-engine-config-I2717: CheckSkipChronicGapHeal + ChronicGapSelfHeal
 # removed entirely. alpha-engine-config-I6494: CheckSkipMorningEnrich's skip
-# edge now routes to CheckSkipScanner (weekday Scanner still runs when the
+# edge now routes to CheckSkipPredictorInference (the weekday Scanner was removed by I7811 when the
 # spot data phase is skipped); Scanner then joins CheckSkipPredictorInference.
 _CHAIN = [
-    ("CheckSkipMorningEnrich", "LaunchMorningEnrichSpot", "skip_morning_enrich", "CheckSkipScanner"),
-    ("CheckSkipScanner", "Scanner", "skip_scanner", "CheckSkipPredictorInference"),
+    # I7811 (Brian ruling 2026-08-20): the scanner forms its cuts WEEKLY, so
+    # CheckSkipScanner/Scanner are gone from this pipeline and the morning-enrich
+    # skip lands on the predictor gate directly.
+    ("CheckSkipMorningEnrich", "LaunchMorningEnrichSpot", "skip_morning_enrich", "CheckSkipPredictorInference"),
     ("CheckSkipPredictorInference", "PredictorInference", "skip_predictor_inference", "CheckSkipMorningPlanner"),
     ("CheckSkipMorningPlanner", "RunMorningPlanner", "skip_morning_planner", "CheckSkipRunDaemon"),
     # config#2857 + alpha-engine-config#6692: the skip edge now routes through
@@ -178,12 +180,13 @@ class TestEntryEdgesRouteThroughGates:
 
     def test_arctic_append_spot_success_enters_scanner_gate(self, states):
         # config#1767: the Arctic append also runs on its own spot; its Success
-        # rejoins the trading path at CheckSkipScanner (alpha-engine-config-I6494:
+        # rejoins the trading path at CheckSkipPredictorInference (I7811; was CheckSkipScanner under I6494:
         # weekday Scanner runs before PredictorInference). I2717 removed the
         # intermediate CheckSkipChronicGapHeal gate (heal moved standalone).
         success = [c["Next"] for c in states["CheckMorningArcticAppendSpotStatus"]["Choices"]
                    if c.get("StringEquals") == "Success"]
-        assert success == ["CheckSkipScanner"]
+        # I7811: the scanner gate is gone; the data phase rejoins at the predictor gate.
+        assert success == ["CheckSkipPredictorInference"]
 
     def test_data_phase_no_longer_on_trading_box(self, states):
         # config#1767 deliverable #2: the trading path retains NO data-phase SSM
@@ -305,8 +308,7 @@ class TestPaths:
         order = self._walk(states, "CheckSkipMorningEnrich", skip_flags={"skip_morning_enrich"})
         assert "LaunchMorningEnrichSpot" not in order
         assert "LaunchMorningArcticAppendSpot" not in order
-        assert order[0] == "Scanner"
-        assert order.index("Scanner") < order.index("PredictorInference")
+        assert order[0] == "PredictorInference"
         assert order[-1] == "PipelineComplete"
 
     def test_happy_path_runs_data_phase_on_spot(self, states):
@@ -317,5 +319,4 @@ class TestPaths:
         # Enrich spot precedes append spot precedes Scanner precedes
         # PredictorInference (I6494); I2717 removed chronic-gap-heal hop.
         assert order.index("LaunchMorningEnrichSpot") < order.index("LaunchMorningArcticAppendSpot")
-        assert order.index("LaunchMorningArcticAppendSpot") < order.index("Scanner")
-        assert order.index("Scanner") < order.index("PredictorInference")
+        assert order.index("LaunchMorningArcticAppendSpot") < order.index("PredictorInference")

--- a/tests/test_weekday_sf_rerun.py
+++ b/tests/test_weekday_sf_rerun.py
@@ -105,10 +105,13 @@ class TestDerivePlan:
         plan = mod.derive_plan(mod.DAILY, _events("daily_mid_failure"))
         assert plan.run_date == "2026-08-07"
         assert "InitializeInput" in plan.run_date_provenance
-        assert plan.completed == ["morning_enrich", "scanner"]
+        # I7811 removed the `scanner` stage from the weekday pipeline — the
+        # fixture's history still contains its events, and the helper correctly
+        # no longer derives a stage from them.
+        assert plan.completed == ["morning_enrich"]
         assert plan.failed == ["predictor_inference"]
         assert plan.degraded == []
-        assert set(plan.skip_flags) == {"skip_morning_enrich", "skip_scanner"}
+        assert set(plan.skip_flags) == {"skip_morning_enrich"}
         # daily PRESERVES the original pipeline_role (role-unconditional gates)
         assert plan.emitted_role == "daily"
         assert "skip_predictor_inference" not in plan.skip_flags


### PR DESCRIPTION
## Ruling

**Brian, 2026-08-20:** *"the scanner should be running weekly, generating the two groups, and then this should be what gets passed into research and/or predictor - on a weekly basis."*

This reverses `alpha-engine-config-I6494` Ruling A (2026-08-04). Recorded as a delta rather than a silent re-flip.

## The original justification does not survive measurement

I6494 Ruling A said:

> *"Predictor daily inference still depends on `universe_membership` freshness (`MEMBERSHIP_MAX_AGE_DAYS`); a weekday-stale cut is the failure mode I4818 was opened for."*

Measured 2026-08-20: `crucible-predictor/inference/stages/load_universe.py:113` sets `MEMBERSHIP_MAX_AGE_DAYS = 10` and walks back that far. **A weekly cut is at most 7 days old and never trips the gate that justified daily formation.**

The second reason is what it cost. Daily formation is what put the Scanner on the 06:30-market-open critical path at all, and on 2026-08-20 it hit its 450s Lambda ceiling there and degraded the preopen run — the second ceiling collision in nine days (`alpha-engine-config-I7812`).

## Nothing new is built

The weekly pipeline **already** forms the cut: `step_function.json`'s `ResearchPredictorParallel/Scanner`. The weekday copy is removed and the weekly one becomes the only one — which is what it was before 2026-08-04.

- `Scanner`, `CheckSkipScanner`, `SetScannerDegradedFlag`, `PublishScannerFailureImmediate` removed from `step_function_daily.json`. The three edges that converged on `CheckSkipScanner` now converge on `CheckSkipPredictorInference`, where the whole block already terminated.
- The observe-only leaderboards ride the Scanner invocation, so they leave the daily path with it — `I7813`, satisfied by this removal rather than a separate flag.
- `scripts/weekday_sf_rerun.py` — the `scanner` stage leaves the DAILY table. A table still naming it would emit `skip_scanner` into a definition with no gate to read it, and the helper's own coherence check would reject its own output.
- `tests/test_sf_daily_scanner_wiring.py` becomes a **retirement guard** in the `I7817` shape: it fails if the Scanner returns to the weekday pipeline without a ruling, **and** asserts the weekly one still exists. A change that removed both would satisfy "not in the daily pipeline" while silently ending scanning altogether — hidden for a week and a half by the predictor's own 10-day age walk.

## Consequence, accepted and stated

A failed Saturday scan is no longer repaired by Monday's run; the cut goes stale for the week. It is **detected** — the `ARTIFACT_REGISTRY` rows move to the weekly cadence in `alpha-engine-config-PR7820`, so the freshness monitor pages on a miss — and recovered by an operator replay, which `weekday_sf_rerun.py` already supports.

## Test plan

- **2780 passed** across every SF-touching module. The 2 failures are this laptop's venv (`nousergon-lib` 0.124.70 installed against the repo's 0.124.74 pin) and are identical on `origin/main`.
- All four definitions return `result=OK` from `aws stepfunctions validate-state-machine-definition`.
- 31 tests failed on the removal before being updated; each was a structural pin on the old topology, and the largest (`test_sf_daily_scanner_wiring.py`, 11 tests) was rewritten as the guard rather than deleted.

Rehearsal-path: tests/test_sf_daily_scanner_wiring.py — a Choice/state-topology change, validated against the real AWS API and pinned structurally; no live trading morning is involved.

Verified-when: the next weekday preopen execution contains no `Scanner` state and `PredictorInference` resolves the standing weekly `universe_membership` through the existing age walk.

## Cross-repo — merge order is not optional

1. **`crucible-executor-PR484`** — `signal_reader` reads `scanner/universe/{run_date}` by exact date and is fail-soft, so without it weekly formation silently switches the optimizer's ADV\$ off four days in five, with nothing raising.
2. **this PR**
3. **`alpha-engine-config-PR7820`** — registry cadences, or the freshness monitor pages every weekday for an emission we deliberately stopped.

Tracked: `alpha-engine-config-I7811`, `I7813`. Related: `I7812`, `I7814`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
