### PR TITLE
fix(overseer): register aggregate_costs_handler:corpus_stats alert class (config-I7896)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -872,6 +872,25 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: research_corpus_stats_alerts
+    # alpha-engine-config-I7896 static-chokepoint registration. Emitted by
+    # crucible-research/lambda/aggregate_costs_handler.py::_refresh_corpus_stats
+    # when the distillation corpus_stats refresh fails. The failure is
+    # deliberately non-fatal — the cost parquet is already written by then —
+    # but it is NOT harmless: the config#1542 kill-gate trigger reads
+    # decision_artifacts/distillation/corpus_stats/latest.json, so a frozen
+    # artifact means the 90-day clock silently stops advancing while every
+    # surface still shows a valid file. This alert is the only signal that
+    # happened. Same shape as research_cut_promotion_alerts above (I7876):
+    # an emitter shipped without its playbook row, found by the cross-repo
+    # drift check on alpha-engine-config's main rather than at either repo's
+    # own merge time.
+    # The call site passes no explicit severity, so it takes
+    # publish_observe_alert's default.
+    source: "aggregate_costs_handler:corpus_stats"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
   - class: research_experiment_record_alerts
     source: "research:experiment_record"
     severities: [warning]


### PR DESCRIPTION
## What is unregistered

`crucible-research/lambda/aggregate_costs_handler.py::_refresh_corpus_stats` publishes `source="aggregate_costs_handler:corpus_stats"` and `alert_classes` has no matching row, so the alert never reaches the drain.

Found by the cross-repo drift check on `alpha-engine-config@main`, run `32422679197`:

```
❌ DRIFT FOUND: 1 uncovered source literal(s) in 1 file(s):
  📁 crucible-research/
    🔴 source='aggregate_costs_handler:corpus_stats'
```

That red **silently ejects every entry from `alpha-engine-config`'s merge queue** while each PR keeps reporting a healthy state. A missing playbook row in this repo was blocking merges in another, with nothing saying so.

## Why the alert matters

The refresh failure is deliberately non-fatal — the cost parquet is already written by the time it runs. It is not harmless: `decision_artifacts/distillation/corpus_stats/latest.json` is what the `config#1542` kill-gate trigger reads, so a frozen artifact stops the 90-day clock advancing while every surface still shows a valid file. This alert is the only signal that happened.

## Severity — the part that is easy to get wrong

`severities: [warning]`. The call site passes no explicit `severity`, so it takes `publish_observe_alert`'s default, whose literal value is the string `"WARN"`. The registry vocabulary here is `warning`: **no row in this file uses `warn`**, 25 use `warning`. A row written from the call site's literal would register a severity that never matches.

## Second instance today

The first was `research:cut_promotion` (`alpha-engine-config-I7876`, `nousergon-data-PR1472`). The emitter and its registry row live in different repos, so neither repo's own merge-time CI can catch the gap — the producer PR is green, the registry PR is green, and the drift appears on a third repo's `main` afterwards. The class fix is tracked as `alpha-engine-config-I7896`.

## Test plan

Ran before pushing:

- `pytest tests/test_overseer_playbook_registry.py` — **42 passed**.
- `alpha-engine-config`'s `scripts/check_alert_class_registry_drift.py` against this branch's `playbooks.yaml` and the 8 local fleet repos — **"All publish source literals are registered in alert_classes — no drift."** (79 patterns loaded, up from 78.)

Refs `alpha-engine-config-I7896`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
