### PR TITLE
fix(systemd-drift): route standing drift to console, widen channel repeat window

### DIFF
--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -536,6 +536,14 @@ def main() -> int:
     if uncodified and args.strict:
         exit_code = max(exit_code, 1)
 
+    # Console publish runs on EVERY invocation — clean or not, `--report` or
+    # not — mirroring crucible-dashboard's box_health_hygiene precedent
+    # (alpha-engine-config-I7857): a surface that only publishes when
+    # something is wrong is indistinguishable from one that has died. This is
+    # DISTINCT from `_report_drift` below, which is the channel alert and
+    # stays gated on `--report` + non-empty findings.
+    _publish_console(findings, installed_count=installed_count, drift_count=len(buckets["drift"]))
+
     if findings:
         print(f"FINDINGS: {len(findings)}", file=sys.stderr)
         for f in findings:
@@ -561,6 +569,84 @@ def main() -> int:
     return exit_code
 
 
+# Timer cadence: systemd-unit-drift-check.timer fires OnCalendar=*-*-*
+# 06:17:00 UTC once daily. Declared honestly per the fleet check-result
+# contract — understating makes the console call this check stale early,
+# overstating lets a dead emitter read healthy for longer than it should.
+CONSOLE_CHECK_ID = "systemd_unit_drift"
+CONSOLE_CADENCE_MINUTES = 1440
+
+
+def _publish_console(findings: list[str], *, installed_count: int, drift_count: int) -> None:
+    """Route the standing-drift finding set to the console (alpha-engine-config-I7857).
+
+    Runs on EVERY invocation, findings or not — see the call site in `main()`.
+    This is DISTINCT from `_report_drift`: that function is the Telegram/SNS
+    channel alert (gated on `--report` and on findings being non-empty); this
+    one is the console's standing-state surface, published unconditionally so
+    the console can tell "clean" apart from "dead" via `ran_at` staleness
+    rather than the absence of a row meaning either.
+
+    Why this exists at all: `_report_drift` used to be the ONLY surface for
+    this finding, at `severity="error"` with a 24h dedup window that matches
+    the timer's own cadence exactly — so an UNCHANGED drift re-pages the
+    channel every single day it stays true, forever, with no new information
+    in the repeat. That is precisely the shape alpha-engine-config-I7857
+    audited: `krepis.alerts`' severity tiering only controls the Telegram
+    phone-push, never delivery, so there was never a tier that would have
+    kept this quiet on its own. The channel alert still fires (drift is a
+    real, actionable finding, not hygiene noise) but its repeat window is
+    widened in the same change (see `_report_drift`) — the console is what
+    makes that safe: the standing set is visible here continuously, with its
+    own count, rather than being remembered only between channel repeats.
+
+    Status is `attention`, never `error`, for a non-empty finding set: this
+    check can tell you drift EXISTS but the console's status vocabulary
+    reserves `error` for "the check itself is blind" (mirrors
+    nousergon-lib's fleet_check_result contract and pause_reconcile.py's
+    `publish_error` in this same repo) — a check that ran and found drift is
+    working exactly as designed, not broken.
+    """
+    try:
+        from nousergon_lib import fleet_check_result as fcr
+    except Exception as e:  # noqa: BLE001 — telemetry must not break the check
+        print(
+            f"[check-systemd-unit-drift] console publish skipped — "
+            f"nousergon_lib.fleet_check_result unavailable: {e}",
+            file=sys.stderr,
+        )
+        return
+
+    status = fcr.STATUS_OK if not findings else fcr.STATUS_ATTENTION
+    if findings:
+        summary = (
+            f"{len(findings)} standing finding(s) ({drift_count} drift) on "
+            f"{socket.gethostname()} out of {installed_count} installed unit(s)"
+        )
+    else:
+        summary = f"{installed_count} installed unit(s), all codified and matching"
+
+    try:
+        fcr.emit_result(
+            check_id=CONSOLE_CHECK_ID,
+            label="Systemd unit drift (installed vs repo)",
+            status=status,
+            summary=summary,
+            cadence_minutes=CONSOLE_CADENCE_MINUTES,
+            findings=[{"id": f"finding-{i}", "detail": f} for i, f in enumerate(findings)],
+            deep_link=(
+                "https://github.com/nousergon/nousergon-data/blob/main/"
+                "infrastructure/systemd/check-systemd-unit-drift.py"
+            ),
+        )
+    except Exception as e:  # noqa: BLE001 — telemetry must not break the check
+        print(
+            f"[check-systemd-unit-drift] console publish failed (best-effort, "
+            f"check result unaffected): {e}",
+            file=sys.stderr,
+        )
+
+
 def _report_drift(findings: list[str]) -> None:
     """Alert on detected systemd unit drift.
 
@@ -583,6 +669,19 @@ def _report_drift(findings: list[str]) -> None:
     `krepis.alerts` is the canonical alert CLI (config#1649). It resolves its
     own secrets, so there is no hydration list here to drift out of sync with
     flow-doctor.yaml.
+
+    **Repeat window widened 1440 -> 43200 (alpha-engine-config-I7857).** The
+    timer runs daily, and the old 1440min (24h) window matched that cadence
+    exactly — so an UNCHANGED drift re-paged the channel every single day it
+    stayed true, with no new information in the repeat. This is the same
+    condition wrongly believed fixed by tuning severity/window before
+    (`krepis.alerts` was never actually gating visibility by severity — see
+    that issue). The dedup KEY still derives from the finding SET, so a
+    drift appearing, clearing, or changing pages IMMEDIATELY regardless of
+    the window; the window governs only how often an UNCHANGED set repeats.
+    30 days mirrors the precedent set by crucible-dashboard's box_health
+    `warning` tier (same audit). The standing set stays continuously visible
+    on the console via `_publish_console` above, independent of this window.
     """
     message = (
         f"systemd unit drift on {socket.gethostname()}: "
@@ -596,11 +695,12 @@ def _report_drift(findings: list[str]) -> None:
             severity="error",
             source="check-systemd-unit-drift",
             # Dedup on the FINDINGS, not the message: the same drift persisting
-            # alerts once a day, while a new finding changes the key and pages.
+            # alerts once per window, while a new finding changes the key and
+            # pages immediately regardless of window.
             dedup_key="unit-drift-" + hashlib.sha256(
                 "|".join(sorted(findings)).encode()
             ).hexdigest()[:16],
-            dedup_window_min=1440,
+            dedup_window_min=43200,
         )
     except Exception as e:
         # Fail LOUD. A silent failure here is the exact defect this rewrite

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -19,6 +19,37 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCRIPT_PATH = _REPO_ROOT / "infrastructure" / "systemd" / "check-systemd-unit-drift.py"
 
 
+class _FakeFcr:
+    """Stand-in for ``nousergon_lib.fleet_check_result`` — no real S3 access.
+
+    Mirrors the pattern in ``tests/test_pause_reconcile.py``. Every module test
+    that reaches ``main()`` now also reaches ``_publish_console`` (alpha-engine-
+    config-I7857), and without this the un-mocked ``fcr.emit`` would construct a
+    real boto3 S3 client and attempt a live PutObject whenever local AWS creds
+    happen to be present — exactly the "tests leaked real fan-out" class this
+    repo's conftest.py already guards against for flow-doctor/SSM.
+    """
+
+    STATUS_OK = "ok"
+    STATUS_ATTENTION = "attention"
+    STATUS_ERROR = "error"
+    calls: list[dict] = []
+
+    @classmethod
+    def build(cls, **kw):
+        return kw
+
+    @classmethod
+    def emit(cls, env, dry_run=False):
+        cls.calls.append(env)
+        return "s3://fake/latest.json"
+
+    @classmethod
+    def emit_result(cls, **kw):
+        env = cls.build(**kw)
+        return cls.emit(env)
+
+
 @pytest.fixture()
 def cd(tmp_path, monkeypatch):
     """Load the module fresh per-test, pointed at an isolated repo+installed dir pair."""
