### PR TITLE
test: extend secret scan to installed nousergon_lib/krepis (alpha-engine-config-I7925)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/pause-reconcile.yml
+++ b/.github/workflows/pause-reconcile.yml
@@ -104,7 +104,7 @@ jobs:
       # shape, every call site). Same pin as requirements.txt, for the reason
       # deploy-infrastructure.yml states.
       - name: Install nousergon-lib (envelope builder for the console row)
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82"
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ arcticdb>=6.23.0
 # produced — the source-check is what tells you, and it stays RED until the
 # pin is right, which is the guard against merging the SF JSON ahead of the
 # registry entry.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.79
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.82
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -8,6 +8,16 @@ silently re-introduce an ``os.environ.get("POLYGON_API_KEY")`` style read.
 Non-secret env vars (``LANGCHAIN_PROJECT``, ``EMAIL_SENDER``, etc.) are
 allowed for now — they migrate to alpha-engine-config YAML in PR 8 of the
 arc. The pin here is only the secret-name set.
+
+alpha-engine-config-I7925: this repo-tree scan is blind to a first-party
+*dependency* reading a pinned secret via ``os.environ.get`` from
+``site-packages`` — exactly how ``nousergon_lib.preflight`` reading
+``GITHUB_TOKEN`` bypassed this very invariant and halted preopen trading
+(alpha-engine-config-I7924). ``test_no_secret_environ_reads_in_installed_dependencies``
+below closes that gap using the scanner shared via
+``nousergon_lib.testing.secret_scan`` (lifted there rather than copied a
+third time — this repo, crucible-predictor, and nousergon-lib's own suite
+all call it; see nousergon-lib#345).
 """
 
 from __future__ import annotations
@@ -15,7 +25,16 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
+from nousergon_lib.testing.secret_scan import scan_installed_packages
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# First-party packages this repo installs whose installed tree must also be
+# clean of a pinned-secret os.environ.get read — the repo-tree scan below
+# cannot see inside site-packages.
+_DEPENDENCY_PACKAGES = ("nousergon_lib", "krepis")
 
 # Secret names that must NEVER be read via os.environ.get / os.getenv.
 # EMAIL_SENDER + EMAIL_RECIPIENTS aren't secrets per se but live in SSM
@@ -80,3 +99,26 @@ def test_no_secret_environ_reads():
         "`from nousergon_lib.secrets import get_secret` instead:\n"
         + "\n".join(f"  {p}:{ln}  {name}" for p, ln, name in violations)
     )
+
+
+def test_no_secret_environ_reads_in_installed_dependencies():
+    """The repo-tree scan above cannot see an installed dependency's source.
+
+    ``nousergon_lib.preflight._github_auth_headers()`` reading
+    ``GITHUB_TOKEN`` via a literal ``os.environ.get`` from site-packages is
+    exactly the surface that let an expired credential halt preopen trading
+    (alpha-engine-config-I7924) while this repo's own scan reported clean.
+    """
+    violations, missing = scan_installed_packages(_DEPENDENCY_PACKAGES, _PINNED_SECRETS)
+    if violations:
+        raise AssertionError(
+            "Found os.environ.get reads of pinned secrets inside an "
+            "INSTALLED first-party dependency — this repo's own tree scan "
+            "cannot see this surface:\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )
+    if missing:
+        pytest.skip(
+            "first-party package(s) not importable in this environment — "
+            f"the invariant is unverified against them this run: {', '.join(missing)}"
+        )


### PR DESCRIPTION
## Summary

Deliverable 2 of alpha-engine-config-I7925. This repo's
`test_no_secret_environ_reads.py` (the nousergon-data twin of
crucible-predictor's) only scanned its own tree, so it never saw
`nousergon_lib.preflight._github_auth_headers()` reading `GITHUB_TOKEN`
via a literal `os.environ.get` from an installed dependency — the exact
gap that let an expired credential halt preopen trading
(alpha-engine-config-I7924).

Adds `test_no_secret_environ_reads_in_installed_dependencies`, calling the
scanner shared via `nousergon_lib.testing.secret_scan.scan_installed_packages`
(nousergon-lib-PR345 — lifted rather than a third repo-local copy of the
extended scan logic, per `policy-shared-code`'s second-adoption trigger:
this repo, `crucible-predictor`, and `nousergon-lib`'s own suite all call it).

## Update — unblocked, pin bumped to v0.124.82 at all 31 sites, CI green

Root pin had already moved to `v0.124.79` by the time this landed (the
earlier `nousergon-data-PR1484` sweep), uniformly across every site.
`nousergon-lib-PR345` merged and `nousergon-lib` has since moved to
v0.124.82 (re-checked immediately before writing this pin, per its
merge-time autobump), which also carries `nousergon-lib-PR346` (ambient
GitHub credential pickup off by default — the structural fix for the same
incident this scan test guards against).

Bumped `v0.124.79` → `v0.124.82` at all 31 pin sites `test_lib_pin_lockstep.py`
enforces plus one more caught by a repo-wide grep:
`requirements.txt`, `requirements-daily-news.txt`, `Dockerfile`,
`.github/workflows/deploy-infrastructure.yml` (the fourth site
`test_requirements_and_dockerfile_pins_match` checks), and 26
`infrastructure/lambdas/*/requirements.txt` files. Also caught
`.github/workflows/pause-reconcile.yml`, which carries its own hardcoded
`pip install "nousergon-lib@..."` line for the same drift-check pattern as
`deploy-infrastructure.yml` but is **not** covered by
`test_lib_pin_lockstep.py` — moved for consistency; a gap in that test's
coverage is noted but out of this PR's scope. `_LAMBDA_PIN_EXEMPTIONS` is
currently empty (no `floor`/`ceiling`/`group` exemptions), so every Lambda
tracks root directly — no exemption bookkeeping needed here.

This repo is a `_FLOOR_REPOS` entry in `crucible-predictor`'s co-install
parity guard (predictor/backtester pair) and intentionally lags that pair;
this bump is unrelated to that guard and needed only to satisfy this repo's
own scan test and lockstep guard.

Full local suite: 6285 passed, 13 skipped, 0 failed — no bs4/tenacity/yfinance
collection errors observed. `test_no_secret_environ_reads.py` +
`test_lib_pin_lockstep.py`: 6 passed. CI now green on all checks.

## Test plan

- Repo-tree assertion (`test_no_secret_environ_reads`): passes.
- New installed-dependency assertion (`test_no_secret_environ_reads_in_installed_dependencies`):
  passes against the released `v0.124.82` pin.
- `test_lib_pin_lockstep.py`: passes — all 31 sites in lockstep.
- Full suite: 6285 passed, 13 skipped.

## Merge order

Independent of `crucible-predictor-PR536` — different repo, same
dependency, no shared file.

alpha-engine-config-I7925

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
