### PR TITLE
fix(rerun): carry the cadence's own declared skips into a recovery (alpha-engine-config-I8153)

### DIFF
--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -124,6 +124,15 @@ CADENCE_ROLES = frozenset({"daily", "weekly", "eod", "shell-run", "exercise"})
 TERMINAL_STATUSES = frozenset({"SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"})
 RERUNNABLE_SOURCE_STATUSES = frozenset({"FAILED", "TIMED_OUT", "ABORTED"})
 
+# The CADENCE trigger's declared input — the single source of truth for the
+# scheduled run's own skip set (tests/test_saturday_trigger_skip_parity.py
+# pins that this is where it lives, and that a disable here names its
+# re-enable issue).
+_CFN_ORCHESTRATION = (
+    Path(__file__).resolve().parent.parent
+    / "infrastructure" / "cloudformation" / "alpha-engine-orchestration.yaml"
+)
+
 
 # ---------------------------------------------------------------------------
 # Declarative stage table — pinned against infrastructure/step_function.json
@@ -669,6 +678,58 @@ BACKTESTER_OVERSHADOWED = (
 )
 
 
+class CadenceSkipsUnreadable(RuntimeError):
+    """The cadence trigger's declared input could not be read.
+
+    Raised rather than defaulted. An empty cadence-skip set and an unreadable
+    one are the same value and opposite facts: the first says the scheduled run
+    skips nothing, the second says we do not know — and defaulting the second to
+    the first silently re-enables every stage the cadence has deliberately
+    disabled, which is precisely the failure this loader exists to prevent.
+    """
+
+
+def cadence_declared_skips(path: Path = None) -> dict:
+    """The ``skip_*`` flags the SCHEDULED weekly run declares for itself.
+
+    Parsed out of ``SaturdayTrigger.Targets[saturday-pipeline].Input`` in
+    ``infrastructure/cloudformation/alpha-engine-orchestration.yaml`` — the
+    declared source of truth for the cadence input, and the same block
+    ``tests/test_saturday_trigger_skip_parity.py`` reads. Textual rather than
+    via a YAML loader because the value is a ``!Sub`` block scalar whose CFN
+    intrinsics ``yaml.safe_load`` cannot resolve; only ``skip_*`` keys are read,
+    and every ``${...}`` placeholder sits in a value this function ignores.
+    """
+    p = _CFN_ORCHESTRATION if path is None else path
+    try:
+        text = p.read_text()
+    except OSError as e:
+        raise CadenceSkipsUnreadable(f"cannot read {p}: {e}") from e
+    try:
+        start = text.index("SaturdayTrigger:")
+    except ValueError as e:
+        raise CadenceSkipsUnreadable(
+            f"{p} has no SaturdayTrigger resource — the cadence trigger moved "
+            f"or was renamed; retarget this loader rather than defaulting it"
+        ) from e
+    m = re.search(r"\n          Input: !Sub \|\n(.*?)\n\n", text[start:], re.S)
+    if not m:
+        raise CadenceSkipsUnreadable(
+            f"{p}: SaturdayTrigger target Input block not found — the CFN shape "
+            f"changed; retarget this loader rather than defaulting it"
+        )
+    try:
+        payload = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        raise CadenceSkipsUnreadable(
+            f"{p}: SaturdayTrigger Input is not parseable JSON: {e}"
+        ) from e
+    return {
+        k: v for k, v in payload.items()
+        if k.startswith("skip_") and v is True
+    }
+
+
 @dataclass
 class RerunPlan:
     run_date: str
@@ -684,6 +745,10 @@ class RerunPlan:
     # skip_* keys inherited from the source execution's own input, dropped by
     # rerun_input() and reported by the plan printer. See its docstring.
     dropped_inherited_skips: list = field(default_factory=list)
