### PR TITLE
fix(deploy): the fail-loud run() made every `run ... || true` fatal — 20 of 43 Lambdas undeployable (alpha-engine-config-I8125)

### DIFF
--- a/infrastructure/lambdas/_shared/deploy_run.sh
+++ b/infrastructure/lambdas/_shared/deploy_run.sh
@@ -77,6 +77,62 @@ run() {
   return 0
 }
 
+# run_tolerating <error-substring> <command...>
+#
+# For the one shape `run` cannot express: a command whose failure is EXPECTED
+# and benign for exactly one reason, and fatal for every other.
+#
+# WHY THIS EXISTS (alpha-engine-config-I8125). `run` above calls `exit`, not
+# `return`. That is deliberate and correct — but `exit` inside a function
+# terminates the SHELL, and `cmd || true` cannot catch it: `||` guards a
+# non-zero RETURN, and there is no return to guard. So the moment run() started
+# exiting, every pre-existing `run ... || true` in this repo became fatal
+# rather than tolerant, silently and everywhere at once.
+#
+# Measured 2026-08-21: 24 sites across 20 of 43 deploy.sh scripts, every one an
+# `aws lambda add-permission` — the call that returns ResourceConflictException
+# whenever its statement-id already exists, i.e. on EVERY deploy after the
+# first. Twenty Lambdas became undeployable in a single merge, and
+# `deploy-overseer-backstop-responder` failed five consecutive times before
+# anyone read the log. The guard's own `2>/dev/null` on those call sites
+# suppressed the message that would have named it.
+#
+# `|| true` was always too broad anyway: it swallowed AccessDenied and a
+# malformed ARN exactly as readily as the conflict it was written for. This
+# names the tolerated failure, so anything else still fails loud — strictly
+# stronger than what it replaces, which is why the fix is this rather than
+# restoring a `return`.
+#
+#   run_tolerating "ResourceConflictException" \
+#     aws lambda add-permission --function-name "$FN" --statement-id "$SID" ...
+#
+# stderr is captured rather than discarded so the tolerated case can be
+# RECOGNISED; on a match it is reported at info level, never hidden. Do not
+# add `2>/dev/null` at the call site — that is what made the original failure
+# unreadable.
+run_tolerating() {
+  local expected="${1:?run_tolerating: expected-error substring required}"
+  shift
+  if ${DRY_RUN:-false}; then
+    echo "DRY: $*"
+    return 0
+  fi
+  local output status=0
+  output="$("$@" 2>&1)" || status=$?
+  if [ "${status}" -eq 0 ]; then
+    [ -n "${output}" ] && echo "${output}"
+    return 0
+  fi
+  if [[ "${output}" == *"${expected}"* ]]; then
+    echo "  (tolerated: ${expected}) $1 ${2:-}"
+    return 0
+  fi
+  echo "ERROR: command failed (exit ${status}): $*" >&2
+  echo "ERROR: ${output}" >&2
+  echo "ERROR: tolerated failures for this call are limited to: ${expected}" >&2
+  exit "${status}"
+}
+
 # verify_code_deployed <function-name> <region> <zip-path>
 #
 # Reads back the LIVE CodeSha256 after an update-function-code /

--- a/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh
@@ -165,13 +165,14 @@ if $BOOTSTRAP; then
       --rule "${rule}" \
       --targets "Id=1,Arn=${FN_ARN}" \
       --region "${REGION}"
-    run aws lambda add-permission \
+    run_tolerating "ResourceConflictException" \
+      aws lambda add-permission \
       --function-name "${FUNCTION_NAME}" \
       --statement-id "eventbridge-${rule}" \
       --action lambda:InvokeFunction \
       --principal events.amazonaws.com \
       --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
-      --region "${REGION}" 2>/dev/null || true
+      --region "${REGION}"
   done
 fi
 

--- a/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
@@ -127,13 +127,14 @@ echo "Reconciling SNS subscription: ${BACKSTOP_TOPIC_ARN} -> ${FUNCTION_NAME}"
 
 # Give SNS permission to invoke the Lambda (idempotent — 2>/dev/null||true on
 # existing statements)
-run aws lambda add-permission \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission \
   --function-name "${FUNCTION_NAME}" \
   --statement-id "sns-${BACKSTOP_TOPIC_NAME}" \
   --action lambda:InvokeFunction \
   --principal sns.amazonaws.com \
   --source-arn "${BACKSTOP_TOPIC_ARN}" \
