### PR TITLE
fix(readiness-probe): an unmeasured deploy-drift verdict pages, it is not clean (config-I8142)

### DIFF
--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/index.py
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/index.py
@@ -21,6 +21,14 @@ timezone, DST-correct) — 45 minutes before the 05:15 PT preopen trigger.
      inside the preopen SF itself — one implementation, not a second one
      free to drift; see `alpha-engine-predictor/inference/deploy_drift.py`).
   3. `sf_drift=false` -> clean. Write the verdict, no page, no dispatch.
+  3a. `sf_drift` ABSENT (or `sf_drift_state == "unmeasured"`) -> the probe
+     could not measure definition freshness at all. NOT clean: this is the
+     exact input the preopen `DeployDriftGate` fail-closed branch halts on
+     45 minutes later, so it pages immediately, with runway, and does NOT
+     self-heal — a `workflow_dispatch` on an unmeasured verdict acts on
+     evidence nobody has (alpha-engine-config-I8142). Reading absence as
+     clean is the same defect one hop downstream from the one I8142 fixed
+     in the probe itself.
   4. `sf_drift=true` -> self-heal: fire a `workflow_dispatch` on
      `nousergon-data`'s `deploy-infrastructure.yml` (it is idempotent by
      design — re-running it is always safe, see that workflow's own header
@@ -225,6 +233,65 @@ def _poll_dispatch_conclusion(dispatched_at: datetime) -> tuple[str, str]:
     )
 
 
