### PR TITLE
fix(sf-consumers): a run-day gate no-op is neither a watchdog clear nor a recovery (alpha-engine-config-I8045)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -195,6 +195,7 @@ from nousergon_lib.flow_doctor_fleet import PIPELINE_OBSERVER_TELEGRAM_TOPICS
 # ``main``), so this costs the Lambda no cold-start weight beyond the file.
 try:  # deployed layout: flat next to index.py in /var/task
     from weekly_sf_silence_deadman import (  # noqa: E402
+        GATE_NOOP_MAX_SECONDS,
         _is_gate_noop,
         compute_expected_slots,
         evaluate,
@@ -207,6 +208,7 @@ except ModuleNotFoundError:  # in-repo layout (pytest, ci.yml glob runner)
         0, str(Path(__file__).resolve().parents[3] / "scripts")
     )
     from weekly_sf_silence_deadman import (  # noqa: E402
+        GATE_NOOP_MAX_SECONDS,
         _is_gate_noop,
         compute_expected_slots,
         evaluate,
@@ -493,12 +495,51 @@ def _pipeline_role(client: object, execution_arn: str) -> Optional[str]:
     return role if isinstance(role, str) and role else None
 
 
+# Pseudo-status for a SUCCEEDED execution that deliberately did no work.
+# It is NOT "SUCCEEDED" and it is NOT a failure — a third bucket, so no
+# caller can accidentally sum it into either (alpha-engine-config-I8045).
+GATE_SKIP = "GATE_SKIP"
+
+
+def _row_is_gate_noop(exec_row: "dict", status_filter: str) -> bool:
+    """Is this ListExecutions row a run-day-gate no-op?
+
+    ``ne-weekly-freshness-pipeline``'s cron fires THU-SAT and the gate
+    self-selects the single correct day; on the other two days the execution
+    terminates SUCCEEDED in 2.7-5.7s at ``WeeklyRunDaySkip`` having entered
+    five states and dispatched nothing. Measured live 2026-08-21 across the
+    trailing 30 executions: EVERY scheduled SUCCEEDED run in that window was
+    one of these, and the liveness check below read them as a clear.
+
+    Uses ``GATE_NOOP_MAX_SECONDS`` — the SAME ceiling
+    ``weekly_sf_silence_deadman._is_gate_noop`` applies, imported rather than
+    restated, so the two checks in this one Lambda can never disagree about
+    what a no-op is (the I6991/2026-08-16 failure mode).
+
+    Costs no extra API call: ``ListExecutions`` already returns startDate and
+    stopDate. The stronger predicate — the DECLARED terminal state, which
+    also catches a SUCCEEDED-but-dispatched-nothing run of any duration — is
+    `nousergon_lib.pipeline_status.classify_work` (nousergon-lib-PR347); this
+    Lambda adopts it when it can take the pin.
+    """
+    if status_filter != "SUCCEEDED":
+        return False
+    start = exec_row.get("startDate")
+    stop = exec_row.get("stopDate")
+    if start is None or stop is None:
+        return False
+    if not hasattr(start, "astimezone") or not hasattr(stop, "astimezone"):
+        return False
+    return (stop - start).total_seconds() < GATE_NOOP_MAX_SECONDS
+
+
 def _status_counts_in_window(
     sf_arn: str,
     window_seconds: int,
     *,
     client: Optional[object] = None,
     role_filter: Optional[frozenset] = None,
+    gate_noop_aware: bool = False,
 ) -> "dict[str, int]":
     """Return counts of executions that STARTED for ``sf_arn`` in the last
     ``window_seconds``, keyed by terminal status (``RUNNING``, ``SUCCEEDED``,
@@ -570,8 +611,11 @@ def _status_counts_in_window(
                     else start.replace(tzinfo=timezone.utc)
                 )
                 if start_utc >= cutoff_utc:
+                    bucket = status_filter
+                    if gate_noop_aware and _row_is_gate_noop(exec_row, status_filter):
+                        bucket = GATE_SKIP
                     if role_filter is None:
-                        counts[status_filter] = counts.get(status_filter, 0) + 1
+                        counts[bucket] = counts.get(bucket, 0) + 1
                         continue
                     described += 1
                     if described > _MAX_ROLE_DESCRIBES:
@@ -588,7 +632,7 @@ def _status_counts_in_window(
                     if _pipeline_role(client, exec_row.get("executionArn")) in (
                         role_filter
                     ):
-                        counts[status_filter] = counts.get(status_filter, 0) + 1
+                        counts[bucket] = counts.get(bucket, 0) + 1
                 else:
                     # Executions are returned newest-first; once we see one
                     # older than the cutoff we can stop paging this status.
@@ -687,6 +731,7 @@ def _check_sf(
     window_seconds: int,
     client: Optional[object] = None,
     role_filter: Optional[frozenset] = None,
+    gate_noop_aware: bool = False,
 ) -> CheckResult:
     if not is_watch_day:
         logger.info(
@@ -700,16 +745,50 @@ def _check_sf(
         )
 
     counts = _status_counts_in_window(
-        sf_arn, window_seconds, client=client, role_filter=role_filter
+        sf_arn,
+        window_seconds,
+        client=client,
+        role_filter=role_filter,
+        gate_noop_aware=gate_noop_aware,
     )
     seen = sum(counts.values())
+    gate_skips = counts.get(GATE_SKIP, 0)
     # "Fired" and "healthy" are separate questions (alpha-engine-config-I6991).
     # RUNNING counts as healthy-so-far — a still-in-flight execution is not a
     # failure and must not be reported as one. Only SUCCEEDED/RUNNING clear
     # the check; a window whose every execution terminated FAILED/TIMED_OUT/
     # ABORTED is an alert, not a "watchdog clear".
+    # A run-day gate no-op is bucketed as GATE_SKIP and is deliberately in
+    # NEITHER term (alpha-engine-config-I8045). It is not a success — it
+    # dispatched nothing — and it is not a failure — it was correct to do
+    # nothing. Before I8045 it landed in `SUCCEEDED` and cleared this check
+    # on its own, so a window holding one gate-out and one genuinely failed
+    # weekly run reported "watchdog clear" and the failure never paged.
     healthy_seen = counts.get("SUCCEEDED", 0) + counts.get("RUNNING", 0)
     window_hours = window_seconds // 3600
+
+    if healthy_seen == 0 and gate_skips > 0 and gate_skips == seen:
+        # Everything in the window was a designed skip. The schedule fired and
+        # the control plane is fine, so this is neither NEVER_FIRED nor
+        # FIRED_AND_FAILED — and it does NOT page from here: the weekly-SF
+        # silence deadman owns the "the real run is missing" alert, and
+        # `observability-policy.md` §7.2a is one notification per failure, not
+        # one per detector that noticed it. Recorded loudly and carried on the
+        # CheckResult so the absence is visible rather than inferred.
+        logger.warning(
+            "watchdog: sf=%s saw %d execution(s) in the last %dh and EVERY one was "
+            "a run-day-gate no-op (<%ds, dispatched nothing). Not a clear: no real "
+            "run succeeded. The weekly-SF silence deadman owns the page for this "
+            "condition; this check reports ONLY_GATE_SKIPS.",
+            sf_label, seen, window_hours, GATE_NOOP_MAX_SECONDS,
+        )
+        return CheckResult(
+            sf_label=sf_label,
+            sf_arn=sf_arn,
+            checked=True,
+            executions_seen=seen,
+            outcome="ONLY_GATE_SKIPS",
+        )
 
     if healthy_seen > 0:
         logger.info(
@@ -1725,6 +1804,9 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         window_seconds=_eod_window_seconds(now_utc),
     )
     saturday = _check_sf(
+        # alpha-engine-config-I8045: the weekly SF is the one state machine
+        # with a run-day gate, so it is the one that needs GATE_SKIP bucketing.
+        gate_noop_aware=True,
         sf_label="Saturday SF",
         sf_arn=SATURDAY_SF_ARN,
         is_watch_day=is_sunday,

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -1958,3 +1958,145 @@ def test_list_bucket_prefix_condition_covers_the_same_pipelines():
             f"CompletionMarkerRead grants the object read — the two must list "
             f"the same pipelines."
         )
+
+
+# ── alpha-engine-config-I8045: a run-day gate no-op is not a clear ────────
+#
+# Real executions of `ne-weekly-freshness-pipeline`, captured live 2026-08-21
+# with `AWS_PROFILE=ne-admin aws stepfunctions list-executions`:
+#
+#   2026-08-21T02:00:49  SUCCEEDED  5.705s   InitializeInput -> ... -> WeeklyRunDaySkip
+#   2026-08-20T02:00:49  SUCCEEDED  3.465s   InitializeInput -> ... -> WeeklyRunDaySkip
+#   2026-08-15T02:00:49  FAILED     3h53m    died inside PredictorBacktest
+#
+# The cron fires THU-SAT and the gate self-selects the one correct day, so
+# two of three firings terminate SUCCEEDED in seconds having dispatched
+# nothing. That is correct behaviour. Reading it as a watchdog clear is not.
+
+_GATEOUT_0821 = 5.705   # measured
+_GATEOUT_0820 = 3.465   # measured
+_REAL_FAILED = 14003.967  # measured
+
+
+def _row(*, seconds_ago: float, duration: float, arn: str = "arn:aws:states:us-east-1:1:execution:sf:e"):
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(seconds=seconds_ago)
+    return {"startDate": start, "stopDate": start + timedelta(seconds=duration), "executionArn": arn}
+
+
+def test_a_gate_noop_alone_no_longer_reads_as_a_watchdog_clear():
+    """RED before I8045: this returned CLEAR off the 3.5s 08-20 gate-out."""
+    client = _make_status_filtered_sfn_client(
+        {"SUCCEEDED": [_row(seconds_ago=3600, duration=_GATEOUT_0820)]}
+    )
+    result = index._check_sf(
+        sf_label="Saturday SF",
+        sf_arn=SAT_ARN,
+        is_watch_day=True,
+        skip_reason_if_not_watching="(unused)",
+        window_seconds=7 * 24 * 3600,
+        client=client,
+        gate_noop_aware=True,
+    )
+    assert result.outcome == "ONLY_GATE_SKIPS", "a designed no-op is not a clear"
+    # ...and it does not page: the silence deadman owns that alert.
+    assert result.alert_emitted is False
+
+
+def test_a_gate_noop_no_longer_masks_a_real_failure_in_the_same_window():
+    """The operational harm. The 7-day weekly window held BOTH the 08-15
+    failure and the 08-20/08-21 gate-outs; the gate-outs cleared the check
+    and the failure never paged."""
+    client = _make_status_filtered_sfn_client(
+        {
+            "SUCCEEDED": [
+                _row(seconds_ago=3600, duration=_GATEOUT_0821, arn="…:e21"),
+                _row(seconds_ago=90000, duration=_GATEOUT_0820, arn="…:e20"),
+            ],
+            "FAILED": [_row(seconds_ago=6 * 24 * 3600, duration=_REAL_FAILED, arn="…:e15")],
+        }
+    )
+    result = index._check_sf(
+        sf_label="Saturday SF",
+        sf_arn=SAT_ARN,
+        is_watch_day=True,
+        skip_reason_if_not_watching="(unused)",
+        window_seconds=7 * 24 * 3600,
+        client=client,
+        gate_noop_aware=True,
+    )
+    assert result.outcome == "FIRED_AND_FAILED", (
+        "two gate-outs must not clear a window whose only real run failed"
+    )
+    assert result.alert_emitted is True
+    message = _alerts_mod.publish.call_args.kwargs["message"]
+    assert "FAILED=1" in message
+    # The skips are named, not hidden — the reader can see why the count of
+    # executions exceeds the count of real runs.
+    assert "GATE_SKIP=2" in message
+
+
+def test_the_same_window_read_status_blind_still_clears_proving_the_defect():
+    """The RED half, executable: with gate_noop_aware off — which is what
+    every call site did before I8045 — the identical window reports CLEAR."""
+    client = _make_status_filtered_sfn_client(
+        {
+            "SUCCEEDED": [_row(seconds_ago=3600, duration=_GATEOUT_0821)],
+            "FAILED": [_row(seconds_ago=6 * 24 * 3600, duration=_REAL_FAILED)],
+        }
+    )
+    result = index._check_sf(
+        sf_label="Saturday SF",
+        sf_arn=SAT_ARN,
+        is_watch_day=True,
+        skip_reason_if_not_watching="(unused)",
+        window_seconds=7 * 24 * 3600,
+        client=client,
+        gate_noop_aware=False,
+    )
+    assert result.outcome == "CLEAR"
+    assert result.alert_emitted is False
+
+
+def test_a_real_weekly_run_is_not_mistaken_for_a_gate_noop():
+    """The inverse failure — reporting a genuine success as a skip would
+    page through working behaviour, which is the fix that must not happen."""
+    client = _make_status_filtered_sfn_client(
+        {"SUCCEEDED": [_row(seconds_ago=3600, duration=_REAL_FAILED)]}
+    )
+    result = index._check_sf(
+        sf_label="Saturday SF",
+        sf_arn=SAT_ARN,
+        is_watch_day=True,
+        skip_reason_if_not_watching="(unused)",
+        window_seconds=7 * 24 * 3600,
+        client=client,
+        gate_noop_aware=True,
+    )
+    assert result.outcome == "CLEAR"
+    assert result.alert_emitted is False
+
+
+def test_the_gate_noop_ceiling_is_the_deadmans_and_not_a_second_copy():
+    """Two checks in one Lambda disagreeing about what a no-op is was the
+    2026-08-16 defect; the constant is imported, never restated."""
+    assert index.GATE_NOOP_MAX_SECONDS is _deadman.GATE_NOOP_MAX_SECONDS
+    assert _GATEOUT_0821 < index.GATE_NOOP_MAX_SECONDS
+    assert _REAL_FAILED > index.GATE_NOOP_MAX_SECONDS
+
+
+def test_the_other_two_pipelines_are_untouched_by_gate_bucketing():
+    """Only the weekly SF has a run-day gate; the preopen/postclose checks
+    must keep their exact prior behaviour."""
+    client = _make_status_filtered_sfn_client(
+        {"SUCCEEDED": [_row(seconds_ago=60, duration=2.0)]}
+    )
+    result = index._check_sf(
+        sf_label="Weekday SF",
+        sf_arn=WKD_ARN,
+        is_watch_day=True,
+        skip_reason_if_not_watching="(unused)",
+        window_seconds=24 * 3600,
+        client=client,
+    )
+    assert result.outcome == "CLEAR"

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/index.py
@@ -650,6 +650,69 @@ def _state_machine_arn_from_execution(execution_arn: str) -> str:
     return without_name.replace(":execution:", ":stateMachine:", 1)
 
 
+# Terminal states that end an execution SUCCEEDED having deliberately done
+# no work. Reaching one is CORRECT behaviour — and it is NOT a recovery.
+#
+# alpha-engine-config-I8045. `ne-weekly-freshness-pipeline` fires THU-SAT and
+# self-selects its run day; on the other two days it terminates SUCCEEDED in
+# 2.7-5.7s at `WeeklyRunDaySkip` having entered five states and dispatched
+# nothing. Measured live 2026-08-21 across the trailing 30 executions.
+#
+# SINGLE SOURCE: `nousergon_lib.pipeline_status.registry.SKIP_TERMINALS`
+# (nousergon-lib-PR347). This copy exists only because this Lambda cannot
+# take the lib pin until that PR merges and publishes, and because its
+# `deploy.sh` vendoring list is held by a concurrent session. Replace this
+# constant and `_reached_declared_skip_terminal` with
+# `nousergon_lib.pipeline_status.classify_work` when the pin lands —
+# alpha-engine-config-I8045 deliverable 1 follow-up.
+_SKIP_TERMINALS = {
+    "ne-weekly-freshness-pipeline": frozenset({"WeeklyRunDaySkip", "ShellRunComplete"}),
+    "ne-preopen-trading-pipeline": frozenset({"NotifyHolidaySkip"}),
+    "ne-postclose-trading-pipeline": frozenset(),
+}
+
+
+def _reached_declared_skip_terminal(execution_arn: str, *, client=None) -> bool:
+    """Did this SUCCEEDED execution end at a DECLARED no-work terminal?
+
+    One `GetExecutionHistory` call with `reverseOrder=True`, so the terminal
+    entered state is in the first page regardless of how long the run was.
+
+    Fail-safe posture matches the rest of this function: on ANY error, or on
+    a state machine with no declared skip terminals, returns False — i.e.
+    "not a skip", which lets the caller treat a SUCCEEDED execution as a
+    genuine recovery exactly as it did before. A broken check must never
+    invent a repair dispatch, and it must never invent a stand-down either;
+    False is the pre-I8045 behaviour, so a failure here degrades to the old
+    reading rather than to a new one. Every such degradation is logged.
+    """
+    sm_name = execution_arn.split(":")[6] if len(execution_arn.split(":")) > 6 else ""
+    skips = _SKIP_TERMINALS.get(sm_name, frozenset())
+    if not skips:
+        return False
+    try:
+        sfn = client or boto3.client("stepfunctions", region_name=REGION)
+        resp = sfn.get_execution_history(
+            executionArn=execution_arn, maxResults=50, reverseOrder=True
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-safe, recorded on this WARNING
+        logger.warning(
+            "skip-terminal check GetExecutionHistory failed for %s (treating as a "
+            "real run, which is the pre-I8045 reading): %s: %s",
+            execution_arn, type(exc).__name__, exc,
+        )
+        return False
+    for event in resp.get("events") or []:
+        details = event.get("stateEnteredEventDetails")
+        if details and details.get("name"):
+            return str(details["name"]) in skips
+    logger.warning(
+        "skip-terminal check found no stateEntered event for %s — treating as a "
+        "real run", execution_arn,
+    )
+    return False
+
+
 def _reevaluate_after_defer(fields: dict) -> dict | None:
     """On a DEFERRED invocation (defer_generation >= 1), re-check the state
     machine before dispatching: the live box that forced the defer may have
@@ -684,23 +747,44 @@ def _reevaluate_after_defer(fields: dict) -> dict | None:
 
     latest = executions[0]  # ListExecutions returns newest-first
     status = str(latest.get("status") or "")
+    latest_arn = str(latest.get("executionArn") or "")
     if status in ("RUNNING", "SUCCEEDED", "PENDING_REDRIVE"):
         # RUNNING/SUCCEEDED: the live box (or an operator) already recovered
         # the pipeline. PENDING_REDRIVE: a redrive is in flight — launching a
         # repair box now would duplicate it.
-        logger.info(
-            "deferred re-evaluation: latest execution %s is %s — recovered, "
-            "no dispatch needed", latest.get("executionArn"), status,
-        )
-        return {"launched": False, "reason": "recovered",
-                "latest_execution_arn": latest.get("executionArn"),
-                "latest_status": status}
+        #
+        # ...unless the SUCCEEDED execution is a declared no-work skip
+        # (alpha-engine-config-I8045). The deferred path re-checks the state
+        # machine minutes-to-hours after a real failure, and on the weekly SF
+        # a THU/FRI run-day gate-out lands in exactly that window: a 3-second
+        # SUCCEEDED execution that entered no stage would stand the repair
+        # dispatch down and leave the real failure unrepaired, silently,
+        # reporting "recovered". A skip is not a recovery — nothing happened.
+        if status == "SUCCEEDED" and _reached_declared_skip_terminal(latest_arn):
+            logger.info(
+                "deferred re-evaluation: latest execution %s SUCCEEDED at a declared "
+                "no-work terminal — this is a designed skip, NOT a recovery; "
+                "proceeding with the repair dispatch", latest_arn,
+            )
+        else:
+            logger.info(
+                "deferred re-evaluation: latest execution %s is %s — recovered, "
+                "no dispatch needed", latest_arn, status,
+            )
+            return {"launched": False, "reason": "recovered",
+                    "latest_execution_arn": latest.get("executionArn"),
+                    "latest_status": status}
 
     # FAILED / TIMED_OUT / ABORTED — still broken; retarget the dispatch at
     # the NEWEST failed execution so the repair agent diagnoses the current
     # failure, not a stale one. The ARN comes from AWS but is embedded into a
     # shell command downstream — hold it to the same allowlist as the event's.
-    newest_arn = str(latest.get("executionArn") or "")
+    #
+    # Retarget ONLY when the newest execution is itself a failure. A declared
+    # no-work skip fell through to here (above); pointing the repair agent at
+    # a 3-second gate-out would hand it an execution with no failure to
+    # diagnose, so the originally-reported failed execution stays the target.
+    newest_arn = latest_arn if status in ("FAILED", "TIMED_OUT", "ABORTED") else ""
     if _ARN_RE.match(newest_arn):
         if newest_arn != fields["execution_arn"]:
             logger.info(
@@ -713,8 +797,9 @@ def _reevaluate_after_defer(fields: dict) -> dict | None:
         # rather than embedding an unvalidated string into the SSM shell
         # command; recorded via this WARNING log.
         logger.warning(
-            "deferred re-evaluation: newest execution ARN %r fails the ARN "
-            "allowlist — keeping the original execution_arn", newest_arn,
+            "deferred re-evaluation: newest execution ARN %r is not a retarget "
+            "candidate (malformed, or a non-failure terminal) — keeping the "
+            "original execution_arn %s", newest_arn, fields["execution_arn"],
         )
     return None
 

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py
@@ -127,17 +127,37 @@ class _FakeScheduler:
 
 
 class _FakeSfn:
-    def __init__(self, executions=None, error=None):
+    def __init__(self, executions=None, error=None, terminal_states=None, history_error=None):
         self.calls = []
+        self.history_calls = []
         # newest-first, mirroring the real ListExecutions ordering.
         self.executions = list(executions or [])
         self.error = error
+        # execution ARN -> the state it terminated at. Anything not named
+        # here answers with a real workload state, so an execution a test
+        # does not speak about reads as a genuine run (I8045).
+        self.terminal_states = dict(terminal_states or {})
+        self.history_error = history_error
 
     def list_executions(self, **kw):
         self.calls.append(kw)
         if self.error is not None:
             raise self.error
         return {"executions": self.executions}
+
+    def get_execution_history(self, **kw):
+        self.history_calls.append(kw)
+        if self.history_error is not None:
+            raise self.history_error
+        assert kw.get("reverseOrder") is True, (
+            "the terminal state must be read from the REVERSED history, or a "
+            "long execution's terminal falls off the first page"
+        )
+        name = self.terminal_states.get(kw["executionArn"], "WriteCompletionMarker")
+        return {"events": [
+            {"type": "ExecutionSucceeded"},
+            {"type": "SucceedStateEntered", "stateEnteredEventDetails": {"name": name}},
+        ]}
 
 
 class _FakeContext:
@@ -1053,3 +1073,110 @@ def test_non_drill_dispatch_carries_no_drill_tag_and_is_drill_false(monkeypatch)
     assert "sf-watch-drill" not in calls["extra_tags"]
     cmd = idx._test_ssm.sent[0]["Parameters"]["commands"][0]
     assert 'export SF_IS_DRILL="false"' in cmd
+
+
+# ── alpha-engine-config-I8045 — a designed skip is not a recovery ─────────
+#
+# `ne-weekly-freshness-pipeline`'s cron fires THU-SAT and the run-day gate
+# self-selects the one correct day. Captured live 2026-08-21: the 08-20 and
+# 08-21 scheduled executions both terminated SUCCEEDED in 3.5s / 5.7s at
+# `WeeklyRunDaySkip`, entering five states and dispatching nothing.
+#
+# The deferred path re-checks the state machine minutes-to-hours after a real
+# failure — precisely the window a THU/FRI gate-out lands in. Reading it as
+# "recovered" stands the repair dispatch down and leaves the real failure
+# unrepaired, while reporting success.
+
+_WEEKLY_EXEC = "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline"
+
+
+def test_a_run_day_gate_out_is_not_a_recovery_and_the_repair_still_dispatches(monkeypatch):
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-new",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(
+            executions=[
+                {"executionArn": f"{_WEEKLY_EXEC}:gate-out", "status": "SUCCEEDED"},
+                {"executionArn": f"{_WEEKLY_EXEC}:run-1", "status": "FAILED"},
+            ],
+            terminal_states={f"{_WEEKLY_EXEC}:gate-out": "WeeklyRunDaySkip"},
+        ),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out.get("reason") != "recovered", (
+        "a 3-second WeeklyRunDaySkip must never stand the repair dispatch down"
+    )
+    assert launched == [True], "the repair box must still launch"
+    # And the dispatch must NOT be retargeted at the gate-out — a skip has no
+    # failure for the repair agent to diagnose.
+    (sent,) = idx._test_ssm.sent
+    assert "gate-out" not in json.dumps(sent)
+
+
+def test_a_genuine_success_is_still_a_recovery(monkeypatch):
+    """The inverse failure. Treating every SUCCEEDED as a skip would launch a
+    repair box against a healthy pipeline on every deferred invocation."""
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-new",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(
+            executions=[{"executionArn": f"{_WEEKLY_EXEC}:real", "status": "SUCCEEDED"}],
+            terminal_states={f"{_WEEKLY_EXEC}:real": "WriteCompletionMarker"},
+        ),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["reason"] == "recovered"
+    assert launched == []
+
+
+def test_the_shell_run_terminal_is_also_a_declared_skip(monkeypatch):
+    """`ShellRunComplete` is the Friday-PM preflight-only terminal: green,
+    no completion marker, no artifacts. Also not a recovery."""
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-new",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(
+            executions=[
+                {"executionArn": f"{_WEEKLY_EXEC}:shell", "status": "SUCCEEDED"},
+                {"executionArn": f"{_WEEKLY_EXEC}:run-1", "status": "FAILED"},
+            ],
+            terminal_states={f"{_WEEKLY_EXEC}:shell": "ShellRunComplete"},
+        ),
+    )
+    idx.handler(_event(defer_generation=1), _FakeContext())
+    assert launched == [True]
+
+
+def test_a_broken_history_read_degrades_to_the_pre_i8045_reading(monkeypatch):
+    """Fail-safe posture, stated. A broken check must not invent a repair
+    dispatch; it degrades to treating the success as real, which is exactly
+    what this code did before, and logs."""
+    launched = []
+    idx = _load(
+        monkeypatch,
+        launch_impl=lambda types_, subnets, **kw: launched.append(True) or "i-new",  # noqa: E731
+        env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(
+            executions=[{"executionArn": f"{_WEEKLY_EXEC}:x", "status": "SUCCEEDED"}],
+            history_error=RuntimeError("AccessDenied"),
+        ),
+    )
+    out = idx.handler(_event(defer_generation=1), _FakeContext())
+    assert out["reason"] == "recovered"
+    assert launched == []
+
+
+def test_only_one_extra_api_call_and_only_on_a_succeeded_latest(monkeypatch):
+    """A RUNNING or FAILED latest must not pay for a history read."""
+    idx = _load(
+        monkeypatch, env={"SF_WATCH_DISPATCH_ENABLED": "true"},
+        sfn=_FakeSfn(executions=[{"executionArn": f"{_WEEKLY_EXEC}:r", "status": "RUNNING"}]),
+    )
+    idx.handler(_event(defer_generation=1), _FakeContext())
+    assert idx._test_sfn.history_calls == []


