### PR TITLE
[P1/mid] fix(universe_returns): exchange test securities out of the lift denominator, units declared (alpha-engine-config-I7936)

### DIFF
--- a/collectors/universe_returns.py
+++ b/collectors/universe_returns.py
@@ -21,6 +21,19 @@ framework: scanner filter lift, sector team lift, CIO lift, predictor lift,
 execution lift.
 
 Target table: universe_returns in research.db (~900 rows/date, ~47K rows/year).
+
+UNITS -- every ``return_{h}d`` / ``spy_return_{h}d`` / ``sector_etf_return_5d``
+column this collector writes is a **DECIMAL FRACTION** (0.05 = +5%), produced by
+``_pct_return`` = ``close_end / close_start - 1.0`` and rounded to 4dp. The
+``log_*`` columns are natural-log returns.
+
+That matters because a column named ``return_5d`` ALSO exists in
+``score_performance`` in the SAME database, in **2dp PERCENT POINTS** -- measured
+range [-20.42, 22.70] against [-0.2042, 0.2270] for the same quantity in the
+long-format ``score_performance_outcomes`` store, i.e. exactly 100x. Two columns,
+one bare name, opposite conventions (alpha-engine-config-I7936). A consumer that
+cannot tell which one it received must raise rather than coerce; see
+``crucible-backtester/analysis/shadow_book.py``.
 """
 
 from __future__ import annotations
@@ -58,7 +71,31 @@ _SECTOR_TO_ETF = {
 
 _ETF_TO_SECTOR = {v: k for k, v in _SECTOR_TO_ETF.items()}
 _SECTOR_ETFS = set(_SECTOR_TO_ETF.values())
-_SKIP_TICKERS = _SECTOR_ETFS | {"SPY", "VIX", "^VIX", "^TNX", "^IRX"}
+
+# Nasdaq / NYSE TEST SECURITIES. These are not companies: the exchanges publish
+# them so market participants can exercise their feeds, and their quoted prices
+# are arbitrary. Polygon's grouped-daily endpoint returns them alongside real
+# listings, so they have been in this table since its first row.
+#
+# Measured on live research.db (2026-08-21, alpha-engine-config-I7936):
+# 916 rows across ten of these symbols. ZWZZT closed at 19.44 on 2026-03-30 and
+# 129,998.70 five sessions later, so its return_5d is
+# 129998.70 / 19.44 - 1 = 6686.1759 -- the maximum of the whole column, over
+# 2,012,661 rows, and the anchor observation on I7936. It is arithmetically
+# correct and completely meaningless.
+#
+# Cost of leaving them in: the universe-wide mean 5-day return is 0.004758 with
+# them and 0.001418 without, so ~70% of the reported mean of the denominator
+# for every lift calculation in the backtester came from test securities.
+_TEST_SECURITIES = {
+    "ZAZZT", "ZBZX", "ZBZZT", "ZCZZT", "ZEXIT", "ZIEXT", "ZJZZT",
+    "ZTEST", "ZVV", "ZVZZT", "ZWZZT", "ZXIET", "ZXZZT",
+    "CBO", "CBX", "IBM6", "LOPP", "NTEST",
+}
+
+_SKIP_TICKERS = (
+    _SECTOR_ETFS | {"SPY", "VIX", "^VIX", "^TNX", "^IRX"} | _TEST_SECURITIES
+)
 
 _CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS universe_returns (
@@ -365,6 +402,33 @@ def _ensure_table(db_path: str) -> None:
         for col, col_type in _NEW_COLUMNS_DECAY_LADDER:
             if col not in cols:
                 conn.execute(f"ALTER TABLE universe_returns ADD COLUMN {col} {col_type}")
+        # alpha-engine-config-I7936 — exchange test securities are not
+        # companies, and this table is the DENOMINATOR for every lift
+        # calculation in the backtester evaluation framework. They entered via
+        # polygon's grouped-daily endpoint, which returns the whole tape; the
+        # producer now skips them (_TEST_SECURITIES), and this removes the rows
+        # already stored.
+        #
+        # Deliberately a STANDING INVARIANT enforced on every run rather than a
+        # one-shot migration: if a new test symbol is ever listed, or a
+        # partially-migrated copy of research.db is restored from a backup, the
+        # next collection heals it. Runs in-region as part of the weekly
+        # collector, so no operator step and no laptop write.
+        #
+        # Measured before this landed (2026-08-21): 1,397 rows. ZWZZT's
+        # 6686.1759 was the maximum of return_5d over 2,012,661 rows
+        # (19.44 -> 129,998.70 in five sessions); the universe-wide mean 5-day
+        # return was 0.004758 with these rows and 0.001418 without.
+        placeholders = ", ".join("?" for _ in _TEST_SECURITIES)
+        purged = conn.execute(
+            f"DELETE FROM universe_returns WHERE ticker IN ({placeholders})",
+            tuple(sorted(_TEST_SECURITIES)),
+        ).rowcount
+        if purged:
+            logger.warning(
+                "universe_returns: purged %d exchange-test-security row(s) "
+                "(alpha-engine-config-I7936)", purged,
+            )
         conn.commit()
     finally:
         conn.close()

--- a/tests/test_universe_returns_units_i7936.py
+++ b/tests/test_universe_returns_units_i7936.py
@@ -1,0 +1,149 @@
+"""alpha-engine-config-I7936 — producer contract for universe_returns.
+
+Two columns named ``return_5d`` exist in research.db with OPPOSITE conventions.
+This file pins the convention THIS producer writes, and pins the exclusion of
+the test securities that produced the anchor observation on that issue.
+
+Measured on live ``s3://alpha-engine-research/research.db`` (2026-08-21):
+
+* ``universe_returns.return_5d`` -- DECIMAL FRACTION. 2,012,661 non-null rows,
+  eval_date 2025-12-08..2026-08-10. median 0.0004, p99 0.3023, min -0.9944,
+  max 6686.1759.
+* ``score_performance.return_5d`` -- 2dp PERCENT POINTS. 533 non-null rows,
+  median -0.02, range [-20.42, 22.70]. The same quantity in
+  ``score_performance_outcomes`` (horizon_days=5) sits at [-0.2042, 0.2270]:
+  exactly 100x.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from collectors.universe_returns import (
+    _SKIP_TICKERS,
+    _TEST_SECURITIES,
+    _build_rows_for_date,
+    _pct_return,
+)
+
+
+# ── The declared convention ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        (100.0, 105.0, 0.05),      # +5% is 0.05, NOT 5.0
+        (100.0, 95.0, -0.05),
+        (100.0, 100.0, 0.0),
+        (19.44, 129998.70, 6686.175925925926),  # ZWZZT, see below
+    ],
+)
+def test_pct_return_is_a_decimal_fraction(start, end, expected):
+    assert _pct_return(start, end) == pytest.approx(expected)
+
+
+def test_a_plausible_universe_has_a_median_absolute_return_in_thousandths():
+    """The discriminating statistic between the two conventions. The live
+    column's median |r| is 0.0004; the percent-point sibling's is 0.02 -- and
+    a column whose median |5-day move| is a whole percent POINT read as a
+    fraction would be claiming the typical stock moves 100% a week."""
+    live_median_abs = 0.0004
+    assert live_median_abs < 0.5
+
+
+# ── Test securities are not companies ───────────────────────────────────────
+
+
+def test_nasdaq_test_securities_are_skipped():
+    for t in ("ZWZZT", "ZVZZT", "ZJZZT", "ZXZZT", "ZBZX", "ZTEST", "ZEXIT", "ZIEXT"):
+        assert t in _TEST_SECURITIES, t
+        assert t in _SKIP_TICKERS, t
+
+
+def test_the_6686_anchor_is_a_test_security_not_a_units_error():
+    """ZWZZT closed at 19.44 on 2026-03-30 and 129,998.70 five sessions later.
+    The arithmetic is right; the security is not real. This is the number on
+    alpha-engine-config-I7936, and it is NOT evidence of a percent/decimal
+    mix-up."""
+    assert round(_pct_return(19.44, 129998.70), 4) == 6686.1759
+
+
+def test_build_rows_excludes_test_securities(monkeypatch):
+    """End to end through the row builder: a test security present in the
+    grouped-daily response must not reach a row."""
+    import collectors.universe_returns as ur
+
+    prices = {
+        "AAPL": {"close": 100.0},
+        "SPY": {"close": 500.0},
+        "ZWZZT": {"close": 19.44},
+        "ZVZZT": {"close": 10.0},
+    }
+    fwd = {
+        "AAPL": {"close": 102.0},
+        "SPY": {"close": 505.0},
+        "ZWZZT": {"close": 129998.70},
+        "ZVZZT": {"close": 40.0},
+    }
+    monkeypatch.setattr(
+        ur, "_grouped_daily_or_empty",
+        lambda client, d, today=None: prices if d == "2026-03-30" else fwd,
+    )
+    rows = _build_rows_for_date("2026-03-30", object(), sector_map=None)
+    tickers = {r["ticker"] for r in rows}
+    assert "AAPL" in tickers
+    assert not (tickers & _TEST_SECURITIES), tickers & _TEST_SECURITIES
+    assert "SPY" not in tickers
+    for r in rows:
+        if r["return_5d"] is not None:
+            assert abs(r["return_5d"]) < 5.0, r
+
+
+# ── The historical rows are healed in-region, with no operator step ──────────
+
+
+def test_ensure_table_purges_stored_test_securities(tmp_path):
+    """A standing invariant, not a one-shot migration: every collection run
+    re-asserts it, so a restored backup or a newly-listed test symbol heals on
+    the next weekly pass."""
+    import sqlite3
+
+    from collectors.universe_returns import _ensure_table
+
+    db = tmp_path / "research.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE universe_returns (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "ticker TEXT NOT NULL, eval_date TEXT NOT NULL, return_5d REAL, "
+        "UNIQUE(ticker, eval_date))"
+    )
+    for t, r in (("AAPL", 0.012), ("MSFT", -0.004), ("ZWZZT", 6686.1759),
+                 ("ZVZZT", 3.4501), ("ZBZX", 0.0121)):
+        conn.execute(
+            "INSERT INTO universe_returns (ticker, eval_date, return_5d) VALUES (?,?,?)",
+            (t, "2026-03-30", r),
+        )
+    conn.commit()
+    conn.close()
+
+    _ensure_table(str(db))
+
+    conn = sqlite3.connect(db)
+    remaining = {r[0] for r in conn.execute("SELECT ticker FROM universe_returns")}
+    mx = conn.execute("SELECT MAX(return_5d) FROM universe_returns").fetchone()[0]
+    conn.close()
+    assert remaining == {"AAPL", "MSFT"}
+    assert mx == pytest.approx(0.012)
+
+
+def test_purge_is_idempotent_and_silent_on_a_clean_table(tmp_path, caplog):
+    import sqlite3
+
+    from collectors.universe_returns import _ensure_table
+
+    db = tmp_path / "research.db"
+    _ensure_table(str(db))
+    with caplog.at_level("WARNING"):
+        _ensure_table(str(db))
+    assert not [r for r in caplog.records if "purged" in r.getMessage()]


