### PR TITLE
test(contracts): declare the S3 SF-definition contract the preopen halt now depends on (alpha-engine-config-I7927)

### DIFF
--- a/infrastructure/contracts/sf_definition_s3.consumer.json
+++ b/infrastructure/contracts/sf_definition_s3.consumer.json
@@ -1,0 +1,49 @@
+{
+  "$comment": "SF-level consumer contract for the staged Step Function DEFINITIONS this repo's deploy uploads to S3 (alpha-engine-config-I7927; M0 rule: producer/consumer contract at birth, filed here at the moment the artifact acquired a second, trading-critical consumer). PRODUCER: infrastructure/deploy-infrastructure.sh, step 2 — it stamps '[git:<sha>] ' onto each definition's top-level Comment and uploads EXACTLY the bytes it then feeds to update-state-machine, so the S3 copy and the live definition are written from one source in one run. CONSUMERS: (1) CloudFormation, via DefinitionS3Location, on stack-create or resource replacement; (2) infrastructure/step-functions/check-definition-drift.py, the three-way repo/live/S3 drift backstop; (3) NEW as of I7927 — crucible-predictor inference/deploy_drift.py::_fetch_s3_definition, the preopen and postclose DeployDriftCheck probe, which reads these objects to obtain the EXPECTED definition and the expected deploy SHA without calling api.github.com. That third consumer is why this contract exists: DeployDriftGate halts the trading day when it cannot reach a verdict, so the key names below are now trading-critical, and changing one in the deploy would silently take the probe off its in-region source and back onto GitHub with nothing failing. ENFORCED BY tests/test_sf_definition_s3_consumer_contract.py, which pins this file against deploy-infrastructure.sh's actual upload lines.",
+  "contract_id": "sf_definition_s3-1.0.0",
+  "bucket": "alpha-engine-research",
+  "producer": {
+    "script": "infrastructure/deploy-infrastructure.sh",
+    "step": "2. Stamp SF definitions with git SHA + upload to S3",
+    "stamp": "The top-level `Comment` is rewritten to `[git:<sha>] <original>`.rstrip() before upload. The same stamped bytes are passed to update-state-machine in step 3 and the same <sha> is applied as the CloudFormation stack's `git-sha` tag in step 4, so all three artifacts name one deploy.",
+    "key_rule": "The S3 key is the definition's own repo path, verbatim. The consumers rely on that identity rather than on a separate mapping, so the two never need separate upkeep."
+  },
+  "definitions": [
+    {
+      "pipeline": "ne-weekly-freshness-pipeline",
+      "repo_path": "infrastructure/step_function.json",
+      "s3_key": "infrastructure/step_function.json",
+      "drift_probe_consumer": false,
+      "note": "Stamp semantics only in the drift probe — no market-open deadline, so a lost weekly run costs a rerun rather than a session."
+    },
+    {
+      "pipeline": "ne-preopen-trading-pipeline",
+      "repo_path": "infrastructure/step_function_daily.json",
+      "s3_key": "infrastructure/step_function_daily.json",
+      "drift_probe_consumer": true,
+      "note": "TRADING-CRITICAL. crucible-predictor _SF_DEFINITION_PATHS maps this pipeline to this exact path and reads s3://alpha-engine-research/<that path>. DeployDriftGate halts on a verdict it cannot reach."
+    },
+    {
+      "pipeline": "ne-postclose-trading-pipeline",
+      "repo_path": "infrastructure/step_function_eod.json",
+      "s3_key": "infrastructure/step_function_eod.json",
+      "drift_probe_consumer": true
+    },
+    {
+      "pipeline": "alpha-engine-groom-dispatch",
+      "repo_path": "infrastructure/step_function_groom.json",
+      "s3_key": "infrastructure/step_function_groom.json",
+      "drift_probe_consumer": false
+    }
+  ],
+  "consumer": {
+    "repo": "nousergon/crucible-predictor",
+    "symbol": "inference/deploy_drift.py::_fetch_s3_definition",
+    "reads": [
+      "the canonicalised definition body, as the EXPECTED definition for sf_drift",
+      "the `[git:<sha>]` stamp inside the body, as the EXPECTED deploy SHA for cf_drift and for asserting the S3 copy describes the live machine"
+    ],
+    "missing_input_behavior": "Falls back to the raw.githubusercontent comparison, then to the stamp verdict. With no expectation obtainable at all, sf_drift and cf_drift are OMITTED and DeployDriftGate's IsPresent guard halts — fail closed on unknown, never a defaulted false (alpha-engine-config-I7048, Brian ruling 2026-08-09 config#6615)."
+  },
+  "change_rule": "Renaming or re-prefixing any s3_key above, or dropping the Comment stamp, breaks the preopen probe's in-region source SILENTLY — it degrades to the GitHub path, which is exactly the dependency I7927 removed, and nothing fails until the morning GitHub is down. Change this file in the same commit, or not at all."
+}

