### PR TITLE
fix(deploy): canary detects Lambda's native runtime-error envelope (alpha-engine-config-I7855)

### DIFF
--- a/infrastructure/canary_status.py
+++ b/infrastructure/canary_status.py
@@ -1,0 +1,65 @@
+"""Classify a Lambda invoke response for deploy.sh's post-deploy canary.
+
+Extracted from ``deploy.sh``'s inline ``python3 -c ...`` (2026-08-20,
+alpha-engine-config-I7855) so the classification logic is unit-testable and
+the Lambda-native runtime-error envelope isn't silently swallowed.
+
+Detection blindness this closes: an init-time crash (e.g. a ``ConfigError``
+raised at module import, before the handler's own try/except can run) makes
+Lambda return its OWN error shape —
+``{"errorMessage": "...", "errorType": "...", "stackTrace": [...]}`` — which
+carries none of this handler's own contract keys (``status``, ``statusCode``,
+``error``). The old parser fell through every branch to
+``d.get('error', 'UNKNOWN')``, so the canary reported the uninformative
+literal ``UNKNOWN`` and the real diagnosis (the ConfigError's message) was
+discarded — exactly what happened to alpha-engine-data-collector v341's
+rollback: CloudWatch had the real error, the canary output did not.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def classify(payload: dict) -> str:
+    """Return a short classification string for a canary invoke response.
+
+    Checked in order:
+      1. The handler's own contract: ``status`` in (OK, SKIPPED) passes.
+      2. ``statusCode == 500`` -> ``ENV_ERROR`` (handler's own error shape).
+      3. Lambda's NATIVE runtime-error envelope (``errorMessage``/
+         ``errorType`` — present on any init-time or unhandled-exception
+         crash, regardless of what the handler's own contract defines) ->
+         surfaced verbatim as ``"{errorType}: {errorMessage}"`` so the
+         actual cause reaches deploy.sh's stdout instead of ``UNKNOWN``.
+      4. The handler's own free-form ``error`` field, else the literal
+         ``UNKNOWN``.
+    """
+    status = payload.get("status", "")
+    if status in ("OK", "SKIPPED"):
+        return status
+    if payload.get("statusCode") == 500:
+        return "ENV_ERROR"
+    if "errorMessage" in payload or "errorType" in payload:
+        error_type = payload.get("errorType", "UnknownError")
+        error_message = payload.get("errorMessage", "")
+        return f"{error_type}: {error_message}"
+    return str(payload.get("error", "UNKNOWN"))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: canary_status.py <path-to-invoke-response.json>", file=sys.stderr)
+        return 2
+    try:
+        with open(sys.argv[1]) as f:
+            payload = json.load(f)
+    except Exception:
+        print("PARSE_ERROR")
+        return 0
+    print(classify(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -160,17 +160,8 @@ aws lambda invoke \
   --region "$REGION" \
   "$CANARY_OUT" > /dev/null
 
-CANARY_STATUS=$(python3 -c "
-import json, sys
-d = json.load(open('$CANARY_OUT'))
-s = d.get('status', '')
-if s in ('OK', 'SKIPPED'):
-    print(s)
-elif d.get('statusCode') == 500:
-    print('ENV_ERROR')
-else:
-    print(d.get('error', 'UNKNOWN'))
-" 2>/dev/null || echo "PARSE_ERROR")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANARY_STATUS=$(python3 "$SCRIPT_DIR/canary_status.py" "$CANARY_OUT" 2>/dev/null || echo "PARSE_ERROR")
 rm -f "$CANARY_OUT"
 
 if [ "$CANARY_STATUS" != "OK" ] && [ "$CANARY_STATUS" != "SKIPPED" ]; then

--- a/tests/test_canary_status_classify.py
+++ b/tests/test_canary_status_classify.py
@@ -1,0 +1,110 @@
+"""tests/test_canary_status_classify.py
+
+Covers infrastructure/canary_status.py — the classifier deploy.sh's
+post-deploy canary uses to decide roll-forward vs. roll-back.
+
+Root incident (alpha-engine-config-I7855): alpha-engine-data-collector's
+v341 canary invoke crashed at Lambda cold-start (a ConfigError raised at
+module import). The invoke response was Lambda's OWN native error envelope
+(errorMessage/errorType/stackTrace) — not this handler's status/statusCode
+contract at all — and the old inline parser fell through every branch to
+the literal "UNKNOWN", discarding the real cause. deploy.sh's operator (and
+any unattended reader of its output) saw "Canary returned 'UNKNOWN'" instead
+of the actual ConfigError text that was sitting in CloudWatch the whole time.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "infrastructure"))
+
+from canary_status import classify  # noqa: E402
+
+
+class TestHandlerContract:
+    """The handler's own status/statusCode contract, unchanged from before."""
+
+    def test_status_ok_passes(self):
+        assert classify({"status": "OK"}) == "OK"
+
+    def test_status_skipped_passes(self):
+        assert classify({"status": "SKIPPED"}) == "SKIPPED"
+
+    def test_status_code_500_is_env_error(self):
+        assert classify({"statusCode": 500, "body": "boom"}) == "ENV_ERROR"
+
+    def test_free_form_error_field_surfaced(self):
+        assert classify({"status": "FAILED", "error": "quota exceeded"}) == "quota exceeded"
+
+    def test_no_recognizable_shape_is_unknown(self):
+        assert classify({"status": "FAILED"}) == "UNKNOWN"
+
+    def test_empty_payload_is_unknown(self):
+        assert classify({}) == "UNKNOWN"
+
+
+class TestLambdaNativeErrorEnvelope:
+    """The class of bug this file exists to close: an init-time crash
+    returns Lambda's own error shape, which the handler's contract never
+    defines and the old parser silently swallowed as 'UNKNOWN'.
+    """
+
+    def test_init_time_config_error_surfaced_verbatim(self):
+        # Mirrors the actual v341 payload shape (errorType/errorMessage,
+        # stackTrace present but irrelevant to classification).
+        payload = {
+            "errorMessage": (
+                "diagnosis.enabled=True requires diagnosis.provider to be "
+                "set explicitly — flow-doctor has no default LLM vendor."
+            ),
+            "errorType": "ConfigError",
+            "stackTrace": ["  File \"/var/task/handler.py\", line 43, in <module>"],
+        }
+        result = classify(payload)
+        assert result != "UNKNOWN"
+        assert "ConfigError" in result
+        assert "diagnosis.provider" in result
+
+    def test_error_type_present_without_message(self):
+        result = classify({"errorType": "Runtime.ExitError"})
+        assert result.startswith("Runtime.ExitError")
+
+    def test_error_message_present_without_type(self):
+        result = classify({"errorMessage": "boom"})
+        assert "UnknownError" in result
+        assert "boom" in result
+
+    def test_native_envelope_takes_priority_over_free_form_error(self):
+        # A response can't legally carry both in practice, but the native
+        # envelope is Lambda's own signal that init/execution crashed
+        # outside the handler's control — it must win if somehow present
+        # alongside a stale/unrelated 'error' key.
+        payload = {"errorType": "Runtime.ExitError", "errorMessage": "crash", "error": "stale"}
+        assert classify(payload) == "Runtime.ExitError: crash"
+
+
+class TestCLIEntrypoint:
+    def test_main_parses_file_and_prints_classification(self, tmp_path, capsys):
+        import json
+        from canary_status import main
+
+        f = tmp_path / "response.json"
+        f.write_text(json.dumps({"status": "OK"}))
+        sys.argv = ["canary_status.py", str(f)]
+        rc = main()
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "OK"
+
+    def test_main_unparseable_file_prints_parse_error(self, tmp_path, capsys):
+        from canary_status import main
+
+        f = tmp_path / "bad.json"
+        f.write_text("not json")
+        sys.argv = ["canary_status.py", str(f)]
+        rc = main()
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "PARSE_ERROR"