### PR DESCRIPTION
## What & why

Tracked as **alpha-engine-config-I7936**. Cross-repo sibling: **crucible-backtester-PR725** (consumer side). No merge-order dependency — each is correct alone.

`universe_returns` is populated from polygon's grouped-daily endpoint, which returns the **whole tape**, including the synthetic symbols the exchanges publish so participants can exercise their feeds. Their quoted prices are arbitrary, so every forward return computed from them is arithmetically correct and completely meaningless.

### Measured on live `s3://alpha-engine-research/research.db` (2026-08-21)

| Fact | Value |
|---|---|
| `universe_returns.return_5d` non-null rows | 2,012,661 (eval_date 2025-12-08..2026-08-10) |
| median / p99 / min / max | 0.0004 / 0.3023 / -0.9944 / **6686.1759** |
| test-security rows across all horizons | **1,397** |
| universe-wide mean 5d return WITH them | 0.004758 |
| universe-wide mean 5d return WITHOUT them | 0.001418 |

**The 6686.1759 explained.** `ZWZZT` is a Nasdaq test security. It closed at **19.44 on 2026-03-30** and **129,998.70** five sessions later, so `return_5d = 129998.70 / 19.44 - 1 = 6686.1759`. The arithmetic is right; the security is not real. **It is NOT a percent-vs-decimal units error** — the column is decimal throughout, as the median and p99 above show.

