### PR TITLE
feat(weekly-sf): the observe-only scanner leaderboard becomes a post-Director leaf state (alpha-engine-config-I7813)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -67,7 +67,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/pause-reconcile.yml
+++ b/.github/workflows/pause-reconcile.yml
@@ -104,7 +104,7 @@ jobs:
       # shape, every call site). Same pin as requirements.txt, for the reason
       # deploy-infrastructure.yml states.
       - name: Install nousergon-lib (envelope builder for the console row)
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78"
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -5946,7 +5946,7 @@
     },
     "CheckSkipPostEval": {
       "Type": "Choice",
-      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator \u2014 bypassing the four full-run-only tail stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck \u2192 ReportCard \u2192 Director, none of which previously had a skip gate) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester\u2192Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior.",
+      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator \u2014 bypassing the five full-run-only tail stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck \u2192 ReportCard \u2192 Director \u2192 ScannerLeaderboard, none of which previously had a skip gate; ScannerLeaderboard is the alpha-engine-config-I7813 observe-only board leaf) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester\u2192Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior.",
       "Choices": [
         {
           "And": [
@@ -6290,10 +6290,10 @@
           ],
           "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal advisory path this alert decorates.",
           "ResultPath": "$.report_card_degraded_notify_error",
-          "Next": "CheckShellRunNotify"
+          "Next": "CheckSkipScannerLeaderboard"
         }
       ],
-      "Next": "CheckShellRunNotify"
+      "Next": "CheckSkipScannerLeaderboard"
     },
     "Director": {
       "Type": "Task",
@@ -6554,6 +6554,20 @@
             }
           ],
           "Next": "NotifyCompleteParityDegraded"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.scanner_leaderboard_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.scanner_leaderboard_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "alpha-engine-config-I7813. LAST in the list on purpose: a run that also degraded a gate, a health check, the parity verdict, the report card or a Branch A fail-open matches one of the rules above and gets that (more consequential) notification, while the leaf's own PublishScannerLeaderboardDegraded alert has already named it. This rule exists so a run whose ONLY degradation is the observe-only board cannot reach NotifyComplete's \"All steps completed successfully\" while terminating in DegradedRun.",
+          "Next": "NotifyCompleteScannerLeaderboardDegraded"
         }
       ],
       "Default": "NotifyComplete"
@@ -7652,15 +7666,141 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckShellRunNotify"
+          "Next": "CheckSkipScannerLeaderboard"
         }
       ],
       "Default": "Director"
     },
