### PR TITLE
[P0/high] Alarm suppressions become declared and self-expiring; an undeclared mute of ANY alarm is a finding (config-I8047)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -80,7 +80,7 @@
     }
   },
   "paused_alarms": {
-    "_why": "alpha-engine-config-I7174. Nine watch-plane/liveness alarms fire `no datapoints were received ... treated as [Breaching]` for no reason other than that the component they watch is deliberately off under the 2026-08-07/2026-08-12 rulings above - the alarm has no input telling it 'gated off by declaration' from 'upstream died' (sf-pipeline-policy.md 2.6 rule 1). Each entry here names the alarm and the `watches` triggers whose presence in `paused`/`pending` (module.paused_names()) is what JUSTIFIES silencing it - never a free-text trigger name that no checker reads, the exact defect the `_reactive-notifier-rules` prose key already cost this file once. `pause_reconcile.py::alarm_entries()`/`automation_pause.py::alarm_entries()` compute justification live from `watches`, so un-pausing a trigger (removing/moving its entry out of `paused`) makes its alarm's entry here stop being justified on the VERY NEXT read - no second edit, no separate AWS CLI command. `automation_pause.py --enforce` then (a) disables actions on a justified-but-armed alarm and (b) RE-ENABLES actions on an alarm whose entry is no longer justified - (b) is deliberately NOT a mirror of the trigger-enforce asymmetry (`enforce()` never re-enables a paused TRIGGER, because that would restart scheduled work unattended); re-arming an alarm only resumes paging, so the same asymmetry does not apply. Silencing is `disable-alarm-actions`, never `delete-alarms`: history and config survive so coverage can be reconstructed later (property 1). `pause_reconcile.py --check` grades the same two directions read-only and its `--publish` row always lists every currently-justified entry as a declared, bounded gap (property 2) rather than omitting it.",
+    "_why": "alpha-engine-config-I7174. Nine watch-plane/liveness alarms fire `no datapoints were received ... treated as [Breaching]` for no reason other than that the component they watch is deliberately off under the 2026-08-07/2026-08-12 rulings above - the alarm has no input telling it 'gated off by declaration' from 'upstream died' (sf-pipeline-policy.md 2.6 rule 1). Each entry here names the alarm and the `watches` triggers whose presence in `paused`/`pending` (module.paused_names()) is what JUSTIFIES silencing it - never a free-text trigger name that no checker reads, the exact defect the `_reactive-notifier-rules` prose key already cost this file once. `pause_reconcile.py::alarm_entries()`/`automation_pause.py::alarm_entries()` compute justification live from `watches`, so un-pausing a trigger (removing/moving its entry out of `paused`) makes its alarm's entry here stop being justified on the VERY NEXT read - no second edit, no separate AWS CLI command. `automation_pause.py --enforce` then (a) disables actions on a justified-but-armed alarm and (b) RE-ENABLES actions on an alarm whose entry is no longer justified - (b) is deliberately NOT a mirror of the trigger-enforce asymmetry (`enforce()` never re-enables a paused TRIGGER, because that would restart scheduled work unattended); re-arming an alarm only resumes paging, so the same asymmetry does not apply. Silencing is `disable-alarm-actions`, never `delete-alarms`: history and config survive so coverage can be reconstructed later (property 1). `pause_reconcile.py --check` grades the same two directions read-only and its `--publish` row always lists every currently-justified entry as a declared, bounded gap (property 2) rather than omitting it. EVERY entry additionally carries `issue` and `re_exam` (alpha-engine-config-I8047, Brian ruling 2026-08-21 option (b)). The 14 alarms in this block were disabled BY HAND from the laptop on 2026-08-13/14 (CloudTrail `DisableAlarmActions`, principal `AWSReservedSSO_AdministratorAccess/cipher813`), following the 2026-08-12 groomer/Overseer pause. Brian ruled the mute stands and must be DECLARED and SELF-EXPIRING rather than undone. `watches` grades whether the RESOURCE condition still holds; `issue` + `re_exam` grade whether the REASON still holds, which is the condition that actually rots (alpha-engine-config-I8090). `issue` names the OPEN ruling whose closure ends the pause — a closed owning issue means either the pause ended (these must be re-armed) or it was closed without the work, and both are loud. `re_exam` is the date past which the suppression is no longer justified by anything. Neither field feeds `alarm_justified()` and neither can move live state: `enforce()` must never re-arm the response plane's own alarms unattended on a calendar tick — that is Brian's ruling to revisit (`principles.md` 2.5). `automation_pause.py` enforces that both fields are PRESENT and well-formed (offline, no credential); `alpha-engine-config`'s `suppression-declaration-sweep` grades them against the clock and the tracker, because only a job running in the tracker repo can resolve an issue's state.",
     "alpha-engine-watch-plane-alert-drain-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the overseer alert-drain liveness probe; treat_missing_data=breaching is correct when alert-drain is supposed to run and wrong while it is declared off (2026-08-07 ruling, response plane paused).",
       "watches": [
@@ -88,46 +88,60 @@
         "alpha-engine-alert-drain-1000utc",
         "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-canary-replay-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the overseer canary-replay liveness probe; silenced while alpha-engine-canary-replay-liveness-probe-tick is paused.",
       "watches": [
         "alpha-engine-canary-replay-liveness-probe-tick"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the ci-watch-liveness-probe reclaim leg (config#3173, mirrors sf-watch's two reclaim legs); silenced while both ci-watch reclaim rules are paused.",
       "watches": [
         "alpha-engine-ci-watch-spot-interruption",
         "alpha-engine-ci-watch-instance-terminated"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-errors": {
-      "reason": "sf-watch liveness-probe Errors; silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984) disabling sf-watch while the three scheduled pipelines are made reliable by hand. Re-exam 2026-09-09, same predicate as the paused sf-watch entries this watches.",
+      "reason": "sf-watch liveness-probe Errors; silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984) disabling sf-watch while the three scheduled pipelines are made reliable by hand.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-throttles": {
       "reason": "sf-watch liveness-probe Throttles; same ruling and same watched triggers as alpha-engine-watch-plane-sf-watch-liveness-probe-errors.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-ssm-reachability-probe-dead": {
       "reason": "SSM reachability probe deadman; silenced while alpha-engine-ssm-reachability-probe-5min is paused.",
       "watches": [
         "alpha-engine-ssm-reachability-probe-5min"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-ssm-reachability-probe-unreachable": {
       "reason": "SSM reachability probe unreachable-count; same watched trigger as alpha-engine-ssm-reachability-probe-dead.",
       "watches": [
         "alpha-engine-ssm-reachability-probe-5min"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-intake-age": {
       "reason": "overseer intake queue age; a CONSEQUENCE of alert-drain being paused (nothing drains the intake queue the alarm's tap fills), not of its own trigger. Watches the same alert-drain schedules the drain itself needs running.",
@@ -136,7 +150,9 @@
         "alpha-engine-alert-drain-1000utc",
         "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-intake-dlq-depth": {
       "reason": "overseer intake DLQ depth; same consequence and same watched triggers as alpha-engine-watch-plane-overseer-intake-age.",
@@ -145,35 +161,45 @@
         "alpha-engine-alert-drain-1000utc",
         "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-errors": {
       "reason": "overseer liveness-probe Errors. Period=28800 with treat_missing_data=breaching, so an 8h window with no invocation latches ALARM - and the probe's only two triggers are paused. Added 2026-08-14 (alpha-engine-config-I7023): this alarm and its two siblings were the four still paging Brian after the I7174 reconciler silenced the rest, because the I7174 entry list was built from the alarms observed in ALARM on 2026-08-13 and these read OK at that moment - the backstop responder was re-invoking the probe on every firing (alpha-engine-config-I7330), manufacturing the datapoint that cleared them.",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-throttles": {
       "reason": "overseer liveness-probe Throttles; same shape, same window and same paused triggers as the Errors sibling above. Added 2026-08-14 (alpha-engine-config-I7023).",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the overseer liveness probe. This is the alarm whose ENTIRE job is detecting a probe that stopped running, so while the probe is deliberately stopped it can only report the pause back to us. Added 2026-08-14 (alpha-engine-config-I7023).",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the sf-watch liveness probe. Its -errors and -throttles siblings were declared under I7174 and this one was not, so it stayed armed on the same paused triggers - the family-completeness check added with this entry is what makes that shape impossible to repeat. Silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984); re-exam 2026-09-09, same predicate as the sf-watch entries it watches.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     },
     "alpha-engine-watch-plane-overseer-intake-dlq-severe-content": {
       "reason": "Severe-content count on the overseer intake DLQ. Same watched triggers and same argument as its two declared siblings (-age, -dlq-depth): the DLQ holds 138 messages whose oldest is 331h because alert-drain is paused, so this alarm reports the pause and nothing else. Added 2026-08-14 after it paged Brian - it is notBreaching, so the I7023 completeness check (scoped to breaching alarms) did not reach it; it pages by oscillating OK<->ALARM with both AlarmActions and OKActions on the backstop topic. Widening that population is tracked separately.",
@@ -182,7 +208,9 @@
         "alpha-engine-alert-drain-1000utc",
         "alpha-engine-alert-drain-1600utc",
         "alpha-engine-alert-drain-2200utc"
-      ]
+      ],
+      "issue": "alpha-engine-config-I6984",
+      "re_exam": "2026-09-09"
     }
   },
   "armed_alarms": {

--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -88,12 +88,23 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 MANIFEST = Path(__file__).parent.resolve() / "automation_pause.json"
 REGION = "us-east-1"
+
+#: Every ``paused_alarms`` entry must name the OPEN tracker issue whose closure
+#: ends the pause, in the fleet's own reference grammar. A free-text owner is
+#: one nothing can resolve, which is the defect this field exists to remove
+#: (alpha-engine-config-I8047 / -I8090).
+DECLARATION_ISSUE_RE = re.compile(r"^alpha-engine-config-I\d+$")
+
+#: And the date past which the suppression is no longer justified by anything.
+DECLARATION_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def load_manifest(path: Path = MANIFEST) -> dict:
@@ -174,6 +185,13 @@ def alarm_entries(manifest: dict | None = None) -> list[dict]:
             "name": name,
             "reason": entry.get("reason", ""),
             "watches": list(entry.get("watches", [])),
+            # alpha-engine-config-I8047. Surfaced with the same `.get` default
+            # as `reason` rather than a KeyError, because a malformed entry must
+            # reach `declaration_findings()` and be REPORTED, not crash the
+            # whole check — a detector that dies on the defect it looks for is
+            # indistinguishable from one that found nothing.
+            "issue": entry.get("issue", ""),
+            "re_exam": entry.get("re_exam", ""),
         })
     return out
 
@@ -275,23 +293,34 @@ def _alarm_actions_enabled(name: str) -> bool | None:
     return out == "True"
 
 
-def _live_breaching_alarms() -> dict[str, bool]:
-    """``{alarm name: ActionsEnabled}`` for every live alarm that latches on silence.
+def _live_alarm_actions() -> dict[str, dict[str, bool]]:
+    """``{alarm name: {"enabled": ActionsEnabled, "breaching": bool}}`` for EVERY live alarm.
 
-    ``TreatMissingData=breaching`` is the whole population that can go ALARM with
-    nothing wrong, so it is the population the two manifest blocks must between
-    them cover. Paginated explicitly: DescribeAlarms caps at 100 per page and a
-    truncated first page would silently shrink the very set being graded for
-    completeness.
+    One enumeration, two populations, because the manifest is graded against
+    both and two independent scans of the same account can disagree with each
+    other about it.
+
+    ``TreatMissingData=breaching`` is the population that can go ALARM with
+    nothing wrong, so it is what ``armed_alarms`` must classify. ``enabled`` is
+    a WIDER question and is asked of every alarm (alpha-engine-config-I8047):
+    an alarm muted by hand cannot page whatever its missing-data treatment is,
+    and restricting the silence scan to the breaching subset made an undeclared
+    mute of a ``notBreaching`` alarm invisible. That is not hypothetical — nine
+    of the fourteen alarms Brian disabled by hand on 2026-08-13/14 are
+    ``notBreaching``, so had they never been declared, the completeness check
+    would have reported nothing at all.
+
+    Paginated explicitly: DescribeAlarms caps at 100 per page and a truncated
+    first page would silently shrink the very set being graded for completeness.
     """
-    alarms: dict[str, bool] = {}
+    alarms: dict[str, dict[str, bool]] = {}
     token: str | None = None
     while True:
         args = [
             "cloudwatch", "describe-alarms", "--max-items", "100",
             "--query",
-            "{a: MetricAlarms[?TreatMissingData=='breaching'].{n: AlarmName, e: ActionsEnabled}, "
-            "t: NextToken}",
+            "{a: MetricAlarms[].{n: AlarmName, e: ActionsEnabled, "
+            "b: TreatMissingData}, t: NextToken}",
             "--output", "json",
         ]
         if token:
@@ -301,10 +330,28 @@ def _live_breaching_alarms() -> dict[str, bool]:
             raise RuntimeError(f"aws cloudwatch describe-alarms: {err}")
         page = json.loads(out or "{}")
         for row in page.get("a") or []:
-            alarms[row["n"]] = bool(row["e"])
+            alarms[row["n"]] = {
+                "enabled": bool(row["e"]),
+                "breaching": row.get("b") == "breaching",
+            }
         token = page.get("t")
         if not token:
             return alarms
+
+
+def _live_breaching_alarms() -> dict[str, bool]:
+    """``{alarm name: ActionsEnabled}`` for every live alarm that latches on silence."""
+    return {n: v["enabled"] for n, v in _live_alarm_actions().items() if v["breaching"]}
+
+
+def _live_silenced_alarms() -> set[str]:
+    """Every live alarm whose actions are OFF, regardless of missing-data treatment.
+
+    The population `alarm_coverage_findings()` grades for DECLARATION. A muted
+    alarm is indistinguishable from a healthy one on every surface, so the
+    question "is this mute declared" is asked of all of them.
+    """
+    return {n for n, v in _live_alarm_actions().items() if not v["enabled"]}
 
 
 def _set_alarm_actions(name: str, enabled: bool) -> None:
@@ -431,7 +478,74 @@ def alarm_findings() -> list[dict]:
                 ),
             })
 
+    out.extend(declaration_findings())
     out.extend(alarm_coverage_findings())
+    return out
+
+
+def declaration_findings(manifest: dict | None = None) -> list[dict]:
+    """Is every ``paused_alarms`` entry's REASON still gradeable — not just its resource?
+
+    ``alarm_justified()`` asks whether the trigger a suppression ``watches`` is
+    still paused. That is the WEAKER of the two conditions
+    (alpha-engine-config-I8090): what rots is the justification. A declaration
+    saying "silenced under the 2026-08-12 ruling" keeps looking true forever,
+    including after the ruling has been executed, reversed, or closed without
+    the work.
+
+    Two fields make the reason gradeable, and this function asserts only that
+    they are PRESENT and WELL-FORMED. It deliberately does not resolve the
+    issue's state or compare the date to today:
+
+      * resolving the issue needs a credential for `nousergon/alpha-engine-config`,
+        which this repo has none of and should not acquire to read a tracker;
+      * so both temporal predicates are graded in one place, by
+        `alpha-engine-config`'s `suppression-declaration-sweep`, which runs in
+        the repo that owns the tracker and reads this manifest from the public
+        checkout. Splitting "expired" from "owning issue closed" across two
+        reports would give two half-answers to one question.
+
+    What this DOES do is make that sweep impossible to satisfy vacuously: an
+    entry with no `issue` cannot be graded against the tracker at all, and an
+    entry with no `re_exam` has no date to be past. An ungradeable declaration
+    reads exactly like a healthy one, which is the whole class.
+    """
+    out: list[dict] = []
+    for entry in alarm_entries(manifest):
+        name, issue, re_exam = entry["name"], entry["issue"], entry["re_exam"]
+        if not DECLARATION_ISSUE_RE.match(issue):
+            out.append({
+                "trigger": name, "surface": "cloudwatch",
+                "kind": "alarm-declaration-unowned",
+                "detail": (
+                    f"paused_alarms entry carries issue={issue!r}, which is not a "
+                    f"resolvable tracker reference (expected e.g. "
+                    f"'alpha-engine-config-I6984'). A suppression whose owner cannot "
+                    f"be resolved can never be found stale — the clock and the "
+                    f"tracker are the only two things that can retire it, and this "
+                    f"field is what makes the second one reachable."
+                ),
+            })
+        if not DECLARATION_DATE_RE.match(re_exam):
+            out.append({
+                "trigger": name, "surface": "cloudwatch",
+                "kind": "alarm-declaration-undated",
+                "detail": (
+                    f"paused_alarms entry carries re_exam={re_exam!r}, which is not an "
+                    f"ISO date (YYYY-MM-DD). Without one the suppression has no expiry "
+                    f"and outlives its justification silently, which is "
+                    f"alpha-engine-config-I8047 one level up."
+                ),
+            })
+            continue
+        try:
+            date.fromisoformat(re_exam)
+        except ValueError:
+            out.append({
+                "trigger": name, "surface": "cloudwatch",
+                "kind": "alarm-declaration-undated",
+                "detail": f"re_exam={re_exam!r} is not a real calendar date.",
+            })
     return out
 
 
@@ -448,6 +562,31 @@ def alarm_coverage_findings() -> list[dict]:
     declared_paused = {e["name"] for e in alarm_entries()}
     declared_armed = armed_alarm_names()
     live = _live_breaching_alarms()
+
+    # ── an UNDECLARED mute, of any alarm (alpha-engine-config-I8047) ────────
+    #
+    # The breaching scan below asks "is every alarm that can latch on silence
+    # classified". This asks the narrower, louder question the ruling turns on:
+    # is every alarm that is CURRENTLY SILENCED declared as such. The two
+    # populations are not the same, and the difference is where the defect
+    # lives — nine of the fourteen alarms Brian muted by hand on 2026-08-13/14
+    # are `notBreaching`, so the breaching scan could not have seen them had
+    # they never been declared. Codifying those fourteen as declared,
+    # self-expiring suppressions is only half the ruling; this is the half that
+    # must not weaken, because a mute nobody declared is still the defect.
+    for name in sorted(_live_silenced_alarms() - declared_paused - declared_armed):
+        out.append({
+            "trigger": name, "surface": "cloudwatch", "kind": "alarm-undeclared-silence",
+            "detail": (
+                "ActionsEnabled=false live, and it appears in neither paused_alarms "
+                "nor armed_alarms. A detector was muted with nothing recording who "
+                "did it, why, or what would end it — and a muted alarm is "
+                "indistinguishable from a healthy one on every surface the fleet "
+                "reads. Either re-arm it, or add a paused_alarms entry naming the "
+                "trigger(s) it watches, the owning issue and a re_exam date. "
+                "observability-policy 8.3: DISABLED is DECLARED, never inferred."
+            ),
+        })
 
     for name in sorted(set(live) - declared_paused - declared_armed):
         out.append({

--- a/infrastructure/pause_reconcile.py
+++ b/infrastructure/pause_reconcile.py
@@ -606,6 +606,11 @@ def reconcile(
                 ),
             })
 
+    # The declaration's own shape, offline (alpha-engine-config-I8047). Kept in
+    # `automation_pause` and merely re-exported into this verdict rather than
+    # re-derived: a second copy of the grammar is a second place to loosen it.
+    findings.extend(ap.declaration_findings(m))
+
     return sorted(findings, key=lambda f: (f["kind"], f["trigger"]))
 
 
@@ -626,7 +631,9 @@ def declared_alarm_gaps(manifest: dict | None = None) -> list[dict]:
             "id": entry["name"], "kind": "declared-silenced-alarm",
             "detail": (
                 f"silenced because {', '.join(entry['watches'])} "
-                f"{'is' if len(entry['watches']) == 1 else 'are'} paused. {entry['reason']}"
+                f"{'is' if len(entry['watches']) == 1 else 'are'} paused; owned by "
+                f"{entry['issue'] or '<UNOWNED>'}, re-exam "
+                f"{entry['re_exam'] or '<UNDATED>'}. {entry['reason']}"
             ),
         }
         for entry in ap.alarm_entries(m)

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -835,7 +835,14 @@ def classified_world(module, monkeypatch, request):
     live = {e["name"]: False for e in module.alarm_entries()}
     live.update({name: True for name in module.armed_alarm_names()})
     if request.node.get_closest_marker("real_alarm_scan") is None:
-        monkeypatch.setattr(module, "_live_breaching_alarms", lambda: live)
+        # ONE stub, at the single primitive both populations derive from
+        # (alpha-engine-config-I8047). Stubbing `_live_breaching_alarms` alone
+        # left `_live_silenced_alarms` reaching the network the moment it was
+        # added — the fixture's docstring above predicted exactly that, and the
+        # fix is to stub the enumeration rather than each view of it.
+        monkeypatch.setattr(
+            module, "_live_alarm_actions",
+            lambda: {n: {"enabled": e, "breaching": True} for n, e in live.items()})
     return live
 
 
@@ -928,13 +935,13 @@ def test_an_armed_alarm_that_vanished_is_a_finding(module, monkeypatch,
 def test_describe_alarms_pagination_is_followed(module, monkeypatch):
     """A truncated first page would silently shrink the population being graded.
 
-    Opts out of the autouse stub — this is the one test whose subject IS
-    `_live_breaching_alarms`. It fakes `_aws` instead, so it still never reaches
-    the network.
+    Opts out of the autouse stub — this is the one test whose subject IS the
+    live enumeration. It fakes `_aws` instead, so it still never reaches the
+    network.
     """
     pages = [
-        ('{"a": [{"n": "a1", "e": true}], "t": "tok"}', None),
-        ('{"a": [{"n": "a2", "e": false}], "t": null}', "tok"),
+        ('{"a": [{"n": "a1", "e": true, "b": "breaching"}], "t": "tok"}', None),
+        ('{"a": [{"n": "a2", "e": false, "b": "breaching"}], "t": null}', "tok"),
     ]
     seen: list[str | None] = []
 
@@ -997,3 +1004,183 @@ def test_alarms_are_silenced_not_deleted(module):
     assert "delete-alarms" not in src, (
         "a paused alarm must be silenced (disable-alarm-actions), never deleted"
     )
+
+
+# ── the suppression's REASON, not its resource (alpha-engine-config-I8047) ───
+#
+# Brian ruled option (b) on 2026-08-21: the fourteen alarms he disabled by hand
+# on 2026-08-13/14 stay muted, and the mute becomes a DECLARED, SELF-EXPIRING
+# suppression rather than an undeclared one. `watches` already grades the
+# resource condition. These grade the two things that make the REASON
+# gradeable, which is the condition that actually rots (-I8090).
+
+
+def test_every_paused_alarm_names_an_owning_issue_and_a_re_exam_date(manifest, module):
+    """The data half of the ruling. Without both fields the sweep that grades
+    them against the clock and the tracker is satisfied vacuously."""
+    for entry in module.alarm_entries(manifest):
+        assert module.DECLARATION_ISSUE_RE.match(entry["issue"]), (
+            f"{entry['name']} carries issue={entry['issue']!r}; a suppression whose "
+            f"owner cannot be resolved can never be found stale"
+        )
+        assert module.DECLARATION_DATE_RE.match(entry["re_exam"]), (
+            f"{entry['name']} carries re_exam={entry['re_exam']!r}; a suppression "
+            f"with no expiry outlives its justification silently"
+        )
+
+
+def test_the_fourteen_hand_muted_alarms_are_all_declared(manifest, module):
+    """The exact set measured live on 2026-08-21 via
+    `describe-alarms --query 'MetricAlarms[?ActionsEnabled==`false`]'`, and the
+    set CloudTrail shows Brian disabling on 2026-08-13/14. Pinned literally so a
+    silent shrink of the declaration set is a test failure rather than a smaller
+    number in a report."""
+    hand_muted = {
+        "alpha-engine-ssm-reachability-probe-dead",
+        "alpha-engine-ssm-reachability-probe-unreachable",
+        "alpha-engine-watch-plane-alert-drain-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-canary-replay-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-overseer-intake-age",
+        "alpha-engine-watch-plane-overseer-intake-dlq-depth",
+        "alpha-engine-watch-plane-overseer-intake-dlq-severe-content",
+        "alpha-engine-watch-plane-overseer-liveness-probe-errors",
+        "alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-overseer-liveness-probe-throttles",
+        "alpha-engine-watch-plane-sf-watch-liveness-probe-errors",
+        "alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor",
+        "alpha-engine-watch-plane-sf-watch-liveness-probe-throttles",
+    }
+    declared = {e["name"] for e in module.alarm_entries(manifest)}
+    assert hand_muted <= declared, sorted(hand_muted - declared)
+
+
+def test_no_alarm_outside_the_measured_set_was_declared(manifest, module):
+    """The other direction, and the one the ruling is emphatic about. Declaring
+    a suppression is how a count goes down without a condition clearing;
+    `alpha-engine-eval-quality-regression` (latched 106 days, ARMED, the live
+    surface for -I7038) and `alpha-engine-saturday-sf-failed` (true, first
+    correct reading in 53 days) must never appear here."""
+    declared = {e["name"] for e in module.alarm_entries(manifest)}
+    for never in ("alpha-engine-eval-quality-regression",
+                  "alpha-engine-saturday-sf-failed",
+                  "alpha-engine-weekday-sf-failed",
+                  "alpha-engine-eod-sf-failed",
+                  "router-degraded-mode-drill-uncovered-class",
+                  "alpha-engine-director-plan-latency"):
+        assert never not in declared, (
+            f"{never} is an ARMED alarm reporting a real condition; declaring it "
+            f"suppressed would clear a count by silencing the finding"
+        )
+
+
+def _mutated(field: str, value):
+    """The manifest with one paused_alarms entry's declaration broken."""
+    m = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    m["paused_alarms"]["alpha-engine-watch-plane-sf-watch-liveness-probe-errors"][field] = value
+    return m
+
+
+def test_a_declaration_with_no_owning_issue_is_a_finding(module):
+    """RED proof 1 — an unowned declaration cannot be graded against the
+    tracker, so it can never be found stale."""
+    findings = module.declaration_findings(_mutated("issue", ""))
+    assert ("alpha-engine-watch-plane-sf-watch-liveness-probe-errors",
+            "alarm-declaration-unowned") in {(f["trigger"], f["kind"]) for f in findings}
+
+
+def test_a_declaration_with_a_free_text_owner_is_a_finding(module):
+    """A free-text owner is the defect one step earlier: it LOOKS owned. Same
+    shape as the `Pause-owner:` line -I7524 had to make explicit after prose
+    matching declared 40 of 48 triggers owned and 0 latched."""
+    findings = module.declaration_findings(_mutated("issue", "tracked by Brian"))
+    assert "alarm-declaration-unowned" in {f["kind"] for f in findings}
+
+
+def test_a_declaration_with_no_re_exam_date_is_a_finding(module):
+    """RED proof 2 — no date means nothing can ever be past it."""
+    findings = module.declaration_findings(_mutated("re_exam", ""))
+    assert ("alpha-engine-watch-plane-sf-watch-liveness-probe-errors",
+            "alarm-declaration-undated") in {(f["trigger"], f["kind"]) for f in findings}
+
+
+def test_a_re_exam_that_is_not_a_real_date_is_a_finding(module):
+    findings = module.declaration_findings(_mutated("re_exam", "2026-02-31"))
+    assert "alarm-declaration-undated" in {f["kind"] for f in findings}
+
+
+def test_the_live_manifest_produces_no_declaration_findings(module):
+    """The GREEN direction, asserted explicitly: every one of the fourteen
+    carries a well-formed declaration today."""
+    assert module.declaration_findings() == []
+
+
+def test_declaration_findings_never_move_live_state(module, monkeypatch):
+    """A suppression whose reason expired must be REPORTED, never auto-re-armed.
+
+    `enforce()` re-enables an alarm whose `watches` justification lapsed, and
+    that is safe: the same manifest edit that restores the trigger makes it
+    happen. An expiry is different — it is a calendar tick, and re-arming the
+    response plane's own liveness alarms on one would undo a ruling of Brian's
+    unattended (`principles.md` 2.5). So the declaration predicate is
+    deliberately absent from `alarm_justified()` and therefore from `enforce()`.
+    """
+    broken = _mutated("re_exam", "1999-01-01")
+    monkeypatch.setattr(module, "load_manifest", lambda: broken)
+    monkeypatch.setattr(module, "_live_state", lambda surface, name: "DISABLED")
+    monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
+    acted: list = []
+    monkeypatch.setattr(module, "_set_alarm_actions",
+                        lambda name, enabled: acted.append((name, enabled)))
+    module.enforce(alarms_only=True)
+    assert acted == [], (
+        "an expired declaration re-armed an alarm unattended — that is Brian's "
+        "ruling to revisit, not the enforcer's"
+    )
+
+
+# ── an UNDECLARED mute, of any alarm, is still a defect ─────────────────────
+
+
+def test_a_hand_muted_undeclared_alarm_is_a_finding(module, monkeypatch):
+    """RED proof 4 — the half of the ruling that must not weaken."""
+    world = {e["name"]: {"enabled": False, "breaching": True}
+             for e in module.alarm_entries()}
+    world.update({n: {"enabled": True, "breaching": True}
+                  for n in module.armed_alarm_names()})
+    world["alpha-engine-some-new-detector"] = {"enabled": False, "breaching": False}
+    monkeypatch.setattr(module, "_live_alarm_actions", lambda: world)
+    kinds = {(f["trigger"], f["kind"]) for f in module.alarm_coverage_findings()}
+    assert ("alpha-engine-some-new-detector", "alarm-undeclared-silence") in kinds, kinds
+
+
+def test_the_undeclared_silence_scan_is_not_limited_to_breaching_alarms(module, monkeypatch):
+    """The precise gap -I8047 closes. Nine of the fourteen alarms Brian muted
+    are `notBreaching`; the pre-existing completeness scan enumerated only
+    `TreatMissingData=breaching`, so an undeclared mute of any of them was
+    invisible to every check in the fleet."""
+    world = {e["name"]: {"enabled": False, "breaching": True}
+             for e in module.alarm_entries()}
+    world.update({n: {"enabled": True, "breaching": True}
+                  for n in module.armed_alarm_names()})
+    world["alpha-engine-quiet-mute"] = {"enabled": False, "breaching": False}
+    monkeypatch.setattr(module, "_live_alarm_actions", lambda: world)
+    findings = module.alarm_coverage_findings()
+    assert {"alpha-engine-quiet-mute"} == {
+        f["trigger"] for f in findings if f["kind"] == "alarm-undeclared-silence"}
+    assert not [f for f in findings if f["kind"] == "alarm-undeclared"], (
+        "the breaching scan must not also report it — one mute, one finding"
+    )
+
+
+def test_an_armed_alarm_is_never_reported_as_an_undeclared_silence(module, monkeypatch):
+    """`armed-but-silenced` already owns the armed block; two findings for one
+    condition is how a report gets skimmed."""
+    world = {e["name"]: {"enabled": False, "breaching": True}
+             for e in module.alarm_entries()}
+    world.update({n: {"enabled": False, "breaching": True}
+                  for n in module.armed_alarm_names()})
+    monkeypatch.setattr(module, "_live_alarm_actions", lambda: world)
+    findings = module.alarm_coverage_findings()
+    assert not [f for f in findings if f["kind"] == "alarm-undeclared-silence"]
+    assert {f["kind"] for f in findings} == {"armed-but-silenced"}

--- a/tests/test_pause_reconcile.py
+++ b/tests/test_pause_reconcile.py
@@ -271,11 +271,22 @@ def test_non_service_lifecycles_match_the_registry(mod):
 
 def _manifest_with_alarm(watches: dict[str, str] | None = None,
                           alarm_watches: list[str] | None = None,
-                          reason: str = "r") -> dict:
+                          reason: str = "r",
+                          issue: str = "alpha-engine-config-I6984",
+                          re_exam: str = "2999-01-01") -> dict:
+    """A synthetic manifest with one `paused_alarms` entry.
+
+    `issue`/`re_exam` default to a well-formed, far-future declaration
+    (alpha-engine-config-I8047) so a test about the ALARM STATE directions is
+    not also asserting the declaration's shape. Overriding either is how the
+    declaration direction is proven RED — see
+    `test_an_undeclared_owner_is_a_finding_in_the_reconciler` below.
+    """
     m = _manifest(paused=watches or {})
     m["paused_alarms"] = {
         "_why": "prose, must be skipped",
-        "probe-alarm": {"reason": reason, "watches": alarm_watches or []},
+        "probe-alarm": {"reason": reason, "watches": alarm_watches or [],
+                        "issue": issue, "re_exam": re_exam},
     }
     return m
 
@@ -556,3 +567,39 @@ def test_the_run_summary_is_written_by_the_same_invocation_as_the_verdict(mod):
         "the reconciler runs more than once per workflow run; one run, one verdict"
     )
     assert "--markdown" in text and "--github-output" in text
+
+
+def test_an_undeclared_owner_is_a_finding_in_the_reconciler(mod):
+    """The reconciler carries the declaration verdict too — one report, not a
+    second surface a reader has to know to check (alpha-engine-config-I8047)."""
+    m = _manifest_with_alarm(watches={"tick": "ruled off"}, alarm_watches=["tick"],
+                             issue="")
+    findings = _reconcile(
+        mod, manifest=m, rows={},
+        triggers=[{"surface": "events", "name": "tick", "state": "DISABLED"}],
+        alarm_actions_of=lambda name: False,
+    )
+    assert ("alarm-declaration-unowned", "probe-alarm") in [
+        (f["kind"], f["trigger"]) for f in findings]
+
+
+def test_an_undated_declaration_is_a_finding_in_the_reconciler(mod):
+    m = _manifest_with_alarm(watches={"tick": "ruled off"}, alarm_watches=["tick"],
+                             re_exam="soon")
+    findings = _reconcile(
+        mod, manifest=m, rows={},
+        triggers=[{"surface": "events", "name": "tick", "state": "DISABLED"}],
+        alarm_actions_of=lambda name: False,
+    )
+    assert ("alarm-declaration-undated", "probe-alarm") in [
+        (f["kind"], f["trigger"]) for f in findings]
+
+
+def test_a_declared_gap_row_names_its_owner_and_expiry(mod):
+    """The console row is the surface a human reads; a declared gap that does
+    not say what would end it is the prose the ruling replaced."""
+    m = _manifest_with_alarm(watches={"tick": "ruled off"}, alarm_watches=["tick"])
+    rows = mod.declared_alarm_gaps(m)
+    assert rows, "the justified entry must render as a declared gap"
+    assert "alpha-engine-config-I6984" in rows[0]["detail"]
+    assert "2999-01-01" in rows[0]["detail"]


### PR DESCRIPTION
## What Brian ruled

`alpha-engine-config-I8047`, 2026-08-21, **option (b)**. CloudTrail shows Brian personally disabling fourteen CloudWatch alarms by hand from the laptop on 2026-08-13/14 (`AWSReservedSSO_AdministratorAccess/cipher813`, `aws-cli/2.34.0 … os/macos`), following his deliberate 2026-08-12 groomer/Overseer pause (`alpha-engine-config-I6984`, still OPEN). Twelve are the watch plane's own liveness monitors.

The ruling: **do not undo his action, and do not leave it undeclared.** Make the deliberate state legible and self-expiring.

## What was already true, re-measured

Re-measured live 2026-08-21 rather than trusted from the issue body:

```
AWS_PROFILE=ne-admin aws cloudwatch describe-alarms --region us-east-1 \
  --query 'MetricAlarms[?ActionsEnabled==`false`].[AlarmName,StateValue]'
```

returns exactly fourteen names, and they are exactly the fourteen `paused_alarms` entries in this repo. The mutes were already declared — `paused_alarms` is the fleet's single owner of alarm-armed state, which is why `nous-ergon-ops`'s `check-drift.py` excludes `ActionsEnabled` from drift and its `check-alarm-age.py` skips disarmed alarms.

**So the issue's premise about codifying `actions_enabled: false` under `nous-ergon-ops/infrastructure/cloudwatch/alarms/` was not executed, deliberately.** Writing the field there would create a second codified owner of armed state that `apply.py` refuses to send and no apply could ever reconcile — the exact condition `check-drift.py`'s `DRIFT_EXCLUDED_FIELDS` comment was written to prevent. Stated as an assumption per engagement-protocol §6.8.

What the declarations actually lacked was any way to go stale, and the completeness scan was looking at the wrong population.

## Three changes

**1. Every entry carries `issue` and `re_exam`.** `alpha-engine-config-I6984` (the open ruling whose closure ends the pause) and `2026-09-09` (the date already written in prose on two entries, now structured and uniform). `watches` grades whether the RESOURCE condition still holds; these grade whether the REASON still holds, which is the condition that actually rots (`alpha-engine-config-I8090`). Enforced here as PRESENT and well-formed — offline, no credential.

**2. Neither field feeds `alarm_justified()`, so neither can move live state.** `enforce()` re-arms an alarm whose `watches` justification lapses, and that is safe: the same manifest edit that restores the trigger causes it. An expiry is a calendar tick, and re-arming the response plane's own liveness alarms on one would undo a ruling of Brian's unattended (`principles.md` §2.5). Pinned by `test_declaration_findings_never_move_live_state`.

**3. `alarm_coverage_findings()` asks "is every SILENCED alarm declared" of every live alarm**, not only of the `TreatMissingData=breaching` subset. **Nine of the fourteen are `notBreaching`** — had they never been declared, the completeness check would have reported nothing at all. This is the half of the ruling that must not weaken: a mute nobody declared is still the defect.

One paginated primitive (`_live_alarm_actions`) now backs both populations, and the autouse test fixture stubs the enumeration rather than each view of it — the regression that fixture's own docstring predicted.

## RED proofs

`champion-challenger-policy` §7.4. Each direction induces the defect and asserts the finding; a green control is asserted too, so a matcher that fires on everything fails.

| Case | Test |
|---|---|
| declaration with no owning issue | `test_a_declaration_with_no_owning_issue_is_a_finding` |
| free-text owner (looks owned, resolves to nothing) | `test_a_declaration_with_a_free_text_owner_is_a_finding` |
| no `re_exam` date | `test_a_declaration_with_no_re_exam_date_is_a_finding` |
| `re_exam` not a real calendar date | `test_a_re_exam_that_is_not_a_real_date_is_a_finding` |
| undeclared hand-mute | `test_a_hand_muted_undeclared_alarm_is_a_finding` |
| undeclared mute of a `notBreaching` alarm | `test_the_undeclared_silence_scan_is_not_limited_to_breaching_alarms` |
| GREEN control: the live manifest | `test_the_live_manifest_produces_no_declaration_findings` |
| no auto-re-arm on expiry | `test_declaration_findings_never_move_live_state` |

The synthetic-manifest builder in `test_pause_reconcile.py` had to gain the two fields — its five failures on first run are themselves the detector firing.

`6330 passed, 17 skipped` locally, full suite.

## Deliberately untouched

- **`alpha-engine-eval-quality-regression`** — latched 106 days, **ARMED**, correct: `agent_quality_score_4w_mean_min` reads ~2.01–2.07 against a 3.0 floor. It is the live surface for `alpha-engine-config-I7038` and stays red until that is fixed.
- **`alpha-engine-saturday-sf-failed`** — went ALARM 2026-08-21 ~21:31Z, minutes after `nous-ergon-ops-PR824` repointed it off a deleted state machine. First correct reading in 53 days.

`test_no_alarm_outside_the_measured_set_was_declared` pins both, plus `router-degraded-mode-drill-uncovered-class` and `alpha-engine-director-plan-latency`, against ever being declared suppressed.

## Cross-repo

Merge order: **this first**, then `nous-ergon-ops-PR831` (registry row), then `alpha-engine-config-PR8115` (the sweep grading `re_exam` against the clock and `issue` against the tracker, which lives there because only a job in the tracker repo can resolve an issue's state — and this repo is public, so it reads the manifest with no credential).

Tracked: `alpha-engine-config-I8047`. A closing keyword is inert across repos; the issue is closed by hand once all three land and are verified.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)