-  --region "${REGION}" 2>/dev/null || true
+  --region "${REGION}"
 
 # Check if an SNS->Lambda subscription already exists
 EXISTING_SUB=$(aws sns list-subscriptions-by-topic \

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -193,13 +193,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   echo "  NOTE: rule is DISABLED. Enable AFTER canary-replay-liveness-probe is verified live:"
   echo "        aws events enable-rule --name ${RULE_NAME} --region ${REGION}"

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -173,13 +173,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
+++ b/infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh
@@ -311,7 +311,19 @@ if $BOOTSTRAP || $WIRE_SUBS; then
       --action lambda:InvokeFunction \
       --principal "logs.${REGION}.amazonaws.com" \
       --source-arn "arn:aws:logs:${REGION}:${ACCOUNT_ID}:log-group:${LOG_GROUP}:*" \
-      --region "${REGION}" 2>&1) || true
+      --region "${REGION}" 2>&1) || PERM_RC=$?
+    # Not `|| true`: that swallowed AccessDenied and a malformed source-arn
+    # exactly as readily as the conflict it was written for, and a deploy that
+    # could not grant CloudWatch Logs permission to invoke this function has
+    # not deployed (alpha-engine-config-I8125). This call keeps its own
+    # capture rather than moving to run_tolerating because PERM_OUT is read
+    # below to decide the propagation sleep.
+    if [ "${PERM_RC:-0}" -ne 0 ] && [[ "${PERM_OUT}" != *ResourceConflictException* ]]; then
+      echo "ERROR: add-permission failed for ${PERM_SID} (exit ${PERM_RC}):" >&2
+      echo "ERROR: ${PERM_OUT}" >&2
+      exit "${PERM_RC}"
+    fi
+    PERM_RC=0
 
     # IAM/Lambda permission propagation is eventually consistent —
     # put-subscription-filter validates the resource policy and fails

--- a/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh
@@ -161,13 +161,14 @@ if $BOOTSTRAP; then
       --rule "${rule}" \
       --targets "Id=1,Arn=${FN_ARN}" \
       --region "${REGION}"
-    run aws lambda add-permission \
+    run_tolerating "ResourceConflictException" \
+      aws lambda add-permission \
       --function-name "${FUNCTION_NAME}" \
       --statement-id "eventbridge-${rule}" \
       --action lambda:InvokeFunction \
       --principal events.amazonaws.com \
       --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
-      --region "${REGION}" 2>/dev/null || true
+      --region "${REGION}"
   done
 fi
 

--- a/infrastructure/lambdas/eod-backstop/deploy.sh
+++ b/infrastructure/lambdas/eod-backstop/deploy.sh
@@ -186,13 +186,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   echo "  NOTE: rule is DISABLED. After soak: aws events enable-rule --name ${RULE_NAME} --region ${REGION}"
 fi

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh
@@ -182,13 +182,14 @@ EOF
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -259,13 +259,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   # Historical-mode cron: daily at 04:00 UTC, off-peak. Fires the same
   # Lambda with event={"mode": "historical"} so it probes the last N
