### PR TITLE
fix(deploy): deploy.yml's runner krepis floor is the real gate for remove-lambda-env (alpha-engine-config-I8030)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,15 +71,23 @@ jobs:
       # matched what was actually installed, so this alert path had been
       # silently dead (ModuleNotFoundError swallowed by `|| true`) since the
       # nousergon_lib migration landed — the exact L221 failure mode this
-      # step exists to prevent. Pin matches requirements.txt's `krepis>=0.6.0`
-      # floor. No extras needed (alerts uses boto3/SNS, preinstalled on
-      # ubuntu-latest).
+      # step exists to prevent. No extras needed (alerts uses boto3/SNS,
+      # preinstalled on ubuntu-latest).
+      #
+      # Raised to >=0.59.24 (alpha-engine-config-I8030/I8037): this is also
+      # the krepis that `deploy.sh` uses to run
+      # `python3 -m krepis.aws remove-lambda-env` on this same runner —
+      # requirements.txt's exact `krepis==` pin governs the Docker image,
+      # not this step. A floor stated as `>=0.6.0` "worked" only because an
+      # unbounded `pip install` resolves to the latest published release —
+      # luck, not a control, the same shape crucible-research-PR716 found
+      # and fixed for its own runner-side floor.
       - name: Set up Python for canary-rollback alert publish
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
-      - name: Install krepis for deploy.sh alerts call
-        run: pip install "krepis>=0.6.0"
+      - name: Install krepis for deploy.sh alerts + env-convergence calls
+        run: pip install "krepis>=0.59.24"
 
       - name: Deploy Phase 2 Lambda (alpha-engine-data-collector)
         working-directory: alpha-engine-data

--- a/tests/test_deploy_lambda_env_converges.py
+++ b/tests/test_deploy_lambda_env_converges.py
@@ -131,3 +131,38 @@ def test_krepis_pin_does_not_need_the_deploy_role_to_list_aliases() -> None:
         f"0.59.24 or the deploy fails on lambda:ListAliases and leaves a "
         f"PARTIAL deploy (alpha-engine-config-I8030)"
     )
+
+
+def test_deploy_workflow_krepis_floor_matches_the_defer_publish_fix() -> None:
+    """`deploy.sh` runs on the GHA runner, not inside the Docker image, so
+    `python3 -m krepis.aws remove-lambda-env` resolves whatever krepis
+    `.github/workflows/deploy.yml` installs — requirements.txt's exact pin
+    (tested above) governs the Lambda image and does not reach this call.
+
+    Before this test the workflow floor was `krepis>=0.6.0`: it "worked"
+    only because an unbounded `pip install` resolves to the latest published
+    release, not because the floor stated the requirement — the same "luck,
+    not a control" shape crucible-research-PR716 found on its own runner
+    floor for alpha-engine-config-I8037. A pin-resolution change (a new
+    dependency capping krepis lower, or a private index serving stale
+    releases) would silently reintroduce the PARTIAL deploy with no local
+    signal, which is why the floor is pinned in a test rather than left to
+    the installer's default behavior.
+    """
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "deploy.yml"
+    )
+    text = workflow.read_text(encoding="utf-8")
+    line = next(
+        ln
+        for ln in text.splitlines()
+        if "pip install" in ln and "krepis" in ln
+    )
+    version = line.split("krepis>=", 1)[1].split('"', 1)[0].strip()
+    parts = tuple(int(p) for p in version.split("."))
+    assert parts >= (0, 59, 24), (
+        f"deploy.yml's runner krepis floor is {version}; the runner also "
+        f"executes krepis.aws remove-lambda-env and needs >= 0.59.24 or a "
+        f"resolvable-lower install silently reintroduces the PARTIAL "
+        f"deploy (alpha-engine-config-I8030)"
+    )


### PR DESCRIPTION
Residue found while verifying `alpha-engine-config-I8030` / `alpha-engine-config-I8037` (both closed by prior PRs in this repo, `nousergon-data-PR1485` and `nousergon-data-PR1488`) — not a duplicate of either.

## What's missing

`nousergon-data-PR1488` bumped `requirements.txt`'s exact `krepis==` pin to `0.59.24` and added a floor test for it. That governs the **Docker image** for `alpha-engine-data-collector`.

`infrastructure/deploy.sh` runs on the **GHA runner**, not inside that image, and its `python3 -m krepis.aws remove-lambda-env` call resolves whatever krepis `.github/workflows/deploy.yml` installs. That step's floor was `krepis>=0.6.0`. The deploy currently succeeds only because an unbounded `pip install` resolves to the latest published release — luck, not a control. This is the identical defect class `crucible-research-PR716` found and fixed on its own runner-side floor for `alpha-engine-config-I8037`'s second finding.

## What changed

- `.github/workflows/deploy.yml`: `pip install "krepis>=0.6.0"` → `>=0.59.24`, comment updated to name both call sites this step feeds (`krepis.alerts publish` and `krepis.aws remove-lambda-env`).
- `tests/test_deploy_lambda_env_converges.py`: new `test_deploy_workflow_krepis_floor_matches_the_defer_publish_fix`, asserting the workflow's floor is `>= 0.59.24`, mirroring the existing `requirements.txt` floor test.

## Test plan

- `python3 -m pytest tests/test_deploy_lambda_env_converges.py -v` — 9 passed (8 existing + 1 new).
- Full suite `pytest -q --continue-on-collection-errors` — 68 failed / 6010 passed / 18 skipped / 49 errors, identical to the pre-existing baseline on unmodified `origin/main` (missing optional deps locally: `bs4`/`tenacity`/`yfinance`, and unrelated `test_postflight.py` collection errors). No new failures from this change.

## Merge order

Independent of any open PR — this is the only outstanding change against this call path. No dependency.

## Post-merge

None by hand. The push to `main` triggers `deploy.yml`, which now installs `krepis>=0.59.24` for the runner-side calls. Worth a one-time watch of that run (`gh run list --repo nousergon/nousergon-data --workflow deploy.yml`) to confirm green, but nothing here is expected to change behavior — the runner has been resolving 0.59.24+ already by luck.

---

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
