### PR TITLE
fix(weekly-sf): ReplayConcordance target_models moves off OpenRouter slug onto registry id (alpha-engine-config-I7898)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2317,14 +2317,14 @@
             },
             "ReplayConcordance": {
               "Type": "Task",
-              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via krepis.llm.LLMClient's OpenRouter transport (alpha-engine-config-I2997, 2026-07-19 -- migrated off langchain_anthropic.ChatAnthropic) against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: deepseek/deepseek-v4-flash (cheap-model concordance vs the champion's Anthropic-tier agents). Runs every Saturday after RationaleClustering.",
+              "Comment": "Weekly cheap-model concordance Lambda (ROADMAP P0, agent-justification gate signal #3). Replays each captured DecisionArtifact in the trailing 8-week window under the configured target model(s) via krepis.router.resolve_model_spec against the LLM model registry (alpha-engine-config-I7898, 2026-08-20 -- migrated off the OpenRouter provider slug onto the registry entry id, paired with crucible-backtester-PR716) against the canonical agent_schemas Pydantic contract; aggregates agreement_score per (agent_id_base, target_model); emits CW metric agent_cheap_model_concordance; persists per-target summary JSON to decision_artifacts/_replay_summary/{YYYY-MM-DD}/{target_model}.json. Default target: deepseek-v4-flash (cheap-model concordance vs the champion's Anthropic-tier agents). Runs every Saturday after RationaleClustering.",
               "Resource": "arn:aws:states:::lambda:invoke",
               "Parameters": {
                 "FunctionName": "alpha-engine-replay-concordance:live",
                 "Payload": {
                   "end_time_iso.$": "$$.Execution.StartTime",
                   "target_models": [
-                    "deepseek/deepseek-v4-flash"
+                    "deepseek-v4-flash"
                   ],
                   "window_days": 56,
                   "max_artifacts": 150,

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -695,9 +695,10 @@ class TestReplayConcordance:
     def test_payload_carries_required_fields(self, states):
         payload = states["ReplayConcordance"]["Parameters"]["Payload"]
         assert payload["end_time_iso.$"] == "$$.Execution.StartTime"
-        # alpha-engine-config-I2997 (2026-07-19): ReplayConcordance migrated
-        # off direct Anthropic to OpenRouter (deepseek/deepseek-v4-flash).
-        assert payload["target_models"] == ["deepseek/deepseek-v4-flash"]
+        # alpha-engine-config-I7898 (2026-08-20): ReplayConcordance migrated
+        # off the OpenRouter provider slug onto the krepis registry entry id
+        # (deepseek-v4-flash), paired with crucible-backtester-PR716.
+        assert payload["target_models"] == ["deepseek-v4-flash"]
         assert payload["window_days"] == 56
         assert payload["max_artifacts"] == 150
 


### PR DESCRIPTION
## What

`infrastructure/step_function.json`'s `ReplayConcordance` state (Saturday weekly-freshness pipeline) hardcodes `target_models: ["deepseek/deepseek-v4-flash"]` — an OpenRouter provider slug. Changes it to `["deepseek-v4-flash"]` — a registry entry id in `alpha-engine-config/private-docs/LLM_MODEL_REGISTRY.yaml` (`status: active`, deliberately excluded from `model_groups` so it stays callable by name — alpha-engine-config-I6908).

## Why now — paired with crucible-backtester-PR716

Tracked as `alpha-engine-config-I7898`. `crucible-backtester-PR716` (open, branch `fix/migrate-off-direct-openrouter`) migrates `replay/runner.py::resolve_target_spec` onto `krepis.router.resolve_model_spec`, which **raises `ValueError` on any id that is not a registry entry**. A provider slug is not a registry entry id — the currently-deployed Lambda accepts the slug and rejects the registry id; once PR716's Lambda deploys, it accepts the registry id and rejects the slug. `crucible-backtester-PR716`'s handler default is already `["deepseek-v4-flash"]`, so this SF payload literal is the last place carrying the old slug.

**No other occurrence found.** Grepped the whole repo for `deepseek/deepseek-v4-flash` and for `target_models`:
- `infrastructure/step_function.json` (`ReplayConcordance` `Payload.target_models` + the state's descriptive `Comment` field, which also named the old slug as "Default target") — fixed, this PR.
- `tests/test_sf_eval_judge_wiring.py::TestReplayConcordance::test_payload_carries_required_fields` — fixed, this PR.
- `tests/test_sf_payload_uniqueness.py` references the `target_models` **key name** only (field-set closure check), not the literal — no change needed.
- `infrastructure/lambdas/weekly-run-scope/fixtures/definition_2026-08-18.json` — a **captured historical execution-history fixture** for the unrelated `weekly-run-scope` Lambda's own tests (`test_handler.py`), not a live-tracking artifact. Deliberately left untouched — editing a captured fixture would misrepresent what was actually captured on 2026-08-18.

## Live-ASL verification (measured, not assumed)

Fetched the live `ne-weekly-freshness-pipeline` definition via `AWS_PROFILE=ne-admin aws stepfunctions describe-state-machine` and diffed its `ReplayConcordance` state against the pre-change repo file: **byte-identical** — no drift, no other field (timeout, retry, other payload keys) differs. The repo file was and is the accurate description of the deployed state before this change.

## Deploy mechanism

**Deploy-mechanism:** `deploy-infrastructure.yml` — triggers on every push to `main` (no path filter, by design — see the workflow's own comment on the drift-elimination trade-off), runs `infrastructure/deploy-infrastructure.sh`, which re-stamps and `update-state-machine`s `ne-weekly-freshness-pipeline` from this exact file, then runs `infrastructure/step-functions/check-definition-drift.py` to confirm live == repo == S3-staged. **Merging this PR is sufficient — no post-merge step required.** This satisfies form (1) of the pull-request-policy post-merge rule (automated ON merge, from code committed in the repo).

## Merge/deploy window — the point of this PR

The old Lambda code accepts only the old slug; the new Lambda code (post `crucible-backtester-PR716`) accepts only the new registry id. This PR and PR716 must land in the **same deploy window**, not before PR716 deploys and not appreciably after. The weekly SF runs **Saturday**.

1. Merge and deploy `crucible-backtester-PR716` first — confirm `alpha-engine-replay-concordance` Lambda is live with the router-based `resolve_target_spec` (its default target is already `deepseek-v4-flash`).
2. Merge this PR (`nousergon-data-PR<N>`) immediately after — `deploy-infrastructure.yml` auto-deploys the SF definition change on merge, no manual step.
3. Do **not** merge this PR before step 1 — the currently-deployed (pre-PR716) Lambda would reject `deepseek-v4-flash` as target_models.
4. Do **not** leave PR716 merged-but-this-PR-unmerged past the next Saturday run — the post-PR716 Lambda rejects the still-deployed old slug and the weekly `ReplayConcordance` state fails every run until this PR deploys.
5. Observable end state: next Saturday's `ne-weekly-freshness-pipeline` execution's `ReplayConcordance` state succeeds (not caught into `MarkReplayConcordanceDegraded`), and `agent_cheap_model_concordance` CW metric is emitted for `deepseek-v4-flash`.

## Tests

Full suite (`pytest tests/`) on this branch: **1 failed, 6177 passed, 13 skipped** (95s). The one failure, `test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday-json_path0]`, is **pre-existing on `origin/main`** (verified in a separate detached worktree at the same base commit, `933d751a` — same failure, same 3 missing states: `NotifyCompleteScannerLeaderboardDegraded`, `PublishScannerLeaderboardDegraded`, `ScannerLeaderboard`, from the unrelated PR#1475 scanner-leaderboard merge) — **not introduced by this change**, and out of scope for I7898 (fix lives in the `nousergon-lib` registry, a different repo).

Targeted tests directly touching the changed payload (`test_sf_eval_judge_wiring.py`, `test_sf_payload_uniqueness.py`, `test_deploy_step_function_single_writer.py`, `test_sf_definition_check_drift.py`): **169 passed**.

No `ruff` in this repo's CI or venv — checked `.github/workflows/ci.yml`; this repo lints via `scripts/lint_extras.py` and two narrow shell-script lint jobs, none of which touch the changed files.

## Cross-repo references

- `alpha-engine-config-I7898` (tracker)
- `crucible-backtester-PR716` (paired change — do not merge or modify from this PR)

**Prepared by:** claude-sonnet-5

Rehearsal-path: tests/test_sf_eval_judge_wiring.py