+
+    # skip_* keys the CADENCE trigger declares for itself, re-applied by
+    # rerun_input() and reported separately from the derived set.
+    cadence_skips: list = field(default_factory=list)
 
     def rerun_input(self) -> dict:
         """The emitted StartExecution input.
@@ -709,17 +774,41 @@ class RerunPlan:
         never clear an inherited one. Dropping them is what makes the emitted
         input equal the printed plan. A skip the operator genuinely wants is
         re-passed explicitly, which is also the only form that leaves a record.
+
+        **Except the ones the cadence declares for itself** (2026-08-22,
+        alpha-engine-config-I8153). I7259's rule is right about *ad-hoc* flags
+        and wrong about *declared* ones, and until this change it could not tell
+        them apart. ``skip_parity`` is not an operator's stray flag: it is a
+        standing disable declared in the cadence trigger's own CFN Input under a
+        Brian ruling, with a tracked re-enable issue (I7309) and two blockers
+        that make the stage unable to finish in any budget. Dropping it meant
+        every mechanical rerun of a scheduled run silently RE-ENABLED a stage
+        the cadence has disabled — so ``--start`` launched a doomed parity
+        family, and the operator's only defence was reading a NOTE and
+        hand-editing the emitted JSON. That is three actions and a piece of
+        tribal knowledge against `sf-pipeline-policy.md` §2.5's target of one.
+
+        The distinction is DECLARED versus AD-HOC, not inherited versus derived.
+        Cadence-declared skips are re-applied from their source of truth and
+        printed on their own line; every other inherited flag is still dropped,
+        exactly as I7259 requires. An unreadable declaration RAISES — see
+        ``CadenceSkipsUnreadable``.
         """
         out = {
             k: v for k, v in self.original_input.items()
             if not k.startswith("skip_")
         }
+        declared = cadence_declared_skips()
+        self.cadence_skips = sorted(declared)
         self.dropped_inherited_skips = sorted(
             k for k in self.original_input
-            if k.startswith("skip_") and k not in self.skip_flags
+            if k.startswith("skip_")
+            and k not in self.skip_flags
+            and k not in declared
         )
         out["run_date"] = self.run_date
         out["pipeline_role"] = EMITTED_ROLE
+        out.update(declared)
         out.update(self.skip_flags)
         return out
 
@@ -1133,6 +1222,13 @@ def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str,
     # Populates plan.dropped_inherited_skips as a side effect; call before
     # reporting them.
     _emitted = plan.rerun_input()