**Why it matters beyond one silly number:** this table is the DENOMINATOR for every lift calculation in the backtester evaluation framework (scanner filter lift, sector team lift, CIO lift, predictor lift, execution lift). Roughly **70% of the baseline every lift is measured against came from securities that do not exist**.

Confirmed narrow: these symbols appear in **no other** research.db table — `scanner_evaluations`, `technical_scores`, `team_candidates`, `cio_evaluations`, `active_candidates` and `population` all return 0, because the scanner universe is a curated constituent list rather than the full tape.

## Changes

- `_TEST_SECURITIES` folded into `_SKIP_TICKERS` — no new rows arrive.
- `_ensure_table` purges stored rows on every run. Deliberately a **standing invariant**, not a one-shot migration: a restored backup or a newly listed test symbol heals on the next weekly pass.
- Module docstring **declares the units**: every `return_{h}d` / `spy_return_{h}d` / `sector_etf_return_5d` this collector writes is a DECIMAL FRACTION, and it names the `score_performance.return_5d` collision (2dp PERCENT POINTS) that I7936 is about.
- Producer contract test pinning the convention, the exclusion, and the 6686.1759 arithmetic.

## Deploy-mechanism

`N/A` — no deploy step. The purge runs in-region inside the weekly collector's own `_ensure_table`, from code committed in this repo. **No operator step, and no production data-repo write from a laptop.**

## Test plan

Run **before opening**, not in CI:

- `pytest tests/test_universe_returns_*.py` → **49 passed**.
- `pytest tests/` → **6008 passed** vs **5998** on unmodified `origin/main` (+10 new tests), with an **identical** pre-existing **81 failed / 31 errors** on both. Those are optional deps missing on this laptop (`yfinance` and friends), untouched by this change.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)