### PR TITLE
ci: wire the fleet-wide OpenRouter direct-linkage guard

### DIFF
--- a/.github/workflows/openrouter-guard.yml
+++ b/.github/workflows/openrouter-guard.yml
@@ -1,0 +1,32 @@
+name: OpenRouter direct-linkage guard
+
+# Thin caller — all scan behavior lives in the reusable workflow. Edit it
+# there, not here: nousergon/nousergon-lib/.github/workflows/openrouter-guard.yml
+#
+# alpha-engine-config-I7864 (epic I6367, Brian's 2026-08-03 ruling: no agent
+# may be directly linked to OpenRouter). Baseline of pre-existing matches:
+# .openrouter-allowlist.yaml.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # `caller-` prefix is load-bearing, not cosmetic: inside a CALLED workflow
+  # `github.workflow` resolves to THIS workflow's name, so a callee declaring
+  # the same expression lands in the same concurrency group and GitHub kills
+  # the run with zero jobs and no check (alpha-engine-config-I7836/I7862).
+  # Enforced by alpha-engine-config's scripts/check_workflow_shape.py
+  # ::check_caller_concurrency_group.
+  group: caller-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    uses: nousergon/nousergon-lib/.github/workflows/openrouter-guard.yml@5a28d15032933f31266d466a51baf764f3282b73  # nousergon-lib#334, merged 2026-08-19

--- a/.openrouter-allowlist.yaml
+++ b/.openrouter-allowlist.yaml
@@ -1,0 +1,29 @@
+# .openrouter-allowlist.yaml — pre-cleared OpenRouter-literal matches
+# (alpha-engine-config-I7864, wiring the fleet-wide guard). Schema:
+# nousergon-lib scripts/openrouter_guard.py::load_allowlist.
+schema_version: 1
+entries:
+  - path: infrastructure/lambdas/expense-collector/iam-policy.json
+    pattern: env_key
+    reason: >-
+      IAM grant for the SSM parameter backing the expense-collector's OpenRouter billing-telemetry read below — not an LLM call site.
+    expires: "2026-09-19"
+    tracking: alpha-engine-config-I7864
+  - path: infrastructure/lambdas/expense-collector/index.py
+    pattern: base_url
+    reason: >-
+      Same exception as above (env_key entry) — the /credits endpoint URL.
+    expires: "2026-09-19"
+    tracking: alpha-engine-config-I7864
+  - path: infrastructure/lambdas/expense-collector/index.py
+    pattern: env_key
+    reason: >-
+      Expense-collector Lambda reads OpenRouter's own account-balance/credits REST API (/api/v1/credits) directly for cost telemetry (console Expenses page) — this is billing metadata, not an LLM completion call, and krepis router has no billing-telemetry surface to proxy through. Same shape as this same file's direct DeepSeek /user/balance and Anthropic Admin API reads for their own billing rows. Deliberate, documented exception.
+    expires: "2026-09-19"
+    tracking: alpha-engine-config-I7864
+  - path: infrastructure/lambdas/expense-collector/test_handler.py
+    pattern: base_url
+    reason: >-
+      Test fixture mocking the /credits billing endpoint above.
+    expires: "2026-09-19"
+    tracking: alpha-engine-config-I7864


### PR DESCRIPTION
## Summary

Wires nousergon-lib's reusable OpenRouter direct-linkage guard (alpha-engine-config-I7864) into this repo for the first time, with the mandatory caller- concurrency-group prefix (alpha-engine-config-I7862) so this run does not collide with the callee's own concurrency group and die with zero jobs.

## Scan findings (pre-PR, against origin/main)

4 matches, all in `infrastructure/lambdas/expense-collector/` (plus its IAM policy and test fixture). All allowlisted — a deliberate, documented exception: the expense-collector reads OpenRouter's own account-balance REST API (`/api/v1/credits`) directly for cost telemetry consumed by the console Expenses page. This is billing metadata, not an LLM completion call — no prompt is ever sent, no agent inference happens — and krepis router has no billing-telemetry surface to proxy through. Same shape as this same file's direct DeepSeek `/user/balance` and Anthropic Admin API reads for their own billing rows; not a violation of I6367 (which governs LLM agent linkage), same as `nous-ergon-ops`'s router-degraded-drill-probe reading `openrouter.ai` as a health-probe target rather than an LLM endpoint.

## Test plan

- `python3 scripts/openrouter_guard.py --repo .` run locally against this branch: `No unexpected direct-OpenRouter references. 4 total match(es), 4 allowlisted.`

Part of alpha-engine-config-I7864. Companion PRs: nousergon-lib-PR339 (header-doc fix), crucible-research-PR692, crucible-executor-PR487, crucible-predictor-PR532, crucible-evaluator-PR245, crucible-backtester-PR715, crucible-dashboard-PR736, nous-ergon-ops (all independent, no ordering dependency).

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)