### PR TITLE
fix(overseer): register research:cut_promotion alert class (alpha-engine-config-I7876)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -858,6 +858,20 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+  - class: research_cut_promotion_alerts
+    # alpha-engine-config-I7876 static-chokepoint registration: the scanner-cut
+    # promotion engine (crucible-research/lambda/scanner_handler.py, calling
+    # scoring/cut_promotion.py::run_cut_promotion inline in the scanner
+    # Lambda handler) is FAIL-SOFT + LOUD — a promotion failure never
+    # downgrades the already-written candidates.json/membership artifacts (the
+    # champion pointer keeps naming the standing champion), but this alert is
+    # the ONLY signal that no promote/hold decision was recorded for the
+    # cycle. Introduced by the 2026-08-20 champion/challenger promotion arc;
+    # publish_observe_alert call site publishes with explicit severity="ERROR".
+    source: "research:cut_promotion"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: research_experiment_record_alerts
     source: "research:experiment_record"
     severities: [warning]


### PR DESCRIPTION
## What & why

Closes the drift `alpha-engine-config`'s `config-validators` -> "Alert-class registry drift" check reports on main:

```
DRIFT FOUND: 1 uncovered source literal(s) in 1 file(s):
  crucible-research/
    source='research:cut_promotion'
       - crucible-research/lambda/scanner_handler.py
```

`crucible-research/lambda/scanner_handler.py:533` publishes `source="research:cut_promotion"` (severity ERROR) when the scanner-cut champion/challenger promotion engine (`scoring/cut_promotion.py::run_cut_promotion`) fails — the only signal that no promote/hold decision was recorded for a cycle (the write is fail-soft: the champion pointer keeps naming the standing champion on failure).

**Verified live, not dead code.** `scanner_handler.handler` is deployed as `FUNCTION_SCANNER` (`crucible-research/infrastructure/deploy.sh:995`), and `alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml` confirms the weekday preopen SF invokes `alpha-engine-research-scanner:live` daily, verified through 2026-08-07. Introduced by the 2026-08-20 champion/challenger promotion arc; its playbook entry was never added — same repair-without-sweep shape as `alpha-engine-config-I7860`.

Adds one `alert_classes` row mirroring the neighboring `research_cuts_leaderboard_alerts` entry's shape.

Tracked as `alpha-engine-config-I7876`.

## Test plan

- `pytest tests/test_overseer_playbook_registry.py` -> 42 passed.
- `alpha-engine-config`'s `scripts/check_alert_class_registry_drift.py` run locally against this branch's `playbooks.yaml` and live `crucible-research` (origin/main, 5c1adb07) -> `All publish source literals are registered in alert_classes — no drift.`
- Confirmed the same command against unmodified main's `playbooks.yaml` still reproduces the reported drift (sanity check both directions).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)