### PR TITLE
fix(overseer): register research:cut_promotion alert class (alpha-engine-config-I7826)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -858,6 +858,19 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+  - class: research_cut_promotion_error
+    # alpha-engine-config-I7826 static-chokepoint registration: the
+    # scanner-cut champion/challenger promotion engine
+    # (crucible-research/lambda/scanner_handler.py, run_cut_promotion)
+    # is observe-only and never blocks the feed — a promotion failure
+    # leaves the standing champion pointer in place — but this alert
+    # is the ONLY signal that a cycle's promotion decision was never
+    # recorded. publish_observe_alert called with explicit
+    # severity="ERROR".
+    source: "research:cut_promotion"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: research_experiment_record_alerts
     source: "research:experiment_record"
     severities: [warning]


### PR DESCRIPTION
## What

Adds an `alert_classes:` row for `research:cut_promotion` to `infrastructure/overseer/playbooks.yaml`, so the static-chokepoint drift check (`alpha-engine-config-I3211`/`I6753`, `scripts/check_alert_class_registry_drift.py` in `alpha-engine-config`) stops flagging it as an uncovered source literal.

## Why

`crucible-research/lambda/scanner_handler.py::run_cut_promotion` (built for `alpha-engine-config-I7826`) calls `publish_observe_alert(source="research:cut_promotion", severity="ERROR", ...)` on a promotion-engine failure. The emitter shipped without a matching registry row — a cross-repo omission the drift check exists to catch, but the check runs in `alpha-engine-config`'s CI against `nousergon-data`'s and `crucible-research`'s live `main`, so nothing in either repo's own CI caught it at merge time.

This is the sole cause of `nousergon/alpha-engine-config` main's red **"Registry, contract and drift validators"** check as of run `32419195293` / job `96587226902`: `❌ DRIFT FOUND: 1 uncovered source literal(s)` — `source='research:cut_promotion'` in `crucible-research/lambda/scanner_handler.py`. A red `main` on that repo silently ejects every PR from its merge queue, so this is currently blocking that repo's merges.

## Verification

Registered as `research_cut_promotion_error`, `severities: [error]` (matching the emitter's explicit `severity="ERROR"`), following the existing `research_cuts_leaderboard_alerts` pattern immediately above it.

Ran `alpha-engine-config/scripts/check_alert_class_registry_drift.py` locally against this file plus fresh clones of all 9 scanned repos — clean:
```
✅ All publish source literals are registered in alert_classes — no drift.
```

Full `nousergon-data` suite: `6163 passed, 13 skipped` via the project `.venv`.

## Note on ROADMAP.md

I was originally dispatched to fix `alpha-engine-config`'s red check as a `private-docs/ROADMAP.md` tombstone re-balloon. That premise was stale: `ROADMAP.md` has been a 1.6KB tombstone since `alpha-engine-config-PR1305` (merged 2026-06-27) and the tombstone check passes cleanly on current `main` (`tombstone OK (1284 bytes, ...)`). The job's actual and only failure is the alert-class drift check fixed here.

## Deploy mechanism
N/A — a registry-data file with no auto-deploy path; `alpha-engine-config`'s next scheduled/triggered run of `config-validators.yml` picks up this repo's `main` on checkout.

---

**Prepared by:** claude-sonnet-5