### PR DESCRIPTION
## What and why

Tracker: **alpha-engine-config-I8045** (P0/high), deliverable 1 — sweep every consumer that reads Step Functions execution status without also reading duration or terminal state. This PR fixes the two **live** blind consumers in this repo. Companion: **nousergon-lib-PR347** (the shared three-way predicate). Merge order: either first — this PR takes no lib dependency, deliberately (see below).

`ne-weekly-freshness-pipeline`'s cron fires THU–SAT and `WeeklyRunDayGate` self-selects the single correct day. On the other two days the execution enters five states and terminates **SUCCEEDED in 2.7–5.7 seconds** at `WeeklyRunDaySkip`, having dispatched nothing. The state's own definition comment calls it a designed no-op. **The pipeline is not defective** — the consumers are.

Measured live 2026-08-21 (`AWS_PROFILE=ne-admin`, trailing 30 executions): every SUCCEEDED scheduled run in that window was a gate-out; the only real scheduled run, 2026-08-15, FAILED after 3h53m; the three 2026-08-18 reruns all failed. Not one full weekly graph completed.

## The two fixes

### 1. `pipeline-watchdog` `_check_sf` (Saturday SF) — a gate-out cleared the check

`healthy_seen = counts["SUCCEEDED"] + counts["RUNNING"]`, and a gate-out landed in `SUCCEEDED`. A 7-day weekly window holding **both** the 08-15 failure **and** the 08-20/08-21 gate-outs therefore reported `watchdog clear` and the failure never paged.