### PR DESCRIPTION
## What & why

`deploy.sh`'s post-deploy canary parser (~lines 154-173) only understood this handler's own `status`/`statusCode` contract. An init-time crash — a raised exception before the handler even runs, e.g. the `ConfigError` that rolled back v341 (alpha-engine-config-I7855, nousergon-data-PR1468) — makes Lambda return its OWN native error shape (`errorMessage`/`errorType`/`stackTrace`), which the old parser fell through every branch to classify as the literal `"UNKNOWN"`, discarding the real cause that was sitting in CloudWatch the whole time.

Per `engagement-protocol-policy.md` §5, detection blindness outranks the defect it hid — this closes the blindness independently of the `ConfigError` fix itself (same root issue, PR1468).

## Change

Extracts the classification logic out of the inline `python3 -c "..."` into `infrastructure/canary_status.py` (now unit-testable), checked in order:
1. handler contract: `status` in `(OK, SKIPPED)` passes
2. `statusCode == 500` -> `ENV_ERROR`
3. **new**: Lambda's native `errorMessage`/`errorType` envelope -> surfaced verbatim as `"{errorType}: {errorMessage}"`
4. handler's own free-form `error` field, else `UNKNOWN`

`deploy.sh` now calls `python3 "$SCRIPT_DIR/canary_status.py" "$CANARY_OUT"` in place of the inline heredoc.

## Test plan

- [x] `tests/test_canary_status_classify.py` — 12 new tests, including a reproduction of the actual v341 payload shape (`errorType: ConfigError`, `errorMessage` containing `diagnosis.provider`) and confirming it is no longer classified `UNKNOWN`
- [x] Full suite: `6154 passed, 13 skipped`
- [x] `shellcheck infrastructure/deploy.sh` — only the pre-existing unrelated `SC2034 BUCKET` warning

Refs alpha-engine-config-I7855. Independent of nousergon-data-PR1468 (same issue, the `ConfigError` root cause) — either can merge first, no ordering dependency between the two.

Prepared by: Claude Opus 5 via Claude Code.