+    "CheckSkipScannerLeaderboard": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config-I7813. Skip-gate for the observe-only scanner leaderboard leaf, same shape as CheckSkipReportCard / CheckSkipDirector. {\"skip_scanner_leaderboard\": true} bypasses the leaf and lands on CheckShellRunNotify \u2014 the exact edge every path into this gate used to take, so setting the flag is behaviourally identical to the pre-I7813 definition. Emitted by scripts/weekly_sf_rerun.py when the original execution already completed the leaf.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_scanner_leaderboard",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_scanner_leaderboard",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckShellRunNotify"
+        }
+      ],
+      "Default": "ScannerLeaderboard"
+    },
+    "ScannerLeaderboard": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7813 \u2014 the observe-only scanner champion/challenger board, scanner/leaderboard/{run_date}.json, as its OWN leaf state placed after the Report Card and the Director. Same Lambda as the Scanner state in ResearchPredictorParallel, invoked with mode=scanner_leaderboard so it builds ONLY the board (crucible-research lambda/scanner_handler.py::_run_scanner_leaderboard); the scan itself, the universe-membership artifact, the funnel-cut leaderboard and the cut-promotion decision all stay in the Scanner state. WHY THIS ONE AND NOT ITS SIBLINGS: the issue's discriminator is 'does any stage branch on the number?'. research/cuts_leaderboard is read by scoring/cut_promotion.py, which writes the live champion pointer \u2014 a CONTROL, so it stays with its consumer. research/producer_leaderboard is read by crucible-backtester optimizer/champion_promotion.py, which runs at the Backtester stage EARLIER than this point \u2014 also a control, and moving it here would starve its consumer. Only scanner/leaderboard is written-and-rendered and nothing else: the dashboard's Experiments view and gate predicates poll it, no stage branches on it. So only it moves (sf-pipeline-policy.md \u00a72.1: this stage can fail without preventing any stage that does not consume its output). NO EXTRA COST: the two boards look like they shared the ~904-symbol closes panel via leaderboard_producers._PANEL_CACHE, but that cache holds ONE entry keyed on the cohort entry-date set, and the two builds walk different prefixes (candidates_shadow/ vs universe_membership/), so the second build has always paid its own read \u2014 measured 2026-08-20, 21 dates vs 23. TimeoutSeconds 440, not a fresh p95: it holds the I6855 invariant that the SF budget must sit BELOW the alpha-engine-research-scanner function timeout (450s) or it can never bind, so an overrun surfaces as States.Timeout naming THIS state. Re-derivation from a measured p95 is alpha-engine-config-I7851, gated on 3 clean weekly runs. IAM: no new grant \u2014 the same FunctionName the Scanner state already invokes.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-scanner:live",
+        "Payload": {
+          "run_date.$": "$.run_date",
+          "dry_run_llm.$": "$.research_dry",
+          "mode": "scanner_leaderboard"
+        }
+      },
+      "TimeoutSeconds": 440,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException",
+            "States.TaskFailed"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Fail-open on the RUN's work, never silent. The board is observe-only, so its failure must not stop the terminal notify or the completion marker \u2014 but it must not vanish either: this route sets $.scanner_leaderboard_degraded, publishes its own named SNS alert, and writes a DEGRADED completion marker so the execution terminates in DegradedRun rather than a clean success (sf-pipeline-policy.md \u00a72.3, the 2026-07-28 Option-A ruling; accepted explicitly in I7813's 'Known consequence').",
+          "Next": "ScannerLeaderboardDegraded",
+          "ResultPath": "$.scanner_leaderboard_error"
+        }
+      ],
+      "ResultPath": "$.scanner_leaderboard_result",
+      "Next": "ScannerLeaderboardComplete"
+    },
+    "ScannerLeaderboardComplete": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7813: success-only witness for the rerun deriver (scripts/weekly_sf_rerun.py), exactly the DirectorComplete pattern and for the same reason \u2014 the success edge and every bypass path would otherwise converge on CheckShellRunNotify, leaving no state that uniquely witnesses 'the leaf actually completed' (the I6055 trap).",
+      "Next": "CheckShellRunNotify"
+    },
+    "ScannerLeaderboardDegraded": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7813: the SF-controlled visible flag CheckGateDegradedNotify reads, set BEFORE the summary so a publish failure downstream still leaves the flag on the execution record.",
+      "Result": true,
+      "ResultPath": "$.scanner_leaderboard_degraded",
+      "Next": "SetScannerLeaderboardDegradedSummary"
+    },
+    "SetScannerLeaderboardDegradedSummary": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7813: mirrors SetReportCardDegradedSummary. $.degraded_summary is what CheckDegradedOutcome reads to route to WriteCompletionMarkerDegraded \u2014 without it the run would end SUCCEEDED with a board nobody wrote. Like every sibling Set*DegradedSummary in this definition it OVERWRITES an earlier stage's summary; the per-stage booleans ($.report_card_degraded, $.gate_degraded, \u2026) are what survive independently, and each degraded stage has already published its own named alert by this point.",
+      "Parameters": {
+        "degraded": true,
+        "reason": "weekly_scanner_leaderboard_fail_open",
+        "run_date.$": "$.run_date"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "PublishScannerLeaderboardDegraded"
+    },
+    "PublishScannerLeaderboardDegraded": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7813: named alert on the leaf's fail-open path, mirroring PublishReportCardDegraded's shape exactly (config#1819 discipline: hardcoded Subject/Message constants, never States.Format against unbounded input; best-effort Catch so a publish failure cannot block the path it decorates).",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekly Pipeline \u2014 ScannerLeaderboard WARNING (observe-only board not written)",
+        "Message": "ScannerLeaderboard (the observe-only scanner champion/challenger board, scanner/leaderboard/{run_date}.json) failed \u2014 see $.scanner_leaderboard_error on the execution record for detail. NON-FATAL for trading: nothing branches on this board, and the week's signals, predictions, report card and Director advisory are unaffected. It is NOT nothing: the scanner champion/challenger comparison has no observation for this cycle, and the run therefore terminates DEGRADED. View pipeline status: https://dashboard.nousergon.ai/pipeline-status",
+        "MessageAttributes": {}
+      },
+      "ResultPath": "$.scanner_leaderboard_degraded_notify",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal path this alert decorates. $.degraded_summary is already set, so the run still terminates DEGRADED.",
+          "ResultPath": "$.scanner_leaderboard_degraded_notify_error",
+          "Next": "CheckShellRunNotify"
+        }
+      ],
+      "Next": "CheckShellRunNotify"
+    },
+    "NotifyCompleteScannerLeaderboardDegraded": {
+      "Type": "Task",
+      "Comment": "alpha-engine-config-I7813: terminal notification for a run whose ONLY degradation is the observe-only board. Registered LAST in CheckGateDegradedNotify's choice list, immediately before the clean Default \u2014 so any run that also degraded a gate, a health check, the parity verdict, the report card or a Branch A fail-open still gets that stage's (or the multi-) notification, which is the more consequential fact. This state exists so the leaf can never reach NotifyComplete's \"All steps completed successfully\" while terminating in DegradedRun.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: scanner leaderboard (run terminates FAILED)",
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because the ScannerLeaderboard leaf failed and scanner/leaderboard/{run_date}.json was not written; a scanner-leaderboard-degraded alert fired earlier in this run. See $.scanner_leaderboard_error on the execution record for detail. The week's trading artifacts, report card and Director advisory are unaffected \u2014 no stage branches on this board \u2014 but the scanner champion/challenger comparison has no observation for this cycle. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+      },
+      "ResultPath": "$.notify_result",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 \u2014 best-effort: a terminal notifier must never change the outcome it reports. The run still routes to CheckDegradedOutcome and terminates DEGRADED.",
+          "ResultPath": "$.notify_error",
+          "Next": "CheckDegradedOutcome"
+        }
+      ],
+      "Next": "CheckDegradedOutcome"
+    },
     "DirectorComplete": {
       "Type": "Pass",
       "Comment": "config#6054: success-only witness for the rerun deriver (scripts/weekly_sf_rerun.py). Director's success and every bypass path previously converged on CheckShellRunNotify, so no state uniquely witnessed 'Director actually completed' \u2014 the I6055-class trap: a rerun could mark a bypassed Director complete and skip it. Entered ONLY via Director's success edge.",
-      "Next": "CheckShellRunNotify"
+      "Next": "CheckSkipScannerLeaderboard"
     },
     "BacktesterLivenessGate": {
       "Type": "Choice",

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,20 @@ arcticdb>=6.23.0
 # same sequencing PR311/PR326 above already established for this exact
 # class of dependency. Until then, that one source-check failure is
 # EXPECTED and tracked by this note, not a silent regression.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.75
+#
+# 2026-08-20: v0.124.75 -> v0.124.78 (alpha-engine-config-I7813). The
+# observe-only scanner leaderboard became its own weekly-SF leaf state
+# (ScannerLeaderboard + PublishScannerLeaderboardDegraded +
+# NotifyCompleteScannerLeaderboardDegraded), and all three are substantive
+# Task states, so tests/test_pipeline_status_registry_source_check.py fails
+# until the pinned lib carries their STATE_TO_ARCHIVE_PAGE entries.
+# nousergon-lib-PR<N> adds all three and MUST merge first; v0.124.78 is the
+# patch autobump that merge is expected to produce from 0.124.77. If another
+# lib PR merges between, this pin moves to whatever tag PR<N>'s merge actually
+# produced — the source-check is what tells you, and it stays RED until the
+# pin is right, which is the guard against merging the SF JSON ahead of the
+# registry entry.
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.78
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -606,6 +606,22 @@ STAGES: tuple[Stage, ...] = (
         # histories only; new executions never enter it.
         degraded_witness=frozenset({"PublishDirectorDegraded"}),
     ),
+    Stage(
+        "scanner_leaderboard", "skip_scanner_leaderboard",
+        "CheckSkipScannerLeaderboard", "ScannerLeaderboard",
+        # alpha-engine-config-I7813. Success-only witness, the DirectorComplete
+        # pattern for the same reason: the leaf's success edge and every bypass
+        # path would otherwise converge on CheckShellRunNotify, so witnessing
+        # there would mark a bypassed leaf complete and skip it on the rerun
+        # (the I6055 trap). Skipping it lands on CheckShellRunNotify, so this
+        # row shares director's inverted-convention exception.
+        frozenset({"ScannerLeaderboardComplete"}),
+        degraded_witness=frozenset({
+            "ScannerLeaderboardDegraded",
+            "SetScannerLeaderboardDegradedSummary",
+            "PublishScannerLeaderboardDegraded",
+        }),
+    ),
 )
 
 STAGES_BY_NAME = {s.name: s for s in STAGES}