The single execution walk now buckets a gate no-op as a third pseudo-status, `GATE_SKIP`, deliberately in **neither** term: it is not a success (it dispatched nothing) and it is not a failure (it was correct to do nothing). A window of nothing but skips returns a new outcome `ONLY_GATE_SKIPS`.

**How the skip renders here:** a loud `WARNING` naming the count and the ceiling, `outcome="ONLY_GATE_SKIPS"` on the `CheckResult`, and **no alert** — the weekly-SF silence deadman already owns the page for "the real weekly run is missing", and `observability-policy.md` §7.2a is one notification per failure, not one per detector that noticed it. When skips coexist with a real failure the existing `FIRED_AND_FAILED` alert fires and its status breakdown names `GATE_SKIP=N`, so the reader can see why the execution count exceeds the real-run count.

The ceiling is `weekly_sf_silence_deadman.GATE_NOOP_MAX_SECONDS`, **imported rather than restated** — two checks in this one Lambda disagreeing about what a no-op is was the measured 2026-08-16 defect. Costs no extra API call: `ListExecutions` already returns `startDate` and `stopDate`. Only the weekly SF passes `gate_noop_aware=True`; it is the one state machine with a run-day gate, and the preopen/postclose checks keep their exact prior behaviour (asserted).

### 2. `sf-watch-spot-dispatcher` `_reevaluate_after_defer` — a gate-out stood the repair down

