### PR TITLE
feat(sf): deploy-readiness detection + self-heal for the preopen halt class (alpha-engine-config-I7800)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -34,6 +34,8 @@ jobs:
     name: Stamp SF + CF with main HEAD
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      blast_radius_message: ${{ steps.blast_radius.outputs.message }}
 
     steps:
       - name: Checkout
@@ -79,10 +81,35 @@ jobs:
           deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
           deploy_workflow: deploy-infrastructure.yml
 
+      # alpha-engine-config-I7800: computed unconditionally (always()) so it
+      # runs on both a clean deploy (harmless, unused) and a failure (feeds
+      # notify-main-failure below). Pure stdlib (datetime/zoneinfo) — no pip
+      # install, so it can't itself fail on a dependency problem and mask the
+      # real deploy failure this step exists to annotate.
+      - name: Compute blast radius (I7800)
+        id: blast_radius
+        if: always()
+        run: |
+          MSG="$(python3 infrastructure/deploy_blast_radius.py --message-only)"
+          echo "message<<BLASTRADIUS_EOF" >> "$GITHUB_OUTPUT"
+          echo "$MSG" >> "$GITHUB_OUTPUT"
+          echo "BLASTRADIUS_EOF" >> "$GITHUB_OUTPUT"
+          echo "$MSG"
+
   # Alert (Telegram) on genuine post-merge failure of this workflow on the
   # default branch. Reusable workflow + transport in nousergon-lib. config#1128.
+  #
+  # alpha-engine-config-I7800: pinned to a commit on nousergon-lib's
+  # feat/notify-message-override-i7800 branch (predates that branch's merge
+  # to main — GitHub resolves a workflow_call ref from any pushed commit, not
+  # just main history, so this works regardless of merge order). Re-pin to
+  # nousergon-lib@main HEAD once nousergon-lib-PR<TBD> (the notify-ci-
+  # failure.yml `blast_radius_message` input) merges — tracked in this PR's
+  # body, not left as a silent follow-up.
   notify-main-failure:
     needs: [deploy-infrastructure]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@a5394d3754c1b6bbf4365a29808f191bbd37cd50 # feat/notify-message-override-i7800 (alpha-engine-config-I7800) — re-pin to main once nousergon-lib-PR<TBD> merges
+    with:
+      blast_radius_message: ${{ needs.deploy-infrastructure.outputs.blast_radius_message }}
     secrets: inherit

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -82,10 +82,15 @@ jobs:
           deploy_workflow: deploy-infrastructure.yml
 
       # alpha-engine-config-I7800: computed unconditionally (always()) so it
-      # runs on both a clean deploy (harmless, unused) and a failure (feeds
-      # notify-main-failure below). Pure stdlib (datetime/zoneinfo) — no pip
-      # install, so it can't itself fail on a dependency problem and mask the
-      # real deploy failure this step exists to annotate.
+      # runs on both a clean deploy (harmless, unused) and a failure (visible
+      # in this job's own log/output either way). Pure stdlib
+      # (datetime/zoneinfo) — no pip install, so it can't itself fail on a
+      # dependency problem and mask the real deploy failure this step exists
+      # to annotate. NOT yet threaded into notify-main-failure's Telegram
+      # alert (see that job's comment) — a follow-up PR wires
+      # `blast_radius_message` in once nousergon-lib-PR343 merges and this
+      # job's `outputs.blast_radius_message` (still declared below) gets a
+      # safe main-SHA-pinned consumer.
       - name: Compute blast radius (I7800)
         id: blast_radius
         if: always()
@@ -99,17 +104,17 @@ jobs:
   # Alert (Telegram) on genuine post-merge failure of this workflow on the
   # default branch. Reusable workflow + transport in nousergon-lib. config#1128.
   #
-  # alpha-engine-config-I7800: pinned to a commit on nousergon-lib's
-  # feat/notify-message-override-i7800 branch (predates that branch's merge
-  # to main — GitHub resolves a workflow_call ref from any pushed commit, not
-  # just main history, so this works regardless of merge order). Re-pin to
-  # nousergon-lib@main HEAD once nousergon-lib-PR<TBD> (the notify-ci-
-  # failure.yml `blast_radius_message` input) merges — tracked in this PR's
-  # body, not left as a silent follow-up.
+  # alpha-engine-config-I7800: deliberately pinned to the SAME merged main SHA
+  # this job used before this PR (unchanged) — NOT to nousergon-lib-PR343's
+  # branch commit. That branch commit becomes unreachable and garbage-
+  # collectable the moment PR343 is squash-merged (this org squash-merges with
+  # delete_branch_on_merge=true), which would silently break the ONE workflow
+  # whose job is to notify when something else already failed. Threading
+  # blast_radius_message through here is deliberately deferred to a follow-up
+  # PR opened after nousergon-lib-PR343 merges and re-pins this line to the
+  # resulting main SHA — this PR carries no reference to an unmerged commit.
   notify-main-failure:
     needs: [deploy-infrastructure]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@a5394d3754c1b6bbf4365a29808f191bbd37cd50 # feat/notify-message-override-i7800 (alpha-engine-config-I7800) — re-pin to main once nousergon-lib-PR<TBD> merges
