### PR TITLE
fix(flow-doctor): declare diagnosis.provider explicitly (alpha-engine-config-I7855)

### DIFF
--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -82,10 +82,21 @@ github:
 # LLM root-cause diagnosis. Required for fix-PR generation (the fix CLI
 # reads the diagnosis metadata embedded in the issue body). Haiku for the
 # soak — cheap; the hard daily dollar cap is the cost backstop.
+#
+# provider: router — resolves a krepis router capability class instead of
+# holding a direct-vendor key. flow-doctor 0.15.0 removed the implicit
+# "anthropic" default (Brian ruling; the fleet's Anthropic account carries
+# a $0 balance — alpha-engine-config-I7460 — and flow-doctor must not
+# construct a direct-Anthropic client anywhere); an unset provider is now a
+# loud ConfigError at import time instead of a silent vendor pick. "router"
+# needs no api_key (krepis resolves the credential) — model_group="low"
+# matches the prior Haiku-tier cost intent; `model` is retained for
+# logging/labeling only, the router resolves the actual model.
 diagnosis:
   enabled: true
+  provider: router
+  model_group: low
   model: claude-haiku-4-5
-  api_key: ${ANTHROPIC_API_KEY}
   max_daily_cost_usd: 0.50
 
 # Auto-fix-PR generation (runs in the flow-doctor-fix GitHub Actions

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,4 +121,14 @@ nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nouse
 # cannot run the commands the SF emits. 0.18.8 is also the version that made
 # the correlation id MANDATORY (`run` exits 2 without it), so this floor pins
 # both halves of the same contract. See tests/test_sf_krepis_correlation_id.py.
+# NOTE (this PR, flow-doctor-provider fix): krepis==0.59.12's own
+# `flow_doctor` extra caps `flow-doctor[diagnosis,s3]` to `<0.10` — a version
+# that predates RouterProvider (added 0.12.0) entirely, so the
+# `diagnosis.provider: router` set below in flow-doctor.yaml is inert until
+# nousergon-data-PR1456 (dependabot: krepis 0.59.12 -> 0.59.18) merges.
+# 0.59.18 is the first krepis release carrying krepis-PR168, which drops the
+# stale `<0.14` cap and the forced `anthropic` SDK pull. Sequence: PR1456
+# before or together with this PR — see tests/test_flow_doctor_wiring.py's
+# test_diagnosis_enabled_requires_explicit_provider docstring for why the
+# schema-level guard does not depend on the installed flow-doctor version.
 krepis==0.59.12  # pinned per §139 — first-party/fast-moving deps are pinned, never floored; alpha-engine-config-I7009 (relaunch-decision --json), I7372 (spot_bootstrap: scan_for_inline_bootstraps + --max-runtime-seconds + extra_clones, all first shipped in 0.59.6). Bumped 0.59.6 -> 0.59.12 for krepis.aws_region.resolve_region() (krepis-PR160, alpha-engine-config-I7428) — validators/stage_output_sweep.py's stepfunctions client needs it. main was at 0.59.11 when krepis-PR160 opened; VERIFIED 2026-08-17 after that merge — autobump published exactly 0.59.12, present on both the PyPI JSON API and the simple index (separate caches; a pin chained behind a release fails with an error reading exactly like 'that version does not exist').

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -185,6 +185,65 @@ class TestFlowDoctorYamlSchema:
         assert cfg["flow_name"] == "data-collector"
         assert cfg["repo"] == "nousergon/nousergon-data"
 
