### PR TITLE
fix(ci): sf-definition-validate two-job shape so its context always reports

### DIFF
--- a/.github/workflows/sf-definition-validate.yml
+++ b/.github/workflows/sf-definition-validate.yml
@@ -16,14 +16,44 @@
 # Credentials: `ne-github-sf-validate` (nous-ergon-ops), which holds exactly
 # states:ValidateStateMachineDefinition and nothing else. Deliberately NOT the
 # deploy role — this job runs on pull_request.
+#
+# Two-job shape (alpha-engine-config-I7798 remaining deliverable, 2026-08-21):
+# a WORKFLOW-level `paths:` filter on `pull_request` means a PR touching none
+# of the infra paths below never reports the `sf-definition-validate` context
+# AT ALL — promoting that context to a required status check then blocks
+# every such PR forever at "Expected — waiting for status" (measured live,
+# reverted the same day). Mirrors rehearsal-path-guard.yml /
+# canary-replay.yml: `label` runs on every `pull_request` event and decides
+# (via dorny/paths-filter) whether this PR touches an infra path; the named
+# `sf-definition-validate` job always RUNS on merge_group/push/
+# workflow_dispatch, and on `pull_request` either runs (path touched) or
+# reports SKIPPED (path untouched) — both outcomes satisfy a required check,
+# unlike a context that never appears. The job NAME stays exactly
+# `sf-definition-validate` so promoting it to a required check later needs
+# no branch-protection edit beyond adding the (now-always-reported) name.
+#
+# `token: ''` + explicit `base:` (alpha-engine-config-I6909): dorny/paths-filter
+# defaults to the GitHub REST API on `pull_request` events, which intermittently
+# failed with a TLS "self-signed certificate" error on GitHub-hosted runners (4
+# of 15 runs in a 2h window, 2026-08-11, three unrelated branches — a runner/
+# network flake, not caused by any PR's content). An empty token switches the
+# action to local `git diff` against the supplied base SHA instead, which needs
+# no outbound API call at all and so cannot hit this failure class.
+#
+# `merge_group` cannot carry a `paths:` filter (unsupported by GitHub Actions
+# on that event type) — it already ran the validate job unconditionally
+# before this change, so `label`'s `if:` only gates the `pull_request` event
+# and merge-queue graduation keeps validating every time, which is the
+# correct behavior right before a merge to main.
+#
+# infra path list MUST stay in lockstep with `push`'s own `paths:` filter
+# below, MINUS this workflow file itself (a direct push of just this file
+# changes no SF definition, so re-running validate on push is pointless) —
+# pinned by tests/test_sf_definition_validate_lockstep.py.
 name: Validate SF Definitions
 
 on:
   pull_request:
-    paths:
-      - 'infrastructure/step_function*.json'
-      - 'infrastructure/deploy-infrastructure.sh'
-      - '.github/workflows/sf-definition-validate.yml'
   merge_group:
     types: [checks_requested]
   push:
@@ -35,17 +65,45 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: sf-definition-validate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate:
+  label:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      infra_changed: ${{ steps.filter.outputs.infra_changed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          token: ''
+          base: ${{ github.event.pull_request.base.sha }}
+          filters: |
+            infra_changed:
+              - 'infrastructure/step_function*.json'
+              - 'infrastructure/deploy-infrastructure.sh'
+              - '.github/workflows/sf-definition-validate.yml'
+
+  sf-definition-validate:
     name: sf-definition-validate
+    needs: label
+    # `always()` overrides the default "skip if a dependency was skipped" —
+    # `label` itself is skipped outright on merge_group/push/workflow_dispatch
+    # (its `if:` excludes those events), and this job must still run for
+    # them. On `pull_request`, this job runs only when `label` found an
+    # infra-path change, and reports SKIPPED otherwise.
+    if: always() && (github.event_name != 'pull_request' || needs.label.outputs.infra_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/tests/test_sf_definition_validate_lockstep.py
+++ b/tests/test_sf_definition_validate_lockstep.py
@@ -1,0 +1,73 @@
+"""Lockstep guard for alpha-engine-config-I7798's two-job restructure of
+sf-definition-validate.yml: the infra path list now appears twice inside the
+same workflow file — once in the `label` job's dorny/paths-filter (decides
+whether the `sf-definition-validate` job runs on a `pull_request` event) and
+once in the `push` trigger's own `paths:` filter (decides whether a direct
+push to `main` re-runs validation).
+
+The two lists are INTENTIONALLY not identical: `push`'s list omits this
+workflow file itself — a direct push that only changes the workflow file
+changes no SF definition, so re-validating on push is pointless — while the
+`label` filter includes it (a PR that edits the workflow deserves its own
+job to actually run). This test asserts the `push` list is a SUBSET of the
+`label` filter's list, with exactly that one documented exclusion, so any
+OTHER drift between the two (an infra path added to one and not the other)
+fails loudly instead of silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sf-definition-validate.yml"
+
+WORKFLOW_FILE_PATH = ".github/workflows/sf-definition-validate.yml"
+
+
+def _label_filter_globs() -> list[str]:
+    definition = yaml.safe_load(WORKFLOW.read_text())
+    steps = definition["jobs"]["label"]["steps"]
+    filter_step = next(s for s in steps if s.get("id") == "filter")
+    filters_block = filter_step["with"]["filters"]
+    parsed = yaml.safe_load(filters_block)
+    return list(parsed["infra_changed"])
+
+
+def _push_paths() -> list[str]:
+    definition = yaml.safe_load(WORKFLOW.read_text())
+    return list(definition[True]["push"]["paths"])  # YAML parses bare `on:` as True
+
+
+def test_push_paths_are_subset_of_label_filter_minus_workflow_file():
+    label_globs = set(_label_filter_globs())
+    push_globs = set(_push_paths())
+
+    assert WORKFLOW_FILE_PATH in label_globs, (
+        "label job's infra_changed filter no longer includes the workflow "
+        "file itself — a PR editing this workflow would silently stop "
+        "running its own validate job"
+    )
+    assert WORKFLOW_FILE_PATH not in push_globs, (
+        "push trigger's paths list now includes the workflow file itself — "
+        "update this test's documented exclusion if that's deliberate"
+    )
+
+    expected_push_globs = label_globs - {WORKFLOW_FILE_PATH}
+    assert push_globs == expected_push_globs, (
+        "sf-definition-validate.yml's push.paths has drifted from the "
+        "label job's infra_changed filter (minus the workflow file) — "
+        f"push={push_globs!r} expected={expected_push_globs!r}"
+    )
+
+
+def test_sf_definition_validate_job_name_unchanged():
+    definition = yaml.safe_load(WORKFLOW.read_text())
+    job = definition["jobs"]["sf-definition-validate"]
+    assert job["name"] == "sf-definition-validate", (
+        "the job NAME must stay exactly 'sf-definition-validate' — a "
+        "rename breaks the future required-check promotion (alpha-engine-"
+        "config-I7798)"
+    )


### PR DESCRIPTION
## What

Restructures `.github/workflows/sf-definition-validate.yml` into the two-job shape already used by `rehearsal-path-guard.yml` / `canary-replay.yml`: a `label` job runs `dorny/paths-filter` (token `''` + explicit `base:`, per alpha-engine-config-I6909) on every `pull_request` event, and the job named `sf-definition-validate` either runs (an infra path changed) or reports SKIPPED (it didn't). Job name is unchanged.

## Why

Diagnosed and measured earlier today (alpha-engine-config-I7798): the workflow's old `pull_request: paths: [...]` filter was at the WORKFLOW level, so a PR touching none of `infrastructure/step_function*.json`, `infrastructure/deploy-infrastructure.sh`, or this workflow file never reported the `sf-definition-validate` context at all. An earlier attempt today to promote that context to a required status check on `main` was reverted the same day because it blocked every such PR at "Expected — waiting for status" forever.

`rehearsal-path-guard.yml` and `canary-replay.yml` already solve this correctly in this repo — mirroring rather than inventing a parallel shortcut.

## What's preserved

- `merge_group: types: [checks_requested]` — unaffected; `merge_group` can't carry a `paths:` filter, so it already ran the job unconditionally before this change, and still does.
- `push: branches: [main]` with its own `paths:` filter, unchanged.
- `workflow_dispatch`.
- The `concurrency` group.
- SHA-pinned actions.
- The single `--validate-only` implementation call — no second validation path introduced.

## Added

`tests/test_sf_definition_validate_lockstep.py` — pins `push.paths` against the `label` job's `infra_changed` filter (minus the workflow file itself, which `push` omits on purpose: a push that only touches the workflow file changes no SF definition). Also asserts the job name stays exactly `sf-definition-validate`.

## What this does NOT do

Does not touch branch protection. `required_status_checks.contexts` on `nousergon-data@main` is unchanged. Promoting `sf-definition-validate` to a required check is Brian's call, to be made only after this lands and is observed reporting SKIPPED on a real PR that doesn't touch the infra paths — my own PR touches the workflow file itself, so it only exercises the "runs" case, not the "reports SKIPPED" case.

Ref: alpha-engine-config-I7798 (issue lives in `alpha-engine-config`; closed by hand there per the cross-repo closing-keyword rule — a closing keyword here would not reach it).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01Lx76v3U1ZrHvs1c6vy2PPd