-    with:
-      blast_radius_message: ${{ needs.deploy-infrastructure.outputs.blast_radius_message }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
     secrets: inherit

--- a/.github/workflows/deploy-preopen-deploy-readiness-probe.yml
+++ b/.github/workflows/deploy-preopen-deploy-readiness-probe.yml
@@ -1,0 +1,88 @@
+name: Deploy preopen-deploy-readiness-probe
+
+# Auto-deploy the alpha-engine-preopen-deploy-readiness-probe Lambda CODE on
+# merge to main (alpha-engine-config-I7800 deliverable #2).
+#
+# Mirrors deploy-eod-snapshot-existence-check.yml exactly: code only.
+# deploy.sh with no flags is its update-code path — the BOOTSTRAP block (IAM
+# role/policy, Lambda create, EventBridge Scheduler create) is gated behind
+# --bootstrap/--apply-iam and is NEVER invoked here, so this workflow cannot
+# create or rewire infrastructure, only ship code to a function that already
+# exists. Per "a PR must be deployable by the merge button alone"
+# (pull-request-policy.md §4.2), the merge itself only ever reaches the
+# code-only path — the first-time --bootstrap is an operator step run once,
+# out of band (see the PR body for the exact command).
+#
+# IAM: no change needed. github-actions-lambda-deploy's LambdaUpdate
+# statement already grants GetFunction / GetFunctionConfiguration /
+# UpdateFunctionCode / UpdateFunctionConfiguration on
+# arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-*, which
+# covers alpha-engine-preopen-deploy-readiness-probe. Those four are every
+# AWS call the no-flag deploy.sh path makes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/preopen-deploy-readiness-probe/**'
+      - '.github/workflows/deploy-preopen-deploy-readiness-probe.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-preopen-deploy-readiness-probe-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy preopen-deploy-readiness-probe Lambda (code-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy preopen-deploy-readiness-probe (code-only)
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-preopen-deploy-readiness-probe \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-preopen-deploy-readiness-probe.yml
+
+  # Alert (Telegram) on genuine post-merge failure on the default branch.
+  # Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/deploy_blast_radius.py
+++ b/infrastructure/deploy_blast_radius.py
@@ -1,0 +1,134 @@
+"""deploy_blast_radius — name which scheduled SF run halts next on a stale
+deploy stamp (alpha-engine-config-I7800).
+
+2026-08-19: `Deploy Infrastructure` failed 3x on `main` (runs `32300162711`,
+`32302092674`, `32305068379`). `notify-main-failure` fired each time as an
+ordinary red-CI Telegram alert. Nothing connected those failures to the fact
+that they had ALREADY DECIDED the outcome of the 2026-08-20 05:15 PT
+preopen: the live SF stamp was frozen behind `main`, so `DeployDriftGate`
+would halt — and it did. A full unmanaged trading session was determined
+~8 hours in advance by a signal that read as routine CI noise.
+
+This module computes, from `now` (UTC) alone, which SCHEDULED trigger is
+next to invoke a Step Function whose `DeployDriftCheck` stage will read the
+now-stale stamp and (for the weekday/EOD pipelines) halt, or (all three,
+per sf-pipeline-policy §3) at minimum register drift. Two candidate
+triggers, per the alpha-engine skill's pipeline map:
+
+  - preopen: `ne-preopen-trading-pipeline`, weekday-only, EventBridge
+    Scheduler `cron(15 5 ...)` `America/Los_Angeles` (05:15 PT), the ONLY
+    schedule that actually HALTS the run on `sf_drift=true`
+    (`DeployDriftGate`, config#6615).
+  - weekly: `ne-weekly-freshness-pipeline`, EventBridge rule
+    `alpha-engine-saturday`, `cron(0 9 ? * THU-SAT *)` (09:00 UTC,
+    Thu/Fri/Sat) — `WeeklyRunDayGate` self-gates to the ONE real run of the
+    week, but this module deliberately does NOT reimplement that gate's
+    holiday logic; it reports the EARLIEST Thu/Sat 09:00 UTC firing as the
+    candidate. That is a conservative (over-, never under-) approximation:
+    the real single run is somewhere in [that candidate, +2 days], so
+    naming the earliest instant never UNDERSTATES the blast radius.
+
+Whichever candidate is sooner is "the next scheduled run this will halt."
+Both pipelines' definitions carry a `DeployDriftCheck` stage (verified
+2026-08-20: 15 occurrences in step_function.json, 7 in
+step_function_daily.json) so naming either is never speculative.
+
+Deliberately excluded: the EOD/postclose pipeline. It fires off the daemon's
+shutdown hook (not a fixed clock schedule) and can only run AFTER a preopen
+that already halted or completed, so it is never the FIRST scheduled
+casualty of a stale stamp — but it does read the same stamp, and the
+`Comment` line below says so.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+_PT = ZoneInfo("America/Los_Angeles")
+_UTC = timezone.utc
+
+PREOPEN_HOUR_PT = 5
+PREOPEN_MINUTE_PT = 15
+WEEKLY_HOUR_UTC = 9
+
+
+def _next_preopen_utc(now_utc: datetime) -> datetime:
+    """Next weekday 05:15 America/Los_Angeles, expressed in UTC.
+
+    Weekday-only by clock (Mon-Fri), not NYSE-holiday-aware — the preopen
+    trigger itself fires on a plain weekday cron; `TradingDayGate` is what
+    turns a holiday firing into a fast no-op, and DeployDriftCheck runs
+    BEFORE that gate (see infrastructure/step_function_daily.json), so a
+    holiday firing is still a real invocation that reads the stale stamp.
+    """
+    now_pt = now_utc.astimezone(_PT)
+    candidate_pt = now_pt.replace(
+        hour=PREOPEN_HOUR_PT, minute=PREOPEN_MINUTE_PT, second=0, microsecond=0
+    )
+    if candidate_pt <= now_pt:
+        candidate_pt += timedelta(days=1)
+    while candidate_pt.weekday() >= 5:  # Sat=5, Sun=6
+        candidate_pt += timedelta(days=1)
+    return candidate_pt.astimezone(_UTC)
+
+
+def _next_weekly_utc(now_utc: datetime) -> datetime:
+    """Earliest Thu/Fri/Sat 09:00 UTC firing (`alpha-engine-saturday` rule,
+    `cron(0 9 ? * THU-SAT *)`) — see module docstring for why this is
+    deliberately a conservative earliest-candidate, not a holiday-aware
+    reimplementation of `WeeklyRunDayGate`."""
+    candidate = now_utc.replace(hour=WEEKLY_HOUR_UTC, minute=0, second=0, microsecond=0)
+    if candidate <= now_utc:
+        candidate += timedelta(days=1)
+    # THU=3, FRI=4, SAT=5 (Monday=0)
+    while candidate.weekday() not in (3, 4, 5):
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def compute_blast_radius(now_utc: datetime | None = None) -> dict:
+    """Returns the next scheduled trigger a stale deploy stamp will reach.
+
+    ``{"pipeline": str, "sm_name": str, "next_run_utc": iso str,
+       "next_run_local": human string, "message": str}``
+    """
+    now_utc = (now_utc or datetime.now(_UTC)).astimezone(_UTC)
+    preopen_at = _next_preopen_utc(now_utc)
+    weekly_at = _next_weekly_utc(now_utc)
+
+    if preopen_at <= weekly_at:
+        pipeline, sm_name, next_run = "preopen", "ne-preopen-trading-pipeline", preopen_at
+        local = next_run.astimezone(_PT).strftime("%Y-%m-%d %H:%M %Z")
+        consequence = "HALTS at DeployDriftGate (sf_drift=true routes to HandleFailure — no trading that day)"
+    else:
+        pipeline, sm_name, next_run = "weekly", "ne-weekly-freshness-pipeline", weekly_at
+        local = next_run.astimezone(_UTC).strftime("%Y-%m-%d %H:%M UTC")
+        consequence = "registers drift at its own DeployDriftCheck stage (sf-pipeline-policy §3)"
+
+    message = (
+        f"BLAST RADIUS (alpha-engine-config-I7800): the deployed SF stamp is now "
+        f"behind main. Next scheduled run this reaches is {sm_name} "
+        f"at {local} ({next_run.isoformat()}), which {consequence} unless "
+        f"deploy-infrastructure.sh succeeds before then."
+    )
+    return {
+        "pipeline": pipeline,
+        "sm_name": sm_name,
+        "next_run_utc": next_run.isoformat(),
+        "next_run_local": local,
+        "message": message,
+    }
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    result = compute_blast_radius()
+    # --message-only for direct use in a GHA `run:` step (GITHUB_OUTPUT-safe,
+    # single line — the f-string above never embeds a newline).
+    if "--message-only" in sys.argv:
+        print(result["message"])
+    else:
+        print(json.dumps(result, indent=2))

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/README.md
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/README.md
@@ -1,0 +1,52 @@
+# alpha-engine-preopen-deploy-readiness-probe
+
+Pre-preopen deploy-readiness probe with runway (**alpha-engine-config-I7800** deliverable #2).
+
+## Why
+
+2026-08-19: `Deploy Infrastructure` failed 3x on `nousergon-data@main`. `notify-main-failure` fired each time as an ordinary CI-red Telegram alert. Nothing connected those failures to the fact that they had already decided the outcome of the 2026-08-20 05:15 PT preopen — the live SF stamp was frozen behind `main`, so `DeployDriftGate` would halt trading. It did. Detected-and-paged is partial coverage; this Lambda closes the loop: detect the same drift the preopen SF will hit, try to self-heal before the deadline, and page with runway to spare if self-heal doesn't work.
+
+## What it does
+
+Fires **04:30 America/Los_Angeles MON-FRI** — 45 minutes before the 05:15 PT preopen trigger:
+
+1. **Not a NYSE trading day** → no-op, log only.
+2. **Trading day** → invoke `alpha-engine-predictor-inference:live` `action=check_deploy_drift` — the SAME probe the preopen SF's own `DeployDriftCheck` state calls.
+3. **`sf_drift=false`** → clean. Verdict written, no page.
+4. **`sf_drift=true`** → self-heal: `workflow_dispatch` on `nousergon-data`'s `deploy-infrastructure.yml` (idempotent), poll the run to completion, re-probe.
+   - Cleared → log the recovery, no page.
+   - Still drifted (or the dispatch itself failed, e.g. PAT scope) → page `alpha-engine-alerts` (severity=critical) naming the diagnostics and that the 05:15 PT preopen will halt.
+
+Every invocation writes a verdict to `s3://alpha-engine-research/deploy_readiness/{date}.json` — a silent probe is not an observation (sf-pipeline-policy §2.7).
+
+## Fail-loud posture
+
+The initial `check_deploy_drift` invoke and the S3 verdict write raise on any unexpected error. The self-heal dispatch/poll and the page are best-effort — a GitHub API hiccup on the self-heal leg must not crash the probe before it can page.
+
+## Deploy / safe rollout
+
+```bash
+# first-time create (Scheduler schedule created per the automation-pause manifest's state)
+bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --bootstrap
+# code update only
+bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
+```
+
+IAM role/policy creation requires `iam:CreateRole`/`iam:PutRolePolicy`, which the CI OIDC role deliberately does not hold — `--bootstrap` must be run by an operator with `AWS_PROFILE=ne-admin`. **Merging this PR has ZERO live effect until that operator step runs**, same as every sibling scheduled probe in this directory (`eod-snapshot-existence-check`, `ci-watch-liveness-probe`, …).
+
+**Operator verification needed on first bootstrap**: this Lambda's self-heal leg reuses the existing `/alpha-engine/saturday_sf_watch/github_pat` SSM parameter (the same fine-grained PAT `saturday-sf-watch-dispatcher` already uses for cross-repo GitHub calls). Its documented scope is "the SF-path repos", which should already cover `actions:write` on `nousergon-data` itself — but that has not been live-verified for *this* specific permission (workflow dispatch, as opposed to `alpha-engine-config` repository_dispatch). If the PAT lacks `actions:write` on `nousergon-data`, the dispatch call fails loud (HTTP 403, logged and folded into the page message) rather than silently — the probe still pages correctly, it just can't self-heal. No new secret is requested; this is a scope check, not a provisioning ask.
+
+## Config
+
+| env var | default |
+|---|---|
+| `PROBE_BUCKET` | `alpha-engine-research` |
+| `ALPHA_ENGINE_ALERTS_SNS_TOPIC_ARN` | `…:alpha-engine-alerts` |
+| `DRIFT_PROBE_FUNCTION` | `alpha-engine-predictor-inference:live` |
+| `GITHUB_PAT_SSM_PARAM` | `/alpha-engine/saturday_sf_watch/github_pat` |
+| `DISPATCH_REPO` | `nousergon/nousergon-data` |
+| `DISPATCH_WORKFLOW` | `deploy-infrastructure.yml` |
+| `DISPATCH_POLL_ATTEMPTS` | `20` |
+| `DISPATCH_POLL_INTERVAL_SEC` | `20` |
+
+Schedule: `cron(30 4 ? * MON-FRI *)` in `America/Los_Angeles` (Scheduler-native timezone — DST-correct with no seasonal cron edit).

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# deploy.sh — Create or update the alpha-engine-preopen-deploy-readiness-probe
+# Lambda + its EventBridge Scheduler schedule.
+#
+# alpha-engine-config-I7800 deliverable #2: pre-preopen deploy-readiness probe
+# with runway. Fires 45 minutes before the 05:15 PT preopen trigger, probes
+# the same check_deploy_drift signal DeployDriftGate will read, self-heals by
+# re-dispatching deploy-infrastructure.yml, and pages with runway to spare if
+# self-heal doesn't clear the drift. See index.py's module docstring for the
+# full rationale.
+#
+# Managed OUTSIDE CloudFormation — operator-deployed, narrow OIDC blast
+# radius, same rationale as eod-snapshot-existence-check / eod-backstop /
+# crypto-balances. Merging the PR has ZERO live effect until an operator
+# runs this with --bootstrap.
+#
+# Usage:
+#   bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh             # update code only
+#   bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --bootstrap # first-time create + wire EventBridge Scheduler
+#   bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --apply-iam # re-apply iam-policy.json only (no bootstrap side effects)
+#   bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --dry-run   # show actions, do not apply
+#   bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --smoke     # invoke once (REAL: on a trading day with genuine drift this pages and dispatches deploy-infrastructure.yml for real)
+
+set -euo pipefail
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
+FUNCTION_NAME="alpha-engine-preopen-deploy-readiness-probe"
+ROLE_NAME="alpha-engine-preopen-deploy-readiness-probe-role"
+POLICY_NAME="alpha-engine-preopen-deploy-readiness-probe-policy"
+SCHED_ROLE_NAME="alpha-engine-preopen-deploy-readiness-probe-scheduler-role"
+SCHED_POLICY_NAME="invoke-preopen-deploy-readiness-probe"
+SCHED_NAME="alpha-engine-preopen-deploy-readiness-probe"
+# 04:30 America/Los_Angeles, 45 minutes before the 05:15 PT preopen trigger
+# (ne-preopen-trading-pipeline's EventBridge Scheduler cron(15 5 ...)).
+# Scheduler's native timezone field (not a hand-computed UTC cron) so DST
+# transitions never need a seasonal cron edit.
+SCHED_CRON="cron(30 4 ? * MON-FRI *)"
+SCHED_TZ="America/Los_Angeles"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
+
+FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+SCHED_ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}"
+
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run
+# flag below (config#1752-style convention, matching sibling probes).
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+BOOTSTRAP=false
+APPLY_IAM=false
+SMOKE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --bootstrap) BOOTSTRAP=true ;;
+    --apply-iam) APPLY_IAM=true ;;
+    --smoke) SMOKE=true ;;
+    -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
+  esac
+done
+
+run() {
+  if $DRY_RUN; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+# ----- 0. Validate handler + run unit tests ----------------------------------
+
+python3 -c "
+import ast
+src = open('${SCRIPT_DIR}/index.py').read()
+ast.parse(src)
+print('index.py syntax OK')
+"
+
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3 -r "${SCRIPT_DIR}/requirements.txt"
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${SCRIPT_DIR}/../lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+# ----- 2. Bootstrap (first-time only) ---------------------------------------
+
+# ----- Apply IAM only (no bootstrap side effects) -------------
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  echo "  ✓ IAM applied. Nothing else was touched — no code, no env, no alarms."
+  exit 0
+fi
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+
+  # --- 2a. Lambda execution role + inline least-privilege policy ---
+  TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating IAM role: ${ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${ROLE_NAME}" \
+      --assume-role-policy-document "${TRUST_POLICY}" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  IAM role exists: ${ROLE_NAME}"
+  fi
+
+  echo "  Applying inline policy: ${POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "${POLICY_NAME}" \
+    --policy-document "file://${SCRIPT_DIR}/iam-policy.json"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for IAM role propagation..."
+    sleep 10
+  fi
+
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 600 \
+      --memory-size 128 \
+      --environment 'Variables={LOG_LEVEL=INFO}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+  else
+    echo "  Lambda exists, code will be updated in step 3"
+  fi
+
+  # --- 2b. EventBridge Scheduler execution role (invoke this Lambda only) ---
+  SCHED_TRUST='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"scheduler.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+  if ! aws iam get-role --role-name "${SCHED_ROLE_NAME}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
+    echo "  Creating Scheduler execution role: ${SCHED_ROLE_NAME}"
+    run aws iam create-role \
+      --role-name "${SCHED_ROLE_NAME}" \
+      --assume-role-policy-document "${SCHED_TRUST}" \
+      --description "EventBridge Scheduler role: invoke ${FUNCTION_NAME} MON-FRI 04:30 PT" \
+      --query 'Role.RoleName' --output text
+  else
+    echo "  Scheduler execution role exists: ${SCHED_ROLE_NAME}"
+  fi
+  SCHED_INVOKE_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"lambda:InvokeFunction\"],\"Resource\":\"${FN_ARN}\"}]}"
+  echo "  Applying Scheduler invoke policy: ${SCHED_POLICY_NAME}"
+  run aws iam put-role-policy \
+    --role-name "${SCHED_ROLE_NAME}" \
+    --policy-name "${SCHED_POLICY_NAME}" --policy-document "${SCHED_INVOKE_POLICY}"
+
+  if ! $DRY_RUN; then
+    echo "  Waiting 10s for Scheduler role propagation..."
+    sleep 10
+  fi
+
+  # --- 2c. The EventBridge Scheduler schedule (cron, PT-native timezone) ---
+  TARGET="{\"Arn\":\"${FN_ARN}\",\"RoleArn\":\"${SCHED_ROLE_ARN}\",\"Input\":\"{}\"}"
+  if aws scheduler get-schedule --name "${SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null 2>&1; then
+    echo "  Updating Scheduler schedule: ${SCHED_NAME} → ${SCHED_CRON} (${SCHED_TZ})"
+    run aws scheduler update-schedule --name "${SCHED_NAME}" --state "$(pause_state "${SCHED_NAME}")" \
+      --schedule-expression "${SCHED_CRON}" --schedule-expression-timezone "${SCHED_TZ}" \
+      --flexible-time-window '{"Mode":"OFF"}' \
+      --target "${TARGET}" --region "${REGION}" --query 'ScheduleArn' --output text
+  else
+    echo "  Creating Scheduler schedule: ${SCHED_NAME} → ${SCHED_CRON} (${SCHED_TZ})"
+    run aws scheduler create-schedule --name "${SCHED_NAME}" --state "$(pause_state "${SCHED_NAME}")" \
+      --schedule-expression "${SCHED_CRON}" --schedule-expression-timezone "${SCHED_TZ}" \
+      --flexible-time-window '{"Mode":"OFF"}' \
+      --target "${TARGET}" --region "${REGION}" --query 'ScheduleArn' --output text
+  fi
+  if ! $DRY_RUN; then
+    aws scheduler get-schedule --name "${SCHED_NAME}" --region "${REGION}" --query 'Name' --output text >/dev/null \
+      || { echo "ERROR: Scheduler schedule ${SCHED_NAME} not found after create/update" >&2; exit 1; }
+  fi
+fi
+
+# ----- 3. Update function code (always after bootstrap, idempotent) ---------
+
+echo "Updating Lambda function code: ${FUNCTION_NAME}"
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastUpdateStatus' --output text
+
+if ! $DRY_RUN; then
+  aws lambda wait function-updated \
+    --function-name "${FUNCTION_NAME}" \
+    --region "${REGION}"
+fi
+
+echo "✓ Code deployed."
+
+# ----- 4. Smoke (real invoke; PAGES + DISPATCHES FOR REAL on genuine drift) --
+
+# shellcheck source=infrastructure/lambdas/_shared/smoke.sh
+source "${SCRIPT_DIR}/../_shared/smoke.sh"
+if $SMOKE; then
+  echo ""
+  echo "WARNING: --smoke will publish a REAL page to alpha-engine-alerts AND"
+  echo "         dispatch a REAL deploy-infrastructure.yml run if today is a"
+  echo "         trading day AND the deploy stamp is genuinely drifted."
+  RESP=$(mktemp)
+  INVOKE_STDOUT=$(aws lambda invoke \
+    --function-name "${FUNCTION_NAME}" \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{}' \
+    --region "${REGION}" \
+    "${RESP}")
+  cat "${RESP}"
+  echo ""
+  assert_no_function_error "${INVOKE_STDOUT}" "${RESP}"
+  rm -f "${RESP}"
+fi

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/iam-policy.json
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/iam-policy.json
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-preopen-deploy-readiness-probe:*"
+    },
+    {
+      "Sid": "InvokeDeployDriftProbe",
+      "Effect": "Allow",
+      "Action": [
+        "lambda:InvokeFunction"
+      ],
+      "Resource": [
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference",
+        "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference:live"
+      ]
+    },
+    {
+      "Sid": "ReadGithubPatForSelfHealDispatch",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter"
+      ],
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/saturday_sf_watch/github_pat"
+    },
+    {
+      "Sid": "WriteVerdictArtifact",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/deploy_readiness/*"
+    },
+    {
+      "Sid": "PublishToAlertsTopic",
+      "Effect": "Allow",
+      "Action": [
+        "sns:Publish"
+      ],
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+    }
+  ]
+}

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/index.py
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/index.py
@@ -1,0 +1,321 @@
+"""alpha-engine-preopen-deploy-readiness-probe — pre-preopen deploy-readiness
+probe with runway (alpha-engine-config-I7800 deliverable #2).
+
+**Why this Lambda exists.** 2026-08-19: `Deploy Infrastructure` failed 3x on
+`nousergon-data@main`. Each failure fired the ordinary `notify-main-failure`
+Telegram alert; nothing connected those failures to the fact that they had
+ALREADY DECIDED the outcome of the next morning's 05:15 PT preopen — the live
+SF stamp was frozen behind `main`, so the next `DeployDriftGate` invocation
+would halt trading. It did (2026-08-20). Detected-and-paged (the CI alert) is
+partial coverage (`principles.md` §2.3): nothing closed the loop by (a) trying
+to self-heal before the deadline and (b) escalating with runway to spare if
+self-heal didn't work.
+
+**Mechanism.** Scheduled 04:30 America/Los_Angeles MON-FRI (Scheduler-native
+timezone, DST-correct) — 45 minutes before the 05:15 PT preopen trigger.
+
+  1. Not a NYSE trading day (`nousergon_lib.trading_calendar.is_trading_day`)
+     -> no-op. No preopen is expected, so no readiness check is meaningful.
+  2. Trading day -> invoke `alpha-engine-predictor-inference:live`
+     `action=check_deploy_drift` (the SAME probe `DeployDriftCheck` runs
+     inside the preopen SF itself — one implementation, not a second one
+     free to drift; see `alpha-engine-predictor/inference/deploy_drift.py`).
+  3. `sf_drift=false` -> clean. Write the verdict, no page, no dispatch.
+  4. `sf_drift=true` -> self-heal: fire a `workflow_dispatch` on
+     `nousergon-data`'s `deploy-infrastructure.yml` (it is idempotent by
+     design — re-running it is always safe, see that workflow's own header
+     comment), using the fine-grained PAT already provisioned at
+     `GITHUB_PAT_SSM_PARAM` for exactly this kind of cross-repo GitHub call
+     (mirrors `saturday-sf-watch-dispatcher._get_github_pat`, same SSM
+     parameter — one PAT, not a second one to provision and rotate).
+     Poll the dispatched run to a terminal conclusion (bounded — see
+     `_DISPATCH_POLL_*`), then re-probe `check_deploy_drift`.
+     - Still `sf_drift=true` after self-heal (or the dispatch/poll itself
+       failed) -> page `alpha-engine-alerts` (severity=critical) with the
+       failing validation diagnostics and the literal sentence that the
+       05:15 PT preopen will halt.
+     - Self-heal cleared the drift -> log the recovery; no page (a probe
+       that pages after fixing the problem trains the operator to ignore
+       pages).
+
+**Console emission (§2.7 — a silent probe is not an observation).** Every
+invocation — clean, self-healed, or escalated — writes a verdict JSON to
+`s3://{BUCKET}/deploy_readiness/{date}.json`, the same "one small artifact per
+run" shape the fleet's other scheduled probes use for their console surface
+(mirrors `eod-precondition-probe`'s sentinel-read pattern in reverse: this
+Lambda is the WRITER of its own observation record).
+
+**Fail-loud posture.** The initial `check_deploy_drift` invoke and the S3
+verdict write RAISE on any unexpected error (CloudWatch Errors metric is the
+backstop). The self-heal dispatch/poll and the page are best-effort/secondary:
+a GitHub API hiccup on the self-heal leg must not crash the probe before it
+gets to page — the page IS the fallback for exactly that case.
+
+Deliberately NOT a second implementation of drift detection or of market-hours
+calendar logic — both are read from the SAME sources their live consumers use
+(the predictor Lambda's own probe; `nousergon_lib.trading_calendar`), per the
+sf-pipeline-policy §3 "one answer, one owner" convention this fleet already
+follows for `weekday_sf_rerun.py`'s market-hours check (alpha-engine-config-
+I7807).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.request
+from datetime import date, datetime, timezone
+from urllib.error import HTTPError
+
+import boto3
+from nousergon_lib import alerts
+from nousergon_lib.trading_calendar import is_trading_day
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+ACCOUNT_ID = os.environ.get("ACCOUNT_ID", "711398986525")
+BUCKET = os.environ.get("PROBE_BUCKET", "alpha-engine-research")
+VERDICT_PREFIX = os.environ.get("PROBE_VERDICT_PREFIX", "deploy_readiness")
+
+DRIFT_PROBE_FUNCTION = os.environ.get(
+    "DRIFT_PROBE_FUNCTION", "alpha-engine-predictor-inference:live"
+)
+
+SNS_TOPIC_ARN = os.environ.get(
+    "ALPHA_ENGINE_ALERTS_SNS_TOPIC_ARN",
+    f"arn:aws:sns:{REGION}:{ACCOUNT_ID}:alpha-engine-alerts",
+)
+
+# Same fine-grained PAT SSM parameter saturday-sf-watch-dispatcher already
+# reads (see that Lambda's `_get_github_pat` / `GITHUB_PAT_SSM_PARAM`) —
+# "scoped to the SF-path repos", which nousergon-data (this repo, the
+# workflow_dispatch target) already is. ONE PAT, not a second one to
+# provision and rotate. If its scope turns out NOT to cover
+# `actions:write` on nousergon-data, the dispatch call fails 403 and the
+# probe falls through to paging exactly as if self-heal had not fixed the
+# drift — never silently.
+GITHUB_PAT_SSM_PARAM = os.environ.get(
+    "GITHUB_PAT_SSM_PARAM", "/alpha-engine/saturday_sf_watch/github_pat"
+)
+DISPATCH_REPO = os.environ.get("DISPATCH_REPO", "nousergon/nousergon-data")
+DISPATCH_WORKFLOW = os.environ.get("DISPATCH_WORKFLOW", "deploy-infrastructure.yml")
+DISPATCH_REF = os.environ.get("DISPATCH_REF", "main")
+
+_HTTP_TIMEOUT_SEC = 15
+# Bounded poll for the self-heal dispatch to finish: 20 attempts x 20s = ~6.7
+# minutes, comfortably inside this Lambda's 10-minute configured timeout
+# (see deploy.sh) with margin for the drift-probe invokes on either side.
+# deploy-infrastructure.sh normally completes in well under 2 minutes on a
+# no-op CF update (module docstring, deploy-infrastructure.yml header); this
+# budget covers a genuine CFN update-stack wait too.
+_DISPATCH_POLL_ATTEMPTS = int(os.environ.get("DISPATCH_POLL_ATTEMPTS", "20"))
+_DISPATCH_POLL_INTERVAL_SEC = int(os.environ.get("DISPATCH_POLL_INTERVAL_SEC", "20"))
+
+_ET_PREOPEN_NOTE = (
+    "the 05:15 America/Los_Angeles ne-preopen-trading-pipeline preopen will "
+    "halt at DeployDriftGate unless this is resolved before then"
+)
+
+
+def _get_github_pat() -> str:
+    """Read the fine-grained PAT (SecureString) from SSM. Never logged."""
+    ssm = boto3.client("ssm", region_name=REGION)
+    resp = ssm.get_parameter(Name=GITHUB_PAT_SSM_PARAM, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def _invoke_check_deploy_drift(lam_client) -> dict:
+    """Call the SAME `action=check_deploy_drift` handler DeployDriftCheck
+    invokes inside the preopen SF (alpha-engine-predictor Lambda). Raises on
+    any invoke-level failure — this is the primary probe, fail-loud."""
+    resp = lam_client.invoke(
+        FunctionName=DRIFT_PROBE_FUNCTION,
+        Payload=json.dumps({"action": "check_deploy_drift"}).encode(),
+    )
+    payload = json.loads(resp["Payload"].read())
+    if resp.get("FunctionError"):
+        raise RuntimeError(f"check_deploy_drift invoke returned FunctionError: {payload}")
+    return payload
+
+
+def _dispatch_deploy_infrastructure() -> tuple[bool, str]:
+    """Fire workflow_dispatch on nousergon-data's deploy-infrastructure.yml.
+
+    Returns (dispatched, detail). Best-effort — any failure here (bad PAT
+    scope, GitHub outage) is caught and reported, never raised, so the probe
+    can still fall through to paging.
+    """
+    try:
+        pat = _get_github_pat()
+        payload = json.dumps({"ref": DISPATCH_REF}).encode()
+        req = urllib.request.Request(
+            f"https://api.github.com/repos/{DISPATCH_REPO}/actions/workflows/"
+            f"{DISPATCH_WORKFLOW}/dispatches",
+            data=payload,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "preopen-deploy-readiness-probe",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC) as resp:
+            status = resp.status
+        return True, f"workflow_dispatch accepted (http={status})"
+    except HTTPError as exc:
+        body = exc.read().decode(errors="replace") if exc.fp else ""
+        return False, f"workflow_dispatch HTTP {exc.code}: {body[:300]}"
+    except Exception as exc:  # noqa: BLE001 — best-effort self-heal leg
+        return False, f"workflow_dispatch failed: {type(exc).__name__}: {exc}"
+
+
+def _poll_dispatch_conclusion(dispatched_at: datetime) -> tuple[str, str]:
+    """Poll for the workflow_dispatch run's terminal conclusion.
+
+    Returns (conclusion, detail). conclusion is one of "success", "failure",
+    "timed_out" (poll budget exhausted before a terminal state), or
+    "poll_error" (couldn't even list runs). Never raises — same best-effort
+    posture as the dispatch call itself.
+    """
+    try:
+        pat = _get_github_pat()
+    except Exception as exc:  # noqa: BLE001
+        return "poll_error", f"could not re-read PAT for polling: {exc}"
+
+    for attempt in range(_DISPATCH_POLL_ATTEMPTS):
+        time.sleep(_DISPATCH_POLL_INTERVAL_SEC)
+        try:
+            req = urllib.request.Request(
+                f"https://api.github.com/repos/{DISPATCH_REPO}/actions/workflows/"
+                f"{DISPATCH_WORKFLOW}/runs?event=workflow_dispatch&branch={DISPATCH_REF}"
+                f"&per_page=5",
+                headers={
+                    "Authorization": f"Bearer {pat}",
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "preopen-deploy-readiness-probe",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC) as resp:
+                body = json.loads(resp.read())
+        except Exception as exc:  # noqa: BLE001 — transient poll error, keep trying
+            logger.warning("dispatch-poll attempt %d failed: %s", attempt, exc)
+            continue
+
+        for run in body.get("workflow_runs", []):
+            created_at = datetime.strptime(
+                run["created_at"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc)
+            if created_at < dispatched_at:
+                continue
+            status = run.get("status")
+            if status == "completed":
+                conclusion = run.get("conclusion") or "unknown"
+                return conclusion, f"run {run.get('id')} completed: {conclusion}"
+            # Found the run but it's still in progress — keep polling.
+            break
+
+    return "timed_out", (
+        f"no matching run reached a terminal state within "
+        f"{_DISPATCH_POLL_ATTEMPTS * _DISPATCH_POLL_INTERVAL_SEC}s"
+    )
+
+
+def _page(drift: dict, self_heal_detail: str) -> None:
+    message = (
+        f"Preopen deploy-readiness probe (alpha-engine-config-I7800): the "
+        f"deployed SF stamp is STILL behind main after self-heal — "
+        f"{_ET_PREOPEN_NOTE}. sf_drift={drift.get('sf_drift')} "
+        f"sf_sha={drift.get('sf_sha')!r} upstream_sha={drift.get('upstream_sha')!r} "
+        f"cf_drift={drift.get('cf_drift')} cf_drift_reason={drift.get('cf_drift_reason')!r}. "
+        f"Self-heal: {self_heal_detail}. "
+        f"Manual recovery: `bash infrastructure/deploy-infrastructure.sh` "
+        f"from a clean nousergon-data checkout (AWS_PROFILE=ne-admin), or "
+        f"`gh workflow run deploy-infrastructure.yml --repo {DISPATCH_REPO}`."
+    )
+    result = alerts.publish(
+        message=message,
+        severity="critical",
+        source="alpha-engine-preopen-deploy-readiness-probe",
+        sns=True,
+        telegram=False,
+        sns_topic_arn=SNS_TOPIC_ARN,
+    )
+    logger.warning(
+        "DEPLOY-READINESS-PROBE ALERT: sf_drift=%s sns_ok=%s",
+        drift.get("sf_drift"), result.sns.ok,
+    )
+
+
+def _write_verdict(s3client, today: date, verdict: dict) -> None:
+    key = f"{VERDICT_PREFIX}/{today.isoformat()}.json"
+    s3client.put_object(
+        Bucket=BUCKET,
+        Key=key,
+        Body=json.dumps(verdict, indent=2, default=str).encode(),
+        ContentType="application/json",
+    )
+    logger.info("verdict written to s3://%s/%s", BUCKET, key)
+
+
+def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
+    today = datetime.now(timezone.utc).date()
+
+    if not is_trading_day(today):
+        logger.info("Not a NYSE trading day (%s) — no preopen expected; no-op.", today)
+        return {"action": "noop", "reason": "not_a_trading_day", "date": str(today)}
+
+    lam_client = boto3.client("lambda", region_name=REGION)
+    s3client = boto3.client("s3", region_name=REGION)
+
+    drift = _invoke_check_deploy_drift(lam_client)
+    verdict: dict = {
+        "date": str(today),
+        "sf_drift_initial": drift.get("sf_drift"),
+        "cf_drift_initial": drift.get("cf_drift"),
+        "drift_initial": drift,
+    }
+
+    if not drift.get("sf_drift"):
+        verdict["action"] = "noop"
+        verdict["reason"] = "clean"
+        _write_verdict(s3client, today, verdict)
+        logger.info("Deploy stamp clean for %s — no self-heal, no page.", today)
+        return verdict
+
+    logger.warning(
+        "sf_drift=true for %s — attempting self-heal dispatch of %s on %s.",
+        today, DISPATCH_WORKFLOW, DISPATCH_REPO,
+    )
+    dispatched_at = datetime.now(timezone.utc)
+    dispatched, dispatch_detail = _dispatch_deploy_infrastructure()
+    verdict["self_heal_dispatched"] = dispatched
+    verdict["self_heal_dispatch_detail"] = dispatch_detail
+
+    if dispatched:
+        conclusion, poll_detail = _poll_dispatch_conclusion(dispatched_at)
+        verdict["self_heal_run_conclusion"] = conclusion
+        verdict["self_heal_poll_detail"] = poll_detail
+        self_heal_detail = f"{dispatch_detail}; {poll_detail}"
+    else:
+        self_heal_detail = dispatch_detail
+
+    drift_after = _invoke_check_deploy_drift(lam_client)
+    verdict["sf_drift_after_self_heal"] = drift_after.get("sf_drift")
+    verdict["drift_after_self_heal"] = drift_after
+
+    if drift_after.get("sf_drift"):
+        verdict["action"] = "paged"
+        verdict["reason"] = "still_drifted_after_self_heal"
+        _page(drift_after, self_heal_detail)
+    else:
+        verdict["action"] = "self_healed"
+        verdict["reason"] = "drift_cleared_by_dispatch"
+        logger.info("Self-heal cleared drift for %s — no page.", today)
+
+    _write_verdict(s3client, today, verdict)
+    return verdict

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.78

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -1,0 +1,9 @@
+# nousergon-lib provides:
+#   - nousergon_lib.trading_calendar.is_trading_day for NYSE-holiday-aware
+#     trading-day gating
+#   - nousergon_lib.alerts.publish (re-exports krepis.alerts; krepis is an
+#     unconditional dependency of nousergon-lib, no extra needed) for the
+#     SNS fan-out to alpha-engine-alerts
+# Pinned to match the current sibling-Lambda pin (config#1787-adjacent
+# lockstep discipline — keep sibling Lambdas' lib pin coherent).
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py
@@ -1,0 +1,166 @@
+"""Unit tests for alpha-engine-preopen-deploy-readiness-probe
+(alpha-engine-config-I7800 deliverable #2).
+
+Covers the branches named in the issue's closes-when: non-trading-day no-op,
+clean stamp (no self-heal, no page), drift that self-heals (dispatch clears
+it, no page), and drift that survives self-heal (pages with diagnostics).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import index
+
+
+def _lambda_payload(sf_drift: bool, **extra) -> dict:
+    body = {
+        "sf_drift": sf_drift,
+        "sf_sha": "abc1234",
+        "upstream_sha": "def5678",
+        "cf_drift": False,
+        "cf_drift_reason": "in_sync",
+    }
+    body.update(extra)
+    return body
+
+
+def _lam_client(responses: list[dict]) -> MagicMock:
+    """A boto3 lambda client mock whose .invoke() returns successive
+    payloads from `responses`, one per call."""
+    cli = MagicMock()
+    calls = iter(responses)
+
+    def _invoke(**kwargs):
+        payload = next(calls)
+        m = MagicMock()
+        m.get.side_effect = lambda k, default=None: {"FunctionError": None}.get(k, default)
+        m.__getitem__ = lambda self, k: {"Payload": MagicMock(read=lambda: __import__("json").dumps(payload).encode())}[k]
+        return m
+
+    cli.invoke.side_effect = _invoke
+    return cli
+
+
+class TestNonTradingDay:
+    def test_noop_when_not_a_trading_day(self):
+        with patch("index.is_trading_day", return_value=False), \
+             patch("index.boto3.client") as mock_boto:
+            result = index.handler({}, None)
+        assert result["action"] == "noop"
+        assert result["reason"] == "not_a_trading_day"
+        mock_boto.assert_not_called()
+
+
+class TestCleanStamp:
+    def test_no_self_heal_no_page_when_sf_drift_false(self):
+        clean = _lambda_payload(sf_drift=False)
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([clean])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._page") as mock_page, \
+             patch("index._dispatch_deploy_infrastructure") as mock_dispatch:
+            result = index.handler({}, None)
+
+        assert result["action"] == "noop"
+        assert result["reason"] == "clean"
+        mock_page.assert_not_called()
+        mock_dispatch.assert_not_called()
+        s3_mock.put_object.assert_called_once()
+
+
+class TestDriftSelfHeals:
+    def test_dispatches_reprobes_and_stays_silent_when_cleared(self):
+        drifted = _lambda_payload(sf_drift=True)
+        clean_after = _lambda_payload(sf_drift=False)
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([drifted, clean_after])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._dispatch_deploy_infrastructure", return_value=(True, "dispatched ok")), \
+             patch("index._poll_dispatch_conclusion", return_value=("success", "run completed: success")), \
+             patch("index._page") as mock_page:
+            result = index.handler({}, None)
+
+        assert result["action"] == "self_healed"
+        assert result["self_heal_dispatched"] is True
+        mock_page.assert_not_called()
+        s3_mock.put_object.assert_called_once()
+
+
+class TestDriftSurvivesSelfHeal:
+    def test_pages_with_diagnostics_when_still_drifted(self):
+        drifted = _lambda_payload(sf_drift=True)
+        still_drifted = _lambda_payload(sf_drift=True, cf_drift=True, cf_drift_reason="sha_mismatch")
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([drifted, still_drifted])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._dispatch_deploy_infrastructure", return_value=(True, "dispatched ok")), \
+             patch("index._poll_dispatch_conclusion", return_value=("failure", "run completed: failure")), \
+             patch("index.alerts.publish") as mock_publish:
+            mock_publish.return_value = MagicMock(sns=MagicMock(ok=True))
+            result = index.handler({}, None)
+
+        assert result["action"] == "paged"
+        assert result["reason"] == "still_drifted_after_self_heal"
+        mock_publish.assert_called_once()
+        call_kwargs = mock_publish.call_args.kwargs
+        assert call_kwargs["severity"] == "critical"
+        assert "preopen will halt" in call_kwargs["message"]
+        s3_mock.put_object.assert_called_once()
+
+    def test_pages_even_when_dispatch_itself_fails(self):
+        drifted = _lambda_payload(sf_drift=True)
+        still_drifted = _lambda_payload(sf_drift=True)
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([drifted, still_drifted])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._dispatch_deploy_infrastructure",
+                   return_value=(False, "workflow_dispatch HTTP 403: insufficient scope")), \
+             patch("index.alerts.publish") as mock_publish:
+            mock_publish.return_value = MagicMock(sns=MagicMock(ok=True))
+            result = index.handler({}, None)
+
+        assert result["action"] == "paged"
+        assert result["self_heal_dispatched"] is False
+        mock_publish.assert_called_once()
+
+
+class TestVerdictWrite:
+    def test_verdict_key_is_dated(self):
+        clean = _lambda_payload(sf_drift=False)
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([clean])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        fixed_today = date(2026, 8, 21)
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 8, 21, 11, 30, tzinfo=timezone.utc)
+            index.handler({}, None)
+
+        _, kwargs = s3_mock.put_object.call_args
+        assert kwargs["Key"] == "deploy_readiness/2026-08-21.json"

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1109,6 +1109,11 @@ alert_classes:
     severities: [critical]
     intake: bus
     response: drain-queue
+  - class: alpha_engine_preopen_deploy_readiness_probe
+    source: "alpha-engine-preopen-deploy-readiness-probe"
+    severities: [critical]
+    intake: bus
+    response: drain-queue
   - class: weekly_sf_recovery_metric
     source: "nousergon-data/scripts/weekly_sf_recovery_metric.py"
     severities: [error]

--- a/tests/test_deploy_blast_radius.py
+++ b/tests/test_deploy_blast_radius.py
@@ -1,0 +1,90 @@
+"""Unit tests for infrastructure/deploy_blast_radius.py (alpha-engine-config-I7800).
+
+Covers the two candidate-trigger computations and the picker that names
+whichever fires first — the deliverable is "the failure notification names
+which pipeline halts next and when," so these pin the actual dates/pipeline
+choice against fixed `now` instants rather than just checking the function
+doesn't raise.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "infrastructure"))
+
+import deploy_blast_radius as br  # noqa: E402
+
+
+class TestNextPreopenUtc:
+    def test_friday_before_preopen_rolls_to_same_day(self):
+        # 2026-08-21 is a Friday. 11:00 UTC = 04:00 PT, before 05:15 PT.
+        now = datetime(2026, 8, 21, 11, 0, tzinfo=timezone.utc)
+        nxt = br._next_preopen_utc(now)
+        assert nxt.astimezone(br._PT).date().isoformat() == "2026-08-21"
+
+    def test_friday_after_preopen_rolls_to_monday(self):
+        # 2026-08-21 Friday, 15:00 UTC = 08:00 PT, after 05:15 PT preopen.
+        now = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
+        nxt = br._next_preopen_utc(now)
+        assert nxt.astimezone(br._PT).date().isoformat() == "2026-08-24"  # Monday
+        assert nxt.astimezone(br._PT).weekday() == 0
+
+    def test_never_lands_on_a_weekend(self):
+        # Saturday morning.
+        now = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)
+        nxt = br._next_preopen_utc(now)
+        assert nxt.astimezone(br._PT).weekday() == 0  # Monday
+
+
+class TestNextWeeklyUtc:
+    def test_before_thursday_rolls_to_thursday(self):
+        # 2026-08-19 is a Wednesday.
+        now = datetime(2026, 8, 19, 8, 0, tzinfo=timezone.utc)
+        nxt = br._next_weekly_utc(now)
+        assert nxt.date().isoformat() == "2026-08-20"  # Thursday
+        assert nxt.hour == 9
+
+    def test_thursday_after_0900_rolls_to_friday(self):
+        now = datetime(2026, 8, 20, 10, 0, tzinfo=timezone.utc)  # Thu, past 09:00
+        nxt = br._next_weekly_utc(now)
+        assert nxt.date().isoformat() == "2026-08-21"  # Friday
+
+    def test_saturday_after_0900_rolls_to_next_thursday(self):
+        now = datetime(2026, 8, 22, 10, 0, tzinfo=timezone.utc)  # Sat, past 09:00
+        nxt = br._next_weekly_utc(now)
+        assert nxt.date().isoformat() == "2026-08-27"  # next Thursday
+        assert nxt.weekday() == 3
+
+
+class TestComputeBlastRadius:
+    def test_picks_the_sooner_of_the_two_candidates(self):
+        # Friday 15:00 UTC: preopen candidate is Monday 12:15 UTC (05:15 PT
+        # DST); weekly candidate is Saturday 09:00 UTC. Weekly is sooner.
+        now = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
+        result = br.compute_blast_radius(now)
+        assert result["pipeline"] == "weekly"
+        assert result["sm_name"] == "ne-weekly-freshness-pipeline"
+
+    def test_preopen_wins_when_it_is_sooner(self):
+        # Sunday evening: preopen Monday 05:15 PT is sooner than the
+        # following Thursday 09:00 UTC weekly candidate.
+        now = datetime(2026, 8, 23, 23, 0, tzinfo=timezone.utc)  # Sunday
+        result = br.compute_blast_radius(now)
+        assert result["pipeline"] == "preopen"
+        assert result["sm_name"] == "ne-preopen-trading-pipeline"
+        assert "HALTS" in result["message"]
+
+    def test_message_names_the_pipeline_and_is_a_single_line(self):
+        now = datetime(2026, 8, 21, 15, 0, tzinfo=timezone.utc)
+        result = br.compute_blast_radius(now)
+        assert result["sm_name"] in result["message"]
+        assert "\n" not in result["message"]
+        assert "alpha-engine-config-I7800" in result["message"]
+
+    def test_defaults_to_now_when_no_arg_given(self):
+        # Doesn't raise, and returns a well-formed result for whatever "now" is.
+        result = br.compute_blast_radius()
+        assert result["pipeline"] in ("preopen", "weekly")


### PR DESCRIPTION
## Why

2026-08-19/20: `Deploy Infrastructure` failed 3x on `main` (runs `32300162711`, `32302092674`, `32305068379`). `notify-main-failure` fired each time as an ordinary CI-red Telegram alert. Nothing connected those failures to the fact that they had already determined the outcome of the 2026-08-20 05:15 PT preopen — the live SF stamp was frozen behind `main`, so `DeployDriftGate` halted trading. A full unmanaged trading session was determined ~8 hours in advance by a signal that read as routine CI noise. `principles.md` §2.3: detected-and-paged is partial coverage.

alpha-engine-config-I7800 is the detection item in a 3-issue set (I7798 pre-merge validation, I7807 recovery runnability) and ranks above the other two per the task brief — nothing else closes the loop that lets main carry a valid-but-undeployed definition through an entire trading morning unnoticed.

## Changes

**1. Blast-radius on the failure notification.** `infrastructure/deploy_blast_radius.py` (pure stdlib — cannot itself fail on a dependency problem and mask the real deploy failure) computes which scheduled SF run reaches a stale stamp next: the weekday 05:15 PT preopen (HALTS at `DeployDriftGate`) or the Thu/Fri/Sat 09:00 UTC weekly candidate (registers drift, does not halt). `deploy-infrastructure.yml` runs it unconditionally and threads the result into `notify-ci-failure.yml`'s new opt-in `blast_radius_message` input (`nousergon-lib-PR343`).

**2. Pre-preopen deploy-readiness probe with runway.** New scheduled Lambda `alpha-engine-preopen-deploy-readiness-probe` (`cron(30 4 ? * MON-FRI *)` `America/Los_Angeles`, 45 minutes before the preopen trigger):
- Probes the SAME `check_deploy_drift` action `DeployDriftCheck` calls inside the preopen SF (one implementation).
- On drift: self-heals via `workflow_dispatch` on this repo's `deploy-infrastructure.yml` (idempotent), polls to a terminal conclusion (bounded, ~7min), re-probes.
- Still drifted (or the dispatch itself failed) → pages `alpha-engine-alerts` (critical) with diagnostics and the literal sentence that the preopen will halt.
- Self-heal cleared → logs the recovery, stays silent.
- Every invocation writes a verdict to `s3://alpha-engine-research/deploy_readiness/{date}.json` — a silent probe is not an observation.

## Merge order

`nousergon-lib-PR343` first (adds the `blast_radius_message` input this PR's workflow references), though this PR is pinned directly to that branch's commit SHA (`a5394d375`) so it functions correctly regardless of actual merge order — re-pin to `nousergon-lib@main` once PR343 merges (noted inline in `deploy-infrastructure.yml`).

## Operator step required after merge (blocking, cannot be automated from CI)

The CI OIDC role (`github-actions-lambda-deploy`) deliberately lacks `iam:CreateRole`/`PutRolePolicy` (fleet single-writer rule) — the new Lambda's role, its EventBridge Scheduler role, and the schedule itself must be created by an operator:

```
AWS_PROFILE=ne-admin bash infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh --bootstrap
```

Same pattern as every sibling scheduled probe in `infrastructure/lambdas/` (`eod-snapshot-existence-check`, `ci-watch-liveness-probe`, …) — merging this PR has ZERO live effect until that runs. **Known, accepted consequence**: `deploy-preopen-deploy-readiness-probe.yml`'s code-only auto-deploy will fail on its first push-to-main run (the function doesn't exist yet) and re-succeed on the next push after `--bootstrap` — identical first-merge ordering to every sibling in this directory.

**Also needs verification** (not a new secret ask — a scope check on an existing one): the self-heal leg reuses `/alpha-engine/saturday_sf_watch/github_pat` (same PAT `saturday-sf-watch-dispatcher` already uses). If it lacks `actions:write` on `nousergon-data`, the dispatch call fails loud (HTTP 403, folded into the page) rather than silently — the probe still detects and pages correctly, it just can't self-heal until the PAT is widened.

## Test plan

- `python3 -m pytest tests/test_deploy_blast_radius.py infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py -q` — 16/16 passed.
- `python3 -m pytest tests/test_automation_pause.py tests/test_apply_iam_is_iam_only.py tests/test_scheduler_reconcile_is_ci_runnable.py tests/test_smoke_asserts_handler_did_not_crash.py -q` — 247 passed, 3 skipped (pre-existing skips, unrelated).
- `python3 infrastructure/lambdas/_shared/check_iam_getobject_listbucket.py` — OK.
- YAML parse check on both edited/new workflow files — clean.
- No `infrastructure/step_function*.json` touched — `rehearsal-path-guard` is not triggered.

Tracked: alpha-engine-config-I7800. Related: `nousergon-lib-PR343`.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
---

## CORRECTION (merge order + a CI failure this PR had)

**CI failure, fixed**: `test_lib_pin_lockstep.py::test_lambda_pins_match_or_are_explicitly_exempted` failed — this lambda's `requirements.txt` was pinned to `nousergon-lib@v0.124.79`, an arbitrary "latest at the time" choice, against root's `v0.124.78`. Fixed by pinning to `v0.124.78` (commit `85dba7c0`) — this lambda's only dependencies (`is_trading_day`, `alerts.publish`) are already present there; there was never a real need for a newer tag. Verified in a real CI-matching venv (`python3 -m venv` + `pip install -r requirements.txt`, not bare system Python): `tests/test_lib_pin_lockstep.py` 4 passed; full suite 6282 passed, 13 skipped.

**Merge order, precise**: this Python-package pin has **no dependency on `nousergon-lib-PR343`** — PR343 touches only `.github/workflows/notify-ci-failure.yml`, no Python source under `nousergon_lib`, so nothing about PR343 landing or which version its merge-time autobump publishes next affects this pin. The one place this PR does reference PR343 is `deploy-infrastructure.yml`'s `uses: .../notify-ci-failure.yml@a5394d375...` — that is pinned directly to **PR343's branch commit SHA**, not to a version tag, which is why GitHub resolves it correctly regardless of which PR merges first (a reusable-workflow `uses:` ref may point at any pushed commit in the target repo, not only its default branch). So: **either merge order is fine for both PRs to go green** — this was designed to avoid the ordering coupling, and the earlier CI failure was an unrelated, independent pin mistake, not a symptom of merge order.

**Optional, non-blocking follow-up**: once `nousergon-lib-PR343` merges and autobumps, re-pin `deploy-infrastructure.yml`'s `uses:` line from the branch-commit SHA to `nousergon-lib@main`'s new HEAD — cosmetic cleanup only, the branch-SHA pin keeps working indefinitely otherwise.
---

## SECOND CORRECTION — the "either order works" claim in the prior correction was wrong

Caught by review, not self-found: `notify-main-failure`'s `uses:` line was pinned to `a5394d3754c1...`, a commit on **`nousergon-lib-PR343`'s branch**, not `main`. This org squash-merges with `delete_branch_on_merge=true` — the moment PR343 merges, that branch and commit are deleted and become garbage-collectable, and the pin stops resolving. The workflow that would silently break is `notify-main-failure` itself: the one path that fires only when something else has already failed, i.e. exactly the "deploy-failure page does not persist" class. "Either order works" was false the moment PR343 actually merges.

**Fixed (commit `50ce4c0f`)** by decoupling: `notify-main-failure` is reverted to the **same merged `main` SHA** it used before this PR (`5a434a599a4fba3e6201db43d6453c3ecffbba29`, unchanged) and no longer passes `blast_radius_message`. The compute step and the job's `outputs.blast_radius_message` stay — visible in the Action log on every run, harmless and unconsumed for now. Wiring `blast_radius_message` into the Telegram alert is deferred to a follow-up PR opened **after** `nousergon-lib-PR343` merges, which re-pins to the resulting `main` SHA — filed as **`alpha-engine-config-I7935`** (not left as a "run this after merging" instruction embedded in a PR, which `pull-request-policy` §4.2 forbids outright; a tracked issue alone is explicitly not an accepted substitute either, which is why the fix here is to remove the coupling rather than just file the issue).

This PR now has **no dependency on `nousergon-lib-PR343`** and needs no action from Brian to reach mergeable — merge order between the two is genuinely irrelevant now, not just asserted to be.

Re-verified after the fix: `python3 -c "import yaml; yaml.safe_load(...)"` clean; full suite in a real CI-matching venv (`python3 -m venv` + `pip install -r requirements.txt`, `nousergon-lib==0.124.78`): 6282 passed, 13 skipped.