### PR TITLE
fix(rerun): weekday_sf_rerun emits the market-hours override (config-I7807)

### DIFF
--- a/scripts/weekday_sf_rerun.py
+++ b/scripts/weekday_sf_rerun.py
@@ -251,6 +251,10 @@ class RerunPlan:
     skip_flags: dict = field(default_factory=dict)   # flag -> True
     warnings: list = field(default_factory=list)
     notes: list = field(default_factory=list)
+    # config-I7807: populated only for a preopen recovery started while the
+    # NYSE session is open. None on every other path, so a run that does not
+    # need the override never silently carries one.
+    market_hours_override: dict | None = None
 
     def rerun_input(self) -> dict:
         out = dict(self.original_input)
@@ -258,6 +262,21 @@ class RerunPlan:
         if self.emitted_role is not None:
             out["pipeline_role"] = self.emitted_role
         out.update(self.skip_flags)
+        # alpha-engine-config-I7807. A recovery started while the NYSE session
+        # is open halts at MarketHoursBoundary without this field, so a helper
+        # whose whole purpose is "recovery is ONE mechanical command"
+        # (sf-pipeline-policy §2.5) was emitting an input guaranteed to fail on
+        # the case it exists for. Measured 2026-08-20 against the morning's
+        # failed preopen: the printed input carried no override, and the same
+        # shape shows twice on 2026-08-19 — operator-rerun-...-151046 FAILED in
+        # 3s, then ...-151134-override SUCCEEDED, the same command run twice
+        # with a field added by hand.
+        #
+        # §3 makes the override "the normal instrument of this rule, not an
+        # exception to it": the boundary exists to make an in-session start
+        # DELIBERATE and AUDITABLE, not rare.
+        if self.market_hours_override is not None:
+            out["market_hours_override"] = self.market_hours_override
         return out
 
 
@@ -384,6 +403,78 @@ def _print_plan(pipeline: Pipeline, plan: RerunPlan, source_arn: str, source_sta
     )
 
 