Any SUCCEEDED latest execution short-circuited the dispatch as `"recovered"`. The deferred path re-checks the state machine minutes-to-hours after a real failure — **exactly the window a THU/FRI gate-out lands in** — so an unrelated 3-second skip stood the repair dispatch down and left the real failure unrepaired, while returning `{"launched": false, "reason": "recovered"}`. This is the autonomous-repair loop silently declining to repair.

A SUCCEEDED latest is now checked against the declared skip terminals with one `GetExecutionHistory` call using `reverseOrder=True`, so the terminal entered state is in the first page regardless of how long the run was. A skip proceeds with the dispatch, and **does not retarget** it — a gate-out has no failure for the repair agent to diagnose, so the originally-reported failed execution stays the target. `RUNNING` / `PENDING_REDRIVE` / failure paths pay for no extra call (asserted).

**Fail-safe posture, stated:** on any error, or a state machine with no declared skip terminals, the check returns "not a skip" — i.e. the pre-I8045 reading. A broken check must not invent a repair dispatch, and it must not invent a stand-down either; degrading to the previous behaviour rather than a new one is the smaller surprise. Every such degradation logs a `WARNING`.

## Why a local skip-terminal list and not the lib (written rationale)

The correct layer is `nousergon_lib.pipeline_status.registry.SKIP_TERMINALS` + `classify_work`, landed in **nousergon-lib-PR347**. This Lambda cannot take that pin until PR347 merges *and* publishes to PyPI, and its `deploy.sh` vendoring list is held by a concurrent session. So `_SKIP_TERMINALS` here is a **declared stopgap**, carrying an inline comment naming the lib symbol that replaces it and the tracked follow-up. The watchdog fix takes no such copy — it imports the ceiling that already existed in this repo.