@@ -302,13 +303,14 @@ EOF
   rm -f "${HIST_TARGET_JSON}"
 
   HIST_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${HISTORICAL_RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${HISTORICAL_RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${HIST_RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   # Intraday mini-rule (config#1297): 30-min, weekdays 14-21 UTC (covers US
   # market hours 13:30-20:00 UTC with a buffer either side). Fires the same
@@ -343,13 +345,14 @@ EOF
   rm -f "${INTRADAY_TARGET_JSON}"
 
   INTRADAY_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${INTRADAY_RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${INTRADAY_RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${INTRADAY_RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/friday-shell-run-report/deploy.sh
+++ b/infrastructure/lambdas/friday-shell-run-report/deploy.sh
@@ -153,9 +153,10 @@ FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
 run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
 
 RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission --function-name "${FUNCTION_NAME}" \
   --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
-  --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+  --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}"
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 

--- a/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
+++ b/infrastructure/lambdas/overseer-backstop-responder/deploy.sh
@@ -167,13 +167,14 @@ FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
 echo "Reconciling SNS subscription: ${BACKSTOP_TOPIC_ARN} -> ${FUNCTION_NAME}"
 
 # Give SNS permission to invoke the Lambda
-run aws lambda add-permission \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission \
   --function-name "${FUNCTION_NAME}" \
   --statement-id "sns-${BACKSTOP_TOPIC_NAME}" \
   --action lambda:InvokeFunction \
   --principal sns.amazonaws.com \
   --source-arn "${BACKSTOP_TOPIC_ARN}" \
-  --region "${REGION}" 2>/dev/null || true
+  --region "${REGION}"
 
 # Check if an SNS->Lambda subscription already exists
 EXISTING_SUB=$(aws sns list-subscriptions-by-topic \

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -219,13 +219,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
@@ -193,13 +193,14 @@ if $BOOTSTRAP; then
   # sibling dispatcher's identical bootstrap-before-CFN ordering).
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
   echo "  Granting events.amazonaws.com invoke permission from ${RULE_ARN}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true  # swallowed: idempotent re-bootstrap hits ResourceConflictException when the statement already exists; add-permission has no --if-not-exists, and a stale statement here is harmless (same-shaped statement every time)
+    --region "${REGION}"   # swallowed: idempotent re-bootstrap hits ResourceConflictException when the statement already exists; add-permission has no --if-not-exists, and a stale statement here is harmless (same-shaped statement every time)
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh
@@ -123,8 +123,9 @@ if $BOOTSTRAP; then
   run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission --function-name "${FUNCTION_NAME}" --statement-id "eventbridge-${RULE_NAME}" \
-    --action lambda:InvokeFunction --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission --function-name "${FUNCTION_NAME}" --statement-id "eventbridge-${RULE_NAME}" \
+    --action lambda:InvokeFunction --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}"
 fi
 
 # ----- 3. Update function code ----------------------------------------------

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -206,13 +206,14 @@ EOF
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------

--- a/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/sf-telegram-notifier/deploy.sh
@@ -195,13 +195,14 @@ run aws events put-targets \
   --region "${REGION}"
 
 RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-run aws lambda add-permission \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission \
   --function-name "${FUNCTION_NAME}" \
   --statement-id "eventbridge-${RULE_NAME}" \
   --action lambda:InvokeFunction \
   --principal events.amazonaws.com \
   --source-arn "${RULE_ARN}" \
-  --region "${REGION}" 2>/dev/null || true
+  --region "${REGION}"
 
 # ----- 2c. Groom dispatch SF — FAILURE statuses only (2026-07-28) -----------
 #
@@ -249,13 +250,14 @@ run aws events put-targets \
   --targets "Id=1,Arn=${FN_ARN}" \
   --region "${REGION}"
 
-run aws lambda add-permission \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission \
   --function-name "${FUNCTION_NAME}" \
   --statement-id "eventbridge-${GROOM_RULE_NAME}" \
   --action lambda:InvokeFunction \
   --principal events.amazonaws.com \
   --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${GROOM_RULE_NAME}" \
-  --region "${REGION}" 2>/dev/null || true
+  --region "${REGION}"
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
@@ -261,13 +261,14 @@ if $BOOTSTRAP_IAM; then
       --rule "${rule}" \
       --targets "Id=1,Arn=${FN_ARN}" \
       --region "${REGION}"
-    run aws lambda add-permission \
+    run_tolerating "ResourceConflictException" \
+      aws lambda add-permission \
       --function-name "${FUNCTION_NAME}" \
       --statement-id "eventbridge-${rule}" \
       --action lambda:InvokeFunction \
       --principal events.amazonaws.com \
       --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${rule}" \
-      --region "${REGION}" 2>/dev/null || true
+      --region "${REGION}"
   done
 fi
 

--- a/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
+++ b/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
@@ -157,11 +157,12 @@ if $BOOTSTRAP; then
     --region "${REGION}" --query 'RuleArn' --output text
   run aws events put-targets --rule "${TICK_RULE}" \
     --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
-  run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${TICK_RULE}" --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${TICK_RULE}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   echo "  Creating EventBridge rule: ${WARN_RULE} ($(pause_state "${WARN_RULE}"))"
   run aws events put-rule --name "${WARN_RULE}" \
@@ -171,11 +172,12 @@ if $BOOTSTRAP; then
     --region "${REGION}" --query 'RuleArn' --output text
   run aws events put-targets --rule "${WARN_RULE}" \
     --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
-  run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${WARN_RULE}" --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${WARN_RULE}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 fi
 
 # ----- 3. Update function code ----------------------------------------------

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -175,13 +175,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   # ── CloudWatch alarm on weekly-freshness-spot reaps ─────────────────────────
   # RETIRED as an alarm-creation path (alpha-engine-config-I7359, executing the

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -170,13 +170,14 @@ if $BOOTSTRAP; then
     --region "${REGION}"
 
   RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-  run aws lambda add-permission \
+  run_tolerating "ResourceConflictException" \
+    aws lambda add-permission \
     --function-name "${FUNCTION_NAME}" \
     --statement-id "eventbridge-${RULE_NAME}" \
     --action lambda:InvokeFunction \
     --principal events.amazonaws.com \
     --source-arn "${RULE_ARN}" \
-    --region "${REGION}" 2>/dev/null || true
+    --region "${REGION}"
 
   apply_alarms
 fi

--- a/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
+++ b/infrastructure/lambdas/sweep-artifact-monitor/deploy.sh
@@ -142,9 +142,10 @@ FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
 run aws events put-targets --rule "${RULE_NAME}" --targets "Id=1,Arn=${FN_ARN}" --region "${REGION}"
 
 RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}"
-run aws lambda add-permission --function-name "${FUNCTION_NAME}" \
+run_tolerating "ResourceConflictException" \
+  aws lambda add-permission --function-name "${FUNCTION_NAME}" \
   --statement-id "eventbridge-${RULE_NAME}" --action lambda:InvokeFunction \
-  --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}" 2>/dev/null || true
+  --principal events.amazonaws.com --source-arn "${RULE_ARN}" --region "${REGION}"
 
 # ----- 3. Update function code (always after bootstrap, idempotent) ---------
 

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -133,11 +133,16 @@ fi
 if [ "$CUTOVER" -eq 1 ]; then
     echo "==> CUTOVER: repointing $RULE_NAME at $FUNCTION_NAME"
     TARGET_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
-    aws lambda add-permission --function-name "$FUNCTION_NAME" \
+    # `|| echo "(permission exists)"` reported that same reassuring line for
+    # AccessDenied and a malformed source-arn too, with the real message sent
+    # to /dev/null (alpha-engine-config-I8125). The conflict is the ONE benign
+    # failure; everything else means the rule cannot invoke this function.
+    run_tolerating "ResourceConflictException" \
+      aws lambda add-permission --function-name "$FUNCTION_NAME" \
         --statement-id "${RULE_NAME}-invoke" --action lambda:InvokeFunction \
         --principal events.amazonaws.com \
         --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}" \
-        --region "$REGION" >/dev/null 2>&1 || echo "    (permission exists)"
+        --region "$REGION"
     aws events put-targets --rule "$RULE_NAME" \
         --targets "[{\"Id\":\"1\",\"Arn\":\"${TARGET_ARN}\"}]" --region "$REGION"
     echo "    $RULE_NAME now targets $FUNCTION_NAME."

--- a/tests/test_deploy_shell_flags_fail_loud.py
+++ b/tests/test_deploy_shell_flags_fail_loud.py
@@ -167,3 +167,115 @@ def test_every_lambda_deploy_script_sources_deploy_run() -> None:
         "run() and verify_code_deployed() (alpha-engine-config-I8033):\n  "
         + "\n  ".join(sorted(violations))
     )
+
+
+# ---------------------------------------------------------------------------
+# `run ... || true` is a silent lie now (alpha-engine-config-I8125).
+#
+# run() calls `exit`, not `return`. `exit` inside a function terminates the
+# SHELL, and `cmd || true` cannot catch it — `||` guards a non-zero RETURN and
+# there is no return to guard. So the moment run() started exiting, every
+# pre-existing `run ... || true` became fatal rather than tolerant, silently
+# and everywhere at once.
+#
+# Measured 2026-08-21: 24 sites across 20 of 43 deploy.sh scripts, all
+# `aws lambda add-permission` — which returns ResourceConflictException
+# whenever its statement-id already exists, i.e. on EVERY deploy after the
+# first. Twenty Lambdas became undeployable in one merge, and
+# deploy-overseer-backstop-responder failed five consecutive times before the
+# log was read.
+#
+# The pattern reads as tolerant and behaves as fatal, which is the worst
+# combination a reviewer can be shown. It must never come back.
+# ---------------------------------------------------------------------------
+
+import re  # noqa: E402
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Join backslash continuations so a wrapped command is one line."""
+    return re.sub(r"\\\n\s*", " ", text).splitlines()
+
+
+def test_no_run_invocation_is_guarded_by_or_true() -> None:
+    """`run ... || true` cannot do what it says. Use run_tolerating."""
+    offenders = []
+    for path in _lambda_deploy_scripts():
+        for line in _logical_lines(path.read_text()):
+            stripped = line.strip()
+            if stripped.startswith("run ") and "|| true" in stripped:
+                offenders.append(f"{path.parent.name}: {stripped[:90]}")
+    assert not offenders, (
+        "`run ... || true` reads as tolerant and is fatal — run() exits, and "
+        "`||` cannot catch an exit. Use `run_tolerating \"<ErrorName>\" ...`, "
+        "which names the ONE failure that is benign and still fails loud on "
+        "every other:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_run_tolerating_exists_and_names_its_expected_error() -> None:
+    """The helper must require an expected-error argument.
+
+    A `run_tolerating` with an optional pattern would decay straight back
+    into `|| true` at the first call site that omitted it.
+    """
+    src = (_REPO_ROOT / "infrastructure/lambdas/_shared/deploy_run.sh").read_text()
+    assert "run_tolerating()" in src
+    assert "run_tolerating: expected-error substring required" in src, (
+        "the expected-error argument must be mandatory, or the helper "
+        "degrades to the unconditional swallow it replaces"
+    )
+    assert 'exit "${status}"' in src, "an unexpected failure must still exit"
+
+
+def test_every_add_permission_tolerates_only_the_conflict() -> None:
+    """`aws lambda add-permission` is idempotent-by-conflict.
+
+    It legitimately fails with ResourceConflictException when the statement
+    already exists — the steady state on every deploy after the first — and
+    must NOT be tolerated for AccessDenied or a malformed ARN, which is
+    exactly what the old `|| true` swallowed alongside it.
+    """
+    for path in _lambda_deploy_scripts():
+        lines = _logical_lines(path.read_text())
+        for idx, line in enumerate(lines):
+            if "aws lambda add-permission" not in line:
+                continue
+            # Either the shared wrapper, or a call site that captures the
+            # output itself and checks it — changelog-cloudwatch-mirror reads
+            # PERM_OUT to decide a propagation sleep, so it keeps its own
+            # capture. What is NOT acceptable either way is an unconditional
+            # swallow: the conflict is the ONE benign failure here.
+            # Comment lines are excluded: a comment EXPLAINING why `|| true`
+            # was removed must not read as `|| true` still being there.
+            window_lines = [
+                ln for ln in lines[max(0, idx - 1):idx + 15]
+                if not ln.strip().startswith("#")
+            ]
+            window = " ".join(window_lines)
+            assert "ResourceConflictException" in window, (
+                f"{path.parent.name}: add-permission tolerates exactly one "
+                f"failure — ResourceConflictException, the steady state on "
+                f"every deploy after the first. Wrap it in run_tolerating, or "
+                f"capture and check the output. Got: {line.strip()[:90]}"
+            )
+            assert "|| true" not in window, (
+                f"{path.parent.name}: `|| true` on add-permission swallows "
+                f"AccessDenied and a malformed ARN alongside the conflict"
+            )
+
+
+def test_no_tolerated_call_discards_its_own_stderr() -> None:
+    """`2>/dev/null` on a tolerated call is what made the outage unreadable.
+
+    run_tolerating captures stderr so the tolerated case can be RECOGNISED
+    and reported; discarding it at the call site defeats that and leaves a
+    failing deploy with no message, which is how five consecutive failures
+    went unexplained.
+    """
+    offenders = []
+    for path in _lambda_deploy_scripts():
+        for line in _logical_lines(path.read_text()):
+            if "run_tolerating" in line and "2>/dev/null" in line:
+                offenders.append(f"{path.parent.name}: {line.strip()[:90]}")
+    assert not offenders, "\n  ".join(["tolerated calls must not hide stderr:"] + offenders)


### PR DESCRIPTION
## Tracker

Tracker: alpha-engine-config-I8125 (cross-repo — no closing keyword works from here)

**P0. Twenty of forty-three Lambdas are undeployable right now, and three merged fixes are live nowhere.**

## What happened

`19bcfc58` (#1490, *"fail loud on a failed Lambda code upload"*, merged 20:10Z today) replaced 43 copies of `run()` with a shared one that calls **`exit`** on failure. That is correct and was the point of the change.

But **`exit` inside a function terminates the shell, and `cmd || true` cannot catch it.** `||` guards a non-zero *return*; there is no return to guard. So every pre-existing `run … || true` became fatal — silently, everywhere, in a diff that never touched one of them.

**24 sites across 20 of 43 `deploy.sh` scripts**, and every one is `aws lambda add-permission`, which returns `ResourceConflictException` whenever its statement-id already exists — **the steady state on every deploy after the first**. That is why it broke universally and immediately.

`deploy-overseer-backstop-responder`:

| time (UTC) | result |
|---|---|
| 16:06:26 | success — the last one |
| 20:10:25 | failure — `fix(deploy): fail loud …` |
| 22:19:14 · 23:01:24 · 23:27:08 · 23:45:51 | failure ×4 |

The merges those runs carried are deployed nowhere: **#1496** (`I8109` — the backstop responder's own OK-transition fix), **#1497** (`I8110`), **#1498** (`I8047`, P0). The Lambda that renders every backstop page is still rendering recoveries as emergencies, from code merged hours ago.

Also affected: `freshness-monitor` (×3), `pipeline-watchdog`, `spot-orphan-reaper`, `sf-telegram-notifier` (×2), `eod-backstop`, `saturday-sf-watch-dispatcher`, and every liveness probe.

## Why the log said nothing

Those call sites carry `2>/dev/null`. `run()` prints `ERROR: command failed (exit …)` to **stderr** — into the discard. The GHA log showed `Reconciling SNS subscription: …`, then `##[error]Process completed with exit code 254`, with nothing between. **The suppression that hid the original defect also hid its fix's side effect.**

## The fix

**`run_tolerating <error-substring> <command…>`** in `_shared/deploy_run.sh`: captures stderr instead of discarding it, tolerates exactly the named failure, and **exits on anything else while printing the real message**.

The expected-error argument is **mandatory** (`${1:?…}`). An optional one would decay straight back into `|| true` at the first call site that omitted it.

**This is strictly stronger than what it replaces.** `|| true` swallowed `AccessDenied` and a malformed source-ARN exactly as readily as the conflict it was written for — a deploy that could not grant EventBridge permission to invoke its own function reported success. That is why the fix is a *named* tolerance and not a restored `return`.

Two sites keep their own capture, deliberately:

- **`changelog-cloudwatch-mirror`** reads `PERM_OUT` to decide a propagation sleep, so the capture stays — but it now raises on any non-conflict failure instead of `|| true`.
- **`thinktank-spot-dispatcher`** used `>/dev/null 2>&1 || echo "    (permission exists)"`, which printed that reassuring line for `AccessDenied` too. Converted.

## Test plan

**Behavioural, not inspection** — `run_tolerating` driven with three fakes:

```
(tolerated: ResourceConflictException) fake_conflict
PASS: conflict tolerated
PASS: success passes through
PASS: AccessDenied still fatal
```

**Four derived guards** in `tests/test_deploy_shell_flags_fail_loud.py`, scoped from `git ls-files` so script #44 is covered automatically:

1. no `run … || true` anywhere — the pattern reads as tolerant and behaves as fatal, the worst combination a reviewer can be shown;
2. `run_tolerating` exists and its expected-error argument stays mandatory;
3. every `add-permission` tolerates `ResourceConflictException` and nothing else;
4. no tolerated call discards its own stderr — that suppression is what left five failures unexplained.

`python3 -m pytest tests/ -q` → **6340 passed, 17 skipped**. All 43 scripts pass `bash -n`.

## After merge

Nothing to run. The deploy workflows retry on their own next merge — but the three fixes above will not reach AWS until *some* merge touches each Lambda's path filter, so confirm `deploy-overseer-backstop-responder` goes green and check the live `CodeSha256`, per `I8033`'s own lesson that a workflow's exit code is not evidence of a deploy.

## The general lesson

A `run()` that exits is right. What made this an outage is that the change **altered the meaning of every existing call site without touching one of them**. `|| true` did not appear in that diff and stopped working. The 43-script sweep was reviewed for what it added; nothing asked what it invalidated.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