--- a/tests/test_sf_definition_s3_consumer_contract.py
+++ b/tests/test_sf_definition_s3_consumer_contract.py
@@ -1,0 +1,168 @@
+"""The staged S3 Step Function definitions have a THIRD consumer now, and it
+halts the trading day (``alpha-engine-config-I7927``).
+
+WHAT THIS PINS
+--------------
+``infrastructure/deploy-infrastructure.sh`` stamps each definition with
+``[git:<sha>] `` and uploads exactly the bytes it then feeds to
+``update-state-machine``. Until 2026-08-21 that S3 copy had two consumers:
+CloudFormation's ``DefinitionS3Location`` and
+``infrastructure/step-functions/check-definition-drift.py``.
+
+``crucible-predictor#538`` added a third. ``inference/deploy_drift.py::
+_fetch_s3_definition`` now reads these objects to obtain the **expected**
+definition — and, after ``crucible-predictor#540``, the expected deploy SHA —
+so the preopen ``DeployDriftCheck`` can reach a verdict without calling
+``api.github.com``. ``DeployDriftGate`` **halts trading** when it cannot reach
+one, which makes these key names trading-critical.
+
+THE FAILURE MODE
+----------------
+Rename or re-prefix one of these keys in the deploy, or drop the Comment stamp,
+and the probe does not fail. It falls back to ``raw.githubusercontent.com`` —
+precisely the third-party dependency on the critical path of the trading day
+that I7927 removed — and **nothing goes red** until the morning GitHub is
+unreachable. That is a detection blindness, not a bug that announces itself, so
+it gets a test rather than a comment.
+
+``infrastructure/contracts/sf_definition_s3.consumer.json`` declares the
+contract; this pins that declaration against what the deploy script actually
+does, and against the consumer's own path map, which is reproduced here because
+neither repo's CI can read the other.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import re
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_CONTRACT_PATH = _ROOT / "infrastructure" / "contracts" / "sf_definition_s3.consumer.json"
+_DEPLOY_SH = _ROOT / "infrastructure" / "deploy-infrastructure.sh"
+
+#: ``crucible-predictor inference/deploy_drift.py::_SF_DEFINITION_PATHS`` — the
+#: consumer's own pipeline→path map, reproduced because this repo's CI cannot
+#: read that one. The consumer builds its S3 key from these paths verbatim
+#: (``_fetch_s3_definition(sf_definition_path)``), so a divergence here is a
+#: divergence in what the preopen probe will actually fetch.
+_CONSUMER_PATHS = {
+    "ne-preopen-trading-pipeline": "infrastructure/step_function_daily.json",
+    "ne-postclose-trading-pipeline": "infrastructure/step_function_eod.json",
+}
+
+#: ``crucible-predictor inference/deploy_drift.py::_DEFINITION_BUCKET``.
+_CONSUMER_BUCKET = "alpha-engine-research"
+
+
+def _load_guard():
+    """Import the drift backstop by path — its filename has hyphens."""
+    spec = importlib.util.spec_from_file_location(
+        "check_definition_drift",
+        _ROOT / "infrastructure" / "step-functions" / "check-definition-drift.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def deploy_sh() -> str:
+    return _DEPLOY_SH.read_text()
+
+
+def test_every_declared_definition_is_uploaded_by_the_deploy(contract, deploy_sh):
+    for entry in contract["definitions"]:
+        key = entry["s3_key"]
+        assert f'"s3://$BUCKET/{key}"' in deploy_sh, (
+            f"{entry['pipeline']}: the contract declares s3://{contract['bucket']}"
+            f"/{key} but deploy-infrastructure.sh does not upload to it"
+        )
+
+
+def test_the_declared_bucket_is_the_one_the_deploy_writes(contract, deploy_sh):
+    assert contract["bucket"] == _CONSUMER_BUCKET
+    assert f'BUCKET="{contract["bucket"]}"' in deploy_sh
+
+
+def test_the_s3_key_is_the_repo_path_verbatim(contract):
+    """The consumer derives its key from the definition's repo path rather than
+    from a mapping, so the identity is load-bearing, not cosmetic."""
+    for entry in contract["definitions"]:
+        assert entry["s3_key"] == entry["repo_path"], entry["pipeline"]
+
+
+def test_every_declared_definition_exists_in_the_repo(contract):
+    for entry in contract["definitions"]:
+        assert (_ROOT / entry["repo_path"]).exists(), entry["repo_path"]
+
+
+def test_the_drift_probe_consumers_match_the_consumers_own_path_map(contract):
+    """If the two ever disagree, the preopen probe is fetching a key this repo
+    is not writing — and it degrades to GitHub in silence."""
+    declared = {
+        e["pipeline"]: e["s3_key"]
+        for e in contract["definitions"] if e["drift_probe_consumer"]
+    }
+    assert declared == _CONSUMER_PATHS, (
+        "the contract's drift-probe consumers no longer match crucible-predictor "
+        "_SF_DEFINITION_PATHS. Update BOTH repos in one cross-repo pair of PRs, "
+        "or the preopen probe silently loses its in-region source."
+    )
+
+
+def test_the_deploy_stamps_the_comment_the_consumer_reads(deploy_sh):
+    """``_extract_sf_sha`` matches ``^\\[git:([0-9a-f]{7,40})\\]`` against the
+    top-level ``Comment``. That stamp is how the S3 copy says which deploy wrote
+    it, which is what makes an in-region ``cf_drift`` possible at all."""
+    assert "d['Comment'] = f'[git:{sha}] {orig}'.rstrip()" in deploy_sh
+    assert re.search(r"GIT_SHA=\"\$\{GITHUB_SHA:-", deploy_sh)
+
+
+def test_the_same_sha_tags_the_cloudformation_stack(deploy_sh):
+    """cf_drift compares the stack tag against the S3 copy's stamp. That is only
+    sound because one deploy run writes both from the same ``$GIT_SHA``."""
+    assert deploy_sh.count('--tags "Key=git-sha,Value=$GIT_SHA"') == 2  # create + update
+
+
+def test_the_upload_precedes_the_state_machine_update(deploy_sh):
+    """Order matters for what a *failed* deploy leaves behind. Uploading first
+    means a failed ``update-state-machine`` leaves S3 holding the NEW definition
+    against an OLD live machine — which the probe reads as drift and halts on,
+    the conservative direction. It is also what CloudFormation's
+    ``DefinitionS3Location`` needs on a stack-create or replacement."""
+    upload_at = deploy_sh.index('aws s3 cp "$DAILY_STAMPED"')
+    update_at = deploy_sh.index('update_or_defer_to_cfn "$DAILY_ARN"')
+    assert upload_at < update_at
+
+
+def test_the_contract_states_what_happens_when_the_input_is_missing(contract):
+    """A consumer contract that does not say what an absent input does is the
+    half that gets improvised later (sf-pipeline-policy 2.3a rule 2)."""
+    behavior = contract["consumer"]["missing_input_behavior"]
+    assert "OMITTED" in behavior and "fail closed" in behavior.lower()
+
+
+def test_check_definition_drift_still_guards_the_same_keys(contract):
+    """The three-way backstop and this contract must not drift apart: it is what
+    catches an out-of-band write to a key the preopen probe now trusts."""
+    guard = _load_guard()
+    guarded = {
+        e["sf_name"]: f"{guard.S3_PREFIX}{e['definition_file']}"
+        for e in guard.SF_DEFINITIONS
+    }
+    assert guard.S3_BUCKET == contract["bucket"]
+    for entry in contract["definitions"]:
+        assert guarded.get(entry["pipeline"]) == entry["s3_key"], (
+            f"{entry['pipeline']}: the contract declares {entry['s3_key']} but "
+            "check-definition-drift.py diffs "
+            f"{guarded.get(entry['pipeline'])!r}"
+        )


### PR DESCRIPTION
Tracked as **alpha-engine-config-I7927**. A closing keyword cannot reach that tracker from this repo.

**This PR was rewritten.** Its first cut added a new versioned deploy manifest. `crucible-predictor#538` then landed a design needing no new artifact at all, so the manifest is **withdrawn** — see *What this replaces* below. What remains is contract + test only, no behaviour change.

## Finding

`crucible-predictor#538` gave the staged S3 Step Function definitions a **third consumer, and it halts the trading day.**

`inference/deploy_drift.py::_fetch_s3_definition` reads `s3://alpha-engine-research/infrastructure/step_function_daily.json` to obtain the **expected** definition — and, with `crucible-predictor-PR540`, the expected deploy SHA — so `DeployDriftCheck` can reach a verdict without `api.github.com`. `DeployDriftGate` halts trading when it cannot reach one. Those key names are now trading-critical and nothing in this repo said so. Until 2026-08-21 the artifact's only consumers were CloudFormation's `DefinitionS3Location` and `check-definition-drift.py`.

**The failure mode is silent by construction.** Rename or re-prefix one of these keys in `deploy-infrastructure.sh`, or drop the `[git:<sha>] ` Comment stamp, and the probe does not fail — it falls back to `raw.githubusercontent.com`, precisely the third-party dependency on the critical path of the trading day that I7927 removed, and **nothing goes red** until the morning GitHub is unreachable. Detection blindness, not a bug that announces itself, so it gets a test rather than a comment.

## Change

* `infrastructure/contracts/sf_definition_s3.consumer.json` — declares the producer and its step, the key rule (the S3 key *is* the repo path, verbatim, which the consumer relies on instead of a separate mapping), the stamp rule, all four definitions, which two the drift probe reads, and what an absent input does: `sf_drift`/`cf_drift` **OMITTED**, fail closed, never a defaulted `false` (`alpha-engine-config-I7048`, Brian's 2026-08-09 ruling `config#6615`). Mirrors the existing `contracts/pit_stats_pass.consumer.json` shape.
* `tests/test_sf_definition_s3_consumer_contract.py` — 10 tests pinning that declaration against what `deploy-infrastructure.sh` actually does (upload keys, bucket, the Comment stamp expression, the `git-sha` stack tag being the *same* `$GIT_SHA`, upload-before-update ordering), against `check-definition-drift.py`'s own `SF_DEFINITIONS` map, and against `crucible-predictor`'s `_SF_DEFINITION_PATHS` — reproduced in the test because neither repo's CI can read the other.

## What this replaces, and why

The first cut published a new manifest (`git_sha`, `deployed_at`, immutable per-SHA copies, versioned schema, contract tests both sides). `#538` landed while it was in flight, using the definition the deploy **already** uploads — whose `Comment` already carries `[git:<sha>]`, i.e. the deploy SHA, in-region.

Withdrawn on `principles.md` §2.6: after `#538`, the manifest adds a writer, an artifact, a schema and two contract tests for facts an existing artifact already carries — that is *more* to maintain, not less. And on the standing rule to mirror an existing fleet pattern rather than stand up a parallel one. What was genuinely missing was documentation of the artifact that already exists plus a test that its keys cannot move in silence.

`alpha-engine-config-I7981` (the ARTIFACT_REGISTRY row filed for the withdrawn manifest) is stale as a result and should be closed with it.

## Testing

`pytest tests/` — **6294 passed, 13 skipped** (repo `.venv`; the system Python lacks `yfinance` and cannot collect 17 modules — environment gap, not a repo defect). New module: 10 passed.

## Cross-repo

* `crucible-predictor-PR540` is the consumer half (`cf_drift` measured in-region). **Independent — no merge order.** This PR is contract + test only and changes no behaviour; that PR needs nothing from this one.
* No file overlap with `nousergon-data#1483`, `#1484`, `#1129` or `#1007`.

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