## RED before GREEN

Both fixes were run against unmodified `origin/main` with the new tests in place. Dispatcher — behavioural RED, from the captured log:

```
FAILED test_a_run_day_gate_out_is_not_a_recovery_and_the_repair_still_dispatches
FAILED test_the_shell_run_terminal_is_also_a_declared_skip
INFO  index.py:691 deferred re-evaluation: latest execution …:shell is SUCCEEDED
                   — recovered, no dispatch needed
2 failed, 46 passed
```

Watchdog — 5 failed, 82 passed on `origin/main`, including `test_a_gate_noop_no_longer_masks_a_real_failure_in_the_same_window`. On this branch: **87 passed** and **48 passed** respectively.

`test_the_same_window_read_status_blind_still_clears_proving_the_defect` keeps the RED executable in-repo: the identical window with `gate_noop_aware=False` — what every call site did before — still returns `CLEAR`.

Fixture durations (`5.705`, `3.465`, `14003.967` seconds) are the **measured** values from the real executions above, not round numbers.

The inverse failure is guarded on both sides: `test_a_real_weekly_run_is_not_mistaken_for_a_gate_noop` and `test_a_genuine_success_is_still_a_recovery`. Reporting a correct skip as a failure would page through working-as-designed behaviour, and that is not an acceptable fix.

## Testing

Local: `pytest infrastructure/lambdas/pipeline-watchdog/test_handler.py` → 87 passed; `pytest infrastructure/lambdas/sf-watch-spot-dispatcher/test_handler.py` → 48 passed. Whole repo: **81 failed, 6003 passed, 18 skipped, 48 errors** — byte-identical to the same command on unmodified `origin/main` in this checkout (missing local optional deps, e.g. `yfinance`); no delta from this branch.

## Out of scope, named rather than dropped

The wider I8045 sweep found blind consumers in `nousergon-console`, `crucible-dashboard`, `crucible-evaluator` (`sf_success_rate_4w`), `crucible-predictor` and `alpha-engine-config`, plus three CloudWatch alarms in `nous-ergon-ops` whose `StateMachineArn` dimensions still name pre-rename state machines. All are reported on alpha-engine-config-I8045; none are touched here.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiC2G8obx19xCoXXrXE9ds