+    def test_diagnosis_enabled_requires_explicit_provider(self):
+        """A config that enables diagnosis must name its provider.
+
+        flow-doctor 0.15.0 made an unset ``diagnosis.provider`` a loud
+        ConfigError at ``load_config`` time (Brian ruling: no default LLM
+        vendor, ever). This repo's pinned krepis==0.59.12 still resolves an
+        older flow-doctor (<0.10 per that krepis release's own `flow_doctor`
+        extra cap) whose parser silently defaulted `provider` to
+        `"anthropic"` instead of raising — so the installed library cannot
+        be relied on to catch this class of bug in CI today, only in a
+        strict-mode production init once the krepis pin catches up
+        (nousergon-data-PR1456). This assertion is therefore a plain
+        schema check on the yaml itself, independent of whatever
+        flow-doctor version happens to be installed: it is what let
+        alpha-engine-data-collector deploy v341 with `diagnosis.enabled:
+        true` and no `provider:` key, crashing at Lambda cold-start
+        (Runtime.ExitError, INIT_REPORT status=error) instead of failing
+        this test.
+        """
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        diagnosis = cfg.get("diagnosis")
+        if not diagnosis or not diagnosis.get("enabled"):
+            return
+        provider = diagnosis.get("provider")
+        assert provider in ("router", "openai_compat"), (
+            f"diagnosis.enabled=True requires diagnosis.provider to be "
+            f"'router' or 'openai_compat', got {provider!r} — flow-doctor "
+            f"has no default LLM vendor (0.15.0)."
+        )
+        if provider == "router":
+            assert diagnosis.get("model_group") in ("low", "med", "high", "ultra"), (
+                "diagnosis.provider='router' requires diagnosis.model_group "
+                "(one of: low, med, high, ultra)"
+            )
+        if provider == "openai_compat":
+            assert diagnosis.get("base_url"), (
+                "diagnosis.provider='openai_compat' requires diagnosis.base_url"
+            )
+
+    def test_auto_fix_diagnosis_provider_agrees(self):
+        """fix/cli.py's FixGenerator reuses diagnosis.provider/model_group
+        verbatim (flow_doctor.fix.cli.generate_fix) — auto_fix.enabled must
+        not be on without the same provider contract diagnosis needs.
+        """
+        import yaml
+        with open(REPO_ROOT / "flow-doctor.yaml") as f:
+            cfg = yaml.safe_load(f)
+        auto_fix = cfg.get("auto_fix")
+        if not auto_fix or not auto_fix.get("enabled"):
+            return
+        diagnosis = cfg.get("diagnosis") or {}
+        assert diagnosis.get("provider") in ("router", "openai_compat"), (
+            "auto_fix.enabled=True generates fixes via diagnosis.provider "
+            "(flow_doctor.fix.cli) — it must be set to 'router' or "
+            "'openai_compat', same as diagnosis above."
+        )
+
     def test_yaml_has_email_and_github_notify_channels(self):
         import yaml
         with open(REPO_ROOT / "flow-doctor.yaml") as f:


### PR DESCRIPTION
## What & why

flow-doctor 0.15.0 removed `diagnosis.provider`'s implicit `"anthropic"` default (Brian ruling — no silent vendor pick). `flow-doctor.yaml` here had `diagnosis.enabled: true` with no `provider:`, which crashed `alpha-engine-data-collector`'s Lambda v341 at cold-start (`ConfigError` raised at `flow_doctor/core/config.py:568` / `load_config`, reached from `krepis.logging._attach_flow_doctor` at MODULE IMPORT, before `handler.py`'s own try/except could run) — canary rolled back to v340.

Sets `diagnosis.provider: router` + `model_group: low` (matches the prior Haiku-tier cost intent; router resolves the model/credential through krepis, needs no `api_key`). Drops the unused `api_key: ${ANTHROPIC_API_KEY}` (fleet Anthropic account is $0-balance, alpha-engine-config-I7460).

Fleet enumeration of every `flow-doctor.yaml` in the org — full table in alpha-engine-config-I7855. **Only this repo currently has `diagnosis.enabled: true`**; no other repo needs a yaml change today.

## Guard added (why it doesn't rely on the installed flow-doctor version)

`tests/test_flow_doctor_wiring.py::TestFlowDoctorYamlSchema::test_diagnosis_enabled_requires_explicit_provider` + `test_auto_fix_diagnosis_provider_agrees` — plain schema assertions on the parsed yaml. Verified both FAIL against the pre-fix yaml and PASS against this fix.

They're schema-level, not a runtime `load_config()` call, because **this repo's pinned `krepis==0.59.12` resolves an older flow-doctor (`<0.10`, via that krepis release's own `flow_doctor` extra cap) whose parser still silently defaults `provider` to `"anthropic"` instead of raising** — the existing wiring test (`TestSetupLoggingAttach`) that already exercises `setup_logging()` against the real yaml could not have caught this under the current pin, and did not. Confirmed by reproducing locally: a fresh venv install of this repo's `requirements.txt` resolves `flow-doctor==0.9.0`, not the `0.15.0` that's live in the Lambda's build.

## Depends on

**`nousergon-data-PR1456`** (already-open dependabot: krepis 0.59.12 -> 0.59.18) must merge before or together with this PR. 0.59.18 is the first krepis release carrying krepis-PR168 (drops the stale `<0.14` flow-doctor cap + forced `anthropic` SDK pull). Until PR1456 lands, `provider: router` set here is inert — the installed flow-doctor doesn't have `RouterProvider` (added 0.12.0) under the current pin. See the `requirements.txt` comment added in this PR.

## Test plan

- [x] `tests/test_flow_doctor_wiring.py` — 17 passed (was 15; 2 new)
- [x] New guard tests verified to fail against the pre-fix yaml, pass against the fix
- [x] Full suite: `6144 passed, 13 skipped` (fresh venv, this repo's `requirements.txt`)

Closes alpha-engine-config-I7855 (cross-repo — closed by hand once verified live, per fleet convention; a closing keyword does not cross repos).

Prepared by: Claude Opus 5 via Claude Code.