### PR TITLE
docs(rag): correct stale scanner_candidates claim in _rag_scope.py

### DIFF
--- a/rag/pipelines/_rag_scope.py
+++ b/rag/pipelines/_rag_scope.py
@@ -59,9 +59,13 @@ account-wide 5 req/min, for names no arm decides on.
       → attractiveness_top_60   this scope, and Think Tank's window
         → attractiveness_top_20 the predictor's scored cut
 
-``scanner_candidates`` is still emitted by the producer — it remains the
-incumbent challenger arm and the week-over-week churn baseline
-(alpha-engine-config-I4983). Only its role as the *corpus scope* changed.
+``scanner_candidates`` was retired outright (alpha-engine-config-I7818,
+crucible-research-PR697/crucible-dashboard-PR738): the producer no longer
+emits it. The live scanner cut is ``scanner_champion_60`` (basis=
+``scanner_champion_rank``, the sector teams' input set — renamed from
+``scanner_gate_baseline_60``, itself the successor to ``scanner_candidates``
+per I7578); it plays no role here, since this module's scope is
+``attractiveness_top_60`` regardless of which cut is the scanner's champion.
 
 WHY NOT THE TOP-20 PREDICTOR CUT. Scoping the corpus to 20 would starve the
 Think Tank challenger, whose input is the 60, and make the champion/challenger


### PR DESCRIPTION
## Summary
- `rag/pipelines/_rag_scope.py`'s docstring claimed `scanner_candidates` "is still emitted by the producer." False as of today — `alpha-engine-config-I7818` (crucible-research-PR697, crucible-dashboard-PR738) retired it outright; the live scanner cut is `scanner_champion_60`.
- No behavior change: this module never read `scanner_candidates` as a literal — it resolves scope via `attractiveness_top_60` / `nousergon_lib.decision_set`. Docstring-only fix.
- Checked `nousergon-lib/src/nousergon_lib/decision_set.py:18,27` per the issue — that file's mentions are already past-tense ("The RAG corpus scoped itself to ``scanner_candidates``"), not a forward-looking claim. No edit needed there.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` — syntax valid
- [x] No dedicated test targets this docstring; no code path touched

Closes alpha-engine-config-I7893

🤖 Generated with [Claude Code](https://claude.com/claude-code)