### PR TITLE
fix(sweep): run-mode awareness for stage_output_sweep.py (I7392)

### DIFF
--- a/tests/test_stage_output_sweep.py
+++ b/tests/test_stage_output_sweep.py
@@ -349,6 +349,385 @@ class TestVerdicts:
         assert f["verdict"] not in sos.DEFECT_VERDICTS
 
 
+# ---------------------------------------------------------------------------
+# I7392 — run-mode awareness: the `dry` verdict, same-cycle sibling
+# attribution, self-exclusion, alert suppression, and run_mode parsing.
+# ---------------------------------------------------------------------------
+
+
+class TestDryVerdict:
+    """The 2026-08-21 Friday shell run: ApplyShellRunDefaults guarantees zero
+    producer writes, by construction. A missing/stale key on that run is not
+    a defect — it is the dry-path contract working as designed.
+    """
+
+    def _one(self, template, head_map, run_mode, **kw):
+        decls = sos.declared_outputs([_row("a", template, "Backtester")], pipeline=PIPELINE)
+        kw.setdefault("execution_start", EXEC_START)
+        kw.setdefault("cycle_date", RUN_DATE)
+        return sos.evaluate(
+            decls, run_date=RUN_DATE, head=_head_from(head_map), run_mode=run_mode, **kw
+        )[0]
+
+    def test_missing_key_on_a_dry_run_is_dry_not_missing(self):
+        f = self._one("b/{date}.json", {}, sos.RUN_MODE_DRY)
+        assert f["verdict"] == sos.DRY
+        assert f["verdict"] != sos.MISSING
+        assert f["verdict"] not in sos.DEFECT_VERDICTS
+
+    def test_stale_key_on_a_dry_run_is_dry_not_stale(self):
+        f = self._one(
+            "b/{date}.json",
+            {f"b/{RUN_DATE}.json": EXEC_START - timedelta(days=5)},
+            sos.RUN_MODE_DRY,
+        )
+        assert f["verdict"] == sos.DRY
+        assert f["verdict"] != sos.STALE
+        assert f["verdict"] not in sos.DEFECT_VERDICTS
+
+    def test_missing_key_on_a_real_run_is_still_missing(self):
+        """The carve-out is scoped to run_mode=dry only — a real weekly or
+        exercise run with a genuinely missing artifact must still fail loud.
+        """
+        f = self._one("b/{date}.json", {}, "weekly")
+        assert f["verdict"] == sos.MISSING
+
+    def test_missing_key_with_unknown_run_mode_is_still_missing(self):
+        """Unknown run_mode must never be treated as license to go quiet —
+        same "fail toward asserting" rule as entered_stages=None."""
+        f = self._one("b/{date}.json", {}, None)
+        assert f["verdict"] == sos.MISSING
+
+    def test_a_key_actually_written_under_a_dry_run_still_reports_wrote(self):
+        """SignalsEnvelope/ChallengerShadow run for-real even under
+        shell_run=true — a key they DID write must still read WROTE, not be
+        swept into the dry downgrade."""
+        f = self._one(
+            "b/{date}.json",
+            {f"b/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)},
+            sos.RUN_MODE_DRY,
+        )
+        assert f["verdict"] == sos.WROTE
+
+    def test_s3_error_on_a_dry_run_is_still_unmeasured_not_dry(self):
+        """Predicate 3 (analogous to I7392's sibling issue I7412's own
+        predicate 3): the dry path must still fail loud on a real defect. A
+        denied S3 read on a dry run is a harness fault, not evidence the
+        dry-path contract explains an absence."""
+        f = self._one(
+            "b/{date}.json", {f"b/{RUN_DATE}.json": "error:AccessDenied"}, sos.RUN_MODE_DRY
+        )
+        assert f["verdict"] == sos.UNMEASURED
+        assert f["verdict"] != sos.DRY
+
+
+class TestSiblingAttribution:
+    """I7392 item D: three artifacts on the 2026-08-21 run were flagged STALE
+    at 14min-1h old — written by the postclose pipeline for the SAME cycle,
+    minutes before this execution started. Anchored on cycle_date instead of
+    execution_start, that stops reading as a silent stage.
+    """
+
+    def _one(self, last_modified, cycle_date=RUN_DATE, run_mode=None):
+        decls = sos.declared_outputs([_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE)
+        head = _head_from({f"b/{RUN_DATE}.json": last_modified})
+        return sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, head=head,
+            cycle_date=cycle_date, run_mode=run_mode,
+        )[0]
+
+    def test_same_cycle_write_minutes_before_start_is_wrote_by_sibling(self):
+        f = self._one(EXEC_START - timedelta(minutes=14))
+        assert f["verdict"] == sos.WROTE_BY_SIBLING
+        assert f["verdict"] not in sos.DEFECT_VERDICTS
+        assert "cycle_date" in f["detail"]
+
+    def test_same_cycle_write_one_hour_before_start_is_wrote_by_sibling(self):
+        f = self._one(EXEC_START - timedelta(hours=1))
+        assert f["verdict"] == sos.WROTE_BY_SIBLING
+
+    def test_a_prior_cycle_write_is_still_stale(self):
+        """The regression guard: an object genuinely from an OLDER cycle
+        (last_modified's date != cycle_date) must not be laundered into
+        wrote_by_sibling just because it predates execution_start."""
+        f = self._one(EXEC_START - timedelta(days=87))
+        assert f["verdict"] == sos.STALE
+
+    def test_sibling_attribution_beats_the_dry_downgrade(self):
+        """A same-cycle sibling write explains the object regardless of THIS
+        run's own mode — it must not collapse into `dry` on a shell run."""
+        f = self._one(EXEC_START - timedelta(minutes=14), run_mode=sos.RUN_MODE_DRY)
+        assert f["verdict"] == sos.WROTE_BY_SIBLING
+
+
+class TestSelfExclusion:
+    """I7392 item C: the sweep's own verdict key is checked before it is
+    written, so asserting it against itself is a guaranteed false MISSING on
+    every run, forever — on real scheduled runs too, not only rehearsals.
+    """
+
+    def test_own_verdict_key_is_excluded_not_evaluated(self):
+        row = _row(
+            "stage_output_sweep_verdict",
+            sos.VERDICT_KEY_TEMPLATE.replace("{pipeline}", PIPELINE).replace(
+                "{run_date}", "{run_date}"
+            ),
+            "WeeklySubstrateHealthCheck",
+        )
+        decls = sos.declared_outputs([row], pipeline=PIPELINE)
+        findings = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, head=_head_from({}),
+            cycle_date=RUN_DATE, pipeline=PIPELINE, verdict_bucket=sos.DEFAULT_BUCKET,
+        )
+        assert findings == []
+
+    def test_a_different_pipelines_verdict_key_is_not_excluded(self):
+        """The exclusion is scoped to THIS pipeline's own verdict key —
+        another pipeline's verdict artifact is a real declared artifact."""
+        other_pipeline = "ne-preopen-trading-pipeline"
+        row = _row(
+            "other_verdict",
+            sos.VERDICT_KEY_TEMPLATE.replace("{pipeline}", other_pipeline).replace(
+                "{run_date}", "{run_date}"
+            ),
+            "SomeStage",
+        )
+        decls = sos.declared_outputs([row], pipeline=PIPELINE)
+        findings = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, head=_head_from({}),
+            cycle_date=RUN_DATE, pipeline=PIPELINE, verdict_bucket=sos.DEFAULT_BUCKET,
+        )
+        assert len(findings) == 1
+        assert findings[0]["verdict"] == sos.MISSING
+
+    def test_without_a_pipeline_argument_self_exclusion_is_a_no_op(self):
+        """Backward-compatible default: callers that do not pass `pipeline`
+        (e.g. call sites predating I7392) see the pre-existing behaviour."""
+        row = _row(
+            "stage_output_sweep_verdict",
+            sos.VERDICT_KEY_TEMPLATE.replace("{pipeline}", PIPELINE).replace(
+                "{run_date}", "{run_date}"
+            ),
+            "WeeklySubstrateHealthCheck",
+        )
+        decls = sos.declared_outputs([row], pipeline=PIPELINE)
+        findings = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START, head=_head_from({}),
+            cycle_date=RUN_DATE,
+        )
+        assert len(findings) == 1
+        assert findings[0]["verdict"] == sos.MISSING
+
+
+class TestParseRunMode:
+    def test_shell_run_true_is_dry_regardless_of_pipeline_role(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(
+            json.dumps({"shell_run": True, "pipeline_role": "shell-run", "skip_parity": True}),
+            notes=notes,
+        )
+        assert mode == sos.RUN_MODE_DRY
+        assert notes == []
+
+    def test_pipeline_role_used_when_shell_run_absent(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(json.dumps({"pipeline_role": "weekly"}), notes=notes)
+        assert mode == "weekly"
+        assert notes == []
+
+    def test_pipeline_role_exercise(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(json.dumps({"pipeline_role": "exercise"}), notes=notes)
+        assert mode == "exercise"
+
+    def test_shell_run_false_falls_back_to_pipeline_role(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(
+            json.dumps({"shell_run": False, "pipeline_role": "weekly"}), notes=notes,
+        )
+        assert mode == "weekly"
+
+    def test_missing_input_degrades_to_none_with_a_note(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(None, notes=notes)
+        assert mode is None
+        assert len(notes) == 1
+
+    def test_unparseable_json_degrades_to_none_with_a_note(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode("{not json", notes=notes)
+        assert mode is None
+        assert len(notes) == 1
+
+    def test_non_object_json_degrades_to_none_with_a_note(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode("[1, 2, 3]", notes=notes)
+        assert mode is None
+        assert len(notes) == 1
+
+    def test_neither_field_present_degrades_to_none_with_a_note(self):
+        notes: list[str] = []
+        mode = sos._parse_run_mode(json.dumps({"skip_parity": True}), notes=notes)
+        assert mode is None
+        assert len(notes) == 1
+
+
+class TestExecutionContextRunMode:
+    def test_shell_run_input_sets_dry_run_mode(self):
+        class _Sfn(_FakeSfn):
+            def describe_execution(self, executionArn):  # noqa: N803
+                return {
+                    "startDate": EXEC_START,
+                    "status": "FAILED",
+                    "input": json.dumps({"shell_run": True, "pipeline_role": "shell-run"}),
+                }
+
+        ctx = sos.read_execution_context("arn:x", sfn_client=_Sfn())
+        assert ctx.run_mode == sos.RUN_MODE_DRY
+
+    def test_weekly_input_sets_weekly_run_mode(self):
+        class _Sfn(_FakeSfn):
+            def describe_execution(self, executionArn):  # noqa: N803
+                return {
+                    "startDate": EXEC_START,
+                    "status": "SUCCEEDED",
+                    "input": json.dumps({"pipeline_role": "weekly"}),
+                }
+
+        ctx = sos.read_execution_context("arn:x", sfn_client=_Sfn())
+        assert ctx.run_mode == "weekly"
+
+
+class TestShouldAlert:
+    def _doc(self, **kw):
+        base = {"enforce": False, "run_mode": None}
+        base.update(kw)
+        return base
+
+    def test_observe_weekly_alerts(self):
+        assert sos._should_alert(self._doc(run_mode="weekly")) is True
+
+    def test_observe_dry_run_suppresses(self):
+        assert sos._should_alert(self._doc(run_mode=sos.RUN_MODE_DRY)) is False
+
+    def test_observe_exercise_suppresses(self):
+        assert sos._should_alert(self._doc(run_mode="exercise")) is False
+
+    def test_observe_unknown_run_mode_alerts(self):
+        """Fail toward alerting on an unresolved run_mode — same posture as
+        entered_stages=None and cycle_date=None elsewhere in this module."""
+        assert sos._should_alert(self._doc(run_mode=None)) is True
+
+    def test_enforce_mode_always_alerts_even_on_dry(self):
+        assert sos._should_alert(self._doc(enforce=True, run_mode=sos.RUN_MODE_DRY)) is True
+
+
+class TestEmitMetrics:
+    class _FakeCloudWatch:
+        def __init__(self):
+            self.calls = []
+
+        def put_metric_data(self, **kw):
+            self.calls.append(kw)
+
+    def test_emits_stage_output_defects_dimensioned_by_pipeline_and_run_mode(self):
+        cw = self._FakeCloudWatch()
+        document = {
+            "pipeline": PIPELINE, "run_mode": sos.RUN_MODE_DRY,
+            "defects": [{}, {}],
+        }
+        sos._emit_metrics(cw, document)
+        assert len(cw.calls) == 1
+        call = cw.calls[0]
+        assert call["Namespace"] == "AlphaEngine/Substrate"
+        datum = call["MetricData"][0]
+        assert datum["MetricName"] == "StageOutputDefects"
+        assert datum["Value"] == 2.0
+        dims = {d["Name"]: d["Value"] for d in datum["Dimensions"]}
+        assert dims == {"Pipeline": PIPELINE, "RunMode": sos.RUN_MODE_DRY}
+
+    def test_unknown_run_mode_dimensions_as_the_literal_string(self):
+        cw = self._FakeCloudWatch()
+        sos._emit_metrics(cw, {"pipeline": PIPELINE, "run_mode": None, "defects": []})
+        dims = {d["Name"]: d["Value"] for d in cw.calls[0]["MetricData"][0]["Dimensions"]}
+        assert dims["RunMode"] == "unknown"
+
+    def test_sweep_metric_emit_failure_does_not_lose_the_verdict(self, registry_file):
+        """Matches _publish_verdict's contract: a CW-emit fault must not sink
+        the sweep's primary deliverable (I7392 item E, freshness-monitor's
+        split-trap convention)."""
+        class _BoomCloudWatch:
+            def put_metric_data(self, **kw):
+                raise RuntimeError("cloudwatch down")
+
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START,
+            registry_path=registry_file, s3_client=s3, cloudwatch_client=_BoomCloudWatch(),
+            alert=False, emit_metrics=True,
+        )
+        assert doc["status"] == "stage_output_missing"
+
+    def test_emit_metrics_default_off_does_not_touch_boto3(self, registry_file, monkeypatch):
+        """sweep()'s default must not construct a real boto3 CloudWatch
+        client — every other test in this file relies on that, and a
+        default-on metric emit would silently start making live AWS calls."""
+        def _boom(*a, **kw):
+            raise AssertionError("boto3.client must not be called when emit_metrics=False")
+
+        import boto3
+
+        monkeypatch.setattr(boto3, "client", _boom)
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START,
+            registry_path=registry_file, s3_client=s3, alert=False,
+        )
+        assert doc["status"] == "stage_output_missing"
+
+
+class TestSweepRunModeIntegration:
+    """End-to-end: run_mode threaded from sweep()'s explicit argument through
+    to the published document and the alert-suppression decision."""
+
+    def test_dry_run_mode_downgrades_defects_and_suppresses_the_alert(
+        self, registry_file, monkeypatch
+    ):
+        alerted = []
+        monkeypatch.setattr(sos, "_alert", lambda doc: alerted.append(doc))
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START,
+            registry_path=registry_file, s3_client=s3, run_mode=sos.RUN_MODE_DRY,
+        )
+        assert doc["counts"].get(sos.DRY) == 1
+        assert doc["defects"] == []
+        assert doc["status"] == "ok"
+        assert alerted == []
+
+    def test_weekly_run_mode_still_alerts_on_a_real_defect(self, registry_file, monkeypatch):
+        alerted = []
+        monkeypatch.setattr(sos, "_alert", lambda doc: alerted.append(doc))
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START,
+            registry_path=registry_file, s3_client=s3, run_mode="weekly",
+        )
+        assert doc["status"] == "stage_output_missing"
+        assert len(alerted) == 1
+
+    def test_exercise_run_mode_publishes_but_does_not_alert(self, registry_file, monkeypatch):
+        alerted = []
+        monkeypatch.setattr(sos, "_alert", lambda doc: alerted.append(doc))
+        s3 = _FakeS3({f"good/{RUN_DATE}.json": EXEC_START + timedelta(hours=1)})
+        doc = sos.sweep(
+            run_date=RUN_DATE, cycle_date=RUN_DATE, execution_start=EXEC_START,
+            registry_path=registry_file, s3_client=s3, run_mode="exercise",
+        )
+        assert doc["status"] == "stage_output_missing"
+        assert alerted == []
+
+
 class TestEnteredStages:
     def test_stage_not_entered_is_skipped_when_the_set_is_known(self):
         decls = sos.declared_outputs([_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE)
@@ -791,7 +1170,11 @@ class TestExecutionContext:
         )
         assert ctx.start == EXEC_START
         assert ctx.entered_stages == frozenset({"A", "B"})
-        assert ctx.notes == []
+        # _FakeSfn's describe_execution carries no 'input' field, so run_mode
+        # degrades to UNKNOWN with one context note — never to silence.
+        assert ctx.run_mode is None
+        assert len(ctx.notes) == 1
+        assert "run_mode is UNKNOWN" in ctx.notes[0]
 
     def test_paginates_the_history(self):
         """A four-hour weekly run's history runs to thousands of events; a
@@ -967,7 +1350,7 @@ class TestAlertBody:
             "pipeline": PIPELINE, "run_date": RUN_DATE, "enforce": False,
             "entered_stages_known": False,
             "defects": [{"stage": "ParityReplay", "artifact_id": "parity_report",
-                         "verdict": sos.STALE}],
+                         "verdict": sos.STALE, "severity": "critical"}],
             "unmeasured": [{"stage": "Backtester", "artifact_id": "x",
                             "verdict": sos.UNMEASURED}],
         })
@@ -975,7 +1358,47 @@ class TestAlertBody:
         assert "OBSERVE" in message
         assert "DEFECT" in message and "UNMEASURED" in message
         assert "NOT evidence of health" in message
+        assert "1 artifact(s) across 1 stage(s)" in message
+        # severity comes from the MAX finding severity ("critical" here), not
+        # from the defect COUNT — see the warning-only test below for the
+        # other polarity (I7392 item B).
         assert published["kw"]["severity"] == "error"
+
+    def test_many_warning_defects_alert_at_warn_not_error(self, monkeypatch):
+        """The regression this replaces: 82 warning-severity findings alone
+        used to force severity='error' purely from the defect COUNT. Now the
+        MAX finding severity decides — all-warning stays 'warn' regardless
+        of how many there are.
+        """
+        published = {}
+
+        class _Result:
+            any_ok = True
+
+        class _Alerts:
+            @staticmethod
+            def publish(message, **kw):
+                published["kw"] = kw
+                published["message"] = message
+                return _Result()
+
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "nousergon_lib", type("M", (), {"alerts": _Alerts}))
+        monkeypatch.setitem(_sys.modules, "nousergon_lib.alerts", _Alerts)
+
+        sos._alert({
+            "pipeline": PIPELINE, "run_date": RUN_DATE, "enforce": False,
+            "entered_stages_known": True,
+            "defects": [
+                {"stage": f"Stage{i}", "artifact_id": f"a{i}",
+                 "verdict": sos.MISSING, "severity": "warning"}
+                for i in range(82)
+            ],
+            "unmeasured": [],
+        })
+        assert published["kw"]["severity"] == "warn"
+        assert "82 artifact(s) across 82 stage(s)" in published["message"]
 
     def test_unmeasured_only_alerts_at_warn_not_error(self, monkeypatch):
         published = {}

--- a/validators/stage_output_sweep.py
+++ b/validators/stage_output_sweep.py
@@ -72,6 +72,24 @@ always in the alarming direction. The verdict set keeps the two apart:
                   no stage is ever declared skipped, because "I don't know
                   which stages ran" must not become "the stage was allowed not
                   to run"
+  ``dry``         (alpha-engine-config-I7392) the stage entered but this
+                  execution ran under the dry-path contract (``shell_run``),
+                  which forbids every routed producer from writing. A
+                  would-be ``missing``/``stale`` verdict downgrades to
+                  ``dry`` here rather than being reported as either — counted
+                  in NEITHER ``defects`` NOR ``wrote``, exactly like
+                  ``skipped``/``unresolved``. Only reachable when the run's
+                  ``run_mode`` resolved to ``"dry"``; a stage that DID write
+                  under a dry run (an exempted producer — SignalsEnvelope,
+                  ChallengerShadow) still reports ``wrote``, because the key
+                  check happens before this downgrade
+  ``wrote_by_sibling``
+                  (I7392) the key exists, predates ``execution_start``, but
+                  its ``LastModified`` falls on this run's ``cycle_date`` —
+                  the signature of a same-cycle sibling pipeline (e.g. the
+                  postclose SF) writing the artifact minutes before this
+                  execution started, not of a silent stage. Not a defect;
+                  distinct from ``wrote`` so it stays visible in the counts
 
 ``unmeasured`` is deliberately NOT silent. Absence of a measurement is a
 first-class finding with its own exit code and its own alert, because the
@@ -161,11 +179,13 @@ UNRESOLVED_PRODUCER_STAGE = "UNRESOLVED"
 # Verdicts. Ordered worst-first for reporting; the ordering is not a severity
 # ladder used for suppression — every non-`wrote` verdict is reported.
 WROTE = "wrote"
+WROTE_BY_SIBLING = "wrote_by_sibling"
 STALE = "stale"
 MISSING = "missing"
 UNMEASURED = "unmeasured"
 UNRESOLVED = "unresolved"
 SKIPPED = "skipped"
+DRY = "dry"
 
 #: Verdicts that mean "this run has a data defect".
 DEFECT_VERDICTS = frozenset({MISSING, STALE})
@@ -173,6 +193,19 @@ DEFECT_VERDICTS = frozenset({MISSING, STALE})
 #: Verdicts that mean "the check could not answer". Never merged into
 #: :data:`DEFECT_VERDICTS` — see the module docstring.
 UNMEASURED_VERDICTS = frozenset({UNMEASURED})
+
+#: alpha-engine-config-I7392 — the ``run_mode`` discriminator meaning "this
+#: execution ran under the dry-path contract (``shell_run``), which forbids
+#: every routed producer from writing". Distinct from the ``dry`` VERDICT
+#: above: this is the run-level classification; that is the per-finding
+#: outcome it produces.
+RUN_MODE_DRY = "dry"
+
+#: The one run_mode that is a genuine, artifact-producing run. Any other
+#: resolved run_mode (``"exercise"``, ``RUN_MODE_DRY``) — or an unresolved one
+#: — suppresses the OBSERVE-mode alert per I7392 item B; verdict publish and
+#: the CloudWatch metric still happen regardless.
+RUN_MODE_WEEKLY = "weekly"
 
 _PLACEHOLDER_RE = re.compile(r"\{([a-z_]+)\}")
 
@@ -191,22 +224,77 @@ _ENTERED_EVENT_SUFFIX = "StateEntered"
 class ExecutionContext:
     """What the sweep could establish about the execution it is asserting over.
 
-    Both fields degrade INDEPENDENTLY and honestly. A denied
-    ``GetExecutionHistory`` must not take the start time down with it, and
-    neither failure may be reported as a fact about the pipeline.
+    All three fields degrade INDEPENDENTLY and honestly. A denied
+    ``GetExecutionHistory`` must not take the start time down with it, a
+    malformed ``input`` must not take either down with it, and no failure may
+    be reported as a fact about the pipeline.
     """
 
-    __slots__ = ("start", "entered_stages", "notes")
+    __slots__ = ("start", "entered_stages", "notes", "run_mode")
 
     def __init__(
         self,
         start: datetime | None = None,
         entered_stages: frozenset[str] | None = None,
         notes: list[str] | None = None,
+        run_mode: str | None = None,
     ) -> None:
         self.start = start
         self.entered_stages = entered_stages
         self.notes = notes or []
+        self.run_mode = run_mode
+
+
+def _parse_run_mode(raw_input: Any, *, notes: list[str]) -> str | None:
+    """Classify an execution's ``run_mode`` from its ``describe_execution``
+    ``input`` (alpha-engine-config-I7392).
+
+    ``shell_run: true`` is the sole gate ``CheckShellRun``
+    (``nousergon-data/infrastructure/step_function.json``) tests before
+    routing to ``ApplyShellRunDefaults``, which threads ``--preflight-only``
+    into every spot stage and ``dry_run``/``research_dry`` into every
+    LLM/Lambda stage — so ``shell_run=true`` is treated as authoritative over
+    whatever ``pipeline_role`` says. Absent that, ``pipeline_role`` (e.g.
+    ``"weekly"``, ``"exercise"``) is reported as-is.
+
+    Returns ``None`` — never a guess — when ``input`` is missing, not a
+    string, or not parseable JSON, or when neither field is present. The
+    caller renders ``None`` as "degrade to today's behaviour", which for
+    finding classification means no ``missing``/``stale`` verdict is ever
+    downgraded to ``dry``, and for alerting means the OBSERVE-mode
+    non-weekly suppression in ``_should_alert`` never fires on a guess.
+    """
+    if not isinstance(raw_input, str):
+        notes.append(
+            "describe_execution returned no usable 'input' — run_mode is "
+            "UNKNOWN, degrading to today's behaviour (no dry-verdict "
+            "downgrade, no alert suppression)"
+        )
+        return None
+    try:
+        payload = json.loads(raw_input)
+    except Exception as exc:  # noqa: BLE001
+        notes.append(
+            f"execution input is not parseable JSON ({type(exc).__name__}: "
+            f"{exc}) — run_mode is UNKNOWN, degrading to today's behaviour"
+        )
+        return None
+    if not isinstance(payload, dict):
+        notes.append(
+            "execution input parsed but is not a JSON object — run_mode is "
+            "UNKNOWN, degrading to today's behaviour"
+        )
+        return None
+    if payload.get("shell_run") is True:
+        return RUN_MODE_DRY
+    role = payload.get("pipeline_role")
+    if isinstance(role, str) and role:
+        return role
+    notes.append(
+        "execution input carries neither shell_run=true nor a usable "
+        "pipeline_role — run_mode is UNKNOWN, degrading to today's behaviour"
+    )
+    return None
 
 
 def read_execution_context(
@@ -254,10 +342,12 @@ def read_execution_context(
             context.start = _utc(start)
         else:
             context.notes.append("describe_execution returned no usable startDate")
+        context.run_mode = _parse_run_mode(described.get("input"), notes=context.notes)
     except Exception as exc:  # noqa: BLE001
         context.notes.append(
             f"describe_execution failed ({type(exc).__name__}: {exc}) — staleness "
-            f"is undecidable for this run"
+            f"is undecidable for this run, and run_mode is UNKNOWN (degrading to "
+            f"today's behaviour — never to silence)"
         )
 
     try:
@@ -500,6 +590,9 @@ def evaluate(
     head: Callable[[str, str], tuple[str, Any]],
     entered_stages: frozenset[str] | None = None,
     cycle_date: str | None = None,
+    run_mode: str | None = None,
+    pipeline: str | None = None,
+    verdict_bucket: str = DEFAULT_BUCKET,
 ) -> list[dict]:
     """Assign a verdict to every declared (stage, artifact) pair.
 
@@ -519,7 +612,23 @@ def evaluate(
             stage absent from it is ``skipped`` (a degraded run legitimately
             skips stages, and a detector that cries wolf on those is a detector
             that gets turned off).
+        run_mode: (I7392) ``RUN_MODE_DRY`` when this execution ran under the
+            dry-path contract. Only then does a would-be ``missing``/``stale``
+            verdict downgrade to ``dry``. ``None`` (unknown) never downgrades
+            — see the module docstring's ``dry`` verdict entry.
+        pipeline, verdict_bucket: (I7392) when both are supplied, a
+            declaration whose resolved key equals THIS sweep's own verdict
+            key (``VERDICT_KEY_TEMPLATE`` for this ``pipeline``/``run_date``
+            in ``verdict_bucket``) is excluded entirely rather than evaluated
+            — the sweep checks its declared artifacts before writing its own
+            verdict, so that key is guaranteed ``missing`` on every run,
+            forever, and is not a finding about the pipeline.
     """
+    self_key = (
+        VERDICT_KEY_TEMPLATE.format(pipeline=pipeline, run_date=run_date)
+        if pipeline
+        else None
+    )
     findings: list[dict] = []
     for declaration in declarations:
         stage = declaration["stage"]
@@ -563,14 +672,35 @@ def evaluate(
             continue
 
         finding["key"] = key
+
+        # I7392 self-exclusion: this sweep's own verdict key is checked
+        # BEFORE it is written (evaluate() runs, then _publish_verdict()), so
+        # asserting it here is a guaranteed false MISSING on every run,
+        # scheduled or rehearsal alike. Excluded rather than evaluated —
+        # never appears in findings at all.
+        if (
+            self_key is not None
+            and declaration["bucket"] == verdict_bucket
+            and key == self_key
+        ):
+            continue
+
         state, detail = head(declaration["bucket"], key)
 
         if state == "error":
             finding["verdict"] = UNMEASURED
             finding["detail"] = f"S3 head_object could not answer: {detail}"
         elif state == "absent":
-            finding["verdict"] = MISSING
-            finding["detail"] = "no object at the declared key"
+            if run_mode == RUN_MODE_DRY:
+                finding["verdict"] = DRY
+                finding["detail"] = (
+                    "no object at the declared key, but this execution ran "
+                    "under the dry-path contract (shell_run=true), which "
+                    "forbids the declaring stage from writing — not a defect"
+                )
+            else:
+                finding["verdict"] = MISSING
+                finding["detail"] = "no object at the declared key"
         else:
             last_modified = _utc(detail) if isinstance(detail, datetime) else None
             finding["last_modified"] = (
@@ -591,6 +721,31 @@ def evaluate(
                 )
             elif last_modified >= execution_start:
                 finding["verdict"] = WROTE
+            elif cycle_date and last_modified.date().isoformat() == cycle_date:
+                # I7392 same-cycle sibling attribution: the object predates
+                # THIS execution but was written on the same cycle_date — the
+                # signature of a sibling pipeline (e.g. postclose) writing the
+                # artifact for the same cycle shortly before this execution
+                # started, not of a silent stage. Checked before the `dry`
+                # downgrade below: a sibling-written object explains itself
+                # regardless of this run's own mode.
+                age = execution_start - last_modified
+                finding["verdict"] = WROTE_BY_SIBLING
+                finding["detail"] = (
+                    f"object predates this execution by {age.days}d "
+                    f"{age.seconds // 3600}h{age.seconds % 3600 // 60}m but was "
+                    f"written on this run's cycle_date={cycle_date} — attributed "
+                    f"to a same-cycle sibling pipeline, not a silent stage"
+                )
+            elif run_mode == RUN_MODE_DRY:
+                age = execution_start - last_modified
+                finding["verdict"] = DRY
+                finding["detail"] = (
+                    f"object predates this execution by {age.days}d "
+                    f"{age.seconds // 3600}h and this execution ran under the "
+                    f"dry-path contract (shell_run=true), which forbids the "
+                    f"declaring stage from writing — not a defect"
+                )
             else:
                 age = execution_start - last_modified
                 finding["verdict"] = STALE
@@ -638,9 +793,12 @@ def sweep(
     execution_arn: str | None = None,
     sfn_client: Any = None,
     cycle_date: str | None = None,
+    run_mode: str | None = None,
+    cloudwatch_client: Any = None,
     alert: bool = True,
     publish: bool = True,
     enforce: bool = False,
+    emit_metrics: bool = False,
 ) -> dict:
     """Assert every artifact this pipeline's stages declare was written by this
     run. Returns the full verdict document; never raises for a finding.
@@ -657,6 +815,8 @@ def sweep(
             execution_start = context.start
         if entered_stages is None:
             entered_stages = context.entered_stages
+        if run_mode is None:
+            run_mode = context.run_mode
         for note in context_notes:
             logger.warning("Execution context degraded: %s", note)
 
@@ -672,6 +832,7 @@ def sweep(
             "pipeline": pipeline,
             "run_date": run_date,
             "enforce": enforce,
+            "run_mode": run_mode,
             "error": str(exc),
             "checked": 0,
             "counts": {},
@@ -693,6 +854,9 @@ def sweep(
         head=lambda b, k: _head(s3_client, b, k),
         entered_stages=entered_stages,
         cycle_date=cycle_date,
+        run_mode=run_mode,
+        pipeline=pipeline,
+        verdict_bucket=bucket,
     )
     summary = summarise(findings)
 
@@ -703,6 +867,7 @@ def sweep(
         "run_date": run_date,
         "cycle_date": cycle_date,
         "enforce": enforce,
+        "run_mode": run_mode,
         "execution_start": (
             execution_start.isoformat() if execution_start else None
         ),
@@ -721,16 +886,89 @@ def sweep(
     }
 
     logger.info(
-        "Stage-output sweep pipeline=%s run_date=%s enforce=%s: %s",
-        pipeline, run_date, enforce, summary["counts"],
+        "Stage-output sweep pipeline=%s run_date=%s enforce=%s run_mode=%s: %s",
+        pipeline, run_date, enforce, run_mode, summary["counts"],
     )
 
     if publish:
         _publish_verdict(s3_client, bucket, document)
-    if alert and summary["status"] != "ok":
+
+    # I7392 item E — best-effort, independently trapped (matches
+    # freshness-monitor's split-trap convention): a PutMetricData grant
+    # regression must never suppress the verdict artifact already written
+    # above, and a metric-emit failure must never be reported as a sweep
+    # finding.
+    if emit_metrics:
+        try:
+            _emit_metrics(cloudwatch_client, document)
+        except Exception as exc:  # noqa: BLE001 — secondary observability
+            logger.warning(
+                "Stage-output CW metric emit failed (non-fatal): %s", exc,
+                exc_info=True,
+            )
+
+    if alert and summary["status"] != "ok" and _should_alert(document):
         _alert(document)
+    elif alert and summary["status"] != "ok":
+        logger.info(
+            "Stage-output alert SUPPRESSED: OBSERVE mode, run_mode=%s is not "
+            "%r — findings are still in the published verdict artifact "
+            "(alpha-engine-config-I7392)",
+            run_mode, RUN_MODE_WEEKLY,
+        )
 
     return document
+
+
+def _should_alert(document: dict) -> bool:
+    """I7392 item B: OBSERVE mode on a non-weekly run_mode publishes the
+    verdict artifact and the metric, but nothing to the alert bus.
+
+    ENFORCE mode always alerts on a finding — enforcement failing a run
+    silently, with no alert explaining why, would be worse than the noise
+    this suppresses. An UNKNOWN run_mode (``None``) never suppresses either:
+    failing toward alerting matches every other honest-degradation rule in
+    this module (entered_stages, cycle_date) — "I don't know the run_mode"
+    must not become "assume it's safe to stay quiet".
+    """
+    if document.get("enforce"):
+        return True
+    run_mode = document.get("run_mode")
+    if run_mode is None:
+        return True
+    return run_mode == RUN_MODE_WEEKLY
+
+
+def _emit_metrics(cloudwatch_client: Any, document: dict) -> None:
+    """I7392 item E: ``StageOutputDefects`` in ``AlphaEngine/Substrate``,
+    dimensioned by Pipeline + RunMode (both bounded-cardinality — never the
+    high-cardinality run id/date, per observability-policy §4).
+
+    ``alpha-engine-dashboard-role`` already carries
+    ``cloudwatch:PutMetricData`` scoped to the ``AlphaEngine``/``AlphaEngine/*``
+    namespace condition (policy ``alpha-engine-cloudwatch-metrics``, measured
+    2026-08-21) — this needs no new IAM grant.
+    """
+    if cloudwatch_client is None:
+        import boto3  # noqa: PLC0415
+
+        cloudwatch_client = boto3.client("cloudwatch")
+
+    run_mode = document.get("run_mode") or "unknown"
+    cloudwatch_client.put_metric_data(
+        Namespace="AlphaEngine/Substrate",
+        MetricData=[
+            {
+                "MetricName": "StageOutputDefects",
+                "Dimensions": [
+                    {"Name": "Pipeline", "Value": document["pipeline"]},
+                    {"Name": "RunMode", "Value": run_mode},
+                ],
+                "Value": float(len(document["defects"])),
+                "Unit": "Count",
+            }
+        ],
+    )
 
 
 def _publish_verdict(s3_client: Any, bucket: str, document: dict) -> None:
@@ -788,11 +1026,16 @@ def _alert(document: dict) -> None:
     defects = document["defects"]
     unmeasured = document["unmeasured"]
     mode = "ENFORCE" if document["enforce"] else "OBSERVE (exit 0 by design)"
+    # I7392 item B: 97 was ARTIFACTS across 18 STAGES, not 97 stages — the
+    # prior "{n} stage(s)" wording overstated the finding 5.4x on the
+    # 2026-08-21 run. Report both numbers explicitly.
+    defect_stage_count = len({f["stage"] for f in defects})
 
     parts = [
         f"Stage-output sweep [{mode}] {document['pipeline']} "
         f"run_date={document['run_date']}: "
-        f"{len(defects)} stage(s) produced NO output for this run, "
+        f"{len(defects)} artifact(s) across {defect_stage_count} stage(s) "
+        f"produced NO output for this run, "
         f"{len(unmeasured)} could NOT be measured."
     ]
     if defects:
@@ -809,9 +1052,17 @@ def _alert(document: dict) -> None:
         )
     parts.append(f"Full verdict: s3://alpha-engine-research/"
                  f"{VERDICT_KEY_TEMPLATE.format(**{k: document[k] for k in ('pipeline', 'run_date')})}"
-                 " (alpha-engine-config-I7167).")
+                 " (alpha-engine-config-I7167, I7392).")
 
-    severity = "error" if defects else "warn"
+    # I7392 item B: severity from the MAX finding severity, not the defect
+    # COUNT — 82 warning-severity findings alone used to force "error" on the
+    # 2026-08-21 run. "critical" (registry row severity) maps to alert
+    # severity "error"; any other defect (or none) maps to "warn".
+    severity = (
+        "error"
+        if any(f.get("severity") == "critical" for f in defects)
+        else "warn"
+    )
     try:
         result = alerts.publish(
             " ".join(parts),
@@ -884,6 +1135,19 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--no-alert", action="store_true")
     parser.add_argument("--no-publish", action="store_true",
                         help="skip writing the verdict artifact")
+    parser.add_argument(
+        "--no-metrics", action="store_true",
+        help="skip emitting the StageOutputDefects CloudWatch metric "
+             "(AlphaEngine/Substrate, alpha-engine-config-I7392)",
+    )
+    parser.add_argument(
+        "--run-mode", default=None,
+        help="override the run_mode classification (RUN_MODE_DRY='dry', "
+             "'weekly', 'exercise', ...). Normally derived from "
+             "--execution-arn's describe_execution input "
+             "(alpha-engine-config-I7392); an explicit value wins over that "
+             "read, same precedence as --execution-start",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -915,9 +1179,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         registry_path=args.registry,
         execution_arn=args.execution_arn,
         cycle_date=args.cycle_date,
+        run_mode=args.run_mode,
         alert=not args.no_alert,
         publish=not args.no_publish,
         enforce=args.enforce,
+        emit_metrics=not args.no_metrics,
     )
 
     code = exit_code(document)


### PR DESCRIPTION
## What & why

Extends `alpha-engine-config-I7392`. The 2026-08-21 Friday shell run
(`friday-shell-2026-08-21-eod-2026-08-21-1787342451`, FAILED, 14:04:25→14:45:56
PT, input `{"shell_run": true, "pipeline_role": "shell-run", "skip_parity": true}`)
surfaced that `validators/stage_output_sweep.py` has no run-mode awareness: a
dry rehearsal that guarantees zero producer writes by construction (`ApplyShellRunDefaults`
in `nousergon-data/infrastructure/step_function.json`) gets asserted against
the full artifact set, same as a real weekly run.

Measured on that run's verdict artifact
(`s3://alpha-engine-research/_stage_outputs/ne-weekly-freshness-pipeline/2026-08-21.json`):
`checked 125`, `missing 68 · stale 29 · wrote 11 · skipped 16 · unresolved 1`,
severity split 82 warning / 15 critical, and an ERROR-severity email
announcing "97 stage(s) produced NO output" — actually 97 artifacts across
18 stages, zero of them producer failures.

## What changed (per the issue's 2026-08-21 comment, verbatim scope)

- **A. Run-mode awareness.** `read_execution_context()` parses `shell_run`/
  `pipeline_role` from `describe_execution`'s `input`; `ExecutionContext`
  gains `run_mode`. New verdict `dry`: a would-be `missing`/`stale` finding on
  a `run_mode="dry"` execution downgrades to `dry`, counted in neither
  `defects` nor `wrote`, exactly like `skipped`/`unresolved`. A key an
  exempted producer (SignalsEnvelope, ChallengerShadow) actually wrote under a
  dry run still reports `wrote`. Failing to read the input degrades to
  today's behaviour with a `context_notes` entry, never to silence.
  `nousergon_lib.pipeline_status.classify_work` was evaluated first per the
  issue's suggestion — it classifies day-gate-skip/vacuous/partial/complete
  from `entered_states`, with no concept of the `shell_run`/dry-path contract
  carried in execution `input`, so it cannot express this distinction; a
  local discriminator (`_parse_run_mode`) was implemented instead, per the
  issue's own "if it cannot express this, say so" escape clause.
- **B. Alert shape.** `"{n} stage(s)"` → `"{n} artifact(s) across {m} stage(s)"`.
  Severity from the MAX finding severity (`"critical"` → `error`, else
  `warn`), not the defect count — 82 warnings alone previously forced
  `severity="error"`. In OBSERVE mode on a non-`weekly` `run_mode` (`dry`,
  `exercise`), the verdict artifact and the CloudWatch metric still publish;
  nothing goes to the alert bus (`_should_alert`). ENFORCE mode and an
  unresolved `run_mode` always alert — fail toward alerting, matching every
  other honest-degradation rule in this module.
- **C. Self-exclusion.** `evaluate()` takes optional `pipeline`/`verdict_bucket`;
  a declaration whose resolved key equals this sweep's own verdict key
  (checked before it is written) is excluded from findings entirely instead
  of reporting a guaranteed false `missing`, on every run, forever.
- **D. Same-cycle sibling attribution.** A key that predates
  `execution_start` but whose `LastModified` falls on this run's `cycle_date`
  now reports `wrote_by_sibling` instead of `stale` — the signature of a
  same-cycle sibling pipeline (postclose) writing the artifact minutes before
  this execution started. Checked ahead of the `dry` downgrade, so it
  explains the object regardless of this run's own mode; applies on real
  (non-dry) runs too, since that's where the 3 affected artifacts were
  measured.
- **E. `StageOutputDefects` metric**, `AlphaEngine/Substrate`, dimensioned by
  `Pipeline` + `RunMode`. Confirmed clean to add: `aws iam get-role-policy
  --role-name alpha-engine-dashboard-role --policy-name
  alpha-engine-cloudwatch-metrics` (read-only, `AWS_PROFILE=ne-admin`,
  2026-08-21) shows `cloudwatch:PutMetricData` already scoped to
  `AlphaEngine`/`AlphaEngine/*` — no new IAM grant needed. Emitted best-effort
  in its own independent `try`/`except` (mirrors `freshness-monitor`'s
  split-trap convention), so a `PutMetricData` fault never sinks the verdict
  artifact already written. Defaults **off** in `sweep()` (on by default via
  `main()`'s new `--no-metrics` opt-out flag) so no existing or new unit test
  silently starts making live `boto3` CloudWatch calls — guarded by
  `test_emit_metrics_default_off_does_not_touch_boto3`.

**Not weakened:** the `skipped` exclusion, the `unresolved` verdict class,
and the registry-sourced declaration are unchanged — all covered by the
pre-existing 74 tests.

## Test plan

```
python3 -m pytest tests/test_stage_output_sweep.py -q
# 109 passed (74 pre-existing + 35 new, covering A/C/D/E + severity/message
# shape + run_mode parsing + alert suppression, both polarities each)

python3 -m pytest tests/ -q
# 6366 passed, 17 skipped (pre-existing, unrelated), 104.7s
```

All run locally before this PR opened, `AWS_PROFILE` unset (no live AWS
calls in the suite — `test_emit_metrics_default_off_does_not_touch_boto3`
specifically guards against that regressing).

## Deploy-mechanism

N/A — `validators/stage_output_sweep.py` ships as part of the `nousergon-data`
package; `crucible-dashboard`'s `substrate_health_check.sh` (a different repo,
untouched by this PR) already invokes `python -m validators.stage_output_sweep
--execution-arn ...`, and the new `run_mode`/`--no-metrics` behaviour is
derived automatically from the existing `--execution-arn` read — no new CLI
argument is required from that caller.

Tracker: alpha-engine-config-I7392 (extends — do not close via keyword,
cross-repo closing keywords are inert per `pull-request-policy.md`).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)