### PR TITLE
fix(deploy): fail loud on a failed Lambda code upload (alpha-engine-config-I8033)

### DIFF
--- a/infrastructure/lambdas/_shared/deploy_run.sh
+++ b/infrastructure/lambdas/_shared/deploy_run.sh
@@ -1,0 +1,114 @@
+# shellcheck shell=bash
+#
+# deploy_run.sh — shared status-propagating command runner + post-upload
+# code verification, sourced by every lambda's deploy.sh.
+#
+# WHY (alpha-engine-config-I8033): every deploy.sh in this repo defined its
+# own run() as `if $DRY_RUN; then echo ...; else "$@"; fi` — a plain
+# function whose failure is NOT reliably fatal even under `set -euo
+# pipefail`:
+#
+#   1. bash's errexit is suppressed for a command inside an if/else BODY
+#      when that same function has, earlier in the script, been invoked as
+#      part of an if/while/until CONDITION or an && / || list — a
+#      documented bash quirk, not a bug in any one script, and one every
+#      copy of the old run() was exposed to identically.
+#   2. Independent of (1): `aws lambda update-function-code` on a 25MB
+#      artifact was measured 2026-08-21 to print
+#      "aws: [ERROR]: Connection was closed before we received a valid
+#      response..." to stderr and still return exit 0. No amount of shell-
+#      side error propagation catches a CLI that misreports its own exit
+#      status — set -e is necessary but not sufficient.
+#
+# run() below closes (1): it captures $? explicitly right after the command
+# and calls `exit` itself rather than depending on errexit noticing a
+# nonzero return somewhere up the call chain. verify_code_deployed() closes
+# (2): it is the only check here that does not trust the CLI's reported
+# exit code at all — it reads back the function's live CodeSha256 and
+# compares it to a locally-computed digest of the artifact just built.
+#
+# Usage (matches the calling convention every deploy.sh already uses):
+#   # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+#   source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
+#   run aws lambda update-function-code --function-name "$FUNCTION_NAME" \
+#     --zip-file "fileb://$ZIP" --region "$REGION" \
+#     --query 'LastUpdateStatus' --output text
+#   if ! $DRY_RUN; then
+#     aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION"
+#   fi
+#   verify_code_deployed "$FUNCTION_NAME" "$REGION" "$ZIP"
+#
+# Reads $DRY_RUN if the caller defines it (as most deploy.sh scripts do);
+# defaults to false (real run) when unset, so a caller with no --dry-run flag
+# of its own (thinktank-spot-dispatcher) does not need to add one.
+
+run() {
+  if ${DRY_RUN:-false}; then
+    echo "DRY: $*"
+    return 0
+  fi
+  local status=0
+  "$@" || status=$?
+  if [ "${status}" -ne 0 ]; then
+    echo "ERROR: command failed (exit ${status}): $*" >&2
+    exit "${status}"
+  fi
+  return 0
+}
+
+# verify_code_deployed <function-name> <region> <zip-path>
+#
+# Reads back the LIVE CodeSha256 after an update-function-code /
+# create-function call and asserts it matches the artifact just built —
+# independent of whatever exit code the upload call reported or printed.
+# Lambda's CodeSha256 is the base64-encoded SHA-256 digest of the deployed
+# zip; computing the same digest locally and comparing is authoritative
+# regardless of CLI behaviour.
+#
+# Call this AFTER `aws lambda wait function-updated` (when not DRY_RUN) so
+# the read observes the settled state, not an in-flight update.
+verify_code_deployed() {
+  local function_name="${1:?verify_code_deployed: function name required}"
+  local region="${2:?verify_code_deployed: region required}"
+  local zip_path="${3:?verify_code_deployed: zip path required}"
+
+  if ${DRY_RUN:-false}; then
+    echo "DRY: would verify CodeSha256 for ${function_name} against ${zip_path}"
+    return 0
+  fi
+
+  if [ ! -r "${zip_path}" ]; then
+    echo "ERROR: verify_code_deployed: artifact not readable: ${zip_path}" >&2
+    exit 1
+  fi
+
+  # python3 rather than openssl: every deploy.sh in this repo already depends
+  # on python3 (see _shared/pause.sh's identical rationale for jq), so this
+  # adds no new dependency, and it sidesteps any cross-platform difference in
+  # how `openssl base64` wraps or trails its output between the OpenSSL and
+  # LibreSSL builds operators and CI runners carry.
+  local expected actual
+  expected="$(python3 -c '
+import base64, hashlib, sys
+with open(sys.argv[1], "rb") as fh:
+    digest = hashlib.sha256(fh.read()).digest()
+print(base64.b64encode(digest).decode("ascii"))
+' "${zip_path}")"
+
+  if ! actual="$(aws lambda get-function --function-name "${function_name}" \
+        --region "${region}" --query 'Configuration.CodeSha256' --output text 2>&1)"; then
+    echo "ERROR: verify_code_deployed: could not read back live CodeSha256 for ${function_name}: ${actual}" >&2
+    exit 1
+  fi
+
+  if [ "${expected}" != "${actual}" ]; then
+    echo "ERROR: code verification FAILED for ${function_name} in ${region}." >&2
+    echo "ERROR:   expected CodeSha256 (built artifact ${zip_path}): ${expected}" >&2
+    echo "ERROR:   live CodeSha256:                                  ${actual}" >&2
+    echo "ERROR: the upload call may have reported success while shipping nothing" >&2
+    echo "ERROR: new — the function's live code is UNCHANGED (alpha-engine-config-I8033)." >&2
+    exit 1
+  fi
+
+  echo "  ✓ verified live CodeSha256 matches ${zip_path}"
+}