+#: The three states a drift verdict can be in. `check_deploy_drift` OMITS
+#: `sf_drift` when it could not measure it (alpha-engine-config-I7048, I7924,
+#: I8142) and, since I8142, also states it positively in `sf_drift_state`. Read
+#: the positive field when the predictor Lambda is new enough to emit it, and
+#: fall back to key presence otherwise, so this probe is correct across the
+#: rollout window rather than only after it.
+_DRIFT = "drift"
+_NO_DRIFT = "no_drift"
+_UNMEASURED = "unmeasured"
+
+
+def _drift_state(drift: dict) -> str:
+    """Three states, never two. `drift.get("sf_drift")` collapses "no" and "no
+    answer" into one falsy value — the shape behind every instance of this
+    defect class, including the one on the halting gate itself (I8142)."""
+    state = drift.get("sf_drift_state")
+    if state in (_DRIFT, _NO_DRIFT, _UNMEASURED):
+        return state
+    if "sf_drift" not in drift:
+        return _UNMEASURED
+    return _DRIFT if drift["sf_drift"] else _NO_DRIFT
+
+
+def _page_unmeasured(drift: dict) -> None:
+    """The verdict could not be measured. The preopen gate halts on exactly this
+    payload (`Not IsPresent($.drift_result.Payload.sf_drift) -> HandleFailure`),
+    so the whole point of this probe — runway before the 05:15 PT trigger — is
+    to say so now rather than let the session discover it."""
+    message = (
+        f"Preopen deploy-readiness probe (alpha-engine-config-I8142): the "
+        f"deploy-drift verdict is UNMEASURED — the probe could not determine "
+        f"whether the live preopen definition matches what the deploy "
+        f"published, so THE 05:15 PT PREOPEN WILL HALT at DeployDriftGate "
+        f"(its fail-closed branch reads an absent sf_drift). "
+        f"{_ET_PREOPEN_NOTE}. sf_drift_reason={drift.get('sf_drift_reason')!r} "
+        f"sf_definition_reason={drift.get('sf_definition_reason')!r} "
+        f"live_definition_error={drift.get('live_definition_error')!r} "
+        f"sf_sha={drift.get('sf_sha')!r} upstream_sha={drift.get('upstream_sha')!r}. "
+        f"No self-heal was attempted: a deploy dispatch on an unmeasured "
+        f"verdict would act on evidence nobody has. "
+        f"`live_definition_unreadable` means the predictor role could not run "
+        f"states:DescribeStateMachine on the preopen state machine — check the "
+        f"DeployDriftProbe statement of alpha-engine-predictor-inference's role "
+        f"(nous-ergon-ops/infrastructure/iam) before the trigger."
+    )
+    result = alerts.publish(
+        message=message,
+        severity="critical",
+        source="alpha-engine-preopen-deploy-readiness-probe",
+        sns=True,
+        telegram=False,
+        sns_topic_arn=SNS_TOPIC_ARN,
+    )
+    logger.error(
+        "DEPLOY-READINESS-PROBE ALERT: sf_drift UNMEASURED (reason=%s) sns_ok=%s",
+        drift.get("sf_drift_reason"), result.sns.ok,
+    )
+
+
 def _page(drift: dict, self_heal_detail: str) -> None:
     message = (
         f"Preopen deploy-readiness probe (alpha-engine-config-I7800): the "
@@ -273,14 +340,27 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     s3client = boto3.client("s3", region_name=REGION)
 
     drift = _invoke_check_deploy_drift(lam_client)
+    state = _drift_state(drift)
     verdict: dict = {
         "date": str(today),
         "sf_drift_initial": drift.get("sf_drift"),
+        "sf_drift_state_initial": state,
         "cf_drift_initial": drift.get("cf_drift"),
         "drift_initial": drift,
     }
 
-    if not drift.get("sf_drift"):
+    if state == _UNMEASURED:
+        # alpha-engine-config-I8142. `drift.get("sf_drift")` read absence as
+        # clean, so an unmeasured verdict — the very input the preopen gate
+        # halts on — produced action=noop reason=clean and no page, 45 minutes
+        # before the session it had already decided.
+        verdict["action"] = "paged"
+        verdict["reason"] = "unmeasured"
+        _page_unmeasured(drift)
+        _write_verdict(s3client, today, verdict)
+        return verdict
+
+    if state == _NO_DRIFT:
         verdict["action"] = "noop"
         verdict["reason"] = "clean"
         _write_verdict(s3client, today, verdict)
@@ -305,10 +385,19 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         self_heal_detail = dispatch_detail
 
     drift_after = _invoke_check_deploy_drift(lam_client)
+    state_after = _drift_state(drift_after)
     verdict["sf_drift_after_self_heal"] = drift_after.get("sf_drift")
+    verdict["sf_drift_state_after_self_heal"] = state_after
     verdict["drift_after_self_heal"] = drift_after
 
-    if drift_after.get("sf_drift"):
+    if state_after == _UNMEASURED:
+        # I8142, the same collapse on the re-probe: an unmeasured verdict here
+        # is not "the self-heal worked", it is "we no longer know", and the
+        # preopen gate will still halt on it.
+        verdict["action"] = "paged"
+        verdict["reason"] = "unmeasured_after_self_heal"
+        _page_unmeasured(drift_after)
+    elif state_after == _DRIFT:
         verdict["action"] = "paged"
         verdict["reason"] = "still_drifted_after_self_heal"
         _page(drift_after, self_heal_detail)

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py
@@ -164,3 +164,111 @@ class TestVerdictWrite:
 
         _, kwargs = s3_mock.put_object.call_args
         assert kwargs["Key"] == "deploy_readiness/2026-08-21.json"
+
+
+# ── alpha-engine-config-I8142: absence is not clean ──────────────────────────
+#
+# `check_deploy_drift` OMITS `sf_drift` when it could not measure it, and the
+# preopen `DeployDriftGate` halts on exactly that payload. This probe read the
+# same payload with `drift.get("sf_drift")` — falsy — and wrote
+# action=noop reason=clean, 45 minutes before the session it had already
+# decided. The three states must stay three all the way down.
+
+def _unmeasured_payload(**extra) -> dict:
+    """The literal shape the probe emits post-I8142: no `sf_drift` key at all,
+    with the positive state field and the typed cause beside it."""
+    body = {
+        "sf_sha": None,
+        "upstream_sha": "def5678",
+        "sf_drift_state": "unmeasured",
+        "sf_drift_reason": "live_definition_unreadable",
+        "sf_definition_reason": "live_definition_unreadable",
+        "live_definition_error": {
+            "reason": "describe_state_machine_error",
+            "detail": "AccessDeniedException: not authorized",
+        },
+        "cf_drift": False,
+        "cf_drift_reason": "in_sync",
+    }
+    body.update(extra)
+    return body
+
+
+class TestUnmeasuredVerdict:
+    def _run(self, payloads):
+        s3_mock = MagicMock()
+        lam_mock = _lam_client(payloads)
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._dispatch_deploy_infrastructure") as mock_dispatch, \
+             patch("index.alerts.publish") as mock_publish:
+            mock_publish.return_value = MagicMock(sns=MagicMock(ok=True))
+            result = index.handler({}, None)
+        return result, mock_publish, mock_dispatch, s3_mock
+
+    def test_an_unmeasured_verdict_pages_and_is_never_reported_clean(self):
+        result, mock_publish, mock_dispatch, s3_mock = self._run(
+            [_unmeasured_payload()],
+        )
+        assert result["action"] == "paged"
+        assert result["reason"] == "unmeasured"
+        assert result["sf_drift_state_initial"] == "unmeasured"
+        mock_publish.assert_called_once()
+        assert mock_publish.call_args.kwargs["severity"] == "critical"
+        # No self-heal: a deploy dispatch on an unmeasured verdict acts on
+        # evidence nobody has.
+        mock_dispatch.assert_not_called()
+        s3_mock.put_object.assert_called_once()
+
+    def test_the_page_names_the_unreadable_definition_and_the_halt(self):
+        _, mock_publish, _, _ = self._run([_unmeasured_payload()])
+        message = mock_publish.call_args.kwargs["message"]
+        assert "UNMEASURED" in message
+        assert "PREOPEN WILL HALT" in message
+        assert "live_definition_unreadable" in message
+
+    def test_absence_of_the_key_is_unmeasured_without_the_state_field(self):
+        """Rollout safety: a predictor Lambda older than I8142 omits `sf_drift`
+        without emitting `sf_drift_state`. Key presence must still decide."""
+        payload = _unmeasured_payload()
+        payload.pop("sf_drift_state")
+        result, mock_publish, _, _ = self._run([payload])
+        assert result["action"] == "paged"
+        assert result["reason"] == "unmeasured"
+        mock_publish.assert_called_once()
+
+    def test_an_unmeasured_reprobe_is_not_a_self_heal(self):
+        """The same collapse on the second read: after a dispatch, an
+        unmeasured verdict is 'we no longer know', not 'fixed'."""
+        s3_mock = MagicMock()
+        lam_mock = _lam_client([_lambda_payload(sf_drift=True), _unmeasured_payload()])
+
+        def boto_side_effect(service, **kw):
+            return lam_mock if service == "lambda" else s3_mock
+
+        with patch("index.is_trading_day", return_value=True), \
+             patch("index.boto3.client", side_effect=boto_side_effect), \
+             patch("index._dispatch_deploy_infrastructure", return_value=(True, "dispatched ok")), \
+             patch("index._poll_dispatch_conclusion", return_value=("success", "run completed: success")), \
+             patch("index.alerts.publish") as mock_publish:
+            mock_publish.return_value = MagicMock(sns=MagicMock(ok=True))
+            result = index.handler({}, None)
+
+        assert result["action"] == "paged"
+        assert result["reason"] == "unmeasured_after_self_heal"
+        assert result["sf_drift_state_after_self_heal"] == "unmeasured"
+        mock_publish.assert_called_once()
+
+
+class TestDriftStateHelper:
+    def test_the_three_states_are_three(self):
+        assert index._drift_state({"sf_drift": True}) == "drift"
+        assert index._drift_state({"sf_drift": False}) == "no_drift"
+        assert index._drift_state({}) == "unmeasured"
+        # The positive field wins when present — it is the one the producer
+        # states rather than the one a consumer infers.
+        assert index._drift_state({"sf_drift_state": "unmeasured"}) == "unmeasured"


### PR DESCRIPTION
## The defect

`alpha-engine-preopen-deploy-readiness-probe` decided its whole verdict with `drift.get("sf_drift")` — a two-value read of a **three-state** field. `check_deploy_drift` **omits** `sf_drift` when it could not measure it (`alpha-engine-config-I7048`, `I7924`, and now `I8142`), and the preopen `DeployDriftGate` **halts** on exactly that payload:

```json
{ "Not": { "Variable": "$.drift_result.Payload.sf_drift", "IsPresent": true },
  "Next": "HandleFailure" }
```

So on an unmeasured verdict this probe wrote `action=noop, reason=clean`, paged nobody, and returned — 45 minutes before the 05:15 PT session whose outcome that input had already decided. The Lambda exists **for that 45 minutes of runway** (`alpha-engine-config-I7800`); on the one input class it most needed to catch, it reported clean.

Second site, same collapse: after a self-heal dispatch, `drift_after.get("sf_drift")` falsy → `action=self_healed`, no page. An unmeasured re-probe is "we no longer know", not "fixed".

This is the consumer half of the pattern `crucible-predictor-PR546` fixes in the producer — a transport/authorization failure rendered as a definitive negative answer, sixth instance this week and the only one that fails **open**. Fixing the producer alone would have left the collapse standing here, where an omitted key is only as safe as the next `.get()`.

## What changed

- **`_drift_state(drift) -> "drift" | "no_drift" | "unmeasured"`.** It reads the positive `sf_drift_state` field the predictor probe emits post-I8142, and falls back to **key presence** otherwise — so the probe is correct across the rollout window, not only after the predictor Lambda ships. (Covered by a test.)
- **Unmeasured pages critical and does not self-heal.** A `workflow_dispatch` of `deploy-infrastructure.yml` on an unmeasured verdict acts on evidence nobody has. The page names the halt in the literal sentence the operator needs, carries `sf_drift_reason` / `sf_definition_reason` / `live_definition_error`, and points at the predictor role's `DeployDriftProbe` statement — the 2026-08-21 cause.
- **Unmeasured after self-heal pages too**, with its own reason (`unmeasured_after_self_heal`) so the two are distinguishable on the verdict artifact.
- The verdict JSON at `s3://alpha-engine-research/deploy_readiness/{date}.json` gains `sf_drift_state_initial` and `sf_drift_state_after_self_heal`, which is also the surface `alpha-engine-config-I8144`'s §7a.4 observe window is read from.

## Test plan

`infrastructure/lambdas/preopen-deploy-readiness-probe/test_handler.py`, four new cases plus a helper test:
- an unmeasured verdict pages, never reports clean, and never dispatches;
- the page names the unreadable definition and the halt;
- absence of the key alone is unmeasured when `sf_drift_state` is missing (old predictor Lambda);
- an unmeasured re-probe is not a self-heal.

**Revert-failure verified, not assumed:** with the three branch changes reverted, exactly those four fail (4 failed, 7 passed); restored, 11 pass.

Repo suite green locally before pushing: **6365 passed, 17 skipped**.

## Cross-repo

- **`crucible-predictor-PR546`** — the producer: an unreadable live definition now yields UNKNOWN instead of `sf_drift: false`, both live-side verdicts withdrawn together, three states stated positively. **Merge first.**
- **`nousergon-data-PR1506`** — this one, the consumer. Merge second; it handles both payload shapes, so the order is a preference rather than a constraint.
- Independent of `nousergon-data-PR1505` (the EOD gate — different file, no overlap).

Tracker: `alpha-engine-config-I8142`; §7a.4 observe window `alpha-engine-config-I8144`. A closing keyword cannot cross repos, so both are closed by hand.

## Post-merge

Nothing to run. `deploy-preopen-deploy-readiness-probe.yml` auto-deploys this Lambda's code on merge to `main` for this path; the bootstrap path is not reachable from the workflow.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kcq2VbJWrKvqeAP27XjyM