--- a/tests/test_sf_completion_marker_wiring.py
+++ b/tests/test_sf_completion_marker_wiring.py
@@ -41,6 +41,8 @@ REAL_COMPLETION_NOTIFIERS = [
     "NotifyCompleteReportCardDegraded",
     "NotifyCompleteParityDegraded",
     "NotifyCompleteMultipleDegraded",
+    # alpha-engine-config-I7813: the observe-only scanner leaderboard leaf.
+    "NotifyCompleteScannerLeaderboardDegraded",
 ]
 
 PREFLIGHT_NOTIFIERS = [

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -157,6 +157,10 @@ _EXPECTED_SKIPS = {
     # and Director independently.
     "skip_report_card",
     "skip_director",
+    # alpha-engine-config-I7813: the observe-only scanner leaderboard leaf,
+    # placed after Director. Its own gate so a rerun that already produced
+    # the board does not pay a second ~904-symbol closes-panel read.
+    "skip_scanner_leaderboard",
 }
 
 # KEYSTONE + skip-exception rewire: the 8 SPOT workload states. Under
@@ -1075,7 +1079,13 @@ class TestConsolidatedNotify:
         # is now the head of that tail. The success chain is
         # RunScope → CheckSkipReportCard → ReportCard → CheckSkipDirector →
         # Director → DirectorComplete (success-only rerun witness) →
-        # CheckShellRunNotify.
+        # CheckSkipScannerLeaderboard → ScannerLeaderboard →
+        # ScannerLeaderboardComplete (success-only rerun witness) →
+        # CheckShellRunNotify. alpha-engine-config-I7813 inserted the last three:
+        # the observe-only scanner board is a leaf AFTER the advisories, and
+        # every path that previously reached CheckShellRunNotify from this tail
+        # — ReportCard's degraded route, Director's skip route, Director's
+        # success — now passes through its gate first.
         assert substrate_success["Next"] == "RunScope"
         assert states["RunScope"]["Next"] == "CheckSkipReportCard"
         assert states["CheckSkipReportCard"]["Default"] == "ReportCard"
@@ -1083,13 +1093,25 @@ class TestConsolidatedNotify:
         assert report_card["Next"] == "CheckSkipDirector"
         assert all(c["Next"] == "ReportCardDegraded" for c in report_card["Catch"])
         assert_degraded_continuation(states, "ReportCardDegraded", "PublishReportCardDegraded")
-        assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
+        assert states["PublishReportCardDegraded"]["Next"] == "CheckSkipScannerLeaderboard"
         assert states["CheckSkipDirector"]["Default"] == "Director"
         director = states["Director"]
         assert director["Next"] == "DirectorComplete"
-        assert states["DirectorComplete"]["Next"] == "CheckShellRunNotify"
+        assert states["DirectorComplete"]["Next"] == "CheckSkipScannerLeaderboard"
         assert all(c["Next"] == "NormalizeFailureContext" for c in director["Catch"])
         assert all(c["ResultPath"] == "$.error" for c in director["Catch"])
+        # alpha-engine-config-I7813: the leaf, and the property that makes it a
+        # leaf — a fail-open Catch that still names itself, and a success edge
+        # landing on the notify gate the tail always ended at.
+        assert states["CheckSkipScannerLeaderboard"]["Default"] == "ScannerLeaderboard"
+        leaf = states["ScannerLeaderboard"]
+        assert leaf["Next"] == "ScannerLeaderboardComplete"
+        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
+        assert all(c["Next"] == "ScannerLeaderboardDegraded" for c in leaf["Catch"])
+        assert_degraded_continuation(
+            states, "ScannerLeaderboardDegraded", "PublishScannerLeaderboardDegraded"
+        )
+        assert states["PublishScannerLeaderboardDegraded"]["Next"] == "CheckShellRunNotify"
 
     def test_advisory_tail_runs_dry_on_preflight(self, states):
         """ROADMAP L4504: ReportCard + Director were added after the shell-run

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -87,6 +87,11 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # config#1824 weekly run-day gate (pure calendar; mirrors LibPinDriftCheck shape).
     "WeeklyRunDayGate": frozenset({"action"}),
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
+    # alpha-engine-config-I7813: the same scanner Lambda, invoked as a
+    # post-Director leaf with an explicit `mode` so it builds ONLY the
+    # observe-only scanner/leaderboard board. The literal `mode` is what
+    # keeps this payload distinct from Scanner's above.
+    "ScannerLeaderboard": frozenset({"dry_run_llm.$", "run_date.$", "mode"}),
     "RegimeSubstrate": frozenset({"action.$"}),
     "RegimeRetrospectiveEval": frozenset({"action.$"}),
     # alpha-engine-config-I2515 Phase B: replaces the removed multi-agent

--- a/tests/test_sf_report_card_degraded_wiring.py
+++ b/tests/test_sf_report_card_degraded_wiring.py
@@ -101,12 +101,18 @@ def test_only_report_card_degraded_pass_sets_the_flag(states):
 
 def test_publish_report_card_degraded_unchanged_downstream(states):
     """The existing immediate PAGE alert (config#2302) still fires and still
-    proceeds to CheckShellRunNotify — this fix adds a flag upstream of it,
-    it does not change its own wiring."""
+    proceeds to the notify gate — this fix adds a flag upstream of it, it does
+    not change its own wiring.
+
+    alpha-engine-config-I7813 moved the gate one hop: the degraded route now
+    lands on CheckSkipScannerLeaderboard, which routes to CheckShellRunNotify
+    on the skip arm and after the leaf on the run arm. Load-bearing rather than
+    cosmetic — the observe-only board must still be built on a run whose report
+    card failed, because it does not consume the report card."""
     st = states["PublishReportCardDegraded"]
-    assert st["Next"] == "CheckShellRunNotify"
+    assert st["Next"] == "CheckSkipScannerLeaderboard"
     (catch,) = st["Catch"]
-    assert catch["Next"] == "CheckShellRunNotify"
+    assert catch["Next"] == "CheckSkipScannerLeaderboard"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sf_scanner_leaderboard_leaf.py
+++ b/tests/test_sf_scanner_leaderboard_leaf.py
@@ -1,0 +1,197 @@
+"""The observe-only scanner leaderboard runs as a weekly-SF LEAF state
+(alpha-engine-config-I7813).
+
+Why this file exists rather than one more assertion bolted onto the report-card
+wiring suite: the leaf's whole value is a set of *negative* properties — it must
+not gate anything, must not be reachable before the Report Card, must not be
+skipped when the Report Card fails, and must not end the run green when it
+fails. Each of those is a different way the "moved to a leaf" claim can be true
+on paper and false in the definition.
+
+The discriminator the ruling gives (issue body): **does any stage branch on the
+number?** If a Choice or a gate reads it, it is a CONTROL and stays where it is;
+if it is only written and rendered, it is a REPORT and moves. Applied per board:
+
+- ``scanner/leaderboard/{date}.json`` — REPORT. Read by crucible-dashboard's
+  Experiments view and by gate predicates; no stage branches on it. MOVED here.
+- ``research/cuts_leaderboard/{date}.json`` — CONTROL. ``crucible-research``
+  ``scoring/cut_promotion.py`` branches on it and writes the live champion
+  pointer, so it stays inside the Scanner state with its consumer.
+- ``research/producer_leaderboard/{date}.json`` — CONTROL. ``crucible-backtester``
+  ``optimizer/champion_promotion.py`` reads it at the Backtester stage, which
+  runs EARLIER than this leaf; moving it here would starve its consumer. It also
+  already has its own TimeoutSeconds + Catch on EvalRollingMean.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_DEF = Path(__file__).resolve().parents[1] / "infrastructure" / "step_function.json"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(_DEF.read_text())["States"]
+
+
+def _top_level_order(defn_states: dict) -> list[str]:
+    return list(defn_states)
+
+
+def test_the_leaf_runs_after_report_card_and_director(states):
+    """Placement, asserted by REACHABILITY rather than by key order — key order
+    in a JSON object is not execution order, and asserting on it would pass for
+    a state wired anywhere."""
+    assert states["ReportCard"]["Next"] == "CheckSkipDirector"
+    assert states["CheckSkipDirector"]["Default"] == "Director"
+    assert states["Director"]["Next"] == "DirectorComplete"
+    # Every edge that previously ended the advisory tail now enters the gate.
+    assert states["DirectorComplete"]["Next"] == "CheckSkipScannerLeaderboard"
+    assert states["PublishReportCardDegraded"]["Next"] == "CheckSkipScannerLeaderboard"
+    skip_targets = {c["Next"] for c in states["CheckSkipDirector"]["Choices"]}
+    assert skip_targets == {"CheckSkipScannerLeaderboard"}
+
+
+def test_nothing_downstream_reads_the_leafs_output(states):
+    """The blast-radius test (sf-pipeline-policy.md §2.1): can this stage fail
+    without preventing any stage that does not consume its output? It can only
+    be answered YES if no Choice anywhere in the definition branches on the
+    leaf's result — the moment one does, the board is a control again and this
+    placement is wrong."""
+    blob = json.dumps(states)
+    # The Task's own ResultPath is the only place the result may appear, plus
+    # the error path's own error capture.
+    assert states["ScannerLeaderboard"]["ResultPath"] == "$.scanner_leaderboard_result"
+    assert blob.count('"$.scanner_leaderboard_result"') == 1, (
+        "something other than the leaf's own ResultPath references "
+        "$.scanner_leaderboard_result — if a Choice now branches on the board, "
+        "it is a CONTROL and must move back beside its consumer"
+    )
+
+
+def test_a_failed_report_card_does_not_skip_the_leaf(states):
+    """ReportCard's Catch bypasses the Director (no card to weigh) — but the
+    board does not consume the report card, so it must still be built. This is
+    the exact inversion §2.1 forbids: one advisory's failure silencing an
+    unrelated one."""
+    assert all(c["Next"] == "ReportCardDegraded" for c in states["ReportCard"]["Catch"])
+    assert states["ReportCardDegraded"]["Next"] == "SetReportCardDegradedSummary"
+    assert states["SetReportCardDegradedSummary"]["Next"] == "PublishReportCardDegraded"
+    assert states["PublishReportCardDegraded"]["Next"] == "CheckSkipScannerLeaderboard"
+    for catch in states["PublishReportCardDegraded"]["Catch"]:
+        assert catch["Next"] == "CheckSkipScannerLeaderboard"
+
+
+def test_the_leaf_has_its_own_timeout_below_the_function_timeout(states):
+    """alpha-engine-config-I6855's invariant: an SF budget at or above the
+    Lambda's own timeout can never bind, and the overrun then surfaces as an
+    opaque Lambda error instead of a States.Timeout naming the state. The
+    function is 450s; 440 keeps the SF the effective budget. Re-derivation from
+    a measured p95 is alpha-engine-config-I7851."""
+    leaf = states["ScannerLeaderboard"]
+    assert leaf["TimeoutSeconds"] == 440
+    assert leaf["TimeoutSeconds"] < 450
+
+
+def test_the_leaf_invokes_the_scanner_lambda_in_board_only_mode(states):
+    """The leaf reuses the scanner Lambda — so no new IAM grant, and no
+    post-merge operator step — and the ONLY thing separating it from the
+    Scanner state is the explicit mode. A leaf that dropped the mode would
+    silently re-run the whole universe scan after the Report Card and overwrite
+    the day's candidates.json."""
+    payload = states["ScannerLeaderboard"]["Parameters"]["Payload"]
+    assert (
+        states["ScannerLeaderboard"]["Parameters"]["FunctionName"]
+        == states["ResearchPredictorParallel"]["Branches"][0]["States"]["Scanner"][
+            "Parameters"
+        ]["FunctionName"]
+    ), "the leaf must reuse the Scanner state's Lambda, or it needs its own IAM grant"
+    assert payload["mode"] == "scanner_leaderboard"
+    assert payload["run_date.$"] == "$.run_date"
+
+
+def test_a_leaf_failure_degrades_the_run_loudly_and_never_silently(states):
+    """sf-pipeline-policy.md §2.3 + the 2026-07-28 Option-A ruling, accepted
+    explicitly in I7813's 'Known consequence': the board is observe-only, so its
+    failure must not stop the notify or the marker — but the run must not read
+    as a clean success either. Three obligations, each asserted:
+    the flag is set, a NAMED alert fires, and the terminal marker says DEGRADED.
+    """
+    leaf = states["ScannerLeaderboard"]
+    assert all(c["Next"] == "ScannerLeaderboardDegraded" for c in leaf["Catch"])
+    assert all(c["ResultPath"] == "$.scanner_leaderboard_error" for c in leaf["Catch"])
+
+    flag = states["ScannerLeaderboardDegraded"]
+    assert flag["Result"] is True
+    assert flag["ResultPath"] == "$.scanner_leaderboard_degraded"
+    assert flag["Next"] == "SetScannerLeaderboardDegradedSummary"
+
+    summary = states["SetScannerLeaderboardDegradedSummary"]
+    assert summary["Parameters"]["degraded"] is True
+    assert summary["ResultPath"] == "$.degraded_summary"
+    assert summary["Next"] == "PublishScannerLeaderboardDegraded"
+
+    alert = states["PublishScannerLeaderboardDegraded"]
+    assert alert["Resource"] == "arn:aws:states:::sns:publish"
+    assert "ScannerLeaderboard" in alert["Parameters"]["Subject"]
+    # Best-effort: the alert can fail without changing the outcome it reports.
+    assert alert["Next"] == "CheckShellRunNotify"
+    for catch in alert["Catch"]:
+        assert catch["Next"] == "CheckShellRunNotify"
+
+    # $.degraded_summary is what CheckDegradedOutcome routes on.
+    outcome = states["CheckDegradedOutcome"]
+    assert any(
+        cond.get("Variable") == "$.degraded_summary.degraded"
+        for choice in outcome["Choices"]
+        for cond in (choice.get("And") or [choice])
+    )
+    assert states["WriteCompletionMarkerDegraded"]["Next"] == "DegradedRun"
+    assert states["DegradedRun"]["Type"] == "Fail"
+
+
+def test_the_terminal_notify_can_never_call_a_degraded_leaf_a_success(states):
+    """Without its own rule in CheckGateDegradedNotify, a run whose only
+    degradation is the leaf falls through to NotifyComplete — 'All steps
+    completed successfully' — while terminating in DegradedRun. That exact
+    combination is what the config#6685 fix removed for the report card; this
+    pins that the leaf did not reintroduce it."""
+    gate = states["CheckGateDegradedNotify"]
+    matching = [
+        c
+        for c in gate["Choices"]
+        if any(
+            cond.get("Variable") == "$.scanner_leaderboard_degraded"
+            for cond in (c.get("And") or [c])
+        )
+    ]
+    assert len(matching) == 1
+    assert matching[0]["Next"] == "NotifyCompleteScannerLeaderboardDegraded"
+    # LAST before the clean default: a run that ALSO degraded something
+    # consequential must report that instead.
+    assert gate["Choices"][-1] is matching[0]
+    assert gate["Default"] == "NotifyComplete"
+    assert states["NotifyCompleteScannerLeaderboardDegraded"]["Next"] == "CheckDegradedOutcome"
+
+
+def test_the_leaf_is_skippable_and_witnessed_for_rerun(states):
+    """sf-pipeline-policy.md §2.5: recovery is one mechanical command, which
+    needs (a) a skip flag the rerun deriver can emit and (b) a success-ONLY
+    witness. Witnessing on the shared CheckShellRunNotify would mark a bypassed
+    leaf complete and skip it on the rerun — the I6055 trap."""
+    gate = states["CheckSkipScannerLeaderboard"]
+    assert gate["Default"] == "ScannerLeaderboard"
+    assert {c["Next"] for c in gate["Choices"]} == {"CheckShellRunNotify"}
+    assert states["ScannerLeaderboard"]["Next"] == "ScannerLeaderboardComplete"
+    assert states["ScannerLeaderboardComplete"]["Type"] == "Pass"
+    assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
+    # Only the leaf's success edge enters the witness.
+    enterers = [
+        name for name, body in states.items()
+        if body.get("Next") == "ScannerLeaderboardComplete"
+    ]
+    assert enterers == ["ScannerLeaderboard"]

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -139,6 +139,8 @@ _TIMEOUT_EXEMPT: dict[str, dict[str, str]] = {
         "NotifyCompleteReportCardDegraded": "sns:publish completion notifier — SDK call, not a wait (config#6685)",
         "NotifyCompleteMultipleDegraded": "sns:publish completion notifier — SDK call, not a wait (config#6685)",
         "NotifyCompleteParityDegraded": "sns:publish completion notifier — SDK call, not a wait (alpha-engine-config-I6025)",
+        "PublishScannerLeaderboardDegraded": "sns:publish degraded-gate notifier — SDK call, not a wait (alpha-engine-config-I7813)",
+        "NotifyCompleteScannerLeaderboardDegraded": "sns:publish completion notifier — SDK call, not a wait (alpha-engine-config-I7813)",
         "NotifyShellRunComplete": "sns:publish completion notifier — SDK call, not a wait",
         "NotifyComplete": "sns:publish completion notifier — SDK call, not a wait",
         "HandleFailure": "sns:publish failure notifier — SDK call, not a wait",
@@ -267,6 +269,10 @@ _DEGRADED_FLAG_JSONPATHS: dict[str, frozenset[str]] = {
             "$.report_card_degraded",
             "$.parity_degraded",
             "$.research_predictor_degraded",
+            # alpha-engine-config-I7813: the observe-only scanner leaderboard
+            # leaf's own flag. Read LAST in CheckGateDegradedNotify, so a run
+            # that also degraded something consequential still reports that.
+            "$.scanner_leaderboard_degraded",
         }
     ),
     "step_function_daily.json": frozenset({"$.degraded_summary"}),

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -126,9 +126,13 @@ class TestChainOrdering:
             c["Next"] == "ReportCardDegraded" for c in states["ReportCard"]["Catch"]
         )
         assert_degraded_continuation(states, "ReportCardDegraded", "PublishReportCardDegraded")
-        assert states["PublishReportCardDegraded"]["Next"] == "CheckShellRunNotify"
+        # alpha-engine-config-I7813: both edges now pass through the
+        # observe-only scanner leaderboard leaf's gate before the notify gate.
+        assert states["PublishReportCardDegraded"]["Next"] == "CheckSkipScannerLeaderboard"
         assert states["Director"]["Next"] == "DirectorComplete"
-        assert states["DirectorComplete"]["Next"] == "CheckShellRunNotify"
+        assert states["DirectorComplete"]["Next"] == "CheckSkipScannerLeaderboard"
+        assert states["CheckSkipScannerLeaderboard"]["Default"] == "ScannerLeaderboard"
+        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
         assert all(
             c["Next"] == "NormalizeFailureContext" for c in states["Director"]["Catch"]
         )

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -539,14 +539,28 @@ class TestStageTableLockstep:
                 # config#6054: DELIBERATE exception, inverted from the
                 # convention. director's witness is the success-only
                 # DirectorComplete Pass state, and its skip route lands on
-                # CheckShellRunNotify — which every bypass path also enters.
+                # CheckSkipScannerLeaderboard (alpha-engine-config-I7813 —
+                # was CheckShellRunNotify until the observe-only scanner board
+                # became a leaf state between the two) — which every bypass
+                # path also enters.
                 # Witnessing on the skip target would mark a bypassed
                 # Director complete and skip it on the rerun (the I6055
                 # trap). Cost of the inversion: an original run that SKIPPED
                 # director yields a rerun that re-runs it — the safe
                 # direction for an advisory stage.
-                assert skip_targets == {"CheckShellRunNotify"}
+                assert skip_targets == {"CheckSkipScannerLeaderboard"}
                 assert "DirectorComplete" not in skip_targets
+                continue
+            if stage.name == "scanner_leaderboard":
+                # alpha-engine-config-I7813: same inverted convention as
+                # director, and for the same I6055 reason — the witness is the
+                # success-only ScannerLeaderboardComplete Pass, while the skip
+                # route lands on CheckShellRunNotify, which every bypass path
+                # also enters. An original run that skipped the leaf yields a
+                # rerun that re-runs it: the safe direction for an observe-only
+                # board that costs one Lambda invocation.
+                assert skip_targets == {"CheckShellRunNotify"}
+                assert "ScannerLeaderboardComplete" not in skip_targets
                 continue
             if stage.name == "backtester_stage_only":
                 # config#2362 Option A additive gate: deliberately empty


### PR DESCRIPTION
## What

`scanner/leaderboard/{date}.json` stops riding inline inside the `Scanner` Lambda invocation in `ResearchPredictorParallel` — which runs **before** `ReportCard`/`Director` in top-level state order — and becomes its own leaf state placed **after** them:

```
… → RunScope → CheckSkipReportCard → ReportCard → CheckSkipDirector → Director
    → DirectorComplete → CheckSkipScannerLeaderboard → ScannerLeaderboard
    → ScannerLeaderboardComplete → CheckShellRunNotify → …
```

with its own `TimeoutSeconds`, its own `Catch`, its own skip gate, and its own success-only rerun witness. This is deliverable 2 of `alpha-engine-config-I7813`.

## Which board moves, and which two deliberately do not

The ruling's discriminator: **does any stage branch on the number?** Checked per board rather than assumed — and it does not come out the way the issue's table says:

| Artifact | Verdict | Evidence |
|---|---|---|
| `scanner/leaderboard/{date}.json` | **REPORT — moves** | Consumers are `crucible-dashboard/views/46_Experiments.py` (renders) and `gate:*` `Data-ready-when` predicates (poll `n_dates`). No pipeline stage branches on it. |
| `research/cuts_leaderboard/{date}.json` | **CONTROL — stays** | `crucible-research/scoring/cut_promotion.py` branches on it and writes `config/scanner_cut_champion.json`, the pointer the live sector-team feed resolves through. The issue's table predates that engine (`I7826`). |
| `research/producer_leaderboard/{date}.json` | **CONTROL — stays** | `crucible-backtester/optimizer/champion_promotion.py::read_latest_research_producer_leaderboard` reads it — at the **Backtester** stage, *earlier* than this leaf. Moving it here would starve its consumer. It is also already weekly with its own `TimeoutSeconds: 300` + `Catch` on `EvalRollingMean` (the issue's "produced in the EOD SF every exercise-chained trading day" line is stale; `step_function_eod.json` has zero `eval_rolling_mean` references). |

## Degradation is loud, named, and terminal

`sf-pipeline-policy.md` §2.3 + the 2026-07-28 Option-A ruling, accepted explicitly under I7813's *Known consequence*:

- Catch → `ScannerLeaderboardDegraded` sets `$.scanner_leaderboard_degraded`
- → `SetScannerLeaderboardDegradedSummary` sets `$.degraded_summary`
- → `PublishScannerLeaderboardDegraded` fires a **named** WARNING alert (best-effort Catch: it cannot change the outcome it reports)
- `CheckGateDegradedNotify` gains a rule for the flag, registered **last, immediately before the clean `Default`** — a run that also degraded a gate, a health check, the parity verdict, the report card or a Branch A fail-open still gets that (more consequential) notification, while a run whose *only* degradation is this board can never reach `NotifyComplete`'s "All steps completed successfully" while terminating in `DegradedRun`.

Every edge that previously ended the advisory tail at `CheckShellRunNotify` — Director's success, Director's skip route, **and ReportCard's degraded route** — now passes through the leaf's gate first. The last one is load-bearing rather than cosmetic: the board does not consume the report card, so a failed report card must not silence it. That is the §2.1 inversion this whole issue exists to remove.

## No new IAM, no post-merge step

The leaf invokes the **same** `alpha-engine-research-scanner:live` the `Scanner` state already invokes, with `mode: "scanner_leaderboard"` as the only distinguishing payload key. No new grant, nothing to run after the merge.

## Timeout

`440`, unchanged from the `Scanner` state's value and for the same reason (`I6855`): the SF budget must sit **below** the 450s function timeout or it can never bind, and an overrun then surfaces as an opaque Lambda error instead of a `States.Timeout` naming the state. Re-derivation from a measured p95 is deliberately deferred to `alpha-engine-config-I7851`, gated on 3 clean weekly runs.

## Lib pin — why this PR carries a 30-file mechanical bump

The three new states (`ScannerLeaderboard`, `PublishScannerLeaderboardDegraded`, `NotifyCompleteScannerLeaderboardDegraded`) are all **substantive** Task states, and `tests/test_pipeline_status_registry_source_check.py` imports the **installed** `nousergon_lib` — so the PR is red until the pinned lib carries their `STATE_TO_ARCHIVE_PAGE` entries. `nousergon-lib-PR340` adds all three.

`v0.124.75 → v0.124.78` across all 30 pin surfaces (`tests/test_lib_pin_lockstep.py`). `v0.124.78` is the patch autobump PR340's merge is **expected** to produce from `0.124.77`. If another lib PR merges between, this pin moves to whatever tag PR340's merge actually produced — the source-check is what tells you, and it stays **red** until the pin is right, which is precisely the guard against merging the SF JSON ahead of the registry entry. Same sequencing `PR311` / `PR326` / `PR333` already established for this class.

## Merge order

1. `nousergon-lib-PR340` — registry entries for the three new states
2. `crucible-research-PR698` — the Lambda's `mode` parameter
3. `crucible-dashboard-PR739` — that repo's own lib pin bump. Its `tests/test_pipeline_status_registry_drift.py` is executed BY this repo's `sf-stage-consumer-guard.yml` against this PR's definitions, using `crucible-dashboard@main`'s pin — so the required `crucible-dashboard stage consumers vs candidate SF definitions` check here stays red until that pin moves too. Measured, not predicted: it is red on this PR right now naming exactly those three states.
4. **this PR** — the SF leaf + this repo's own 30-file lockstep pin bump

3 and 4 are order-independent of each other; both must follow 1.

The order is not cosmetic: the reverse leaves a window in which the weekly SF's leaf invokes a Lambda that returns `ERROR: unknown mode`, and a window in which the definition references states the pinned registry does not know.

## Test plan

- `origin/main` baseline in this environment: **6163 passed, 13 skipped, 0 failed**
- this branch (with PR340's `src/` on `PYTHONPATH`, standing in for the pin): **6177 passed, 13 skipped, 0 failed**
- New file `tests/test_sf_scanner_leaderboard_leaf.py` (8 cases) pins each property separately, because "moved to a leaf" can be true on paper and false in the definition in several independent ways: reachability after ReportCard/Director (not JSON key order) · **nothing downstream reads `$.scanner_leaderboard_result`**, the structural form of the §2.1 blast-radius test · a failed ReportCard does not skip the leaf · timeout below the function timeout · the leaf reuses the Scanner Lambda and carries the mode · the degraded path sets the flag, alerts by name and lands in `DegradedRun` · the terminal notify can never call a degraded leaf a success · skippable + success-only witness.
- Updated in lockstep, each with the reason inline: `test_sf_structural_contract.py` (timeout exemptions for the two SNS states, new degraded-flag JSONPath), `test_sf_completion_marker_wiring.py`, `test_sf_friday_shell_run_wiring.py`, `test_sf_payload_uniqueness.py`, `test_sf_report_card_degraded_wiring.py`, `test_sf_substrate_check_wiring.py`, `test_weekly_sf_rerun.py`, and `scripts/weekly_sf_rerun.py`'s `STAGES` table.
- **Definition validated locally with the same call the deploy preflight makes** — `aws stepfunctions validate-state-machine-definition --type STANDARD --severity WARNING` → `{"result": "OK", "diagnostics": []}`. The deploy is all-or-nothing across four state machines; one illegal escape freezes all of them.

## Not in this PR

Deliverable 1's full `mode` split as the issue words it (default `scan` skips **both** boards, `leaderboards` builds both) is **not** implemented, and the residual question is a ruling — see the issue and the closing report. What is implemented is the narrower split deliverable 2 requires: the cut leaderboard is a control and cannot be moved with the scanner board. Deliverable 3 (`ARTIFACT_REGISTRY.yaml` cadence rows) is owned by a concurrent track.

Tracked at `alpha-engine-config-I7813`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYDnakeUXcV9NkUwAvda2e

---

Rehearsal-path: nousergon-data/infrastructure/run_weekly_offcycle.sh

`sf-pipeline-policy.md` §7.2's conditional applies — this PR touches `step_function.json`, so the rehearsal must exercise **that exact definition path**, not an approximation. The Friday shell run does: `ApplyShellRunDefaults` sets no `skip_scanner_leaderboard`, so `CheckSkipScannerLeaderboard` takes its `Default` and the leaf is genuinely entered on the shell-run path, immediately after `DirectorComplete`, with `dry_run_llm.$ = $.research_dry` threaded exactly as the `Scanner` state threads it. `scanner_handler`'s `is_dry` short-circuit then returns `{"status": "OK", "dry_run": true}` before any S3 read — so the run exercises the new state's reachability, its `Parameters`, the SF→Lambda invoke and the IAM grant, without doing the board's work. What it does not exercise is the board build itself; that is covered pre-merge by `tests/test_scanner_handler.py::TestScannerLeaderboardLeafMode` in `crucible-research-PR698` (raise-on-unwritten, `unmeasurable`-is-not-a-failure, mode dispatch) and by `tests/test_sf_scanner_leaderboard_leaf.py` here.