@@ -33,6 +64,10 @@ def cd(tmp_path, monkeypatch):
 
     monkeypatch.setattr(module, "SCRIPT_DIR", script_dir)
     monkeypatch.setattr(module, "INSTALLED_DIR", installed_dir)
+
+    _FakeFcr.calls = []
+    monkeypatch.setitem(sys.modules, "nousergon_lib", type(sys)("nousergon_lib"))
+    monkeypatch.setattr(sys.modules["nousergon_lib"], "fleet_check_result", _FakeFcr, raising=False)
 
     return module, script_dir, installed_dir
 
@@ -155,6 +190,25 @@ class TestDriftReportingPath:
             "'drift detected' sends you to the box to find out what"
         )
 
+    def test_report_dedup_window_widened_past_the_timer_cadence(self, cd, monkeypatch):
+        """alpha-engine-config-I7857: the old 1440min (24h) window matched the
+        daily timer exactly, so an UNCHANGED drift re-paged the channel every
+        single day with no new information. Must now exceed 1440 by a wide
+        margin so the console (not a daily repeat) carries the standing state."""
+        module, _, _ = cd
+        captured = {}
+
+        def fake_publish(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setitem(
+            __import__("sys").modules, "krepis.alerts",
+            type("M", (), {"publish": staticmethod(fake_publish)})
+        )
+        module._report_drift(["a.service: DIVERGED"])
+
+        assert captured["dedup_window_min"] > 1440
+
     def test_report_dedups_on_findings_not_message(self, cd, monkeypatch):
         # Same drift persisting should alert once a day; DIFFERENT drift must
         # produce a different key so it pages immediately.
@@ -220,6 +274,79 @@ class TestDriftReportingPath:
             "exports FlowDoctor/FlowDoctorBuilder. Use krepis.alerts (the "
             "canonical CLI, config#1649)."
         )
