### PR TITLE
feat(overseer): a PR that adds an unregistered alert source fails its OWN check (alpha-engine-config-I7896)

### DIFF
--- a/.github/workflows/alert-class-pr-guard.yml
+++ b/.github/workflows/alert-class-pr-guard.yml
@@ -1,0 +1,138 @@
+name: alert-class-pr-guard
+
+# alpha-engine-config-I7896 deliverable 2.
+#
+# THE DEFECT. An alert emitter (`publish_observe_alert(source=...)` and
+# friends) lives in a crucible-* repo; the `alert_classes` row that declares
+# it lives in THIS repo's infrastructure/overseer/playbooks.yaml. Neither
+# repo's own merge-time CI can see the pair, so the producer PR is green, the
+# registry PR is green, and the drift surfaces afterwards on a THIRD repo's
+# main -- alpha-engine-config's push-to-main fleet sweep. A red main THERE
+# silently ejects every entry from that repo's merge queue while each queued
+# PR keeps reporting a healthy state, so a missing row in one repo blocks
+# merges in another with no message anywhere naming the cause. Measured
+# 2026-08-20, twice in one session, ~2h of fleet merge throughput:
+# research:cut_promotion (crucible-research-PR673 -> alpha-engine-config-I7876)
+# and aggregate_costs_handler:corpus_stats (alpha-engine-config-I7896).
+#
+# WHAT THIS IS. A reusable workflow (`workflow_call`) that every emitter repo
+# calls from its own pull_request CI, plus this repo's own pull_request
+# trigger. It runs infrastructure/overseer/alert_class_pr_guard.py against the
+# CALLER's checkout at the PR's base and head and fails only on the DELTA --
+# pre-existing drift never blocks an unrelated PR. This extends the mechanism
+# alpha-engine-config-I7860 / -PR7871 established for the fleet observability
+# registry ("a PR that adds an unregistered component fails its OWN check") to
+# the second registry with the same cross-repo shape.
+#
+# WHY THE SCANNER MOVED HERE. It was alpha-engine-config/scripts/
+# check_alert_class_registry_drift.py -- a PRIVATE repo. Running it from eight
+# PUBLIC emitter repos would have meant putting an org-wide private-checkout
+# PAT into public CI (and failing hard on any fork PR, which gets no secrets).
+# Beside the registry it grades, in a PUBLIC repo, it needs no credential at
+# all. alpha-engine-config's fleet sweep now invokes this same file and stays
+# the backstop, not the first detector -- one scanner, not two.
+#
+# WHY THIS CANNOT DEADLOCK, which is the constraint that shaped it. The
+# I7860 guard produced a CIRCULAR red on its first live day: PR7820 blocked on
+# a nous-ergon-ops row, and the nous-ergon-ops PR carrying that row blocked by
+# a reconcile reading alpha-engine-config@main. Two structural properties stop
+# that here:
+#   1. The dependency graph is a DAG and this workflow adds no reverse edge.
+#      Emitter repos read this registry at PR time; this repo runs NO PR-time
+#      check that reads an emitter repo. A row PR here can therefore always
+#      merge, whatever the emitter PR is doing.
+#   2. An OPEN companion PR in this repo already satisfies the guard -- the
+#      registry is read as the union of the checked-out playbooks.yaml and the
+#      playbooks.yaml at the head of every open PR here that changes it. The
+#      emitter PR goes green the moment the row PR EXISTS. Merge order is free
+#      in either direction, with no second CI round on either side.
+# The I7860 tolerance (`pending_component_pr`) failed live by logging
+# "REST lookup failed (HTTPError); falling back to gh" and then reading
+# "unknown" as "not pending". Here the lookup tries stdlib urllib first and gh
+# second, and an unavailable lookup fails the guard as UNMEASURED -- it never
+# degrades into "no violation". Safe precisely because of (1).
+#
+# runs-on: ubuntu-latest, deliberately NOT the CI_RUNNER_MODE codebuild
+# ternary. Every repo that calls this workflow is PUBLIC, and public repos get
+# unlimited free GitHub-hosted Actions minutes; routing them to self-hosted
+# CodeBuild would convert free minutes into billed ones.
+
+on:
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  alert-class-pr-guard:
+    name: pr-added alert source must carry an alert_classes row
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # fetch-depth: 0 -- the guard materializes the PR's BASE commit as a
+      # detached `git worktree` inside this checkout, so the base commit must
+      # actually be present, not just its ref name.
+      - name: Checkout the repo being graded
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          fetch-depth: 0
+          path: graded
+
+      # nousergon-data is PUBLIC -- no token, no credential, and a fork PR
+      # from a public emitter repo can run this check unchanged.
+      - name: Checkout the registry (nousergon-data, public)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          repository: nousergon/nousergon-data
+          ref: main
+          path: registry
+
+      # A MISSING CHECKOUT IS A HARD FAILURE, NEVER A SKIP. Recorded in
+      # nous-ergon-ops/governance/authority.d/alpha-engine-config-check-lane-
+      # registry-coverage.yaml: an earlier cross-repo check in this fleet
+      # skipped on a missing sibling and "reported green having verified
+      # nothing on every CI run it was collected in".
+      #
+      # WHICH COPY OF THE GUARD RUNS. When the graded repo IS nousergon-data,
+      # the PR's OWN copy runs against the PR's own playbooks.yaml at each ref
+      # -- so a PR that changes the guard is graded by the version it ships,
+      # and a PR that adds an emitter AND its row in one commit passes. Any
+      # other repo runs the copy on nousergon-data@main against that registry.
+      - name: Resolve the guard, and fail if it is absent
+        run: |
+          set -euo pipefail
+          if [ "${{ github.repository }}" = "nousergon/nousergon-data" ]; then
+            s="$GITHUB_WORKSPACE/graded/infrastructure/overseer/alert_class_pr_guard.py"
+          else
+            s="$GITHUB_WORKSPACE/registry/infrastructure/overseer/alert_class_pr_guard.py"
+          fi
+          [ -f "$s" ] || { echo "::error::$s missing -- this check would otherwise report green having verified nothing"; exit 1; }
+          echo "guard: $s"
+          echo "ALERT_CLASS_GUARD=$s" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install guard dependencies
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: A PR-added alert source must carry an alert_classes row
+        env:
+          # Read-only, and used for exactly one thing: listing OPEN PRs in
+          # nousergon-data so a companion row PR that has not merged yet still
+          # satisfies this check. Never used to write anything anywhere.
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          python3 "$ALERT_CLASS_GUARD"
+          --repo "${{ github.event.repository.name }}"
+          --repo-root "$GITHUB_WORKSPACE/graded"
+          --base "${{ github.event.pull_request.base.sha }}"
+          --head "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/alert-class-pr-guard.yml
+++ b/.github/workflows/alert-class-pr-guard.yml
@@ -15,11 +15,11 @@ name: alert-class-pr-guard
 # research:cut_promotion (crucible-research-PR673 -> alpha-engine-config-I7876)
 # and aggregate_costs_handler:corpus_stats (alpha-engine-config-I7896).
 #
-# WHAT THIS IS. A reusable workflow (`workflow_call`) that every emitter repo
-# calls from its own pull_request CI, plus this repo's own pull_request
-# trigger. It runs infrastructure/overseer/alert_class_pr_guard.py against the
-# CALLER's checkout at the PR's base and head and fails only on the DELTA --
-# pre-existing drift never blocks an unrelated PR. This extends the mechanism
+# WHAT THIS IS. This repo's own copy of a check that each of the nine emitter
+# repos carries: check this repo out, run
+# infrastructure/overseer/alert_class_pr_guard.py against the graded repo at
+# the PR's base and head, fail only on the DELTA -- pre-existing drift never
+# blocks an unrelated PR. This extends the mechanism
 # alpha-engine-config-I7860 / -PR7871 established for the fleet observability
 # registry ("a PR that adds an unregistered component fails its OWN check") to
 # the second registry with the same cross-repo shape.
@@ -52,6 +52,18 @@ name: alert-class-pr-guard
 # second, and an unavailable lookup fails the guard as UNMEASURED -- it never
 # degrades into "no violation". Safe precisely because of (1).
 #
+# WHY NOT A REUSABLE WORKFLOW. `uses: nousergon/nousergon-data/.github/
+# workflows/...@main` would have collapsed each caller to three lines, but
+# `@main` is a MUTABLE ref and the fleet action-pin guard rejects it
+# (measured 2026-08-20 on nousergon-lib-PR341: "is pinned to `main`, a mutable
+# ref"). Pinning to a SHA instead would freeze every caller at one revision of
+# the guard and demand nine follow-up PRs after every change here -- and the
+# SHA would not exist until this PR merged. Checking this repo out as DATA and
+# running the script keeps ONE implementation, keeps every caller on the
+# current guard, and pins only SHA-pinned actions. It is the same shape
+# alpha-engine-config's pr-guard-observability.yml already uses against
+# nous-ergon-ops (alpha-engine-config-I7860).
+#
 # runs-on: ubuntu-latest, deliberately NOT the CI_RUNNER_MODE codebuild
 # ternary. Every repo that calls this workflow is PUBLIC, and public repos get
 # unlimited free GitHub-hosted Actions minutes; routing them to self-hosted
@@ -59,7 +71,6 @@ name: alert-class-pr-guard
 
 on:
   pull_request:
-  workflow_call:
 
 permissions:
   contents: read