+# ── config-I7807: the same-day recovery override ─────────────────────────────
+
+def market_is_open(sf_region: str, when: str | None = None) -> tuple[bool, dict]:
+    """Ask the SAME Lambda action `MarketHoursGate` asks.
+
+    Deliberately not a local calendar. The gate this override exists to cross
+    is decided by `alpha-engine-predictor-inference:live` / `check_market_hours`,
+    and a second implementation here could disagree with it — which would either
+    attach an override to a run that does not need one, or withhold it from a run
+    that does, on a holiday or an early close. One answer, one owner.
+    """
+    import boto3
+    lam = boto3.client("lambda", region_name=sf_region)
+    payload = {"action": "check_market_hours", "execution_input": {}}
+    if when:
+        payload["now"] = when
+    resp = lam.invoke(
+        FunctionName="alpha-engine-predictor-inference:live",
+        Payload=json.dumps(payload).encode(),
+    )
+    body = json.loads(resp["Payload"].read())
+    return bool(body.get("is_market_hours")), body
+
+
+def pipeline_is_preopen(pipeline) -> bool:
+    """Only the preopen pipeline can cross the market-hours boundary — the
+    postclose one runs after the close by construction."""
+    return getattr(pipeline, "sm_arn", "").endswith("ne-preopen-trading-pipeline")
+
+
+def session_close_utc(gate: dict) -> str:
+    """Today's NYSE close, in UTC, from the gate's own answer.
+
+    `now_et` and `session_window_et` (e.g. "09:30-16:00") both come back from
+    the gate, so the close is read from the same source that decides the
+    boundary rather than hardcoded — an early-close day has a different window
+    and the override must not outlive it.
+    """
+    from datetime import datetime
+
+    base = datetime.fromisoformat(gate.get("now_et") or "")
+    window = gate.get("session_window_et") or "09:30-16:00"
+    hh, mm = (int(x) for x in window.split("-")[-1].strip().split(":"))
+    close_et = base.replace(hour=hh, minute=mm, second=0, microsecond=0)
+    offset = close_et.utcoffset()
+    if offset is None:
+        return close_et.isoformat() + "Z"
+    return (close_et - offset).replace(tzinfo=None).isoformat() + "Z"
+
+
+def build_market_hours_override(
+    *, source_arn: str, source_status: str, authorized_by: str,
+    reason: str | None, expires_at: str,
+) -> dict:
+    """The `{reason, authorized_by, expires_at}` shape `RecordMarketHoursOverride`
+    consumes. `reason` defaults to the sentence the two successful recoveries
+    used, naming the source execution and the standing rule — §3 wants the
+    crossing auditable, and an operator retyping it each time is how it stops
+    being."""
+    default = (
+        f"Same-day recovery of {source_status} preopen execution "
+        f"{source_arn.rsplit(':', 1)[-1]}. Standing rule sf-pipeline-policy §3 "
+        f"(SFP-3-preopen-same-day-relaunch): a failed preopen is always "
+        f"relaunched while the NYSE session is open."
+    )
+    return {
+        "reason": reason or default,
+        "authorized_by": authorized_by,
+        "expires_at": expires_at,
+    }
+
+
 def main(argv: list | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     ap.add_argument("--execution-arn", required=True,
@@ -392,6 +483,18 @@ def main(argv: list | None = None) -> int:
     mode.add_argument("--dry-run", action="store_true", help="derive + print only (default)")
     mode.add_argument("--start", action="store_true", help="StartExecution with the derived input")
     ap.add_argument("--region", default="us-east-1")
+    # config-I7807 — the same-day recovery override (sf-pipeline-policy §3).
+    ap.add_argument(
+        "--authorized-by",
+        help="who authorized crossing the market-hours boundary. REQUIRED when "
+             "recovering a preopen execution while the NYSE session is open — "
+             "§3 makes the crossing auditable, not rare.",
+    )
+    ap.add_argument(
+        "--market-hours-override-reason",
+        help="override the generated reason line (defaults to one naming the "
+             "source execution and the SFP-3 standing rule)",
+    )
     args = ap.parse_args(argv)
 
     pipeline = pipeline_for_execution_arn(args.execution_arn)
@@ -413,6 +516,40 @@ def main(argv: list | None = None) -> int:
     events = fetch_history(sf, args.execution_arn)
     plan = derive_plan(pipeline, events, start_time=desc.get("startDate"))
     name = operator_rerun_name(plan.run_date)
+
+    # config-I7807: attach the market-hours override when, and only when, the
+    # recovery would cross the boundary. Probed from the gate's own Lambda so
+    # this cannot disagree with the state that enforces it.
+    if pipeline_is_preopen(pipeline):
+        is_open, gate = market_is_open(args.region)
+        if is_open:
+            if not args.authorized_by:
+                raise SystemExit(
+                    "FATAL: the NYSE session is open "
+                    f"({gate.get('now_et')}, {gate.get('reason')!r}), so this "
+                    "recovery crosses the market-hours boundary and needs "
+                    "--authorized-by. sf-pipeline-policy §3 makes that crossing "
+                    "DELIBERATE and AUDITABLE — it does not make it rare, and "
+                    "the standing rule is that a failed preopen is relaunched "
+                    "for as long as the market is open."
+                )
+            plan.market_hours_override = build_market_hours_override(
+                source_arn=args.execution_arn,
+                source_status=source_status,
+                authorized_by=args.authorized_by,
+                reason=args.market_hours_override_reason,
+                expires_at=session_close_utc(gate),
+            )
+            plan.notes.append(
+                "market_hours_override attached — NYSE is OPEN "
+                f"({gate.get('now_et')}); "
+                f"expires_at={plan.market_hours_override['expires_at']}"
+            )
+        else:
+            plan.notes.append(
+                "no market_hours_override needed — NYSE is closed "
+                f"({gate.get('now_et')}, {gate.get('reason')!r})"
+            )
 
     # Role-gating check against the LIVE definition — protects against the
     # SF drifting away from the role assumption PIPELINES encodes (adding

--- a/tests/test_weekday_sf_rerun_market_hours_override.py
+++ b/tests/test_weekday_sf_rerun_market_hours_override.py
@@ -1,0 +1,152 @@
+"""`weekday_sf_rerun.py` emits the market-hours override (config-I7807).
+
+`sf-pipeline-policy` §2.5 sets the target — *mean operator actions to recover
+from any single-stage failure = 1*. §3's standing rule says a failed preopen is
+relaunched **while the NYSE session is open**, and §3's reconciliation clause
+makes `market_hours_override` *"the normal instrument of this rule, not an
+exception to it"*.
+
+The helper did not emit it, so every in-session recovery — the case §2.5 exists
+for — halted at `MarketHoursBoundary`, and the operator hand-wrote the input the
+helper had just printed. Measured twice on 2026-08-19:
+`operator-rerun-2026-08-19-151046` FAILED in 3s, then
+`...-151134-override` SUCCEEDED — the same command, run twice, the second time
+with a field added by hand. Again on 2026-08-20.
+
+The probe deliberately calls the gate's OWN Lambda action rather than deciding
+market hours locally: a second implementation could disagree with the state that
+enforces the boundary, which would either attach an override to a run that does
+not need one or withhold it from a run that does, on a holiday or an early
+close.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "weekday_sf_rerun.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("weekday_sf_rerun", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: the module defines dataclasses, and
+    # `dataclasses._is_type` resolves the defining module out of `sys.modules`
+    # — an unregistered one raises AttributeError at class-creation time.
+    sys.modules["weekday_sf_rerun"] = mod
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+_OPEN_GATE = {
+    "is_market_hours": True,
+    "now_et": "2026-08-20T11:15:00-04:00",
+    "session_window_et": "09:30-16:00",
+    "reason": "regular-session",
+}
+
+
+# ── the override's shape ─────────────────────────────────────────────────────
+
+
+def test_it_carries_the_three_fields_the_sf_consumes():
+    ov = mod.build_market_hours_override(
+        source_arn="arn:aws:states:us-east-1:1:execution:ne-preopen-trading-pipeline:abc123",
+        source_status="FAILED",
+        authorized_by="brian@nousergon.ai",
+        reason=None,
+        expires_at="2026-08-20T20:00:00Z",
+    )
+    assert set(ov) == {"reason", "authorized_by", "expires_at"}
+    assert ov["authorized_by"] == "brian@nousergon.ai"
+
+
+def test_the_default_reason_names_the_source_and_the_standing_rule():
+    """§3 wants the crossing auditable. A reason an operator has to retype every
+    time is how it stops being."""
+    ov = mod.build_market_hours_override(
+        source_arn="arn:aws:states:us-east-1:1:execution:ne-preopen-trading-pipeline:abc123",
+        source_status="FAILED",
+        authorized_by="x",
+        reason=None,
+        expires_at="2026-08-20T20:00:00Z",
+    )
+    assert "abc123" in ov["reason"]
+    assert "FAILED" in ov["reason"]
+    assert "SFP-3-preopen-same-day-relaunch" in ov["reason"]
+
+
+def test_an_explicit_reason_wins():
+    ov = mod.build_market_hours_override(
+        source_arn="arn:...:abc123", source_status="FAILED", authorized_by="x",
+        reason="because I said so", expires_at="2026-08-20T20:00:00Z",
+    )
+    assert ov["reason"] == "because I said so"
+
+
+# ── expiry comes from the gate, not a constant ───────────────────────────────
+
+
+def test_expires_at_is_todays_close_in_utc():
+    assert mod.session_close_utc(_OPEN_GATE) == "2026-08-20T20:00:00Z"
+
+
+def test_an_early_close_shortens_the_override():
+    """A hardcoded 20:00Z would outlive a 13:00 ET half-day close and leave a
+    valid override sitting past the session it authorized."""
+    early = dict(_OPEN_GATE, session_window_et="09:30-13:00")
+    assert mod.session_close_utc(early) == "2026-08-20T17:00:00Z"
+
+
+# ── it lands in the emitted input, and only when needed ──────────────────────
+
+
+def _plan(**kw):
+    return mod.RerunPlan(
+        pipeline_key="daily",
+        run_date="2026-08-20",
+        run_date_provenance="test",
+        original_input={"pipeline_role": "daily"},
+        emitted_role="daily",
+        **kw,
+    )
+
+
+def test_the_override_reaches_the_start_execution_input():
+    ov = {"reason": "r", "authorized_by": "a", "expires_at": "2026-08-20T20:00:00Z"}
+    assert _plan(market_hours_override=ov).rerun_input()["market_hours_override"] == ov
+
+
+def test_a_plan_without_one_emits_no_key_at_all():
+    """A run that does not need the override must not silently carry one — an
+    override attached to an out-of-hours start is an unconsidered crossing
+    wearing a deliberate one's clothes."""
+    assert "market_hours_override" not in _plan().rerun_input()
+
+
+# ── the boundary between "needs one" and "does not" ──────────────────────────
+
+
+def test_only_the_preopen_pipeline_can_need_an_override():
+    """The postclose pipeline runs after the close by construction."""
+    class _P:
+        sm_arn = "arn:aws:states:us-east-1:1:stateMachine:ne-postclose-trading-pipeline"
+
+    class _Q:
+        sm_arn = "arn:aws:states:us-east-1:1:stateMachine:ne-preopen-trading-pipeline"
+
+    assert mod.pipeline_is_preopen(_P()) is False
+    assert mod.pipeline_is_preopen(_Q()) is True
+
+
+@pytest.mark.parametrize("window,expected", [("09:30-16:00", "2026-08-20T20:00:00Z"),
+                                             ("09:30-16:15", "2026-08-20T20:15:00Z")])
+def test_the_window_is_read_not_assumed(window, expected):
+    assert mod.session_close_utc(dict(_OPEN_GATE, session_window_et=window)) == expected


### PR DESCRIPTION
## Why

`sf-pipeline-policy` §2.5 sets the target — *mean operator actions to recover from any single-stage failure = 1* — and §3's standing rule says a failed preopen is relaunched **while the NYSE session is open**. §3's reconciliation clause makes `market_hours_override` *"the normal instrument of this rule, not an exception to it"*.

**The helper did not emit it.** So every in-session recovery — the case §2.5 exists for — halted at `MarketHoursBoundary`, and the operator hand-wrote the input the helper had just printed.

Measured twice on 2026-08-19: `operator-rerun-2026-08-19-151046` FAILED in 3s, then `...-151134-override` SUCCEEDED — the same command run twice, the second time with a field added by hand. Again on 2026-08-20, which is where this was found.

## Changes

- `--authorized-by` and `--market-hours-override-reason`. The first is **required** when the session is open: §3 makes the crossing deliberate and auditable, not rare, so the helper refuses rather than guessing an authorizer.
- The reason defaults to a line naming the source execution, its status and the `SFP-3` clause — the shape both successful recoveries used. A reason an operator retypes each time is how "auditable" stops being true.
- **Market hours are probed from the gate's own Lambda action** (`alpha-engine-predictor-inference:live` / `check_market_hours`), not decided locally. A second implementation could disagree with the state that enforces the boundary, which would either attach an override to a run that does not need one or withhold it from one that does — on a holiday or an early close.
- `expires_at` is derived from the gate's own `session_window_et`, not hardcoded. A 13:00 ET half-day close must not leave a valid override sitting past the session it authorized.
- A plan that does not need one **emits no key at all**. An override on an out-of-hours start is an unconsidered crossing wearing a deliberate one's clothes.

## Test plan

`tests/test_weekday_sf_rerun_market_hours_override.py` — 10 new tests: the emitted shape, the default reason's contents, the UTC close derivation **including an early close**, that the override reaches the `StartExecution` input, that its absence emits no key, and that only the preopen pipeline can need one.

The new module registers itself in `sys.modules` before `exec_module` — the script defines dataclasses, and `dataclasses._is_type` resolves the defining module out of `sys.modules`, so an unregistered one raises at class-creation time. Same idiom `test_weekday_sf_rerun.py` already uses.

Suite: **2796 passed** across every SF-touching module. The 2 failures are this laptop's venv (`nousergon-lib` 0.124.70 against the repo's 0.124.74 pin), identical on `origin/main`.

Rehearsal-path: tests/test_weekday_sf_rerun_market_hours_override.py — the helper is operator-invoked and its output is pure; no live pipeline run is involved.

Tracked: `alpha-engine-config-I7807`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)