+
+
+class TestConsolePublish:
+    """`_publish_console` (alpha-engine-config-I7857) — the standing-drift
+    finding set routed to the console fleet-check surface, published on every
+    run regardless of findings, distinct from the channel alert."""
+
+    def test_publishes_on_clean_run_too(self, cd):
+        """A surface that only publishes when something is wrong is
+        indistinguishable from one that has died — must publish on clean runs."""
+        module, _, _ = cd
+        module._publish_console([], installed_count=4, drift_count=0)
+
+        assert len(_FakeFcr.calls) == 1
+        assert _FakeFcr.calls[0]["status"] == "ok"
+
+    def test_findings_render_as_attention_not_error(self, cd):
+        """A check that ran and found drift is working as designed — `error`
+        is reserved for a check that could not run at all (mirrors
+        pause_reconcile.py's publish_error contract in this same repo)."""
+        module, _, _ = cd
+        module._publish_console(["a.service: DIVERGED"], installed_count=4, drift_count=1)
+
+        assert _FakeFcr.calls[0]["status"] == "attention"
+        assert _FakeFcr.calls[0]["status"] != "error"
+
+    def test_findings_are_carried_in_the_envelope(self, cd):
+        module, _, _ = cd
+        module._publish_console(
+            ["a.service: DIVERGED", "b.timer: DIVERGED"], installed_count=4, drift_count=2,
+        )
+
+        findings = _FakeFcr.calls[0]["findings"]
+        assert len(findings) == 2
+        assert any("a.service" in f["detail"] for f in findings)
+        assert any("b.timer" in f["detail"] for f in findings)
+
+    def test_main_publishes_console_on_every_run_including_clean(self, cd, monkeypatch):
+        """The end-to-end wiring: `main()` must reach `_publish_console`
+        whether or not `--report`/drift is present, mirroring box_health's
+        'publish on every run including clean ones' property."""
+        module, script_dir, installed_dir = cd
+        for name in module.ALL_UNITS:
+            content = f"UNIT {name}\n"
+            _write(script_dir / name, content)
+            _write(installed_dir / name, content)
+
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        exit_code = module.main()
+
+        assert exit_code == 0
+        assert len(_FakeFcr.calls) == 1
+        assert _FakeFcr.calls[0]["status"] == "ok"
+
+    def test_console_publish_failure_does_not_break_the_check(self, cd, capsys):
+        """Telemetry must never fail the check itself — best-effort, logged."""
+        module, _, _ = cd
+
+        class _Boom:
+            STATUS_OK = "ok"
+            STATUS_ATTENTION = "attention"
+
+            @staticmethod
+            def emit_result(**kw):
+                raise RuntimeError("simulated S3 failure")
+
+        import sys as _sys
+        _sys.modules["nousergon_lib"].fleet_check_result = _Boom
+
+        module._publish_console(["a.service: DIVERGED"], installed_count=4, drift_count=1)
+
+        err = capsys.readouterr().err
+        assert "console publish failed" in err
 
 
 class TestCoverageAccounting:


### PR DESCRIPTION
## What & why

`alpha-engine-config-I7857` (fleet audit of every `krepis.alerts` call site). `check-systemd-unit-drift.py`'s only output was a `krepis.alerts` channel page at `severity="error"` with `dedup_window_min=1440` (24h) — exactly the timer's own daily cadence — so an UNCHANGED drift re-paged Telegram/SNS every single day it stayed true, with no new information in the repeat. The design premise that tolerated this (that severity controls visibility) does not hold: `krepis.alerts`' severity tiering only ever gated the Telegram phone-push, never delivery — the naming/wording defect fixed in `krepis-PR170`.

## Changes

- Adds `_publish_console`, called unconditionally from `main()` on **every** run — clean or drifted, `--report` or not — via `nousergon_lib.fleet_check_result.emit_result()`, the same envelope contract every other fleet check publishes to `s3://alpha-engine-research/ops/checks/{check_id}/latest.json`, discovered by the console via S3 prefix with no console deploy needed.
- Status is `attention` for a non-empty finding set, never `error`: this check can tell you drift **exists**; `error` is reserved for the check itself being blind (mirrors `pause_reconcile.py`'s `publish_error` contract in this same repo).
- Widens `_report_drift`'s `dedup_window_min` 1440 → 43200 (30 days), mirroring `crucible-dashboard`'s `box_health` `warning`-tier precedent from the same audit. The dedup key still derives from the finding **set**, so a drift appearing, clearing, or changing still pages immediately regardless of window — only an unchanged standing drift now waits 30 days between channel repeats instead of 1 day.
- Adds `TestConsolePublish` (5 tests: publishes on clean runs, `attention`-not-`error` status, findings carried in the envelope, end-to-end wiring through `main()`, telemetry-failure-is-non-fatal) and one test pinning the widened dedup window. Existing tests updated with a `_FakeFcr` fixture so `main()` no longer risks a real S3 `PutObject` under local AWS creds during tests.

## Companion PR

`nous-ergon-ops-PR784` — the observability registry row for this new console producer, landed in the same arc per §2.2 ("registered with its producer, not after it"). Either may merge first; neither depends on the other's code.

## Test plan

Full suite run locally before opening:

```
/path/to/.venv/bin/python -m pytest -q
6149 passed, 13 skipped
```

Surfaced and fixed, unrelated to this change: the local venv's installed `nousergon-lib` was `0.124.73` against this repo's pinned `v0.124.74` (`requirements.txt:106`), which failed `test_pipeline_status_registry_source_check.py`'s two Saturday-SF assertions on unmodified `main` too (verified via `git stash`). Reinstalled the pinned version; no repo code changed for it.

## Related

Fleet-wide `krepis.alerts` call-site inventory posted as a comment on `alpha-engine-config-I7857`. `krepis-PR170` is the naming/wording fix this PR's design rationale depends on (no code dependency — independent to merge).

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)