--- a/infrastructure/overseer/alert_class_pr_guard.py
+++ b/infrastructure/overseer/alert_class_pr_guard.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""PR-time guard: a PR that adds an UNREGISTERED alert source fails ITS OWN CI.
+
+``alpha-engine-config-I7896`` deliverable 2. Extends the mechanism
+``alpha-engine-config-I7860`` / ``-PR7871`` established for the fleet
+observability registry ("a PR that adds an unregistered component fails its own
+check") to the second registry with the same cross-repo shape: ``alert_classes``
+in ``infrastructure/overseer/playbooks.yaml``.
+
+THE DEFECT
+----------
+An alert emitter (``publish_observe_alert(source=...)`` and friends) lives in a
+``crucible-*`` repo; the row that declares it lives here. Neither repo's own
+merge-time CI can see the pair, so the producer PR is green, the registry PR is
+green, and the drift only surfaces afterwards on a THIRD repo's ``main`` —
+``alpha-engine-config``'s push-to-main sweep. A red ``main`` there silently
+EJECTS every entry from that repo's merge queue while each queued PR keeps
+reporting a healthy state, so a missing playbook row in one repo blocks merges
+in another with no message anywhere naming the cause.
+
+Measured 2026-08-20 — twice in one session, same shape, ~2h of fleet merge
+throughput: ``research:cut_promotion`` (``crucible-research-PR673`` →
+``alpha-engine-config-I7876``) and ``aggregate_costs_handler:corpus_stats``
+(``alpha-engine-config-I7896``).
+
+WHAT THIS DOES
+--------------
+Runs ``alert_class_registry_drift.py`` — the SAME scanner the fleet sweep runs,
+moved here beside the registry rather than duplicated (``policy-shared-code``)
+— against ONE repo's checkout at the PR's BASE and at its HEAD, and fails only
+on the DELTA. Pre-existing drift never blocks an unrelated PR; that is the
+distinction ``observability_registry_pr_guard.py`` draws in its own docstring,
+and it is what keeps the guard from being routed around on day one.
+
+Diffing the two SCAN RESULTS, rather than the changed files, is deliberate and
+covers both directions of the defect:
+
+  * HEAD adds an emitter with no row  → uncovered at HEAD, absent at BASE.
+  * HEAD *removes a row* that a live emitter still needs (only reachable when
+    the graded repo IS this one) → the base scan uses the BASE playbooks and
+    the head scan uses the HEAD playbooks, so the emitter is covered at BASE
+    and uncovered at HEAD. A file-path diff would see a one-line YAML edit and
+    conclude nothing.
+
+THE COMPANION-PR CYCLE, HANDLED FROM THE START
+----------------------------------------------
+The ``I7860`` guard produced a CIRCULAR red on its first live day:
+``alpha-engine-config-PR7820`` was blocked on a row that lived in
+``nous-ergon-ops``, and the ``nous-ergon-ops`` PR carrying that row was blocked
+by a reconcile reading ``alpha-engine-config@main``, where the component did not
+exist yet. Each PR was red because the other had not merged. Two things prevent
+that here, and both are structural rather than hopeful:
+
+1. **The dependency graph is a DAG, and this guard adds no reverse edge.**
+   Emitter repos read this registry at PR time; this repo runs NO PR-time check
+   that reads an emitter repo. (``alpha-engine-config``'s fleet sweep still
+   reads every repo, but it is push-to-main only — a backstop, never a merge
+   gate.) A row PR here therefore can always merge, whatever the emitter PR is
+   doing, so even a hard red on the emitter side resolves in one direction.
+
+2. **An OPEN companion PR in this repo already satisfies the guard.** The
+   registry is read as the union of ``playbooks.yaml`` at the ref CI checked
+   out AND ``playbooks.yaml`` at the head of every open PR in this repo that
+   changes it. The emitter PR goes green the moment the row PR EXISTS —
+   merge order is genuinely free, in either direction, with no second round of
+   CI needed on either side.
+
+   The tolerance the ``I7860`` mechanism carried (``pending_component_pr``)
+   failed live because its resolver logged
+   ``REST lookup ... failed (HTTPError); falling back to gh`` and then returned
+   "unknown", which the caller read as "not pending". So here: the lookup tries
+   stdlib ``urllib`` first (present on BOTH halves of the ``CI_RUNNER_MODE``
+   toggle; ``gh`` is not on the CodeBuild AL2023 image) and ``gh`` second, and
+   if BOTH fail it raises. **An unavailable tolerance fails the guard as
+   ``UNMEASURED``; it never silently degrades into "no violation".** That is
+   safe precisely because of (1): the fix is still one merge away in a
+   direction nothing is blocking.
+
+A DISCOVERER THAT CANNOT READ FAILS AS UNMEASURED, NEVER AS CLEAN
+-----------------------------------------------------------------
+Missing checkout, missing ``playbooks.yaml``, a git operation that fails, an
+unreadable source file, an unavailable pending-PR lookup: every one of these
+exits non-zero with ``UNMEASURED``. Zero-found and cannot-look never share an
+exit code.
+
+Exit 0: this PR introduced no new unregistered alert source (or every new one
+        is already carried by an open companion PR here).
+Exit 1: it did — or the guard could not measure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import alert_class_registry_drift as scan  # noqa: E402
+
+_GIT = shutil.which("git") or "/usr/bin/git"
+_GH = shutil.which("gh") or "gh"
+
+#: Path of the registry file, relative to this repo's root.
+PLAYBOOKS_REL = Path("infrastructure/overseer/playbooks.yaml")
+
+#: The repo that owns the registry. Also the repo this file lives in.
+REGISTRY_REPO = "nousergon/nousergon-data"
+
+#: Cap on how many open PRs the pending-companion lookup will examine. Beyond
+#: this the lookup RAISES rather than truncating — a truncated scan that finds
+#: nothing is indistinguishable from a complete one that finds nothing.
+_MAX_OPEN_PRS = 100
+
+
+class GuardError(RuntimeError):
+    """The guard could not measure. Always fatal — never degraded into a pass."""
+
+
+def _run_git(args: list[str], cwd: Path | None = None) -> str:
+    p = subprocess.run(  # noqa: S603 — argv is ours, no shell
+        [_GIT, *args], cwd=cwd, capture_output=True, text=True, check=False, timeout=120
+    )
+    if p.returncode != 0:
+        raise GuardError(f"git {' '.join(args)} failed: {p.stderr.strip()[:400]}")
+    return p.stdout
+
+
+# ── registry loading ────────────────────────────────────────────────────────
+
+
+def _patterns_from(playbooks: Path) -> list[tuple[str, str, bool]]:
+    if not playbooks.is_file():
+        raise GuardError(f"playbooks.yaml not readable at {playbooks}")
+    try:
+        classes = scan._load_alert_classes(playbooks)  # noqa: SLF001 — reused, not reimplemented
+    except Exception as exc:  # noqa: BLE001 — re-raised as UNMEASURED, never swallowed
+        raise GuardError(f"playbooks.yaml at {playbooks} failed to parse: {exc}") from exc
+    if not classes:
+        raise GuardError(
+            f"playbooks.yaml at {playbooks} declares no alert_classes — an empty "
+            "registry would mark every emitter in the fleet as drift"
+        )
+    return scan._build_registry_patterns(classes)  # noqa: SLF001
+
+
+# ── scanning one repo at one ref ────────────────────────────────────────────
+
+
+def _scan_at(repo_root: Path, ref: str, playbooks_override: Path | None) -> dict[str, set[str]]:
+    """Uncovered source literals in ``repo_root`` at ``ref``.
+
+    ``ref`` resolving to the checkout's own HEAD is scanned in place; any other
+    ref is materialized as a detached ``git worktree`` inside ``repo_root``,
+    read, and torn down — the same mechanism ``observability_registry_pr_guard``
+    uses, and the reason the caller needs ``fetch-depth: 0``.
+
+    When the registry file itself lives INSIDE the graded repo (this repo
+    grading its own PRs), the ref's OWN copy of ``playbooks.yaml`` is used.
+    Otherwise ``playbooks_override`` — the registry as CI checked it out —
+    applies at both refs, because the graded repo does not contain it.
+    """
+    def _do(root: Path) -> dict[str, set[str]]:
+        pb = playbooks_override if playbooks_override is not None else root / PLAYBOOKS_REL
+        return scan._scan_repo(root, _patterns_from(pb))  # noqa: SLF001
+
+    head_sha = _run_git(["rev-parse", "HEAD"], cwd=repo_root).strip()
+    resolved = _run_git(["rev-parse", ref], cwd=repo_root).strip()
+    if resolved == head_sha:
+        return _do(repo_root)
+
+    with tempfile.TemporaryDirectory(prefix="alert-class-pr-guard-") as tmp:
+        wt = Path(tmp) / "base"
+        _run_git(["worktree", "add", "--detach", "--quiet", str(wt), resolved], cwd=repo_root)
+        try:
+            return _do(wt)
+        finally:
+            _run_git(["worktree", "remove", "--force", str(wt)], cwd=repo_root)
+
+
+# ── the pending open companion PR tolerance ─────────────────────────────────
+
+
+def _api_get(path: str) -> object:
+    """GitHub REST GET, urllib first and ``gh`` second. Raises on both failing.
+
+    urllib FIRST because ``gh`` is absent from the CodeBuild AL2023 runner
+    image while urllib is stdlib on both halves of the ``CI_RUNNER_MODE``
+    toggle — the exact asymmetry that made the ``I7860`` tolerance pass on a
+    laptop and fail in CI. ``gh`` remains the fallback for an interactive run
+    with no token exported.
+    """
+    # GH_TOKEN ONLY, deliberately -- not GITHUB_TOKEN. This repo pins
+    # `GITHUB_TOKEN` in `tests/test_no_secret_environ_reads.py`'s
+    # `_PINNED_SECRETS`: every SSM-backed secret must route through
+    # `nousergon_lib.secrets.get_secret()`, never `os.environ`. The token this
+    # function wants is the RUNNER's ephemeral per-job token, which does not
+    # exist in SSM and which `get_secret()` cannot supply -- so rather than
+    # widen that invariant with an allowlist entry, the workflow passes it
+    # explicitly as GH_TOKEN. An ambient token is not silently picked up, which
+    # also makes the credential this check needs visible in the workflow file.
+    token = (os.environ.get("GH_TOKEN") or "").strip()
+    rest_error = "no GH_TOKEN in the environment (the caller workflow must set it)"
+    if token:
+        import urllib.error  # noqa: PLC0415 — only needed on this path
+        import urllib.request  # noqa: PLC0415
+
+        req = urllib.request.Request(  # noqa: S310 — literal https host
+            f"https://api.github.com{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "nousergon-data-alert-class-pr-guard",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+                return json.loads(resp.read().decode())
+        except Exception as exc:  # noqa: BLE001 — fall through to gh, then RAISE
+            rest_error = f"{type(exc).__name__}: {exc}"
+
+    try:
+        out = subprocess.run(  # noqa: S603 — argv is ours, no shell
+            [_GH, "api", path], capture_output=True, text=True, check=False, timeout=60
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise GuardError(
+            f"pending-companion-PR lookup of {path} failed: REST ({rest_error}) and "
+            f"gh ({type(exc).__name__}: {exc})"
+        ) from exc
+    if out.returncode != 0:
+        raise GuardError(
+            f"pending-companion-PR lookup of {path} failed: REST ({rest_error}) and "
+            f"gh (exit {out.returncode}: {out.stderr.strip()[:200]})"
+        )
+    return json.loads(out.stdout or "null")
+
+
+def pending_registry_patterns(registry_repo: str) -> tuple[list[tuple[str, str, bool]], dict[str, int]]:
+    """Registry rows carried by OPEN PRs in ``registry_repo`` but not yet merged.
+
+    Returns ``(patterns, {source: pr_number})``. Raises ``GuardError`` when the
+    lookup cannot be completed — an unknown tolerance is never a granted one.
+    """
+    prs = _api_get(f"/repos/{registry_repo}/pulls?state=open&per_page={_MAX_OPEN_PRS}")
+    if not isinstance(prs, list):
+        raise GuardError(f"unexpected shape from /repos/{registry_repo}/pulls: {type(prs).__name__}")
+    if len(prs) >= _MAX_OPEN_PRS:
+        raise GuardError(
+            f"{registry_repo} has >= {_MAX_OPEN_PRS} open PRs — this lookup would be "
+            "truncated, and a truncated scan that finds nothing reads exactly like a "
+            "complete one that finds nothing"
+        )
+
+    patterns: list[tuple[str, str, bool]] = []
+    origin: dict[str, int] = {}
+    import base64  # noqa: PLC0415
+
+    for pr in prs:
+        number = pr.get("number")
+        sha = (pr.get("head") or {}).get("sha")
+        if not number or not sha:
+            continue
+        try:
+            blob = _api_get(
+                f"/repos/{registry_repo}/contents/{PLAYBOOKS_REL.as_posix()}?ref={sha}"
+            )
+        except GuardError:
+            # The file may legitimately not exist on some head, but a lookup
+            # that FAILED is not the same fact. Re-raise: this whole function
+            # is all-or-nothing by design.
+            raise
+        if not isinstance(blob, dict) or "content" not in blob:
+            continue
+        try:
+            text = base64.b64decode(blob["content"]).decode("utf-8", errors="replace")
+            import yaml  # noqa: PLC0415
+
+            classes = (yaml.safe_load(text) or {}).get("alert_classes") or []
+        except Exception as exc:  # noqa: BLE001
+            raise GuardError(
+                f"{registry_repo}#{number}'s playbooks.yaml could not be parsed: {exc}"
+            ) from exc
+        for pat in scan._build_registry_patterns(classes):  # noqa: SLF001
+            patterns.append(pat)
+            origin.setdefault(pat[1], number)
+    return patterns, origin
+
+
+# ── the paste-ready row ─────────────────────────────────────────────────────
+
+
+def class_name_for(source: str) -> str:
+    """A ``^[a-z0-9_]{3,60}$`` class name derived from the source literal."""
+    slug = re.sub(r"[^a-z0-9]+", "_", source.lower()).strip("_")
+    slug = re.sub(r"_+", "_", slug) or "alert_class"
+    if len(slug) < 3:
+        slug = f"{slug}_alert"
+    return slug[:60].strip("_")
+
+
+def row_yaml(source: str, severity: str) -> str:
+    return (
+        f"  - class: {class_name_for(source)}\n"
+        f"    source: {source}\n"
+        f"    severities: [{severity}]\n"
+        f"    intake: bus\n"
+        f"    response: drain-queue\n"
+    )
+
+
+def _severities_for(repo_root: Path, rel_files: set[str]) -> dict[str, str]:
+    """Best-effort severity per source, read from the emitting files themselves."""
+    out: dict[str, str] = {}
+    for rel in sorted(rel_files):
+        f = repo_root / rel
+        if not f.is_file():
+            continue
+        try:
+            out.update(scan.find_publish_sites(f.read_text(encoding="utf-8", errors="replace")))
+        except OSError as exc:
+            raise GuardError(f"UNREADABLE: {f} ({exc})") from exc
+    return out
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--repo", required=True, help="canonical name of the repo being graded")
+    ap.add_argument("--repo-root", required=True, help="checkout of --repo, with full history")
+    ap.add_argument("--base", required=True, help="git ref for the PR's base sha")
+    ap.add_argument("--head", default="HEAD", help="git ref for the PR's head (default: HEAD)")
+    ap.add_argument(
+        "--playbooks", default=None,
+        help="path to the registry. Default: this file's own repo copy. Omit when the "
+             "graded repo IS the registry repo, so each ref uses its own copy.",
+    )
+    ap.add_argument("--registry-repo", default=REGISTRY_REPO)
+    ap.add_argument(
+        "--no-pending-tolerance", action="store_true",
+        help="do not consult open PRs in the registry repo (tests, and a deliberate "
+             "strict local run)",
+    )
+    args = ap.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    if not (repo_root / ".git").exists():
+        print(
+            f"UNMEASURED: {repo_root} is not a git checkout — this guard would otherwise "
+            "report green having verified nothing",
+            file=sys.stderr,
+        )
+        return 1
+
+    graded_is_registry_repo = (repo_root / PLAYBOOKS_REL).is_file() and args.playbooks is None
+    override = None if graded_is_registry_repo else Path(
+        args.playbooks or (Path(__file__).resolve().parent.parent.parent / PLAYBOOKS_REL)
+    ).resolve()
+
+    print(f"grading: {args.repo} at {repo_root}")
+    print(
+        "registry: "
+        + ("each ref's own infrastructure/overseer/playbooks.yaml (this IS the registry repo)"
+           if graded_is_registry_repo else str(override))
+    )
+    print("scope: publish source literals only — alert_classes rows, nothing else.")
+
+    try:
+        head_bad = _scan_at(repo_root, args.head, override)
+        base_bad = _scan_at(repo_root, args.base, override)
+    except GuardError as exc:
+        print(f"UNMEASURED: {exc}", file=sys.stderr)
+        print("A guard that cannot read its substrate fails as unmeasured, never as clean.",
+              file=sys.stderr)
+        return 1
+
+    newly = {src: files for src, files in head_bad.items() if src not in base_bad}
+    carried = sorted(set(head_bad) & set(base_bad))
+    if carried:
+        print(
+            f"pre-existing drift NOT gated by this PR ({len(carried)}): {', '.join(carried)}\n"
+            "  (the alpha-engine-config fleet sweep owns those — this guard only fails on "
+            "what THIS diff introduced)"
+        )
+
+    if not newly:
+        print("no newly-unregistered alert source in this diff — nothing for this guard to fail.")
+        return 0
+
+    tolerated: dict[str, int] = {}
+    if not args.no_pending_tolerance:
+        try:
+            pend_patterns, pend_origin = pending_registry_patterns(args.registry_repo)
+        except GuardError as exc:
+            print(f"UNMEASURED: {exc}", file=sys.stderr)
+            print(
+                "The rows below ARE missing from the registry as checked out; an open "
+                "companion PR in "
+                f"{args.registry_repo} would have cleared them, but that lookup could not "
+                "run, so this guard will not claim it did. Land the row and re-run.",
+                file=sys.stderr,
+            )
+            _report(newly, {}, repo_root, args, to_stderr=True)
+            return 1
+        del pend_patterns  # coverage is decided per-source below, via pend_origin
+        for src in list(newly):
+            if src == scan.MISSING_SOURCE_SENTINEL:
+                continue
+            matched_pr = next(
+                (n for pat, n in sorted(pend_origin.items())
+                 if scan._source_matches_registry(src, [("", pat, pat.endswith(":*"))])),  # noqa: SLF001
+                None,
+            )
+            if matched_pr is not None:
+                tolerated[src] = matched_pr
+                newly.pop(src)
+
+    for src, number in sorted(tolerated.items()):
+        print(
+            f"TOLERATED-PENDING: {src!r} has no row on the registry as checked out, but "
+            f"{args.registry_repo}#{number} (OPEN) carries one. Merge it, or this drift "
+            "reaches alpha-engine-config@main and reddens it."
+        )
+
+    if not newly:
+        print("every newly-unregistered source is carried by an open companion PR — passing.")
+        return 0
+
+    _report(newly, tolerated, repo_root, args, to_stderr=True)
+    return 1
+
+
+def _report(newly: dict[str, set[str]], _tolerated: dict[str, int], repo_root: Path,
+            args: argparse.Namespace, *, to_stderr: bool) -> None:
+    out = sys.stderr if to_stderr else sys.stdout
+    print(file=out)
+    print(f"FAIL: {len(newly)} alert source(s) introduced by this PR have no "
+          "alert_classes row.", file=out)
+
+    for src, files in sorted(newly.items()):
+        print(f"\n--- {src} ---", file=out)
+        for f in sorted(files):
+            print(f"  emitted by: {args.repo}/{f}", file=out)
+
+        if src == scan.MISSING_SOURCE_SENTINEL:
+            print(
+                "\n  This is a `python -m krepis.alerts publish` invocation with NO "
+                "--source.\n"
+                "  No registry row can ever cover it — the drain ingests it as an "
+                "unknown-source\n"
+                "  finding. The fix is to ADD `--source <literal>` at the call site, then "
+                "register it.",
+                file=out,
+            )
+            continue
+
+        try:
+            severity = _severities_for(repo_root, files).get(src, "dynamic")
+        except GuardError as exc:
+            print(f"  (severity could not be read: {exc}; using `dynamic`)", file=out)
+            severity = "dynamic"
+
+        print(
+            "\n  The row lives in a DIFFERENT repo. Add it there as a companion PR:\n"
+            f"    file:  {args.registry_repo.split('/')[-1]}/{PLAYBOOKS_REL.as_posix()}\n"
+            "    under: alert_classes:\n",
+            file=out,
+        )
+        print(row_yaml(src, severity), file=out)
+        print(
+            "  severity was read from the call site and NORMALIZED to this file's "
+            "vocabulary\n"
+            "  (`WARN` at a call site is `warning` here; nothing matches `warn`). "
+            "`dynamic` means\n"
+            "  the call site's severity is not a literal. Change `intake`/`response` if "
+            "this class\n"
+            "  is drain-blind — an `intake: none` row MUST carry `migration_issue` or "
+            "`operator_reason`.\n",
+            file=out,
+        )
+
+    print(
+        "MERGE ORDER: either PR first, in either direction.\n"
+        f"  This check re-reads the registry on every run AND treats an OPEN {args.registry_repo}\n"
+        "  PR carrying the row as satisfying it, so pushing the companion PR turns this "
+        "check\n"
+        "  green without waiting for it to merge. Nothing in the registry repo is blocked "
+        "by this\n"
+        "  PR, so there is no order in which the two can deadlock.\n",
+        file=out,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/overseer/alert_class_registry_drift.py
+++ b/infrastructure/overseer/alert_class_registry_drift.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""
+Cross-repo drift guard: assert every ``krepis.alerts.publish(source=...)`` /
+``publish_ops_alert`` source literal across the fleet repos has a matching row
+in ``nousergon-data/infrastructure/overseer/playbooks.yaml``'s ``alert_classes:``
+section (alpha-engine-config-I3211 final leg, alpha-engine-config#3305).
+
+A NEW emitter cannot merge without declaring its alert class — this chokepoint
+enforces that by scanning all Python files in the checked-out fleet repos for
+source literals and cross-referencing against the registry's source patterns.
+
+Two emission shapes are covered (alpha-engine-config-I6753 added the second):
+  1. In-process Python calls: ``alerts.publish(source="...")`` and the
+     ``publish_ops_alert`` / ``publish_observe_alert`` / ``publish_ops_digest``
+     wrappers (``*.py`` only).
+  2. CLI-shaped invocations: ``python -m krepis.alerts publish ... --source X``
+     built in subprocess arg-lists, f-strings, or shell scripts (``*.py`` and
+     ``*.sh``). A CLI invocation with NO ``--source`` fails the check outright
+     (reported as ``<missing --source>``) — it is unattributable, so no
+     registry row can ever cover it.
+
+Pattern matching:
+  - Direct literal equality: source=="foo" matches registry row where source=="foo"
+  - Wildcard patterns: registry rows ending with ``:*`` (e.g. ``groom:*``,
+    ``cloudwatch-alarm:*``) match any source with the matching prefix.
+  - ``raw-sns:*``, ``raw-telegram:*``, ``flow-doctor:*``, ``email:*`` rows match
+    any source with that prefix (drain-blind non-bus sources).
+
+Exits 0 on success; exits 1 with a list of uncovered source literals.
+
+**Where this lives, and why it moved** (``alpha-engine-config-I7896``). It was
+``alpha-engine-config/scripts/check_alert_class_registry_drift.py``: a scanner
+in a PRIVATE repo, reading a registry in THIS one, grading emitters in eight
+PUBLIC ones, running only on ``alpha-engine-config``'s push-to-``main``. That
+placement is what made the failure land late and in the wrong repo — twice on
+2026-08-20 (``alpha-engine-config-I7876``, ``-I7896``), each time reddening
+``alpha-engine-config``'s ``main``, which silently ejects every entry from that
+repo's merge queue while each queued PR keeps reporting a healthy state.
+
+It now lives beside the registry it grades, so ``alert_class_pr_guard.py`` can
+run the SAME scanner from an emitter repo's own ``pull_request`` CI over a
+public checkout of this repo — no private checkout, no new credential.
+``alpha-engine-config``'s fleet-wide sweep invokes this file directly and stays
+exactly as it was in every other respect: the backstop, not the first detector.
+
+Usage:
+  python infrastructure/overseer/alert_class_registry_drift.py \\
+    --playbooks infrastructure/overseer/playbooks.yaml \\
+    --repos ../crucible-research crucible-executor crucible-predictor ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# EXCLUDED_DIR_NAMES is defined HERE rather than imported. This scanner moved
+# out of `alpha-engine-config/scripts/` (a PRIVATE repo) into this one — the
+# repo that owns `playbooks.yaml` — under `alpha-engine-config-I7896`, so that
+# the eight PUBLIC emitter repos can run it at their OWN merge time without
+# minting a private-repo checkout credential in public CI. `scan_exclusions.py`
+# stayed behind with the three other alpha-engine-config scanners that import
+# it; `test_alert_class_registry_drift.py::test_excluded_dir_names_matches_the
+# _shared_list_when_it_is_reachable` pins the two lists together whenever both
+# checkouts are present, so the fork cannot drift silently.
+EXCLUDED_DIR_NAMES: frozenset[str] = frozenset({
+    ".worktrees",   # a git worktree is a SECOND checkout — its files are copies
+    ".git",
+    ".venv",
+    "venv",
+    "env",
+    ".tox",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "build",
+    "dist",
+})
+
+# Function/method name patterns that constitute an alert publish call.
+# Covers: alerts.publish, krepis.alerts.publish, publish_ops_alert,
+# publish_observe_alert, publish_ops_digest, etc.
+_PUBLISH_CALL_PATTERN = re.compile(
+    r"""
+    (?:
+        alerts\.publish\s*\(
+        | publish_ops_alert\s*\(
+        | publish_observe_alert\s*\(
+        | publish_ops_digest\s*\(
+    )
+    """,
+    re.VERBOSE,
+)
+
+# Extracts source="..." or source='...' from the call window.
+_SOURCE_ARG_PATTERN = re.compile(r"""source\s*=\s*["']([^"']+)["']""")
+
+# CLI-shaped emission: a subprocess/shell invocation of the krepis.alerts CLI
+# (`python -m krepis.alerts publish ...`), embedded in a .py f-string/arg-list
+# or a .sh script. These never pass through the in-process call shapes above,
+# which is how scan-unlisted-state reached production with no registry row
+# (alpha-engine-config-I6753). Only the `-m` module-invocation shape is
+# matched — krepis ships no console script, so it is the only CLI entry, and
+# the looser `krepis.alerts publish` adjacency also matches PROSE (a
+# box_health.sh comment naming the channel false-positived as a sourceless
+# invocation on the first live run of this check).
+_CLI_CALL_PATTERN = re.compile(r"-m['\",\s]+krepis\.alerts")
+
+# Window scanned forward from each CLI match for its --source argument. Long
+# enough to span multi-line f-string fragments and backslash-continued shell
+# args (box_health.sh's invocation spans ~6 lines); short enough not to
+# swallow a neighbouring, unrelated invocation's --source.
+_CLI_WINDOW_CHARS = 600
+
+# A literal --source token: `--source scan-unlisted-state` or the same
+# quoted/comma-separated inside a Python arg list (`"--source", "router-canary"`).
+# The class includes `/` and `:` — registry sources are frequently path-shaped
+# (`alpha-engine-research/infrastructure/deploy.sh`, `...py::func`), and a
+# class without them truncates at the first slash, mis-reporting a covered
+# emitter as an uncovered prefix.
+_CLI_SOURCE_LITERAL = re.compile(r"--source[\s'\",]+([A-Za-z0-9][\w.\-/:]*)")
+
+# A dynamic --source (`--source "$SRC"` / `--source {var}`): statically
+# unverifiable, skipped — mirroring the in-process scanner, which only
+# matches string literals and ignores source=<variable>.
+_CLI_SOURCE_DYNAMIC = re.compile(r"""--source[\s'\",]+[{$]""")
+
+# Sentinel reported when a CLI invocation carries no --source at all. Such an
+# emitter is unattributable: no registry row can ever match it, and the drain
+# ingests its events as unknown-source findings. Live instance: four
+# claude-code-config call sites also missing the `publish` subcommand, so
+# every invocation died on an argparse error the callers swallowed.
+MISSING_SOURCE_SENTINEL = "<missing --source>"
+
+
+def _find_cli_source_literals(file_text: str) -> tuple[set[str], int]:
+    """CLI-shaped invocations: (literal sources found, count with no --source).
+
+    Dynamic sources (env vars, format interpolation) are skipped, consistent
+    with `_find_publish_source_literals` ignoring non-literal `source=`.
+    """
+    sources: set[str] = set()
+    missing = 0
+    for match in _CLI_CALL_PATTERN.finditer(file_text):
+        window = file_text[match.start(): match.start() + _CLI_WINDOW_CHARS]
+        literal = _CLI_SOURCE_LITERAL.search(window)
+        if literal:
+            sources.add(literal.group(1))
+        elif not _CLI_SOURCE_DYNAMIC.search(window):
+            missing += 1
+    return sources, missing
+
+
+def _load_alert_classes(playbooks_path: Path) -> list[dict]:
+    """Load alert_classes from playbooks.yaml."""
+    data = yaml.safe_load(playbooks_path.read_text())
+    return data.get("alert_classes", [])
+
+
+def _build_registry_patterns(alert_classes: list[dict]) -> list[tuple[str, str, bool]]:
+    """Build a list of (class_name, source_pattern, is_wildcard) tuples.
+
+    Wildcard patterns (ending with ``:*``) are matched by prefix.
+    """
+    patterns = []
+    for cls in alert_classes:
+        source = cls["source"]
+        is_wildcard = source.endswith(":*")
+        patterns.append((cls["class"], source, is_wildcard))
+    return patterns
+
+
+def _find_publish_source_literals(file_text: str, file_path: Path) -> set[str]:
+    """Find all source= string literals within publish call contexts.
+
+    Uses a multi-line-aware approach:
+    1. Find the start of each publish call
+    2. Find the matching closing paren (handling nested parens)
+    3. Within that call, extract source= literal values
+
+    Returns a set of literal source strings found.
+    """
+    sources: set[str] = set()
+    text = file_text
+
+    for match in _PUBLISH_CALL_PATTERN.finditer(text):
+        # Find the matching closing paren for this call.
+        paren_start = text.index("(", match.end() - 1)
+        depth = 0
+        call_end = -1
+        for i in range(paren_start, len(text)):
+            ch = text[i]
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    call_end = i
+                    break
+
+        if call_end == -1:
+            continue  # malformed, skip
+
+        call_body = text[paren_start:call_end]
+        for src_match in _SOURCE_ARG_PATTERN.finditer(call_body):
+            sources.add(src_match.group(1))
+
+    return sources
+
+
+def _source_matches_registry(source: str, patterns: list[tuple[str, str, bool]]) -> bool:
+    """Check if a source value matches any registered alert_class pattern."""
+    for _class_name, pattern, is_wildcard in patterns:
+        if is_wildcard:
+            prefix = pattern[:-2]  # strip trailing ":*"
+            if source.startswith(prefix):
+                return True
+        else:
+            if source == pattern:
+                return True
+    return False
+
+
+def _is_test_file(file_path: Path, repo_root: Path) -> bool:
+    """Check if a file is a test file (test_ prefix or tests/ directory)."""
+    rel = file_path.relative_to(repo_root)
+    parts = rel.parts
+    return any(p == "tests" or p.startswith("test_") for p in parts) or rel.name.startswith(
+        "test_"
+    )
+
+
+def _scan_repo(repo_root: Path, patterns: list[tuple[str, str, bool]]) -> dict[str, set[str]]:
+    """Scan a single repository for uncovered publish source literals.
+
+    Covers in-process Python call shapes (`*.py`) and CLI-shaped invocations
+    of the krepis.alerts CLI (`*.py` and `*.sh`). A CLI invocation with no
+    literal or dynamic ``--source`` at all is reported under
+    ``MISSING_SOURCE_SENTINEL`` — it can never match a registry row.
+
+    Returns a dict mapping source literal to set of file paths where it was found.
+    """
+    uncovered: dict[str, set[str]] = {}
+    scan_files = sorted(repo_root.rglob("*.py")) + sorted(repo_root.rglob("*.sh"))
+
+    for scan_file in scan_files:
+        # Skip the .git directory, __pycache__, and virtual environments.
+        parts = scan_file.relative_to(repo_root).parts
+        # alpha-engine-config-I7867: EXCLUDED_DIR_NAMES is now the one shared
+        # list (this scanner's private copy was the only one of four that
+        # remembered `.worktrees`). `.claude` stays local — agent config is
+        # not a second checkout, and no other scanner wants it skipped.
+        if any(p in EXCLUDED_DIR_NAMES or p == ".claude" for p in parts):
+            continue
+        # Skip vendored/lib stubs.
+        if scan_file.name.endswith("_pb2.py"):
+            continue
+
+        # Skip test files — test source literals are fake/throwaway values.
+        if _is_test_file(scan_file, repo_root):
+            continue
+
+        try:
+            text = scan_file.read_text(encoding="utf-8", errors="replace")
+        except Exception:  # noqa: S112
+            continue
+
+        sources = set()
+        if scan_file.suffix == ".py":
+            sources |= _find_publish_source_literals(text, scan_file)
+        cli_sources, cli_missing = _find_cli_source_literals(text)
+        sources |= cli_sources
+
+        rel_path = str(scan_file.relative_to(repo_root))
+        if cli_missing:
+            uncovered.setdefault(MISSING_SOURCE_SENTINEL, set()).add(rel_path)
+        for source in sources:
+            if not _source_matches_registry(source, patterns):
+                uncovered.setdefault(source, set()).add(rel_path)
+
+    return uncovered
+
+
+def _scan_repos(
+    repo_roots: list[Path],
+    patterns: list[tuple[str, str, bool]],
+) -> dict[str, dict[str, set[str]]]:
+    """Scan multiple repos and return uncovered sources grouped by source literal."""
+    all_uncovered: dict[str, dict[str, set[str]]] = {}
+    for root in repo_roots:
+        repo_name = root.name
+        uncovered = _scan_repo(root, patterns)
+        if uncovered:
+            all_uncovered[repo_name] = uncovered
+    return all_uncovered
+
+
+def check(playbooks_path: Path, repo_roots: list[Path]) -> int:
+    """Main entry point. Returns 0 on success, 1 on drift found."""
+    if not playbooks_path.exists():
+        print(f"❌ playbooks.yaml not found at {playbooks_path}", file=sys.stderr)
+        return 1
+
+    alert_classes = _load_alert_classes(playbooks_path)
+    patterns = _build_registry_patterns(alert_classes)
+
+    print(f"📋 Loaded {len(patterns)} alert class patterns from {playbooks_path}")
+
+    valid_roots = [r for r in repo_roots if r.is_dir()]
+    skipped = [str(r) for r in repo_roots if not r.is_dir()]
+    if skipped:
+        print(f"⚠️  Skipping {len(skipped)} non-existent repo dir(s): {', '.join(skipped)}", file=sys.stderr)
+
+    if not valid_roots:
+        print("❌ No valid repo directories to scan", file=sys.stderr)
+        return 1
+
+    print(f"🔍 Scanning {len(valid_roots)} repo(s): {', '.join(r.name for r in valid_roots)}")
+    all_uncovered = _scan_repos(valid_roots, patterns)
+
+    if all_uncovered:
+        total_sources = sum(len(sources) for repo_d in all_uncovered.values() for sources in repo_d.values())
+        total_files = sum(len(files) for repo_d in all_uncovered.values() for sources in repo_d.values() for files in [sources])
+        print(f"\n❌ DRIFT FOUND: {total_sources} uncovered source literal(s) in {total_files} file(s):\n")
+        for repo_name, repo_sources in sorted(all_uncovered.items()):
+            print(f"  📁 {repo_name}/")
+            for source, files in sorted(repo_sources.items()):
+                print(f"    🔴 source={source!r}")
+                for f in sorted(files):
+                    print(f"       - {repo_name}/{f}")
+            print()
+        return 1
+    else:
+        print("\n✅ All publish source literals are registered in alert_classes — no drift.")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Cross-repo alert class registry drift check"
+    )
+    parser.add_argument(
+        "--playbooks",
+        type=Path,
+        required=True,
+        help="Path to nousergon-data/infrastructure/overseer/playbooks.yaml",
+    )
+    parser.add_argument(
+        "--repos",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="One or more fleet repo root directories to scan",
+    )
+    args = parser.parse_args()
+
+    return check(args.playbooks, args.repos)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Severity inference — used by ``alert_class_pr_guard.py`` to emit a row that
+# is PASTE-READY rather than merely indicative.
+#
+# THE GOTCHA THIS EXISTS FOR (alpha-engine-config-I7896). The severity
+# vocabulary in ``playbooks.yaml`` is ``warning``; ``publish_observe_alert``'s
+# default parameter value is the literal string ``"WARN"``. Measured
+# 2026-08-20: no row in the file uses ``warn``, 35 use ``warning``. A guard
+# that copied the call-site literal into its suggested row would suggest a
+# severity that matches nothing and validates against nothing — the schema's
+# ``severities`` enum is closed. So the literal is NORMALIZED, and a call site
+# whose severity is not a literal at all resolves to ``dynamic``, which is a
+# real enum member (9 rows use it) meaning exactly that.
+# ─────────────────────────────────────────────────────────────────────────────
+
+#: Severity enum accepted by ``playbooks.schema.json``'s ``severities`` items.
+SEVERITY_VOCAB: frozenset[str] = frozenset(
+    {"info", "warning", "error", "critical", "alarm", "dynamic"}
+)
+
+#: Call-site spelling -> registry vocabulary. Keys are lowercased.
+_SEVERITY_ALIASES: dict[str, str] = {
+    "warn": "warning",
+    "warning": "warning",
+    "err": "error",
+    "error": "error",
+    "crit": "critical",
+    "critical": "critical",
+    "fatal": "critical",
+    "info": "info",
+    "notice": "info",
+    "debug": "info",
+    "alarm": "alarm",
+}
+
+#: Default severity each publish wrapper applies when the CALL SITE passes
+#: none. ``None`` means the wrapper has no default (severity is a required
+#: keyword-only argument), so a call site omitting it would be a TypeError —
+#: nothing to infer, and ``dynamic`` is the honest answer.
+_WRAPPER_DEFAULT_SEVERITY: dict[str, str | None] = {
+    "publish_observe_alert": "warning",  # observe_alerts.py: severity: str = "WARN"
+    "publish_ops_alert": None,           # ops_alerts.py: keyword-only, no default
+    "publish_ops_digest": None,
+    "alerts.publish": "error",           # krepis.alerts.publish: severity="error"
+}
+
+# Same shapes as _PUBLISH_CALL_PATTERN, but capturing WHICH wrapper — the
+# wrapper decides the default severity when the call site passes none.
+_PUBLISH_CALL_NAMED = re.compile(
+    r"(alerts\.publish|publish_ops_alert|publish_observe_alert|publish_ops_digest)\s*\("
+)
+
+_SEVERITY_ARG_LITERAL = re.compile(r"""severity\s*=\s*["']([^"']+)["']""")
+_SEVERITY_ARG_ANY = re.compile(r"severity\s*=")
+
+
+def normalize_severity(raw: str) -> str:
+    """Call-site severity literal -> a value the registry schema accepts.
+
+    An unrecognised literal becomes ``dynamic`` rather than being passed
+    through: an invented enum member would make the emitted row fail schema
+    validation, which is a worse failure than an honest "varies".
+    """
+    return _SEVERITY_ALIASES.get(raw.strip().lower(), "dynamic")
+
+
+def find_publish_sites(file_text: str) -> dict[str, str]:
+    """``{source literal: registry severity}`` for every publish call in a file.
+
+    Severity resolution order, per call: an explicit ``severity="..."`` literal
+    (normalized) -> the wrapper's own default -> ``dynamic``. When one source
+    literal is published at two different severities in the same file, the
+    result is ``dynamic`` — the registry row would need both, and ``dynamic``
+    is the value the file already uses for that case.
+    """
+    found: dict[str, set[str]] = {}
+    for match in _PUBLISH_CALL_NAMED.finditer(file_text):
+        wrapper = match.group(1)
+        paren_start = file_text.index("(", match.end() - 1)
+        depth = 0
+        call_end = -1
+        for i in range(paren_start, len(file_text)):
+            if file_text[i] == "(":
+                depth += 1
+            elif file_text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    call_end = i
+                    break
+        if call_end == -1:
+            continue  # malformed, skip — same posture as the scanner above
+        body = file_text[paren_start:call_end]
+
+        literal = _SEVERITY_ARG_LITERAL.search(body)
+        if literal:
+            severity = normalize_severity(literal.group(1))
+        elif _SEVERITY_ARG_ANY.search(body):
+            severity = "dynamic"  # passed, but not statically knowable
+        else:
+            severity = _WRAPPER_DEFAULT_SEVERITY.get(wrapper) or "dynamic"
+
+        for src in _SOURCE_ARG_PATTERN.finditer(body):
+            found.setdefault(src.group(1), set()).add(severity)
+
+    return {
+        src: (sevs.pop() if len(sevs) == 1 else "dynamic")
+        for src, sevs in ((s, set(v)) for s, v in found.items())
+    }

--- a/infrastructure/overseer/alert_class_registry_drift.py
+++ b/infrastructure/overseer/alert_class_registry_drift.py
@@ -138,6 +138,28 @@ _CLI_SOURCE_DYNAMIC = re.compile(r"""--source[\s'\",]+[{$]""")
 # every invocation died on an argparse error the callers swallowed.
 MISSING_SOURCE_SENTINEL = "<missing --source>"
 
+# THE SCANNER MUST NOT SCAN ITSELF (alpha-engine-config-I7896, caught by this
+# guard on its OWN first CI run — nousergon-data-PR1479, run 32436244797).
+#
+# In alpha-engine-config this file was never in the scanned set, so it never
+# came up. Here it is: nousergon-data is one of the nine repos the fleet sweep
+# walks. And these two modules are the one place in the fleet whose JOB is to
+# spell out every publish shape — the docstrings carry
+# `alerts.publish(source="...")`, `--source X`, and a bare `python -m
+# krepis.alerts publish` with no --source as illustrations. The scanner read
+# its own examples as live emitters and reported three: `...`, `X`, and
+# `<missing --source>`.
+#
+# The exclusion is BY EXACT RELATIVE PATH, not by filename and not by "any
+# file that talks about krepis.alerts". A rule of the second kind would blind
+# the scanner to a real emitter that happens to mention the CLI in a comment
+# — the same over-broad instinct that made a box_health.sh PROSE comment
+# false-positive as a sourceless invocation on this check's first live run.
+SELF_EXCLUDED_RELPATHS: frozenset[str] = frozenset({
+    "infrastructure/overseer/alert_class_registry_drift.py",
+    "infrastructure/overseer/alert_class_pr_guard.py",
+})
+
 
 def _find_cli_source_literals(file_text: str) -> tuple[set[str], int]:
     """CLI-shaped invocations: (literal sources found, count with no --source).
@@ -264,6 +286,12 @@ def _scan_repo(repo_root: Path, patterns: list[tuple[str, str, bool]]) -> dict[s
 
         # Skip test files — test source literals are fake/throwaway values.
         if _is_test_file(scan_file, repo_root):
+            continue
+
+        # Skip this scanner and its PR-time guard: their docstrings spell out
+        # every publish shape by design, and the scanner read those examples
+        # as live emitters. See SELF_EXCLUDED_RELPATHS above.
+        if scan_file.relative_to(repo_root).as_posix() in SELF_EXCLUDED_RELPATHS:
             continue
 
         try:

--- a/tests/test_alert_class_pr_guard.py
+++ b/tests/test_alert_class_pr_guard.py
@@ -385,3 +385,48 @@ def test_class_name_is_always_schema_legal():
 # BOTH checkouts are present, so it is the only place the assertion can HARD
 # FAIL rather than skip. A permanently-skipped test here would be a component
 # emitting nothing, rendered green.
+
+
+# ── the scanner must not scan itself ────────────────────────────────────────
+
+
+def test_the_scanner_and_guard_modules_are_excluded_from_the_scan(fleet):
+    """Caught by this guard on its OWN first CI run (nousergon-data-PR1479,
+    run 32436244797): it reported `...`, `X` and `<missing --source>` as live
+    emitters, all of them ILLUSTRATIONS in these two modules' docstrings. In
+    alpha-engine-config the scanner was never in the scanned set; here it is.
+    """
+    repo = fleet["registry"]
+    for rel in sorted(d.SELF_EXCLUDED_RELPATHS):
+        dst = repo / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text((_OVERSEER / Path(rel).name).read_text(encoding="utf-8"))
+    _commit(repo, "the scanner and guard themselves")
+
+    assert _run([
+        "--repo", "nousergon-data", "--repo-root", str(repo),
+        "--base", "HEAD~1", "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 0
+
+
+def test_the_self_exclusion_is_by_exact_path_not_by_filename(fleet, capsys):
+    """A rule keyed on the basename — or worse, on 'mentions krepis.alerts' —
+    would blind the scanner to a real emitter somewhere else in the tree. Only
+    those two exact relative paths are exempt."""
+    repo = fleet["emitter"]
+    impostor = repo / "lambda" / "alert_class_pr_guard.py"
+    _emitter(impostor, "impostor:not_exempt")
+    _commit(repo, "same filename, different path")
+
+    assert _run([
+        "--repo", "crucible-research", "--repo-root", str(repo),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 1
+    assert "impostor:not_exempt" in capsys.readouterr().err
+
+
+def test_the_self_exclusion_names_files_that_actually_exist():
+    """A path that stops resolving is an exemption nobody notices went stale."""
+    for rel in d.SELF_EXCLUDED_RELPATHS:
+        assert (_OVERSEER.parent.parent / rel).is_file(), rel

--- a/tests/test_alert_class_pr_guard.py
+++ b/tests/test_alert_class_pr_guard.py
@@ -1,0 +1,387 @@
+"""Unit tests for ``infrastructure/overseer/alert_class_pr_guard.py``.
+
+`alpha-engine-config-I7896` deliverable 2. Every test builds a real throwaway
+git repo — the guard's whole method is a base-vs-head scan across a detached
+worktree, so a test that mocked git away would exercise none of it.
+
+The cases that matter, and why each is here rather than being obvious:
+
+* **The negative control.** A PR that introduces an unregistered source must go
+  RED. A guard nobody has watched fail is unproven, so this is asserted on the
+  exit code AND on the output naming the target file and emitting a row.
+* **Pre-existing drift must NOT fail an unrelated PR.** That is the distinction
+  that keeps a chokepoint from being routed around on day one.
+* **A removed row must fail in the registry repo's own PR.** The reverse
+  direction of the same defect, and invisible to any file-path diff.
+* **The pending-companion-PR tolerance, both ways.** Granted when an open PR in
+  the registry repo carries the row (this is what stops the `I7860` deadlock
+  from recurring), and UNMEASURED — never clean — when the lookup cannot run.
+* **The severity vocabulary gotcha.** `publish_observe_alert`'s default is the
+  literal `"WARN"`; nothing in `playbooks.yaml` matches `warn`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_OVERSEER = Path(__file__).resolve().parent.parent / "infrastructure" / "overseer"
+sys.path.insert(0, str(_OVERSEER))
+import alert_class_pr_guard as g  # noqa: E402
+import alert_class_registry_drift as d  # noqa: E402
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True, timeout=60
+    )
+    return out.stdout
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "--allow-empty", "-m", message)
+    return _git(root, "rev-parse", "HEAD").strip()
+
+
+def _playbooks(path: Path, sources: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "alert_classes": [
+                    {
+                        "class": g.class_name_for(s),
+                        "source": s,
+                        "severities": ["warning"],
+                        "intake": "bus",
+                        "response": "drain-queue",
+                    }
+                    for s in sources
+                ]
+                or [
+                    {
+                        "class": "placeholder_row",
+                        "source": "placeholder:row",
+                        "severities": ["warning"],
+                        "intake": "bus",
+                        "response": "drain-queue",
+                    }
+                ]
+            }
+        )
+    )
+
+
+def _emitter(path: Path, source: str, severity: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sev = f', severity="{severity}"' if severity else ""
+    path.write_text(
+        "from observe_alerts import publish_observe_alert\n\n\n"
+        f'def go():\n    publish_observe_alert("m", source="{source}"{sev})\n'
+    )
+
+
+@pytest.fixture
+def fleet(tmp_path: Path) -> dict:
+    """A registry checkout and an emitter checkout, both real git repos."""
+    registry = tmp_path / "nousergon-data"
+    emitter = tmp_path / "crucible-research"
+    _init_repo(registry)
+    _init_repo(emitter)
+    _playbooks(registry / g.PLAYBOOKS_REL, ["already:registered"])
+    _commit(registry, "registry")
+    _emitter(emitter / "lambda" / "existing.py", "already:registered")
+    base = _commit(emitter, "base")
+    return {
+        "registry": registry,
+        "emitter": emitter,
+        "playbooks": registry / g.PLAYBOOKS_REL,
+        "base": base,
+    }
+
+
+def _run(argv: list[str]) -> int:
+    return g.main(argv)
+
+
+# ── the negative control ────────────────────────────────────────────────────
+
+
+def test_pr_adding_an_unregistered_source_fails(fleet, capsys):
+    """THE negative control. A guard never observed failing is unproven."""
+    _emitter(fleet["emitter"] / "lambda" / "new.py", "newthing:corpus_stats")
+    _commit(fleet["emitter"], "add emitter")
+
+    rc = _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "newthing:corpus_stats" in err
+    # Actionable without reading source: the exact file, a paste-ready row,
+    # and the merge order. This is the bar the I7860 guard set.
+    assert "infrastructure/overseer/playbooks.yaml" in err
+    assert "source: newthing:corpus_stats" in err
+    assert "class: newthing_corpus_stats" in err
+    assert "MERGE ORDER" in err
+
+
+def test_the_emitted_row_validates_against_the_live_schema(fleet, capsys):
+    """A row that is 'paste-ready' but schema-invalid is not paste-ready."""
+    import json
+
+    _emitter(fleet["emitter"] / "lambda" / "new.py", "newthing:corpus_stats")
+    _commit(fleet["emitter"], "add emitter")
+    _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    err = capsys.readouterr().err
+    block = err[err.index("  - class:"):]
+    row = yaml.safe_load(block.split("\n\n")[0])[0]
+
+    schema = json.loads((_OVERSEER / "playbooks.schema.json").read_text())
+    item = schema["properties"]["alert_classes"]["items"]
+    assert set(item["required"]) <= set(row)
+    assert not set(row) - set(item["properties"])
+    assert row["severities"][0] in item["properties"]["severities"]["items"]["enum"]
+    assert row["intake"] in item["properties"]["intake"]["enum"]
+
+
+def test_a_clean_pr_passes(fleet):
+    _emitter(fleet["emitter"] / "lambda" / "other.py", "already:registered")
+    _commit(fleet["emitter"], "another registered emitter")
+    assert _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 0
+
+
+def test_pre_existing_drift_does_not_fail_an_unrelated_pr(fleet, capsys):
+    """The whole reason this is a DELTA guard and not the fleet sweep."""
+    _emitter(fleet["emitter"] / "lambda" / "old_gap.py", "ancient:gap")
+    base = _commit(fleet["emitter"], "pre-existing drift")
+    (fleet["emitter"] / "README.md").write_text("unrelated\n")
+    _commit(fleet["emitter"], "unrelated change")
+
+    rc = _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", base, "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    assert rc == 0
+    assert "ancient:gap" in capsys.readouterr().out  # named, but not gated
+
+
+# ── the registry repo's own PRs ─────────────────────────────────────────────
+
+
+def test_removing_a_row_fails_the_registry_repos_own_pr(fleet, capsys):
+    """The reverse direction. A file-path diff sees a one-line YAML edit."""
+    _emitter(fleet["registry"] / "collectors" / "emit.py", "data:collector_gap")
+    _playbooks(fleet["playbooks"], ["already:registered", "data:collector_gap"])
+    base = _commit(fleet["registry"], "emitter + row together")
+
+    _playbooks(fleet["playbooks"], ["already:registered"])  # row removed
+    _commit(fleet["registry"], "drop the row")
+
+    rc = _run([
+        "--repo", "nousergon-data", "--repo-root", str(fleet["registry"]),
+        "--base", base, "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    assert rc == 1
+    assert "data:collector_gap" in capsys.readouterr().err
+
+
+def test_registry_repo_may_add_emitter_and_row_in_one_commit(fleet):
+    """No companion PR is needed when both live in the same repo — so the
+    registry repo's own PRs can never be blocked by this guard on a change it
+    is able to make itself. That is half of why the cycle cannot form."""
+    _emitter(fleet["registry"] / "collectors" / "emit.py", "data:same_commit")
+    _playbooks(fleet["playbooks"], ["already:registered", "data:same_commit"])
+    _commit(fleet["registry"], "emitter + row")
+    assert _run([
+        "--repo", "nousergon-data", "--repo-root", str(fleet["registry"]),
+        "--base", "HEAD~1", "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 0
+
+
+# ── the companion-PR tolerance ──────────────────────────────────────────────
+
+
+def test_open_companion_pr_carrying_the_row_satisfies_the_guard(fleet, capsys, monkeypatch):
+    """The `I7860` deadlock, prevented. The emitter PR goes green the moment
+    the row PR EXISTS — it does not have to merge first."""
+    _emitter(fleet["emitter"] / "lambda" / "new.py", "newthing:corpus_stats")
+    _commit(fleet["emitter"], "add emitter")
+
+    monkeypatch.setattr(
+        g, "pending_registry_patterns",
+        lambda repo: ([("newthing_corpus_stats", "newthing:corpus_stats", False)],
+                      {"newthing:corpus_stats": 1476}),
+    )
+    rc = _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD",
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "TOLERATED-PENDING" in out
+    assert "#1476" in out  # the reader is told WHICH PR must still merge
+
+
+def test_an_unavailable_tolerance_is_unmeasured_never_clean(fleet, capsys, monkeypatch):
+    """The `I7860` tolerance failed live by logging an HTTPError and then
+    reading 'unknown' as 'not pending'. Here an unreadable tolerance fails the
+    guard, and says so in those words."""
+    _emitter(fleet["emitter"] / "lambda" / "new.py", "newthing:corpus_stats")
+    _commit(fleet["emitter"], "add emitter")
+
+    def _boom(repo):
+        raise g.GuardError("REST (HTTPError: 500) and gh (exit 1)")
+
+    monkeypatch.setattr(g, "pending_registry_patterns", _boom)
+    rc = _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD",
+    ])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "UNMEASURED" in err
+    assert "newthing:corpus_stats" in err  # still fully actionable
+
+
+def test_tolerance_refuses_to_truncate_a_long_open_pr_list(monkeypatch):
+    monkeypatch.setattr(g, "_api_get", lambda path: [{"number": n, "head": {"sha": "x"}}
+                                                     for n in range(g._MAX_OPEN_PRS)])
+    with pytest.raises(g.GuardError, match="truncated"):
+        g.pending_registry_patterns("nousergon/nousergon-data")
+
+
+# ── cannot-look never equals clean ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("mutate,expect", [
+    (lambda f: ["--repo-root", "/nonexistent/path"], "not a git checkout"),
+    (lambda f: ["--playbooks", "/nonexistent/playbooks.yaml"], "not readable"),
+])
+def test_unreadable_substrate_fails_as_unmeasured(fleet, capsys, mutate, expect):
+    argv = [
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ]
+    override = mutate(fleet)
+    argv[argv.index(override[0]) + 1] = override[1]
+    assert _run(argv) == 1
+    assert expect in capsys.readouterr().err
+
+
+def test_an_empty_registry_is_unmeasured_not_universal_drift(fleet, capsys):
+    fleet["playbooks"].write_text("alert_classes: []\n")
+    assert _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 1
+    assert "declares no alert_classes" in capsys.readouterr().err
+
+
+def test_a_cli_invocation_with_no_source_is_reported_as_unfixable_by_a_row(fleet, capsys):
+    p = fleet["emitter"] / "infrastructure" / "box.sh"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text('#!/bin/bash\npython3 -m krepis.alerts publish --message "hi"\n')
+    _commit(fleet["emitter"], "sourceless CLI invocation")
+    assert _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ]) == 1
+    err = capsys.readouterr().err
+    assert "--source" in err
+    assert "No registry row can ever cover it" in err
+
+
+# ── the severity vocabulary gotcha ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("literal,expected", [
+    ("WARN", "warning"), ("warn", "warning"), ("WARNING", "warning"),
+    ("ERROR", "error"), ("critical", "critical"), ("FATAL", "critical"),
+    ("INFO", "info"), ("alarm", "alarm"), ("not-a-severity", "dynamic"),
+])
+def test_call_site_severity_is_normalized_to_the_registry_vocabulary(literal, expected):
+    assert d.normalize_severity(literal) == expected
+    assert expected in d.SEVERITY_VOCAB
+
+
+def test_publish_observe_alert_default_becomes_warning_not_warn(fleet, capsys):
+    """The measured gotcha: the wrapper's default parameter value is the string
+    `"WARN"`; no row in playbooks.yaml uses `warn`, 35 use `warning`. A row
+    written from the call-site literal would register a severity that matches
+    nothing and fails the schema's closed enum."""
+    _emitter(fleet["emitter"] / "lambda" / "new.py", "newthing:corpus_stats")  # no severity=
+    _commit(fleet["emitter"], "add emitter")
+    _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    err = capsys.readouterr().err
+    assert "severities: [warning]" in err
+    assert "[warn]" not in err
+    assert "[WARN]" not in err
+
+
+def test_a_non_literal_severity_becomes_dynamic(fleet, capsys):
+    p = fleet["emitter"] / "lambda" / "new.py"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        "from observe_alerts import publish_observe_alert\n\n\n"
+        'def go(lvl):\n    publish_observe_alert("m", source="dyn:thing", severity=lvl)\n'
+    )
+    _commit(fleet["emitter"], "dynamic severity")
+    _run([
+        "--repo", "crucible-research", "--repo-root", str(fleet["emitter"]),
+        "--playbooks", str(fleet["playbooks"]),
+        "--base", fleet["base"], "--head", "HEAD", "--no-pending-tolerance",
+    ])
+    assert "severities: [dynamic]" in capsys.readouterr().err
+
+
+def test_class_name_is_always_schema_legal():
+    import re
+    for source in ["a:b", "alpha-engine/executor/main.py", "x", "A::B__C",
+                   "z" * 200, "weekly-sf/stage::fn"]:
+        assert re.fullmatch(r"^[a-z0-9_]{3,60}$", g.class_name_for(source)), source
+
+# NOTE ON THE FORK THIS MOVE CREATED. `scan_exclusions.py` stayed in
+# alpha-engine-config with the three other scanners that import it, so
+# `alert_class_registry_drift.EXCLUDED_DIR_NAMES` is a second copy of that
+# list. The test pinning the two together lives in alpha-engine-config
+# (`scripts/test_alert_class_sibling_contract.py`, run by
+# `alert-class-sibling-contract.yml` at PR time) — that is the only repo where
+# BOTH checkouts are present, so it is the only place the assertion can HARD
+# FAIL rather than skip. A permanently-skipped test here would be a component
+# emitting nothing, rendered green.