+    if plan.cadence_skips:
+        print(
+            f"cadence skips    : {', '.join(plan.cadence_skips)} "
+            "[declared by the scheduled trigger's own CFN Input, re-applied so "
+            "a recovery runs what the cadence runs — NOT derived from what the "
+            "source execution completed]"
+        )
     if plan.dropped_inherited_skips:
         print(
             f"dropped skips    : {', '.join(plan.dropped_inherited_skips)} "

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -1059,3 +1059,62 @@ class TestPredictorSkipFreshness:
             mod.check_predictor_skip_freshness(
                 s3, "2026-08-16", {"skip_predictor_training": True}
             )
+
+
+class TestCadenceDeclaredSkipsAreCarried:
+    """alpha-engine-config-I8153.
+
+    A skip the CADENCE declares for itself is not an operator's stray flag, and
+    dropping it made every mechanical rerun of a scheduled run silently
+    RE-ENABLE a stage the cadence has deliberately disabled. On 2026-08-22 that
+    meant `--start` would have launched the full parity family — a stage
+    alpha-engine-config-I7309 records as unable to finish in any budget — and
+    the only defence was reading a NOTE and hand-editing the emitted JSON.
+    """
+
+    def test_the_cadence_trigger_declares_skip_parity(self, mod):
+        """The loader reads the real CFN, not a fixture: if the declaration
+        moves or is renamed, this fails here rather than at 02:00 on a
+        Saturday."""
+        assert mod.cadence_declared_skips() == {"skip_parity": True}
+
+    def test_the_emitted_input_carries_it(self, mod):
+        plan = mod.derive_plan(_events("director_degraded"))
+        emitted = plan.rerun_input()
+        assert emitted.get("skip_parity") is True, (
+            "the rerun no longer carries the cadence's own skip_parity — a "
+            "recovery would run a stage the scheduled run does not"
+        )
+        assert "skip_parity" in plan.cadence_skips
+
+    def test_it_is_reported_apart_from_the_derived_set(self, mod):
+        """It is NOT derived from what the source execution completed, so it
+        must not read as if it were — the derived set is this script's product
+        and its provenance is the whole reason to trust it."""
+        plan = mod.derive_plan(_events("director_degraded"))
+        plan.rerun_input()
+        assert "skip_parity" not in plan.skip_flags
+        assert "skip_parity" not in plan.dropped_inherited_skips
+
+    def test_a_non_declared_inherited_flag_is_still_dropped(self, mod):
+        """I7259 is unchanged for ad-hoc flags — the new rule splits DECLARED
+        from AD-HOC, it does not re-open inheritance."""
+        plan = mod.derive_plan(_events("director_degraded"))
+        plan.original_input = dict(plan.original_input)
+        plan.original_input["skip_pit_parity_compare"] = True
+        emitted = plan.rerun_input()
+        assert "skip_pit_parity_compare" not in emitted
+        assert "skip_pit_parity_compare" in plan.dropped_inherited_skips
+
+    def test_an_unreadable_declaration_raises_rather_than_defaulting(self, mod, tmp_path):
+        """An empty cadence-skip set and an unreadable one are the same value
+        and opposite facts. Defaulting the second to the first re-enables every
+        stage the cadence disables, silently."""
+        missing = tmp_path / "nope.yaml"
+        with pytest.raises(mod.CadenceSkipsUnreadable):
+            mod.cadence_declared_skips(missing)
+
+        shapeless = tmp_path / "shapeless.yaml"
+        shapeless.write_text("Resources:\n  SomethingElse: {}\n")
+        with pytest.raises(mod.CadenceSkipsUnreadable):
+            mod.cadence_declared_skips(shapeless)


### PR DESCRIPTION
## What & why

`alpha-engine-config-I8153`. Recovering the failed 2026-08-22 scheduled weekly run, `weekly_sf_rerun.py --dry-run` printed:

```
dropped skips    : skip_parity [carried by the source execution's own input, NOT
                   derived from what it completed — re-pass explicitly if still wanted]
```

`skip_parity` is not an operator's stray flag. It is a standing disable declared in the cadence trigger's own CFN Input under Brian's 2026-08-13 ruling, with a tracked re-enable issue (`alpha-engine-config-I7309`) naming two blockers: the walk-forward pass cannot finish inside any budget, and it places zero orders. So `--start` on a failed cadence run **re-enables a stage the cadence has deliberately disabled and that cannot terminate**.

Operator cost against `sf-pipeline-policy.md` §2.5's target of **one** action: run `--dry-run`, notice the NOTE, know why the flag is there (the script does not say), hand-edit the emitted JSON, run the raw `start-execution`. Three actions plus tribal knowledge — and the hand-edited path also bypasses this helper's mutex handling and its name/run_date coupling guard (I7443). That is what I did today, by hand, to get a recovery started.

## The distinction this adds

`rerun_input()` dropped **every** inherited `skip_*` key. That rule is `alpha-engine-config-I7259` and it is correct for *ad-hoc* flags — a hand-added `skip_pit_parity_compare` propagated silently through every subsequent recovery on 2026-08-13. But it cannot tell **declared** from **ad-hoc**, and the real distinction is not inherited-versus-derived: it is whether the flag has a **source of truth outside this execution**.

- `cadence_declared_skips()` reads `skip_*` out of `SaturdayTrigger.Targets[saturday-pipeline].Input` in `infrastructure/cloudformation/alpha-engine-orchestration.yaml` — the same block `tests/test_saturday_trigger_skip_parity.py` already parses, so there is one source of truth and two readers of it.
- Those flags are re-applied and printed on their own `cadence skips` line, **never folded into `derived skips`**: the derived set's provenance is this script's entire product and must not be diluted with something it did not derive.
- Every other inherited flag is still dropped. I7259 is unchanged for ad-hoc flags, and a test pins that.
- An unreadable declaration **raises** `CadenceSkipsUnreadable`. An empty cadence-skip set and an unreadable one are the same value and opposite facts; defaulting the second to the first re-enables every stage the cadence disables, silently — the exact shape of the bug being fixed.

## Verified against the live failure

```
cadence skips    : skip_parity [declared by the scheduled trigger's own CFN Input, ...]
dropped skips    : skip_backtester, skip_portfolio_optimizer_backtest, skip_predictor_backtest [...]
...
"skip_parity": true,
```

## Test plan

- `python3 -m pytest tests/ -q` → **6437 passed, 17 skipped** (full suite, local).
- 5 new tests in `TestCadenceDeclaredSkipsAreCarried`, including one that reads the **real** CFN rather than a fixture — if the declaration moves or is renamed, it fails in CI rather than at 02:00 on a Saturday — and one that pins I7259's ad-hoc drop is intact.

## Out of scope, filed separately

Chained recovery loses the completed set: `--dry-run` defaults to the *latest* FAILED execution, so a second rerun derives from the first rerun's history and re-runs stages the original run had completed (observed today: `skip_backtester` moved from `derived` to `dropped`). Fixing that needs the derivation to union the completed sets across the whole recovery chain for a `run_date`, which is a larger change than this one.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLfcQ6oG8KBy6dT3tMAznY

Rehearsal-path: tests/test_weekly_sf_rerun.py