--- a/infrastructure/lambdas/_shared/deploy_run.sh
+++ b/infrastructure/lambdas/_shared/deploy_run.sh
@@ -41,6 +41,27 @@
 # Reads $DRY_RUN if the caller defines it (as most deploy.sh scripts do);
 # defaults to false (real run) when unset, so a caller with no --dry-run flag
 # of its own (thinktank-spot-dispatcher) does not need to add one.
+#
+# TRANSPORT DECISION (alpha-engine-config-I8033 deliverable 3): every
+# deploy.sh here uploads via a direct `--zip-file fileb://...` PUT, never
+# via S3 (`--code S3Bucket=...`). Moving to S3 was evaluated and REJECTED for
+# now: it would add an S3 write step plus an `s3:PutObject` grant to every
+# one of the 43 lambdas' iam-policy.json (each independently reviewed —
+# infrastructure/iam/README.md's single-writer rule), a materially larger
+# IAM surface, for a failure that verify_code_deployed() above already turns
+# loud regardless of transport. The connection-close measured 2026-08-21 was
+# 1 failure in this repo's deploy history, not a recurring pattern; a bigger
+# transport migration is disproportionate to that base rate. Tracked as a
+# follow-up (alpha-engine-config-I8043) rather than silently dropped.
+#
+# What ships instead: retry envvars, set here so every deploy.sh gets them
+# without an operator having to rediscover
+# `AWS_RETRY_MODE=adaptive AWS_MAX_ATTEMPTS=10` (what actually cleared the
+# measured failure) by hand. `:-` so an operator's own environment always
+# wins. adaptive mode also backs off client-side request rate on repeated
+# throttling/connection errors, not just retrying blindly.
+export AWS_RETRY_MODE="${AWS_RETRY_MODE:-adaptive}"
+export AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-10}"
 
 run() {
   if ${DRY_RUN:-false}; then

--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -57,7 +57,8 @@ for arg in "$@"; do
   esac
 done
 
-run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler syntax + preflight unit tests ---------------------
 PKG=$(mktemp -d)
@@ -182,6 +183,7 @@ run aws lambda update-function-code \
 
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
   CURRENT_ENABLED=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" ALERT_DRAIN_DISPATCH_ENABLED true)
   aws lambda update-function-configuration \
     --function-name "${FUNCTION_NAME}" \

--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -93,9 +93,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -185,6 +184,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
+++ b/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
@@ -43,13 +43,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # Validate index.py syntax locally before shipping.
 python3 -c "
@@ -126,5 +121,7 @@ echo "Waiting for update to complete..."
 aws lambda wait function-updated \
   --function-name "${FUNCTION_NAME}" \
   --region "${REGION}"
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Deployed."

--- a/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
@@ -88,13 +88,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
 
@@ -228,6 +223,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
@@ -46,13 +46,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler syntax -------------------------------------------
 
@@ -172,6 +167,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -78,13 +78,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
@@ -224,6 +219,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -62,13 +62,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
@@ -201,6 +196,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -106,13 +106,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- TARGET_FUNCTIONS drift audit (config#862) ----------------------------
 # Read-only. List live alpha-engine-* Lambdas, subtract the recursion-guard
@@ -243,6 +238,7 @@ if $BOOTSTRAP; then
       --environment 'Variables={CHANGELOG_BUCKET=alpha-engine-research,CHANGELOG_STRUCTURED_PREFIX=changelog/entries,CHANGELOG_QUARANTINE_PREFIX=changelog/quarantine}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
+    verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
   fi
 fi
 
@@ -269,6 +265,8 @@ if ! $BOOTSTRAP; then
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}"
   fi
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
   echo "Ensuring env config..."
   run aws lambda update-function-configuration \

--- a/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-incident-mirror/deploy.sh
@@ -56,13 +56,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # Validate index.py syntax + run handler smoke tests locally before shipping.
 python3 -c "
@@ -152,6 +147,8 @@ echo "Waiting for update to complete..."
 aws lambda wait function-updated \
   --function-name "${FUNCTION_NAME}" \
   --region "${REGION}"
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 # Update env config to include CHANGELOG_STRUCTURED_PREFIX (added in PR 2 of
 # the schema-discipline arc). Idempotent — overwriting in place is a no-op

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -93,13 +93,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 # PKG (the Lambda-zip staging dir) is created up front; the shared handler-
@@ -245,6 +240,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
@@ -87,9 +87,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -181,6 +180,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/crypto-balances/deploy.sh
+++ b/infrastructure/lambdas/crypto-balances/deploy.sh
@@ -63,13 +63,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -189,6 +184,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 # Ensure the runtime config matches (idempotent) — the BTC all-script-types xpub scan + ETH
 # token enumeration need headroom beyond the original 60s.

--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -87,13 +87,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
 
@@ -198,6 +193,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -71,13 +71,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -216,6 +211,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/eod-precondition-probe/deploy.sh
+++ b/infrastructure/lambdas/eod-precondition-probe/deploy.sh
@@ -52,13 +52,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -158,6 +153,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/eod-snapshot-existence-check/deploy.sh
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/deploy.sh
@@ -70,13 +70,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -223,6 +218,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -64,13 +64,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -210,6 +205,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/expense-collector/deploy.sh
+++ b/infrastructure/lambdas/expense-collector/deploy.sh
@@ -147,9 +147,8 @@ if $RECONCILE_SCHEDULES && ! $BOOTSTRAP_IAM && ! $APPLY_IAM && ! $SMOKE; then
   CODE_DEPLOY=false
 fi
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 if $CODE_DEPLOY; then
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
@@ -298,6 +297,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 fi

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -85,13 +85,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- Apply IAM only, then EXIT (config#2825, config-I6661) ---------------
 # Placed FIRST, before packaging, deliberately. "only" has to mean the whole
@@ -371,6 +366,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -55,9 +55,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -167,5 +166,7 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."

--- a/infrastructure/lambdas/groom-inject-mock/deploy.sh
+++ b/infrastructure/lambdas/groom-inject-mock/deploy.sh
@@ -42,7 +42,8 @@ for arg in "$@"; do
   esac
 done
 
-run() { if $DRY_RUN; then echo "[dry-run] $*"; else "$@"; fi; }
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 if $BOOTSTRAP; then
   echo "== mock execution role =="
@@ -79,6 +80,9 @@ if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION
   run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
     --zip-file "fileb://${ZIP}" --region "${REGION}" \
     --query LastUpdateStatus --output text
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
+
 else
   run aws lambda create-function --function-name "${FUNCTION_NAME}" \
     --runtime python3.12 \
@@ -86,6 +90,8 @@ else
     --handler index.handler --zip-file "fileb://${ZIP}" \
     --timeout 60 --memory-size 256 --region "${REGION}" \
     --query FunctionArn --output text
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 fi
 
 echo "Done. Build/refresh the staging state machine with:"

--- a/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
+++ b/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
@@ -52,13 +52,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler syntax -------------------------------------------
 
@@ -212,6 +207,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "Deploy complete."
 

--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -53,13 +53,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 PKG=$(mktemp -d)
@@ -158,6 +153,7 @@ run aws lambda update-function-code \
 
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
   # Preserve operator-owned runtime flags across redeploys (config#1818 class).
   CURRENT_ENABLED=$(preserve_env_flag "${FUNCTION_NAME}" "${REGION}" OVERSEER_DISPATCH_ENABLED true)
   aws lambda update-function-configuration \

--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -121,9 +121,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -267,6 +266,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -84,13 +84,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -247,6 +242,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
@@ -88,13 +88,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
@@ -221,6 +216,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh
@@ -67,13 +67,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -214,6 +209,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -56,7 +56,8 @@ for arg in "$@"; do
   esac
 done
 
-run() { if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi; }
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ---------------------------------
 python3 -c "import ast; ast.parse(open('${SCRIPT_DIR}/index.py').read()); print('index.py syntax OK')"
@@ -130,6 +131,8 @@ fi
 echo "Updating Lambda function code: ${FUNCTION_NAME}"
 run aws lambda update-function-code --function-name "${FUNCTION_NAME}" --zip-file "fileb://${ZIP}" --region "${REGION}" --query 'LastUpdateStatus' --output text
 if ! $DRY_RUN; then aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"; fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 echo "✓ Code deployed."
 
 echo "Updating Lambda environment (flow-doctor SSM hydration)..."

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -67,13 +67,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 # PKG (the Lambda-zip staging dir) is created up front; the shared handler-
@@ -234,6 +229,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -210,13 +210,8 @@ if $RECONCILE_SCHEDULES && ! $BOOTSTRAP_IAM && ! $APPLY_IAM && ! $SMOKE; then
   CODE_DEPLOY=false
 fi
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 # PKG (the Lambda-zip staging dir) is created up front; the shared handler-
@@ -619,6 +614,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -57,13 +57,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler syntax -------------------------------------------
 
@@ -276,6 +271,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
@@ -141,9 +141,8 @@ if $RECONCILE_SCHEDULES && ! $BOOTSTRAP_IAM && ! $APPLY_IAM && ! $SMOKE; then
   CODE_DEPLOY=false
 fi
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -352,6 +351,8 @@ if $BOOTSTRAPPED; then
   if ! $DRY_RUN; then
     aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
   fi
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
   echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -113,13 +113,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 # PKG (the Lambda-zip staging dir) is created up front; the shared handler-
@@ -314,6 +309,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
+++ b/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
@@ -59,9 +59,8 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
@@ -204,6 +203,8 @@ run aws lambda update-function-code \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 echo "✓ Code deployed."
 
 # ----- 4. Optional backfill --------------------------------------------------

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -71,13 +71,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax -----------------------------
 # PKG (the Lambda-zip staging dir) is created up front; the shared handler-
@@ -161,6 +156,7 @@ if $BOOTSTRAP; then
       --environment "${PROD_ENV}" \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
+    verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
   fi
 
   # EventBridge hourly trigger
@@ -223,6 +219,8 @@ if ! $BOOTSTRAP; then
       --function-name "${FUNCTION_NAME}" \
       --region "${REGION}"
   fi
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 fi
 
 echo "✓ Code deployed."

--- a/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
+++ b/infrastructure/lambdas/ssm-liveness-poller/deploy.sh
@@ -57,13 +57,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -171,6 +166,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -58,13 +58,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 PKG="$(mktemp -d)"
 trap 'rm -rf "${PKG}"' EXIT
@@ -157,6 +152,7 @@ if $BOOTSTRAP; then
       --environment "${PROD_ENV}" \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
+    verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${PKG}/function.zip"
   fi
 
   echo "  Creating EventBridge rule: ${RULE_NAME}"
@@ -199,6 +195,8 @@ if ! $BOOTSTRAP; then
   if ! $DRY_RUN; then
     aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
   fi
+
+  verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${PKG}/function.zip"
 fi
 
 echo "✓ Code deployed."

--- a/infrastructure/lambdas/substrate-health-gate/deploy.sh
+++ b/infrastructure/lambdas/substrate-health-gate/deploy.sh
@@ -49,13 +49,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -161,6 +156,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
+++ b/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
@@ -48,9 +48,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -156,5 +155,7 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -42,6 +42,8 @@ RULE_NAME="alpha-research-thinktank-daily"
 # rotation does not silently change where a Think Tank page lands.
 SNS_TOPIC_ARN="${SNS_TOPIC_ARN:-arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
 
@@ -107,6 +109,8 @@ aws lambda update-function-code --function-name "$FUNCTION_NAME" \
     --zip-file fileb:///tmp/thinktank-spot-dispatcher.zip \
     --region "$REGION" --query 'LastModified' --output text
 aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION"
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "/tmp/thinktank-spot-dispatcher.zip"
 
 if [ "$SMOKE" -eq 1 ]; then
     echo "==> SMOKE: firing ONE real Think Tank run on a REAL spot box"

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh
@@ -80,13 +80,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then
-    echo "DRY: $*"
-  else
-    "$@"
-  fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
 
@@ -191,6 +186,8 @@ if ! $DRY_RUN; then
     --function-name "${FUNCTION_NAME}" \
     --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 echo "✓ Code deployed."
 

--- a/infrastructure/lambdas/weekly-preflight/deploy.sh
+++ b/infrastructure/lambdas/weekly-preflight/deploy.sh
@@ -52,9 +52,8 @@ for arg in "$@"; do
   esac
 done
 
-run() {
-  if $DRY_RUN; then echo "DRY: $*"; else "$@"; fi
-}
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Validate handler + run unit tests ----------------------------------
 
@@ -157,6 +156,8 @@ run aws lambda update-function-code --function-name "${FUNCTION_NAME}" \
 if ! $DRY_RUN; then
   aws lambda wait function-updated --function-name "${FUNCTION_NAME}" --region "${REGION}"
 fi
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
 # ----- 5. Publish a version + point the 'live' alias (the SF invokes :live) --
 # The Saturday SF invokes this Lambda as 'alpha-engine-weekly-preflight:live'

--- a/infrastructure/lambdas/weekly-run-scope/deploy.sh
+++ b/infrastructure/lambdas/weekly-run-scope/deploy.sh
@@ -40,7 +40,8 @@ for arg in "$@"; do
   esac
 done
 
-run() { if $DRY_RUN; then echo "  DRY-RUN: $*"; else "$@"; fi; }
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
 # ----- 0. Tests gate the deploy -------------------------------------------
 # The derivation runs against captured real executions and needs no AWS, so
@@ -85,6 +86,7 @@ if $BOOTSTRAP; then
       --environment 'Variables={LOG_LEVEL=INFO,RESEARCH_BUCKET=alpha-engine-research}' \
       --region "${REGION}" \
       --query 'FunctionArn' --output text
+    verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
     exit 0
   fi
   echo "  Lambda exists, code will be updated below"
@@ -96,3 +98,6 @@ run aws lambda update-function-code \
   --zip-file "fileb://${ZIP}" \
   --region "${REGION}" \
   --query 'LastModified' --output text
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
+

--- a/tests/test_deploy_shell_flags_fail_loud.py
+++ b/tests/test_deploy_shell_flags_fail_loud.py
@@ -1,0 +1,169 @@
+"""Every infrastructure/lambdas/*/deploy.sh must carry `set -euo pipefail`.
+
+alpha-engine-config-I8033. Bootstrapping alpha-engine-preopen-deploy-
+readiness-probe on 2026-08-21, deploy.sh's final step — the code upload —
+failed with a mid-flight connection close, printed an `aws: [ERROR]` line,
+and the SCRIPT EXITED 0. The outcome was benign only because create-function
+had already uploaded identical bytes; on the ordinary (non-bootstrap) path
+the same failure ships nothing and reports success.
+
+Root cause was two-layered:
+
+  1. The `run()` helper every deploy.sh used did not propagate a failing
+     command's exit status to the script (fixed by moving to the shared,
+     status-propagating `run()` in `_shared/deploy_run.sh`).
+  2. `set -euo pipefail` is necessary but NOT sufficient — measured the same
+     day, the AWS CLI itself can print an error and still return exit 0 for
+     a mid-stream connection failure on a large `--zip-file` upload. The
+     durable fix is `_shared/deploy_run.sh::verify_code_deployed`, which
+     reads back the function's live CodeSha256 and compares it to the
+     artifact just built, independent of what the CLI claims.
+
+This test is the narrow, mechanical half of the fix: `set -euo pipefail`
+closes the FIRST layer (an ordinary nonzero exit — from `python3`, `zip`,
+`aws iam ...`, a bad substitution, etc. — must still abort the script) and
+must never silently regress. It does not and cannot verify the second layer
+(that requires reading live AWS state); that is
+`test_deploy_shell_functions_are_defined.py`'s job for reachability of
+`verify_code_deployed` itself, plus the read-back logic's own docstring.
+
+WHY A DERIVED SCOPE AND NOT A HARDCODED LIST. 43 deploy.sh scripts exist
+today; this repo grows a lambda most weeks (data-spot-dispatcher was itself
+added because a prior migration shipped source + IAM + SF wiring with NO
+deploy.sh — config-I1767). A hardcoded list of "the 43 known scripts" leaves
+script #44 uncovered on the day it lands, silently. The universe here is
+every `infrastructure/lambdas/*/deploy.sh` git-tracked file, discovered by
+glob against `git ls-files` — a new deploy.sh is in-scope automatically.
+
+WHY NOT SHELLCHECK. shellcheck flags unquoted variables and dozens of other
+shapes, but does not have a check that FAILS a script for the *absence* of
+`set -e`/`set -u`/`set -o pipefail` — SC2154-adjacent advice is informational
+(and not enabled by `--severity=error`), never a hard failure. This test is
+the derived, fail-loud, no-`set -e`-absent-is-fine substitute.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Accepts any of the standard fail-loud combinations, in either flag or
+# longopt spelling, and in any order/grouping bash allows:
+#   set -euo pipefail / set -eu -o pipefail / set -e; set -u; set -o pipefail
+# `pipefail` MUST be present: a deploy.sh piping a failing command into a
+# `--query`/`--output text`/`grep` (several here do) needs it to fail loud on
+# the pipeline's real failure rather than reporting the last stage's status.
+#
+# A whole `set ...` invocation (everything up to end-of-line, `;`, or `#`),
+# tokenized by whitespace below rather than parsed token-by-token in the
+# regex — bash's `-o` takes its argument as the NEXT WORD regardless of
+# whether `o` was combined into an earlier short-flag cluster (`-euo
+# pipefail`) or given standalone (`-eu -o pipefail`), which a single regex
+# alternation cannot express without re-deriving a mini shell tokenizer.
+_SET_LINE_RE = re.compile(r"^[ \t]*set[ \t]+([^\n;#]+)", re.MULTILINE)
+
+
+def _lambda_deploy_scripts() -> list[Path]:
+    """Every git-tracked infrastructure/lambdas/*/deploy.sh, discovered from
+    the tree rather than hardcoded — see module docstring."""
+    out = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "--", "infrastructure/lambdas/*/deploy.sh"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    files = sorted({_REPO_ROOT / p for p in out})
+    assert files, (
+        "derived-test precondition failed: found ZERO tracked "
+        "infrastructure/lambdas/*/deploy.sh files. This guard measures "
+        "nothing in that state."
+    )
+    # Precondition: this repo has historically had 40+ such scripts
+    # (alpha-engine-config-I8033 enumerated 43 on 2026-08-21). A count this
+    # low means the glob itself is broken, not that the fleet shrank.
+    assert len(files) >= 20, (
+        f"derived-test precondition failed: only {len(files)} deploy.sh "
+        "files found under infrastructure/lambdas/ — expected 40+. The glob "
+        "is almost certainly broken rather than the fleet having shrunk; "
+        "fix _lambda_deploy_scripts() before trusting this guard."
+    )
+    return files
+
+
+def _has_all_flags(text: str) -> tuple[bool, bool, bool]:
+    """(-e present, -u present, pipefail present) anywhere the script sets
+    shell options, unioned across every `set ...` invocation (some scripts
+    split `set -eu` and `set -o pipefail` onto separate lines)."""
+    has_e = has_u = has_pipefail = False
+    for m in _SET_LINE_RE.finditer(text):
+        tokens = m.group(1).split()
+        expect_o_arg = False
+        for tok in tokens:
+            if expect_o_arg:
+                if tok == "pipefail":
+                    has_pipefail = True
+                expect_o_arg = False
+                continue
+            if tok == "-o":
+                expect_o_arg = True
+                continue
+            if tok == "pipefail":
+                # bare `pipefail` with no preceding `-o` is not an option
+                # argument to `set` — ignore (defensive; not a real shape).
+                continue
+            if not tok.startswith("-") or tok.startswith("--"):
+                continue
+            # A short-flag cluster, e.g. `-euo`. `o` inside it means the
+            # NEXT WORD is that flag's argument, exactly as for standalone
+            # `-o`.
+            if "e" in tok:
+                has_e = True
+            if "u" in tok:
+                has_u = True
+            if "o" in tok:
+                expect_o_arg = True
+    return has_e, has_u, has_pipefail
+
+
+def test_every_lambda_deploy_script_sets_euo_pipefail() -> None:
+    violations: list[str] = []
+    for script in _lambda_deploy_scripts():
+        text = script.read_text()
+        has_e, has_u, has_pipefail = _has_all_flags(text)
+        missing = [
+            name
+            for name, present in (("-e", has_e), ("-u", has_u), ("pipefail", has_pipefail))
+            if not present
+        ]
+        if missing:
+            violations.append(f"{script.relative_to(_REPO_ROOT)}: missing {', '.join(missing)}")
+
+    assert not violations, (
+        f"{len(violations)} deploy.sh script(s) do not set the full "
+        "`set -euo pipefail` contract (alpha-engine-config-I8033 class — a "
+        "script without `set -e`/pipefail can exit 0 after a failing "
+        "command, including a failed Lambda code upload):\n  "
+        + "\n  ".join(sorted(violations))
+    )
+
+
+def test_every_lambda_deploy_script_sources_deploy_run() -> None:
+    """The status-propagating `run()` + `verify_code_deployed` live in
+    `_shared/deploy_run.sh` (alpha-engine-config-I8033). Every deploy.sh must
+    source it — `set -e` alone still trusts whatever exit code the AWS CLI
+    reports, which was measured to be wrong for a failed 25MB code upload."""
+    violations: list[str] = []
+    for script in _lambda_deploy_scripts():
+        text = script.read_text()
+        if "_shared/deploy_run.sh" not in text:
+            violations.append(str(script.relative_to(_REPO_ROOT)))
+
+    assert not violations, (
+        f"{len(violations)} deploy.sh script(s) do not source "
+        "_shared/deploy_run.sh, so they lack both the status-propagating "
+        "run() and verify_code_deployed() (alpha-engine-config-I8033):\n  "
+        + "\n  ".join(sorted(violations))
+    )


### PR DESCRIPTION
## Summary

alpha-engine-config-I8033: `infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh`'s final step — the code upload — failed with a mid-flight connection close on 2026-08-21 and the script **exited 0**. Benign in that instance only because `create-function` had already uploaded identical bytes; on the ordinary (non-`--bootstrap`) path the same failure ships nothing and reports success.

**Scope: this was a class, not one script.** All **43** `infrastructure/lambdas/*/deploy.sh` in this repo shared the defective `run()` shape — `if $DRY_RUN; then echo ...; else "$@"; fi`, which never checks or propagates `$?`. 42 of the 43 had this exact `run()`; the 43rd (`thinktank-spot-dispatcher/deploy.sh`) called `aws` directly with no wrapper at all, exposed to the same class of failure. **All 43 are fixed in this PR** — no script was skipped.

## What changed

1. **New `infrastructure/lambdas/_shared/deploy_run.sh`**, sourced by all 43 scripts (replacing every inline `run()` definition):
   - `run()` now captures `$?` explicitly and calls `exit` itself, closing a bash quirk where errexit can be suppressed for a function invoked earlier in an `if`/`while` condition — belt-and-suspenders alongside `set -euo pipefail` (already present in all 43 scripts on `main`, contrary to this issue's evidence for the one script it was filed from; the shared, status-propagating `run()` is the actual gap `set -e` alone didn't close there).
   - **`verify_code_deployed()` — the durable fix.** After every `update-function-code` / `create-function` call (both are covered — 41 update-function-code sites, plus the bootstrap-only create-function branches that don't fall through to a later update-function-code in the same run), it reads back the function's live `CodeSha256` and compares it to a locally-computed SHA-256/base64 digest of the artifact just built. This does **not** trust the AWS CLI's exit code at all — which is the actual gap: the measured failure printed an `aws: [ERROR]` line and still returned exit 0.
   - `AWS_RETRY_MODE=adaptive` / `AWS_MAX_ATTEMPTS=10` now exported for every script (operator-overridable via `:-`) — the exact combination that cleared the measured failure, so the next operator doesn't have to rediscover it.

2. **Transport decision (deliverable 3): direct `--zip-file` kept, S3 rejected — for now.** Moving to S3 (`--code S3Bucket=...`) would add an `s3:PutObject` grant to each of the 43 lambdas' `iam-policy.json` (individually reviewed per `infrastructure/iam/README.md`'s single-writer rule) — a materially larger, security-relevant IAM surface — for a connection-close failure measured **once**, and one `verify_code_deployed()` already turns loud regardless of transport. Filed as a tracked follow-up: **alpha-engine-config-I8043**.

3. **`tests/test_deploy_shell_flags_fail_loud.py`** (new): derived guard (globs `infrastructure/lambdas/*/deploy.sh` from `git ls-files`, not hardcoded) asserting every script carries the full `set -euo pipefail` contract and sources `_shared/deploy_run.sh`, so a 44th script can't silently regress either check.

## Out-of-scope finding, filed separately

While running `shellcheck -S error` across all 43 scripts, found 3 with their `#!/usr/bin/env bash` shebang past line 1 (a `pause.sh` source block precedes it) — benign today (every invocation passes `bash` explicitly) but wrong. Filed as **alpha-engine-config-I8044**, not fixed here.

## Verification

- `bash -n` clean on all 43 scripts + the new shared file.
- `shellcheck -S error` clean on all 43 scripts + the new shared file (the 3 pre-existing SC2148 findings above are unrelated to this change — verified present on `origin/main` before this PR).
- Full local suite: `6302 passed, 17 skipped` (one unrelated pre-existing collection error in `tests/test_no_secret_environ_reads.py` from a stale local venv — `nousergon-lib` installed at 0.124.79 vs. this repo's pinned 0.124.82 — reproduces identically on `main`, not touched by this PR).
- Read-only only: no AWS mutation, no deploy invoked, no bootstrap run. The now-live `preopen-deploy-readiness-probe` schedule was not touched or triggered.

## Test plan

- [x] `bash -n` on all 43 deploy.sh + `_shared/deploy_run.sh`
- [x] `shellcheck -S error` on all 43 deploy.sh + `_shared/deploy_run.sh`
- [x] `.venv/bin/python3 -m pytest tests/ -q --ignore=tests/test_no_secret_environ_reads.py` — 6302 passed, 17 skipped
- [x] New `test_deploy_shell_flags_fail_loud.py` passes and fails correctly when a script is missing a flag (verified via local mutation during development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx76v3U1ZrHvs1c6vy2PPd