--- a/tests/test_alert_class_registry_drift.py
+++ b/tests/test_alert_class_registry_drift.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for ``infrastructure/overseer/alert_class_registry_drift.py`` — the
+cross-repo alert-class registry chokepoint (alpha-engine-config-I3211 final
+leg, #3305), moved into this repo beside the registry it grades under
+``alpha-engine-config-I7896`` so the PUBLIC emitter repos can run it at their
+own merge time (``alert_class_pr_guard.py``) without a private checkout.
+
+Uses synthetic playbooks.yaml trees and synthetic repo source files so the
+test is self-contained and does not depend on network access or live checkouts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "infrastructure" / "overseer"))
+import alert_class_registry_drift as d  # noqa: E402
+
+# ── helpers ──
+
+
+def _make_playbooks(tmp_path: Path, alert_classes: list[dict]) -> Path:
+    """Write a synthetic playbooks.yaml and return its path."""
+    p = tmp_path / "infrastructure" / "overseer"
+    p.mkdir(parents=True)
+    data = {"schema_version": 1, "playbooks": {}, "alert_classes": alert_classes}
+    (p / "playbooks.yaml").write_text(yaml.dump(data))
+    return p / "playbooks.yaml"
+
+
+def _make_repo(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    """Create a synthetic repo under tmp_path with the given files."""
+    root = tmp_path / name
+    for rel, content in files.items():
+        f = root / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content)
+    return root
+
+
+# ── fixtures ──
+
+_BASIC_CLASSES = [
+    {"class": "executor_turnover_tripwire", "source": "alpha-engine/executor/turnover_tripwire.py",
+     "severities": ["dynamic"], "intake": "bus", "response": "drain-queue"},
+    {"class": "freshness_monitor_staleness", "source": "freshness-monitor",
+     "severities": ["dynamic"], "intake": "bus", "response": "playbook:alert-drain"},
+    {"class": "groom_lifecycle_bus_events", "source": "groom:*",
+     "severities": ["error", "warning"], "intake": "bus", "response": "drain-queue"},
+    {"class": "cw_alarms_all", "source": "cloudwatch-alarm:*",
+     "severities": ["alarm"], "intake": "cw-alarm", "response": "drain-queue"},
+    {"class": "research_score_aggregator_gap", "source": "research:score_aggregator",
+     "severities": ["warning"], "intake": "bus", "response": "drain-queue"},
+]
+
+
+# ── tests for _find_publish_source_literals ──
+
+
+class TestFindPublishSourceLiterals:
+    def test_single_line_publish_with_source(self):
+        text = '''from nousergon_lib import alerts
+alerts.publish(source="my-source", severity="warning")'''
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"my-source"}
+
+    def test_multi_line_publish(self):
+        text = """alerts.publish(
+    severity="warning",
+    source="multi-line-source",
+    message="test",
+)"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"multi-line-source"}
+
+    def test_publish_ops_alert(self):
+        text = """publish_ops_alert("test alert", severity="error", source="my-ops-alert")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"my-ops-alert"}
+
+    def test_publish_observe_alert(self):
+        text = """publish_observe_alert("observe alert", source="observe-source")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"observe-source"}
+
+    def test_krepis_alerts_publish(self):
+        text = """krepis.alerts.publish(severity="critical", source="krepis-source")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"krepis-source"}
+
+    def test_multiple_publish_calls(self):
+        text = """alerts.publish(source="first")
+alerts.publish(source="second")
+publish_ops_alert("test", source="third")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"first", "second", "third"}
+
+    def test_nested_parentheses(self):
+        text = """alerts.publish(
+    source="nested-source",
+    message=format_message(get_data("test")),
+)"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"nested-source"}
+
+    def test_no_source_arg(self):
+        text = '''alerts.publish(severity="warning", message="no source here")'''
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == set()
+
+    def test_source_with_single_quotes(self):
+        text = """alerts.publish(source='single-quoted-source')"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"single-quoted-source"}
+
+    def test_non_publish_source_ignored(self):
+        """source= in non-publish contexts should not be extracted."""
+        text = """other_func(source="not-a-publish")
+alerts.publish(source="real-source")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"real-source"}
+
+    def test_source_with_dynamic_value(self):
+        """Dynamic source= values (variables, not literals) are not matched."""
+        text = '''alerts.publish(source=source_var, severity="warning")'''
+        sources = d._find_publish_source_literals(text, Path("dummy.py"))
+        assert sources == set()
+
+    def test_publish_ops_digest(self):
+        text = """publish_ops_digest("digest", source="digest-source")"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"digest-source"}
+
+    def test_very_nested_call(self):
+        text = """alerts.publish(
+    severity="error",
+    source="deeply-nested",
+    extra=some_function(
+        arg1="hello",
+        arg2=other_call(nested=True),
+    ),
+)"""
+        assert d._find_publish_source_literals(text, Path("dummy.py")) == {"deeply-nested"}
+
+
+# ── tests for _source_matches_registry ──
+
+
+class TestSourceMatchesRegistry:
+    def test_exact_match(self):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+        assert d._source_matches_registry("freshness-monitor", patterns)
+
+    def test_wildcard_prefix_match(self):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+        assert d._source_matches_registry("groom:nousergon/alpha-engine-config@main", patterns)
+        assert d._source_matches_registry("cloudwatch-alarm:CPUUtilization", patterns)
+
+    def test_no_match(self):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+        assert not d._source_matches_registry("unknown-source", patterns)
+
+    def test_wildcard_no_match(self):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+        assert not d._source_matches_registry("other-prefix:test", patterns)
+
+    def test_empty_patterns(self):
+        assert not d._source_matches_registry("anything", [])
+
+    def test_research_prefix(self):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+        assert d._source_matches_registry("research:score_aggregator", patterns)
+        assert not d._source_matches_registry("research:unknown", patterns)
+
+
+# ── integration tests with synthetic repos ──
+
+
+class TestScanRepo:
+    def test_all_sources_registered(self, tmp_path):
+        """Repo with only registered sources should pass cleanly."""
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "src/module.py": """alerts.publish(source="freshness-monitor", severity="warning")""",
+            "src/other.py": """alerts.publish(source="alpha-engine/executor/turnover_tripwire.py")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert uncovered == {}
+
+    def test_uncovered_source(self, tmp_path):
+        """Repo with an unregistered source should report it."""
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "src/module.py": """alerts.publish(source="unregistered-source", severity="warning")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert "unregistered-source" in uncovered
+        assert "src/module.py" in uncovered["unregistered-source"]
+
+    def test_skips_test_files(self, tmp_path):
+        """Test files should be excluded from scanning."""
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "tests/test_module.py": """alerts.publish(source="test-only-source")""",
+            "src/test_foo.py": """alerts.publish(source="another-test-source")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert uncovered == {}
+
+    def test_wildcard_coverage(self, tmp_path):
+        """Sources matching wildcard patterns should not be flagged."""
+        classes = _BASIC_CLASSES + [
+            {"class": "research_experiment_record_alerts", "source": "research:experiment_record",
+             "severities": ["warning"], "intake": "bus", "response": "drain-queue"},
+        ]
+        patterns = d._build_registry_patterns(classes)
+
+        repo = _make_repo(tmp_path, "research", {
+            "producers/runner.py": """publish_observe_alert("recording", source="research:experiment_record")""",
+            "lambda/handler.py": """publish_observe_alert("handling", source="research:thinktank_daily")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert "research:experiment_record" not in uncovered
+        # research:thinktank_daily is NOT registered, so should be flagged
+        assert "research:thinktank_daily" in uncovered
+
+    def test_skips_virtual_envs(self, tmp_path):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            ".venv/lib/site-packages/package.py": """alerts.publish(source="venv-source")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert uncovered == {}
+
+    def test_mixed_registered_and_unregistered(self, tmp_path):
+        patterns = d._build_registry_patterns(_BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "src/registered.py": """alerts.publish(source="freshness-monitor")""",
+            "src/unregistered.py": """alerts.publish(source="brand-new-source", severity="error")""",
+        })
+
+        uncovered = d._scan_repo(repo, patterns)
+        assert "freshness-monitor" not in uncovered
+        assert "brand-new-source" in uncovered
+
+
+# ── end-to-end check() tests ──
+
+
+class TestCheck:
+    def test_success_no_drift(self, tmp_path):
+        playbooks = _make_playbooks(tmp_path, _BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "module.py": """alerts.publish(source="freshness-monitor")""",
+        })
+
+        assert d.check(playbooks, [repo]) == 0
+
+    def test_drift_found(self, tmp_path):
+        playbooks = _make_playbooks(tmp_path, _BASIC_CLASSES)
+
+        repo = _make_repo(tmp_path, "test-repo", {
+            "module.py": """alerts.publish(source="unknown-source")""",
+        })
+
+        assert d.check(playbooks, [repo]) == 1
+
+    def test_missing_playbooks(self, tmp_path):
+        fake_path = tmp_path / "nonexistent.yaml"
+        repo = _make_repo(tmp_path, "test-repo", {"m.py": "pass"})
+        assert d.check(fake_path, [repo]) == 1
+
+    def test_no_valid_repos(self, tmp_path):
+        playbooks = _make_playbooks(tmp_path, _BASIC_CLASSES)
+        assert d.check(playbooks, [tmp_path / "nonexistent"]) == 1
+
+    def test_multiple_repos_one_drift(self, tmp_path):
+        playbooks = _make_playbooks(tmp_path, _BASIC_CLASSES)
+
+        repo1 = _make_repo(tmp_path, "repo-ok", {
+            "m.py": """alerts.publish(source="freshness-monitor")""",
+        })
+        repo2 = _make_repo(tmp_path, "repo-drift", {
+            "m.py": """alerts.publish(source="leaked-source")""",
+        })
+
+        assert d.check(playbooks, [repo1, repo2]) == 1
+
+
+# ── CLI-shaped emission (I6753) ──
+
+_CLI_CLASSES = [
+    {"class": "scan_unlisted_state", "source": "scan-unlisted-state",
+     "severities": ["warning"], "intake": "bus", "response": "drain-queue"},
+    {"class": "deploy_notification_research",
+     "source": "alpha-engine-research/infrastructure/deploy.sh",
+     "severities": ["error"], "intake": "bus", "response": "drain-queue"},
+]
+
+
+class TestCliShapedEmission:
+    def test_sh_registered_source_passes(self, tmp_path):
+        """Shell invocation with a registered literal --source: clean."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infra/check.sh": (
+                '"$VENV_PY" -m krepis.alerts publish \\\n'
+                '    --message "$msg" \\\n'
+                "    --severity warning \\\n"
+                "    --source scan-unlisted-state \\\n"
+                '    --dedup-key "$dkey"\n'
+            ),
+        })
+        assert d._scan_repo(repo, patterns) == {}
+
+    def test_py_fstring_unregistered_source_flagged(self, tmp_path):
+        """CLI invocation built in a Python f-string: unregistered source drifts."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infra/scanner.py": (
+                "cmd = (\n"
+                "    f'exec \"{VENV_PY}\" -m krepis.alerts publish '\n"
+                "    f\"--message {msg} --severity critical \"\n"
+                "    f\"--source rogue-new-emitter --dedup-key {key}\"\n"
+                ")\n"
+            ),
+        })
+        uncovered = d._scan_repo(repo, patterns)
+        assert "rogue-new-emitter" in uncovered
+
+    def test_path_shaped_source_not_truncated(self, tmp_path):
+        """A path-shaped --source matches its row in full — never cut at `/`.
+
+        First live run truncated `alpha-engine-research/infrastructure/
+        deploy.sh` to `alpha-engine-research`, mis-reporting a covered
+        emitter as uncovered drift.
+        """
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infrastructure/deploy.sh": (
+                "python3 -m krepis.alerts publish \\\n"
+                "  --severity error \\\n"
+                '  --source "alpha-engine-research/infrastructure/deploy.sh" \\\n'
+                '  --message "deploy failed"\n'
+            ),
+        })
+        assert d._scan_repo(repo, patterns) == {}
+
+    def test_sourceless_cli_invocation_fails(self, tmp_path):
+        """No --source at all: unattributable, reported under the sentinel."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "watch/canary.py": (
+                "subprocess.run(\n"
+                '    ["python3", "-m", "krepis.alerts", "--message", message,\n'
+                '     "--severity", "error"],\n'
+                "    capture_output=True, timeout=20, check=False,\n"
+                ")\n"
+            ),
+        })
+        uncovered = d._scan_repo(repo, patterns)
+        assert d.MISSING_SOURCE_SENTINEL in uncovered
+        assert "watch/canary.py" in uncovered[d.MISSING_SOURCE_SENTINEL]
+
+    def test_python_arglist_source_extracted(self, tmp_path):
+        """subprocess arg-list form: `"--source", "name"` is a literal source."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "watch/canary.py": (
+                "subprocess.run(\n"
+                '    ["python3", "-m", "krepis.alerts", "publish",\n'
+                '     "--message", message, "--severity", "error",\n'
+                '     "--source", "router-canary"],\n'
+                "    check=False,\n"
+                ")\n"
+            ),
+        })
+        uncovered = d._scan_repo(repo, patterns)
+        assert "router-canary" in uncovered  # not registered in _CLI_CLASSES
+        assert d.MISSING_SOURCE_SENTINEL not in uncovered
+
+    def test_dynamic_source_skipped(self, tmp_path):
+        """`--source "$SRC"`: statically unverifiable, skipped — not sourceless."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infra/generic.sh": (
+                'python3 -m krepis.alerts publish --message "$msg" '
+                '--severity "$sev" --source "$SRC"\n'
+            ),
+        })
+        assert d._scan_repo(repo, patterns) == {}
+
+    def test_prose_mention_not_an_invocation(self, tmp_path):
+        """A comment naming the channel is not an invocation (box_health.sh
+        false-positived on `krepis.alerts publish` prose in the first run —
+        only the `-m krepis.alerts` module shape counts)."""
+        patterns = d._build_registry_patterns(_CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infra/notes.sh": (
+                "# the verdict travelled ONLY via `krepis.alerts publish` "
+                "(SNS + Telegram).\n"
+            ),
+        })
+        assert d._scan_repo(repo, patterns) == {}
+
+    def test_check_end_to_end_cli_drift(self, tmp_path):
+        playbooks = _make_playbooks(tmp_path, _CLI_CLASSES)
+        repo = _make_repo(tmp_path, "test-repo", {
+            "infra/new.sh": (
+                'python3 -m krepis.alerts publish --message "x" '
+                "--severity error --source undeclared-cli-emitter\n"
+            ),
+        })
+        assert d.check(playbooks, [repo]) == 1


### PR DESCRIPTION
## The defect

An alert emitter — `publish_observe_alert(source=...)` and friends — lives in a `crucible-*` repo; the `alert_classes` row declaring it lives here, in `infrastructure/overseer/playbooks.yaml`. **Neither repo's own merge-time CI can see the pair.** The producer PR is green, the registry PR is green, and the drift surfaces afterwards on a *third* repo's `main` — `alpha-engine-config`'s push-to-main fleet sweep. A red `main` there **silently ejects every entry from that repo's merge queue while each queued PR keeps reporting a healthy state**, so a missing row in one repo blocks merges in another with no message anywhere naming the cause.

Measured 2026-08-20 — twice in one session, same shape, roughly two hours of fleet merge throughput:

| emitter | landed in | surfaced as |
|---|---|---|
| `research:cut_promotion` | `crucible-research-PR673` | `alpha-engine-config@main` red (`-I7876`) |
| `aggregate_costs_handler:corpus_stats` | pre-existing | `alpha-engine-config@main` red (`-I7896`) |

## What this adds

**`infrastructure/overseer/alert_class_pr_guard.py`** — runs the drift scanner against ONE repo's checkout at the PR's **base** and at its **head**, and fails only on the **delta**. Pre-existing drift never blocks an unrelated PR; that is the distinction `observability_registry_pr_guard.py` draws in its own docstring, and it is what keeps a chokepoint from being routed around on day one.

Diffing two *scan results* rather than changed file paths covers both directions:

- HEAD adds an emitter with no row → uncovered at HEAD, absent at BASE.
- HEAD **removes a row** a live emitter still needs (reachable in this repo's own PRs) → base scan uses the BASE `playbooks.yaml`, head scan uses the HEAD one, so the emitter is covered at BASE and uncovered at HEAD. A file-path diff would see a one-line YAML edit and conclude nothing.

**`.github/workflows/alert-class-pr-guard.yml`** — a `workflow_call` reusable workflow every emitter repo invokes from its own `pull_request` CI, plus this repo's own trigger. When the graded repo IS this one, the PR's own copy of the guard runs against the PR's own registry at each ref, so a PR changing the guard is graded by the version it ships and a PR adding an emitter *and* its row in one commit passes.

## Extending I7860 rather than building a second thing

This is the `alpha-engine-config-I7860` / `-PR7871` mechanism — "a PR that adds an unregistered component fails its OWN check" — applied to the second registry with the same cross-repo shape. Same method (base-vs-head discovery via a detached `git worktree`), same posture (cannot-read is `UNMEASURED`, never clean), same output contract (name the exact file, emit a paste-ready row, state the merge order).

It is a **separate script from `observability_registry_pr_guard.py`, and that is not duplication**: that guard grades `nous-ergon-ops/governance/observability.d/` against workflow/Lambda *schedules*; this one grades `nousergon-data`'s `alert_classes` against publish *source literals*. Different registry, different repo, different discoverer, no shared code path to unify. What is genuinely shared — the scanner — is shared rather than copied (below).

## One scanner, not two — and why it moved into this repo

`check_alert_class_registry_drift.py` was in `alpha-engine-config/scripts/`: a scanner in a **private** repo, reading a registry in **this** one, grading emitters in eight **public** ones, running only on `alpha-engine-config`'s push-to-`main`. That placement is what made the failure land late and in the wrong repo.

Running it from the public emitter repos would have required an org-wide private-checkout PAT in public CI — and would fail hard on any fork PR, which gets no secrets. Beside the registry it grades, in a public repo, it needs **no credential at all**. `alpha-engine-config-PR7909` repoints the fleet sweep at this file and deletes its copy: one scanner, and the sweep becomes the backstop rather than the first detector.

The one thing left behind is `scan_exclusions.py`, which three other `alpha-engine-config` scanners import; `EXCLUDED_DIR_NAMES` is therefore forked. That fork is pinned by `alpha-engine-config/scripts/test_alert_class_sibling_contract.py`, running at PR time in the only repo where both checkouts exist. A parity test **here** could only ever skip, and a permanently-skipped test is a component emitting nothing rendered green.

## The companion-PR cycle, handled from the start

The `I7860` guard produced a **circular** red on its first live day: `alpha-engine-config-PR7820` was blocked on a `nous-ergon-ops` row, and the `nous-ergon-ops` PR carrying that row was blocked by a reconcile reading `alpha-engine-config@main`, where the component did not exist yet. Two structural properties stop that recurring here:

1. **The dependency graph is a DAG and this adds no reverse edge.** Emitter repos read this registry at PR time; this repo runs **no** PR-time check that reads an emitter repo. (`alpha-engine-config`'s fleet sweep still reads every repo, but it is push-to-main only — a backstop, never a merge gate.) A row PR here can therefore always merge, whatever the emitter PR is doing, so even a hard red on the emitter side resolves in one direction.
2. **An OPEN companion PR here already satisfies the guard.** The registry is read as the union of the checked-out `playbooks.yaml` and the `playbooks.yaml` at the head of every open PR in this repo that changes it. The emitter PR goes green the moment the row PR **exists** — merge order is free in either direction, with no second CI round on either side.

The `I7860` tolerance (`pending_component_pr`) failed live by logging `REST lookup ... failed (HTTPError); falling back to gh` and then reading "unknown" as "not pending". Here the lookup tries stdlib `urllib` first (present on both halves of the `CI_RUNNER_MODE` toggle; `gh` is not on the CodeBuild AL2023 image) and `gh` second, and **if both fail it raises**: an unavailable tolerance fails the guard as `UNMEASURED` and still prints the full actionable report. It never degrades into "no violation". That is safe precisely because of (1). A lookup that would be truncated (≥100 open PRs) also raises rather than reporting a partial scan as complete.

## Fail loud

Missing checkout, missing or unparseable `playbooks.yaml`, an `alert_classes:` list that is empty, a failed git operation, an unreadable source file, an unavailable pending-PR lookup — every one exits non-zero with `UNMEASURED`. Zero-found and cannot-look never share an exit code.

## The severity vocabulary gotcha, encoded

`publish_observe_alert`'s default `severity` parameter value is the literal string `"WARN"`; the registry vocabulary is `warning`, and `severities` is a **closed enum** in `playbooks.schema.json`. Measured: no row uses `warn`, 35 use `warning`. A guard emitting a row from the call-site literal would suggest a severity that matches nothing and fails schema validation. So the literal is normalized (`WARN`→`warning`, `FATAL`→`critical`, …), a non-literal `severity=` resolves to `dynamic` (a real enum member, 9 rows use it), and `test_the_emitted_row_validates_against_the_live_schema` validates the emitted row against `playbooks.schema.json` itself.

## Test plan — run before opening

- `pytest tests/test_alert_class_pr_guard.py tests/test_alert_class_registry_drift.py` — **64 passed**. Every guard test builds a real throwaway git repo; the method is a base-vs-head scan across a detached worktree, so mocking git away would exercise none of it.
- **Baseline parity, same environment.** `origin/main` at `c22691e9`: **68 failed, 5890 passed, 14 skipped, 48 errors**. This branch: **68 failed, 5954 passed, 14 skipped, 48 errors** — exactly +64, identical failure and error sets (diffed by test id, not by count). The 68/48 are pre-existing local-environment collection gaps present on both.
- One **real regression caught and fixed** on the way: the guard originally read `os.environ.get("GITHUB_TOKEN")`, which this repo pins in `tests/test_no_secret_environ_reads.py::_PINNED_SECRETS`. Rather than widen that invariant with an allowlist entry, the guard now reads `GH_TOKEN` only and the workflow passes it explicitly — the runner's ephemeral job token is not an SSM secret, and an ambient token is no longer silently picked up.

## Negative control — the guard observed failing

A guard never watched fail is unproven. Run against a real `crucible-research` checkout at `origin/main`:

1. base == head → exit **0**.
2. commit adding `publish_observe_alert(source="negctl_handler:never_registered")` → exit **1**, output naming `crucible-research/lambda/_negctl_handler.py`, emitting `class: negctl_handler_never_registered / source: negctl_handler:never_registered / severities: [warning]` (severity correctly derived from the `"WARN"` default and normalized), and stating the merge order.
3. row added to `playbooks.yaml` → exit **0** again.
4. `--repo-root /nonexistent` → exit 1, `UNMEASURED: ... is not a git checkout`. `--playbooks /nonexistent` → exit 1, `UNMEASURED: playbooks.yaml not readable`.
5. live pending-PR lookup against this repo's 4 open PRs: completed, none carried the row, guard correctly failed. With no token and `gh` off `PATH`: exit 1, `UNMEASURED: ... REST (no GH_TOKEN ...) and gh (FileNotFoundError ...)` — **not** a pass.

Worktree and branch torn down afterwards.

## Sweep — run before it is allowed to block anything

Repair and sweep are one unit. The moved scanner, run against fresh `origin/main` checkouts of all nine fleet repos (`crucible-research`, `-executor`, `-predictor`, `-backtester`, `-dashboard`, `-evaluator`, `nousergon-data`, `-lib`, `-docs`): **79 alert class patterns, "All publish source literals are registered in alert_classes — no drift."** The delta guard was then dry-run over 30 commits of real history in `crucible-research`, `crucible-executor` and `nousergon-data`: silent in all three. Turning it on blocks nothing that exists today.

## Cost

`runs-on: ubuntu-latest`, deliberately not the `CI_RUNNER_MODE` CodeBuild ternary. Every repo calling this is public, and public repos get unlimited free GitHub-hosted minutes; routing them to self-hosted CodeBuild would convert free minutes into billed ones.

## SOTA

A check fails on the change that caused it. A guard whose red lands in a repo the author never touched trains people to treat it as noise — and here it did worse than that: it ejected an unrelated repo's merge queue silently.

## Delta

Adds one job to every emitter repo's PR CI (free minutes) and one cross-repo public checkout. The guard's scope is publish **source literals** only — it does not verify `intake`, `response`, or that the class is actually drained; the emitted row defaults to `intake: bus / response: drain-queue` and says so in its own output.

## Merge order

**This PR first**, then the eight caller workflows in any order — `crucible-research-PR700`, `crucible-executor-PR488`, `crucible-predictor-PR533`, `crucible-backtester-PR717`, `crucible-dashboard-PR741`, `crucible-evaluator-PR246`, `nousergon-lib-PR341`, `nousergon-docs-PR51` — then **`alpha-engine-config-PR7909`** last (its coverage test fails until all eight are in). The caller workflows reference `nousergon/nousergon-data/.github/workflows/alert-class-pr-guard.yml@main` and `alpha-engine-config`'s sweep invokes `alert_class_registry_drift.py` from this repo's checkout; both fail loudly, not silently, until this lands.

Related: `alpha-engine-config-I7896`, `-I7876`, `-I7860`, `-I7870`, `nous-ergon-ops-PR781`, `nousergon-data-PR1476`.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYDnakeUXcV9NkUwAvda2e
