### PR TITLE
fix(recovery): derive the weekly rerun from the CHAIN, and stop booting a box no stage uses (alpha-engine-config-I8161, I8162)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -7410,12 +7410,113 @@
     },
     "CheckSpotDispatchNeeded": {
       "Type": "Choice",
-      "Comment": "config#2248 (root-cause fix for the always-on dashboard box SPOF): the 14 downstream sendCommand/Lambda states (MorningEnrich through WeeklySubstrateHealthCheck, plus SubstrateHealthGate's Payload) all key off $.ec2_instance_id. That field is no longer a hardcoded literal in the SaturdayTrigger EventBridge Input or the Friday shell-run trigger Lambda (both stripped by config#2248) \u2014 it is populated HERE, either by an already-present operator/rerun value (this Choice's first branch: scripts/weekly_sf_rerun.py's rerun_input() passes the ORIGINAL failed execution's ec2_instance_id through verbatim, so a watch-rerun reuses the same still-live launcher box instead of paying for a second spot launch) or by a fresh ephemeral spot this Choice's Default branch dispatches via DispatchWeeklyFreshnessSpot. Sits where CheckMutexRole's cadence-acquire path (via AcquireMutex) AND its bypass Default (operator/recovery/non-cadence roles, which skip the mutex entirely) BOTH converge -- so every execution passes through this gate exactly once, regardless of pipeline_role, never burning a spot launch on a mutex conflict -- and BEFORE CheckShellRun / any of the 14 consumer states (nothing may reference $.ec2_instance_id before this gate resolves it).",
+      "Comment": "config#2248 (root-cause fix for the always-on dashboard box SPOF): the 14 downstream sendCommand/Lambda states (MorningEnrich through WeeklySubstrateHealthCheck, plus SubstrateHealthGate's Payload) all key off $.ec2_instance_id. That field is no longer a hardcoded literal in the SaturdayTrigger EventBridge Input or the Friday shell-run trigger Lambda (both stripped by config#2248) — it is populated HERE, either by an already-present operator/rerun value (this Choice's first branch: scripts/weekly_sf_rerun.py's rerun_input() passes the ORIGINAL failed execution's ec2_instance_id through verbatim, so a watch-rerun reuses the same still-live launcher box instead of paying for a second spot launch) or by a fresh ephemeral spot this Choice's Default branch dispatches via DispatchWeeklyFreshnessSpot. Sits where CheckMutexRole's cadence-acquire path (via AcquireMutex) AND its bypass Default (operator/recovery/non-cadence roles, which skip the mutex entirely) BOTH converge -- so every execution passes through this gate exactly once, regardless of pipeline_role, never burning a spot launch on a mutex conflict -- and BEFORE CheckShellRun / any of the 14 consumer states (nothing may reference $.ec2_instance_id before this gate resolves it). alpha-engine-config-I8162 adds the SECOND branch: bypass the dispatch entirely when EVERY stage that SSM-invokes onto $.ec2_instance_id is skipped by this execution's input, landing straight on the same CheckShellRun convergence with no ec2_instance_id at all (nothing downstream dereferences it once all of those stages are gated off). Recovery is exactly when the skip set is largest, so the most often-unnecessary stage was the one that always ran: watch-rerun-2026-08-22-1 spent 4 of its 16 minutes in DispatchWeeklyFreshnessSpot -> WaitForWeeklyFreshnessSpotBootstrap. The conjunction is NOT hand-maintained here: it is DERIVED from scripts/weekly_sf_rerun.py's STAGES table by reachability over this definition (box_dispatch_flags) and pinned to this state by tests/test_weekly_sf_rerun.py::TestSpotDispatchOnlyWhenABoxStageSurvives. Edit it there, never here — the two drifting in the other direction denies a boot to a stage that then SSM-invokes onto a box it does not have, which FAILS a run rather than costing four minutes.",
       "Choices": [
         {
           "Variable": "$.ec2_instance_id",
           "IsPresent": true,
           "Next": "NormalizeEc2InstanceId"
+        },
+        {
+          "And": [
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_morning_enrich",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_morning_enrich",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_data_phase1",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_data_phase1",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_rag_ingestion",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_rag_ingestion",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_data_phase2",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_data_phase2",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_predictor_training",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_predictor_training",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_backtester",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_backtester",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_evaluator",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_evaluator",
+                  "BooleanEquals": true
+                }
+              ]
+            },
+            {
+              "And": [
+                {
+                  "Variable": "$.skip_post_eval",
+                  "IsPresent": true
+                },
+                {
+                  "Variable": "$.skip_post_eval",
+                  "BooleanEquals": true
+                }
+              ]
+            }
+          ],
+          "Next": "CheckShellRun"
         }
       ],
       "Default": "DispatchWeeklyFreshnessSpot"

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -8,8 +8,15 @@ Derives, from a FAILED ``ne-weekly-freshness-pipeline`` execution, the exact
   output — a fresh manual rerun without an explicit run_date gets a NEW date
   stamped from Execution.StartTime and writes to different artifact prefixes,
   orphaning the prior partial run);
-- the derived ``skip_*`` flag set for every stage the failed execution
-  completed CLEANLY (re-running a succeeded side-effecting stage duplicates
+- the derived ``skip_*`` flag set for every stage the recovery CHAIN
+  completed CLEANLY — the scheduled run plus every prior
+  ``watch-rerun-<run_date>-N``, resolved LATEST-ATTEMPT-WINS
+  (alpha-engine-config-I8161: deriving from the latest failed execution alone
+  means deriving from the last RERUN, whose history contains only the stages
+  it did not skip, so each successive recovery lost more of the original
+  run's progress). Read from execution HISTORIES, never from a previous
+  input's flags, which is what keeps it immune to
+  alpha-engine-config-I7259 (re-running a succeeded side-effecting stage duplicates
   its effects — 2026-07-11: duplicate model-zoo promotion emails,
   config#2252). A stage that DEGRADED — ran, failed, and was absorbed by a
   ``Publish*Degraded`` route so the pipeline could continue (alpha-engine-
@@ -95,7 +102,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 # sys.path insertion (not a package import) so this resolves identically
@@ -678,6 +685,210 @@ BACKTESTER_OVERSHADOWED = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Spot-dispatch necessity — which stages actually need the weekly box
+# (alpha-engine-config-I8162)
+# ---------------------------------------------------------------------------
+# Every recovery used to boot a spot instance unconditionally: CheckSpotDispatchNeeded
+# asked only "is $.ec2_instance_id already present?", so a rerun whose derived skip
+# set left no box stage standing still spent ~4 minutes in
+# DispatchWeeklyFreshnessSpot -> WaitForWeeklyFreshnessSpotBootstrap booting a box
+# nothing used (measured on watch-rerun-2026-08-22-1). Recovery is exactly when the
+# skip set is largest, so the most-often-unnecessary stage was the one that always ran.
+#
+# The predicate the SF now carries is DERIVED here rather than hand-listed there, and
+# tests/test_weekly_sf_rerun.py pins the two against each other. Hand-listing would
+# drift in the asymmetric direction: a stage that needs the box behind a flag the SF
+# thinks covers it FAILS the run, where an unnecessary boot only costs four minutes.
+#
+# Nothing below is a literal list of box stages. The box states are found by their
+# reference to $.ec2_instance_id in the live definition; ownership by a skip flag is
+# established by REACHABILITY — a flag owns a box state when setting that flag (and
+# nothing else) makes the state unreachable.
+
+SPOT_DISPATCH_GATE = "CheckSpotDispatchNeeded"
+# The state every path through the dispatch gate converges on: the IsPresent
+# passthrough (via NormalizeEc2InstanceId), the fresh-boot path (via
+# RouteAfterBootstrapSuccess), and the new no-box-stage bypass. Reachability is
+# measured from HERE so the boot machinery's own $.ec2_instance_id references
+# (WaitForWeeklyFreshnessSpotBootstrap et al.) are structurally excluded: they are
+# how the box is acquired, never a reason to acquire it.
+SPOT_DISPATCH_CONVERGENCE = "CheckShellRun"
+
+
+def _flat_states(sm_def: dict) -> dict:
+    """Every state in the definition by name, Parallel branches and Map
+    iterators flattened in (state names are unique across the definition)."""
+    return dict(_walk_states(sm_def.get("States", {})))
+
+
+def _rule_skip_flag(rule: dict) -> str | None:
+    """The single ``skip_*`` key a Choice rule tests, or None if the rule
+    tests anything else (or more than one thing)."""
+    flags = set()
+    other = False
+
+    def rec(node):
+        nonlocal other
+        if not isinstance(node, dict):
+            return
+        var = node.get("Variable")
+        if isinstance(var, str) and var.startswith("$.skip_"):
+            flags.add(var.removeprefix("$."))
+        elif var is not None:
+            other = True
+        for key in ("And", "Or"):
+            for sub in node.get(key, []) or []:
+                rec(sub)
+        if "Not" in node:
+            rec(node["Not"])
+
+    rec(rule)
+    if other or len(flags) != 1:
+        return None
+    return flags.pop()
+
+
+def _reachable_from(sm_def: dict, start: str, flags: dict) -> set:
+    """States reachable from ``start`` when the ``skip_*`` keys in ``flags``
+    are true on the execution input.
+
+    A three-valued walk: a Choice rule testing a flag in ``flags`` is taken
+    definitively (and its Default becomes unreachable); every other branch is
+    UNKNOWN and both arms are followed. Unknown-as-both makes the result an
+    over-approximation of what runs, which is the safe direction for the one
+    question this answers — "could any state that needs the box still run?"
+    An over-approximation can only make the pipeline boot a box it did not
+    need; an under-approximation would deny one a stage then SSM-invokes onto.
+
+    Catch/Retry targets are followed too: a box state reached only from a
+    failure route still needs a box.
+    """
+    states = _flat_states(sm_def)
+    seen: set = set()
+    stack = [start]
+    while stack:
+        name = stack.pop()
+        if name in seen or name not in states:
+            continue
+        seen.add(name)
+        state = states[name]
+        nxt: set = set()
+        if state.get("Type") == "Choice":
+            for rule in state.get("Choices", []):
+                flag = _rule_skip_flag(rule)
+                if flag is not None and flags.get(flag) is True:
+                    nxt.add(rule["Next"])
+                    break          # this rule matches; Default is unreachable
+                if flag is not None and flag in flags:
+                    continue       # known false — this arm cannot be taken
+                nxt.add(rule["Next"])
+            else:
+                if "Default" in state:
+                    nxt.add(state["Default"])
+        else:
+            if "Next" in state:
+                nxt.add(state["Next"])
+        for catch in state.get("Catch", []) or []:
+            if "Next" in catch:
+                nxt.add(catch["Next"])
+        if state.get("Type") == "Parallel":
+            for branch in state.get("Branches", []):
+                if branch.get("StartAt"):
+                    nxt.add(branch["StartAt"])
+        if state.get("Type") == "Map":
+            it = state.get("Iterator") or state.get("ItemProcessor") or {}
+            if it.get("StartAt"):
+                nxt.add(it["StartAt"])
+        stack.extend(nxt)
+    return seen
+
+
+def _states_referencing_instance(sm_def: dict) -> set:
+    """Every state whose own body dereferences ``$.ec2_instance_id`` — the
+    SSM sendCommand / getCommandInvocation pairs and the Lambda payloads that
+    address the box. Read from the definition, never listed."""
+    # Comment is prose; Branches/Iterator/ItemProcessor hold OTHER states, whose
+    # references belong to them and are counted when the walk reaches them —
+    # folding a container's children into the container would make every Parallel
+    # a box state and no skip flag could ever clear it.
+    nested = {"Comment", "Branches", "Iterator", "ItemProcessor"}
+    out = set()
+    for name, state in _flat_states(sm_def).items():
+        body = json.dumps({k: v for k, v in state.items() if k not in nested})
+        if "ec2_instance_id" in body:
+            out.add(name)
+    return out
+
+
+def box_states_needing_dispatch(sm_def: dict, flags: dict | None = None) -> set:
+    """Box-addressing states still reachable past the dispatch gate under
+    ``flags``. Empty => this execution has no use for a spot instance."""
+    reachable = _reachable_from(sm_def, SPOT_DISPATCH_CONVERGENCE, flags or {})
+    return _states_referencing_instance(sm_def) & reachable
+
+
+def box_dispatch_flags(sm_def: dict) -> tuple:
+    """The ``skip_*`` conjunction under which no box-addressing state can run.
+
+    Derived from the definition, never listed. ``STAGES`` supplies the flag
+    universe — it is already pinned against ``infrastructure/step_function.json``
+    by ``tests/test_weekly_sf_rerun.py`` — and the definition decides which of
+    those flags the conjunction needs:
+
+    1. START from every stage flag and PROVE the conjunction sound: with all of
+       them true, no box-addressing state may remain reachable. It raises if one
+       does, because a box stage behind no skip flag must fail the build here
+       rather than be denied a boot it then SSM-invokes onto.
+    2. MINIMISE finest-to-coarsest: drop a flag when the ones that remain still
+       leave zero box states reachable. Every drop is PROVEN redundant by
+       re-running the reachability check, so the surviving conjunction is exactly
+       as strong as the full one — it just spells the condition in the coarse
+       flags a recovery plan actually emits (``skip_backtester`` rather than
+       ``skip_backtester_stage_only`` plus the four parity branch flags).
+
+    Reachability, not topology reading, is what establishes ownership; and
+    because the walk over-approximates (§``_reachable_from``), every flag this
+    returns is genuinely load-bearing for the bypass.
+    """
+    kept = list(dict.fromkeys(s.flag for s in STAGES))
+    uncovered = box_states_needing_dispatch(sm_def, {f: True for f in kept})
+    if uncovered:
+        raise SystemExit(
+            f"FATAL: box-addressing state(s) {sorted(uncovered)} are reachable "
+            f"even with EVERY stage skip flag set — they belong to no skippable "
+            "stage, so CheckSpotDispatchNeeded cannot be given a sound bypass "
+            "predicate. Add the stage's CheckSkip* gate (and its STAGES row) "
+            "before extending the gate."
+        )
+    for flag in reversed(list(kept)):
+        trial = [f for f in kept if f != flag]
+        if not box_states_needing_dispatch(sm_def, {f: True for f in trial}):
+            kept = trial
+    return tuple(kept)
+
+
+def spot_dispatch_bypass_rule(sm_def: dict) -> dict:
+    """The Choice rule ``CheckSpotDispatchNeeded`` carries for the bypass:
+    every box stage skipped => route straight to the convergence, booting
+    nothing. Each conjunct is the repo's canonical
+    ``And[IsPresent, BooleanEquals]`` pair (tests/test_sf_choice_guards.py:
+    an unguarded absent path is a States.Runtime that bypasses the failure
+    normalizers)."""
+    return {
+        "And": [
+            {
+                "And": [
+                    {"Variable": f"$.{flag}", "IsPresent": True},
+                    {"Variable": f"$.{flag}", "BooleanEquals": True},
+                ]
+            }
+            for flag in box_dispatch_flags(sm_def)
+        ],
+        "Next": SPOT_DISPATCH_CONVERGENCE,
+    }
+
+
 class CadenceSkipsUnreadable(RuntimeError):
     """The cadence trigger's declared input could not be read.
 
@@ -749,6 +960,14 @@ class RerunPlan:
     # skip_* keys the CADENCE trigger declares for itself, re-applied by
     # rerun_input() and reported separately from the derived set.
     cadence_skips: list = field(default_factory=list)
+
+    # The recovery CHAIN this plan was derived from, oldest first, source last
+    # (alpha-engine-config-I8161) — and, per stage, WHICH of those executions
+    # witnessed the surviving verdict. Auditability is the property that makes
+    # a derived skip set trustworthy at all: a skip whose evidence cannot be
+    # named is indistinguishable from an inherited flag.
+    chain: list = field(default_factory=list)
+    witnessed_by: dict = field(default_factory=dict)
 
     def rerun_input(self) -> dict:
         """The emitted StartExecution input.
@@ -871,13 +1090,18 @@ def _simulate_reachable_works(flags: dict, original_input: dict) -> set:
     return ran
 
 
-def derive_plan(events: list[dict], start_time: datetime | None = None) -> RerunPlan:
-    entered = entered_states(events)
-    original_input = execution_input(events)
-    run_date, provenance = derive_run_date(events, start_time)
-    plan = RerunPlan(run_date=run_date, run_date_provenance=provenance,
-                     original_input=original_input)
+def classify_stages(entered: set) -> dict:
+    """One execution's verdict per stage: ``"degraded"`` | ``"completed"`` |
+    ``"failed"``. A stage the execution never attempted is ABSENT from the
+    result — "not observed here" and "did not complete" are different facts,
+    and collapsing them is what made a chained recovery lose the original
+    run's progress (alpha-engine-config-I8161).
 
+    Reads only the set of states an execution ENTERED. It never reads an
+    execution's ``skip_*`` input, which is what keeps the chain derivation
+    immune to alpha-engine-config-I7259's flag-propagation trap.
+    """
+    out: dict = {}
     for stage in STAGES:
         if entered & stage.degraded_witness:
             # Ran, failed, absorbed fail-open (Publish*Degraded route): the
@@ -885,21 +1109,98 @@ def derive_plan(events: list[dict], start_time: datetime | None = None) -> Rerun
             # continuing past a degradation is NOT evidence of completion
             # (I6055: the 2026-08-01 Director hard-fail recorded as
             # "post_eval complete", then skipped by the next rerun).
-            plan.degraded.append(stage.name)
-            plan.notes.append(
-                f"{stage.name}: DEGRADED (entered "
-                f"{sorted(entered & stage.degraded_witness)}) — NOT skipped; "
-                "the rerun re-runs it to retry the absorbed failure"
-            )
+            out[stage.name] = "degraded"
         elif entered & stage.witness:
+            out[stage.name] = "completed"
+        elif stage.detect_failure and (
+            stage.work in entered or (entered & stage.historical_work)
+        ):
+            out[stage.name] = "failed"
+    return out
+
+
+def resolve_chain(links: list) -> tuple:
+    """Fold a recovery CHAIN into one verdict per stage, latest attempt wins.
+
+    ``links`` is ``[(label, entered_states), ...]`` in CHRONOLOGICAL order,
+    the source execution last. Returns ``(outcome_by_stage, witness_by_stage)``
+    where the witness names the execution whose history established the
+    surviving verdict.
+
+    alpha-engine-config-I8161. ``weekly_sf_rerun.py`` defaults to the LATEST
+    failed execution, which after one recovery is the RERUN — and a rerun's
+    history contains only the stages it did not skip, so everything the
+    ORIGINAL run completed reads as not-completed. Measured 2026-08-22:
+    ``skip_backtester``, ``skip_predictor_backtest`` and
+    ``skip_portfolio_optimizer_backtest`` moved from *derived skips* (deriving
+    from the scheduled run) to *dropped skips* (deriving from
+    ``watch-rerun-2026-08-22-1``), so a second recovery would have re-run the
+    whole backtester family — hours of spot compute — for stages that had
+    completed cleanly four hours earlier. Each successive recovery lost more of
+    the original run's progress, inverting the point of the helper.
+
+    The completed set is a property of the ``run_date``, not of one execution.
+    LATEST-ATTEMPT-WINS is the resolution rule and it cuts both ways: a stage
+    that completed in run 1 and failed in run 3 must re-run; a stage that
+    completed in run 1 and was never attempted again stays completed.
+
+    This is evidence-based and therefore immune to alpha-engine-config-I7259:
+    it reads execution HISTORIES, never a previous input's flags. Inheriting
+    ``skip_*`` keys propagates a hand-added flag forever; witnessing a state
+    entry cannot, because a flag nobody's execution acted on leaves no trace in
+    any history.
+    """
+    outcome: dict = {}
+    witness: dict = {}
+    for label, entered in links:
+        for name, verdict in classify_stages(entered).items():
+            outcome[name] = verdict
+            witness[name] = label
+    return outcome, witness
+
+
+def derive_plan(
+    events: list[dict],
+    start_time: datetime | None = None,
+    prior_histories: list | None = None,
+    source_label: str = "source execution",
+) -> RerunPlan:
+    """Derive the recovery plan from the source execution, optionally folding
+    in the EARLIER executions of the same ``run_date`` (``prior_histories`` as
+    ``[(label, events), ...]``, chronological). See ``resolve_chain``: without
+    the chain, every recovery after the first loses the original run's
+    progress (alpha-engine-config-I8161).
+    """
+    entered = entered_states(events)
+    original_input = execution_input(events)
+    run_date, provenance = derive_run_date(events, start_time)
+    plan = RerunPlan(run_date=run_date, run_date_provenance=provenance,
+                     original_input=original_input)
+
+    links = [(label, entered_states(evs)) for label, evs in (prior_histories or [])]
+    links.append((source_label, entered))
+    plan.chain = [label for label, _ in links]
+    entered_by_label = dict(links)
+    outcome, plan.witnessed_by = resolve_chain(links)
+
+    for stage in STAGES:
+        verdict = outcome.get(stage.name)
+        if verdict == "degraded":
+            plan.degraded.append(stage.name)
+            saw = plan.witnessed_by[stage.name]
+            plan.notes.append(
+                f"{stage.name}: DEGRADED in {saw} (entered "
+                f"{sorted(entered_by_label[saw] & stage.degraded_witness)}) "
+                "— NOT skipped; the rerun re-runs it to retry the absorbed "
+                "failure"
+            )
+        elif verdict == "completed":
             plan.completed.append(stage.name)
             if stage.emit_skip:
                 plan.skip_flags[stage.flag] = True
             elif stage.note:
                 plan.notes.append(f"{stage.name}: {stage.note}")
-        elif stage.detect_failure and (
-            stage.work in entered or (entered & stage.historical_work)
-        ):
+        elif verdict == "failed":
             plan.failed.append(stage.name)
 
     if not plan.failed and not plan.degraded:
@@ -1112,6 +1413,91 @@ def next_rerun_name(sf, sm_arn: str, run_date: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# The recovery CHAIN (alpha-engine-config-I8161)
+# ---------------------------------------------------------------------------
+# The completed set for a recovery is a property of the RUN_DATE, not of one
+# execution: the scheduled run plus every watch-rerun-<run_date>-N. Deriving
+# from the last link alone loses everything the original run completed, because
+# a rerun's history contains only the stages it did not skip.
+
+# How far either side of run_date a same-run_date execution may have STARTED.
+# The scheduled run stamps run_date from its own UTC start date, and recoveries
+# follow over the next days (a cross-UTC-midnight recovery of a Saturday cycle
+# is routine — alpha-engine-config-I7443). Purely a bound on how many
+# executions get described; the run_date comparison below is what decides
+# membership.
+CHAIN_WINDOW_DAYS_BEFORE = 1
+CHAIN_WINDOW_DAYS_AFTER = 6
+
+
+def chain_candidates(executions: list, run_date: str, source_arn: str, source_start) -> tuple:
+    """Split ``executions`` into (candidates, non_terminal) for the chain of
+    ``run_date``, oldest first.
+
+    A candidate is TERMINAL, is not the source itself, and started no later
+    than the source — the source is the frontier the operator chose (with
+    ``--execution-arn``, deliberately), and evidence from after it is not part
+    of the chain being recovered. Non-terminal executions in the window are
+    returned separately so the caller can say so rather than silently treat a
+    RUNNING execution's partial history as evidence.
+    """
+    lo = date.fromisoformat(run_date) - timedelta(days=CHAIN_WINDOW_DAYS_BEFORE)
+    hi = date.fromisoformat(run_date) + timedelta(days=CHAIN_WINDOW_DAYS_AFTER)
+    cands, non_terminal = [], []
+    for ex in executions:
+        if ex["executionArn"] == source_arn:
+            continue
+        started = ex["startDate"]
+        if not (lo <= started.astimezone(timezone.utc).date() <= hi):
+            continue
+        if source_start is not None and started > source_start:
+            continue
+        (cands if ex["status"] in TERMINAL_STATUSES else non_terminal).append(ex)
+    cands.sort(key=lambda e: e["startDate"])
+    return cands, non_terminal
+
+
+def collect_chain_histories(sf, sm_arn: str, run_date: str, source: dict) -> tuple:
+    """``([(label, events), ...], warnings)`` for every EARLIER terminal
+    execution of ``run_date``, oldest first.
+
+    Fails LOUDLY if a candidate's history cannot be read. A dropped link is not
+    the conservative direction it looks like: a stage that completed in run 1
+    and FAILED in run 2 reverts to "completed" the moment run 2 goes missing,
+    and the recovery then skips a stage that must re-run.
+    """
+    cands, non_terminal = chain_candidates(
+        list_all_executions(sf, sm_arn), run_date,
+        source["executionArn"], source.get("startDate"),
+    )
+    histories, warnings = [], []
+    if non_terminal:
+        warnings.append(
+            "chain: execution(s) "
+            f"{[e['name'] for e in non_terminal]} are non-terminal in this "
+            "run_date's window and were EXCLUDED — a partial history is not "
+            "evidence. Re-derive once they finish."
+        )
+    for ex in cands:
+        if effective_run_date_of(sf, ex) != run_date:
+            continue
+        try:
+            events = fetch_history(sf, ex["executionArn"])
+        except Exception as exc:  # noqa: BLE001 — an unreadable link is a WRONG plan, not a smaller one
+            raise SystemExit(
+                f"FATAL: could not read the execution history of chain member "
+                f"{ex['name']} ({ex['executionArn']}): {exc!r}. Refusing to "
+                "derive a skip set from an INCOMPLETE chain — a missing link "
+                "can silently turn a stage that FAILED in a later run back "
+                "into 'completed' from an earlier one, which is exactly the "
+                "swallow this helper exists to prevent "
+                "(alpha-engine-config-I8161)."
+            ) from exc
+        histories.append((ex["name"], events))
+    return histories, warnings
+
+
+# ---------------------------------------------------------------------------
 # Skip-coherence pre-flight (alpha-engine-config-I7443, sf-pipeline-policy
 # §2.5: "a skip-set that leaves a downstream JSONPath unresolvable must be
 # rejected by the helper, not discovered as a States.Runtime error thirty
@@ -1213,12 +1599,28 @@ def check_predictor_skip_freshness(s3, run_date: str, skip_flags: dict) -> None:
 def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str, sm_arn: str) -> None:
     print(f"source execution : {source_arn} ({source_status})")
     print(f"run_date         : {plan.run_date}  [{plan.run_date_provenance}]")
+    # alpha-engine-config-I8161: the chain, and which link witnessed what. A
+    # derived skip set whose evidence cannot be named is indistinguishable from
+    # an inherited flag, and auditability is the property that makes this
+    # script trustworthy at all.
+    print(f"chain            : {' -> '.join(plan.chain)}")
     print(f"rerun name       : {name}")
     print(f"pipeline_role    : {EMITTED_ROLE}")
     print(f"completed stages : {', '.join(plan.completed) or '(none)'}")
     print(f"degraded stages  : {', '.join(plan.degraded) or '(none)'}")
     print(f"failed stages    : {', '.join(plan.failed) or '(none identified)'}")
     print(f"derived skips    : {', '.join(sorted(plan.skip_flags)) or '(none)'}")
+    for label in plan.chain:
+        seen = [
+            f"{name} ({plan_verdict})"
+            for name, plan_verdict in (
+                *((n, "completed") for n in plan.completed),
+                *((n, "degraded") for n in plan.degraded),
+                *((n, "failed") for n in plan.failed),
+            )
+            if plan.witnessed_by.get(name) == label
+        ]
+        print(f"  witnessed by {label}: {', '.join(seen) or '(nothing that survives)'}")
     # Populates plan.dropped_inherited_skips as a side effect; call before
     # reporting them.
     _emitted = plan.rerun_input()
@@ -1299,7 +1701,21 @@ def main(argv: list | None = None) -> int:
     verify_skip_flags_live(sm_def, EMITTED_ROLE)
 
     events = fetch_history(sf, source_arn)
-    plan = derive_plan(events, start_time=source.get("startDate"))
+    # alpha-engine-config-I8161: derive from the CHAIN of executions sharing
+    # this run_date, not from the source alone. run_date is resolved first
+    # (cheaply, from the source's own history) because it is what defines the
+    # chain's membership.
+    chain_run_date, _prov = derive_run_date(events, source.get("startDate"))
+    prior, chain_warnings = collect_chain_histories(
+        sf, args.state_machine_arn, chain_run_date, source
+    )
+    plan = derive_plan(
+        events,
+        start_time=source.get("startDate"),
+        prior_histories=prior,
+        source_label=source_arn.rsplit(":", 1)[-1],
+    )
+    plan.warnings.extend(chain_warnings)
     name = next_rerun_name(sf, args.state_machine_arn, plan.run_date)
     sm_name = args.state_machine_arn.rsplit(":", 1)[-1]
     source_role = execution_input(events).get("pipeline_role")

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -1118,3 +1118,331 @@ class TestCadenceDeclaredSkipsAreCarried:
         shapeless.write_text("Resources:\n  SomethingElse: {}\n")
         with pytest.raises(mod.CadenceSkipsUnreadable):
             mod.cadence_declared_skips(shapeless)
+
+
+# ---------------------------------------------------------------------------
+# alpha-engine-config-I8161 — chained recovery derives from the CHAIN
+# ---------------------------------------------------------------------------
+
+def _chain_history(entered, *, run_date="2026-08-22", extra_input=None):
+    """A synthetic history: the ExecutionStarted event plus one stateEntered
+    event per name in ``entered`` (order preserved, though nothing reads it)."""
+    inp = {"pipeline_role": "weekly", "run_date": run_date}
+    if extra_input:
+        inp.update(extra_input)
+    events = [{
+        "type": "ExecutionStarted",
+        "executionStartedEventDetails": {"input": json.dumps(inp)},
+    }]
+    events += [
+        {"type": "ChoiceStateEntered", "stateEnteredEventDetails": {"name": n}}
+        for n in entered
+    ]
+    return events
+
+
+# The backtester family is the measured instance (alpha-engine-config-I8161):
+# skip_backtester's skip route jumps straight to CheckSkipEvaluator, so a rerun
+# that honours it enters NONE of the family's witnesses — every stage the
+# ORIGINAL run completed there reads as not-completed in the rerun's own history.
+_RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY = [
+    "InitializeInput", "CheckSkipBacktester", "Backtester",
+    "CheckSkipPredictorBacktest",              # witness: backtester
+    "PredictorBacktest",
+    "CheckSkipPortfolioOptimizerBacktest",     # witness: predictor_backtest
+    "PortfolioOptimizerBacktest",
+    "CheckSkipParity",                         # witness: portfolio_optimizer_backtest
+    "CheckSkipEvaluator", "EvaluatorDiagnostics",   # ... and dies here
+]
+_RUN2_SKIPPED_THEM_AND_DIED_AT_THE_SAME_PLACE = [
+    "InitializeInput", "CheckSkipBacktester",
+    "CheckSkipEvaluator", "EvaluatorDiagnostics",
+]
+
+
+class TestChainedRecoveryKeepsTheOriginalRunsProgress:
+    """alpha-engine-config-I8161.
+
+    ``weekly_sf_rerun.py`` defaults to the LATEST failed execution, which after
+    one recovery is the RERUN — whose history contains only the stages it did
+    not skip. Measured 2026-08-22: ``skip_backtester``,
+    ``skip_predictor_backtest`` and ``skip_portfolio_optimizer_backtest`` moved
+    from *derived skips* (deriving from the scheduled run) to *dropped skips*
+    (deriving from ``watch-rerun-2026-08-22-1``), so a second recovery would
+    have re-run the backtester family — hours of spot compute — for stages that
+    completed cleanly four hours earlier.
+    """
+
+    def test_a_second_recovery_still_skips_what_the_first_run_completed(self, mod):
+        """The guard the issue specifies: run 1 completes A and B then fails at
+        C; run 2 skips A and B and fails at C again; run 3's plan skips A and B.
+        Against the pre-fix single-execution derivation this FAILS — run 2's
+        history witnesses none of them."""
+        plan = mod.derive_plan(
+            _chain_history(_RUN2_SKIPPED_THEM_AND_DIED_AT_THE_SAME_PLACE),
+            prior_histories=[(
+                "scheduled-run",
+                _chain_history(_RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY),
+            )],
+            source_label="watch-rerun-2026-08-22-1",
+        )
+        assert plan.failed == ["evaluator"]
+        for flag in (
+            "skip_backtester",
+            "skip_predictor_backtest",
+            "skip_portfolio_optimizer_backtest",
+        ):
+            assert plan.skip_flags.get(flag) is True, (
+                f"{flag} was completed by the scheduled run and never attempted "
+                "again — a second recovery must not re-burn it"
+            )
+
+    def test_the_source_alone_would_lose_them(self, mod):
+        """The same source execution WITHOUT the chain — the measured pre-fix
+        behaviour, kept as the contrast that makes the fix legible."""
+        plan = mod.derive_plan(_chain_history(_RUN2_SKIPPED_THEM_AND_DIED_AT_THE_SAME_PLACE))
+        assert "skip_backtester" not in plan.skip_flags
+        assert "skip_predictor_backtest" not in plan.skip_flags
+
+    def test_latest_attempt_wins_when_a_completed_stage_later_fails(self, mod):
+        """A stage that completed in run 1 and FAILED in run 3 must re-run —
+        the chain is a union resolved by recency, never a monotone union of
+        completions."""
+        plan = mod.derive_plan(
+            _chain_history([
+                "InitializeInput", "CheckSkipBacktester", "Backtester",
+                # no CheckSkipPredictorBacktest: Backtester ran and died
+            ]),
+            prior_histories=[(
+                "scheduled-run",
+                _chain_history(_RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY),
+            )],
+            source_label="watch-rerun-2026-08-22-1",
+        )
+        assert "backtester" in plan.failed
+        assert "skip_backtester" not in plan.skip_flags
+        assert plan.witnessed_by["backtester"] == "watch-rerun-2026-08-22-1"
+
+    def test_an_unattempted_stage_keeps_the_earlier_verdict(self, mod):
+        """...and the other direction: completed in run 1, never attempted
+        again, stays completed — with the earlier run named as the witness."""
+        plan = mod.derive_plan(
+            _chain_history(_RUN2_SKIPPED_THEM_AND_DIED_AT_THE_SAME_PLACE),
+            prior_histories=[(
+                "scheduled-run",
+                _chain_history(_RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY),
+            )],
+            source_label="watch-rerun-2026-08-22-1",
+        )
+        assert plan.witnessed_by["backtester"] == "scheduled-run"
+        assert plan.witnessed_by["evaluator"] == "watch-rerun-2026-08-22-1"
+        assert plan.chain == ["scheduled-run", "watch-rerun-2026-08-22-1"]
+
+    def test_a_degraded_stage_in_a_later_link_beats_an_earlier_completion(self, mod):
+        """I6055's rule composes with the chain: degraded is re-run, and a
+        LATER degradation overrides an earlier clean completion."""
+        plan = mod.derive_plan(
+            _chain_history([
+                "InitializeInput", "CheckSkipBacktester", "Backtester",
+                "CheckSkipPredictorBacktest", "PredictorBacktest",
+                "CheckSkipPortfolioOptimizerBacktest",
+                "PortfolioOptimizerBacktest", "CheckSkipParity",
+                "CheckSkipEvaluator", "EvaluatorDiagnostics",
+                "CheckSkipPostEval", "SaturdayHealthCheck",
+                "SaturdayHealthCheckDegraded",
+            ]),
+            prior_histories=[(
+                "scheduled-run",
+                _chain_history(
+                    _RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY
+                    + ["CheckSkipPostEval", "SaturdayHealthCheck", "CheckShellRunNotify"]
+                ),
+            )],
+            source_label="watch-rerun-2026-08-22-1",
+        )
+        assert "post_eval" in plan.degraded
+        assert "post_eval" not in plan.completed
+
+    def test_the_chain_reads_histories_never_a_previous_inputs_flags(self, mod):
+        """Immunity to alpha-engine-config-I7259 is structural, not a rule the
+        chain has to remember: a hand-added ``skip_*`` on an EARLIER execution's
+        input leaves no trace in any history, so it cannot propagate."""
+        plan = mod.derive_plan(
+            _chain_history(_RUN2_SKIPPED_THEM_AND_DIED_AT_THE_SAME_PLACE),
+            prior_histories=[(
+                "scheduled-run",
+                _chain_history(
+                    _RUN1_COMPLETED_THROUGH_THE_BACKTESTER_FAMILY,
+                    extra_input={"skip_rationale_clustering": True},
+                ),
+            )],
+            source_label="watch-rerun-2026-08-22-1",
+        )
+        assert "skip_rationale_clustering" not in plan.skip_flags
+        assert "rationale_clustering" not in plan.completed
+
+
+class TestChainMembership:
+    """Which executions the chain is built FROM — pure, so the membership rule
+    is testable without AWS."""
+
+    @staticmethod
+    def _ex(name, day, hour, status="FAILED"):
+        return {
+            "executionArn": f"arn:aws:states:us-east-1:1:execution:sm:{name}",
+            "name": name,
+            "status": status,
+            "startDate": datetime(2026, 8, day, hour, tzinfo=timezone.utc),
+        }
+
+    def test_earlier_terminal_executions_are_candidates_oldest_first(self, mod):
+        source = self._ex("watch-rerun-2026-08-22-2", 22, 15)
+        execs = [
+            source,
+            self._ex("watch-rerun-2026-08-22-1", 22, 14),
+            self._ex("scheduled", 22, 9, status="FAILED"),
+        ]
+        cands, non_terminal = mod.chain_candidates(
+            execs, "2026-08-22", source["executionArn"], source["startDate"]
+        )
+        assert [e["name"] for e in cands] == ["scheduled", "watch-rerun-2026-08-22-1"]
+        assert non_terminal == []
+
+    def test_the_source_is_the_frontier(self, mod):
+        """An execution that started AFTER the source is not part of the chain
+        being recovered — with --execution-arn the operator chose that frontier
+        deliberately."""
+        source = self._ex("watch-rerun-2026-08-22-1", 22, 14)
+        later = self._ex("watch-rerun-2026-08-22-2", 22, 15)
+        cands, _ = mod.chain_candidates(
+            [source, later], "2026-08-22", source["executionArn"], source["startDate"]
+        )
+        assert cands == []
+
+    def test_a_running_execution_is_excluded_and_reported(self, mod):
+        """A partial history is not evidence — and its exclusion is said out
+        loud rather than inferred from a shorter skip set."""
+        source = self._ex("watch-rerun-2026-08-22-2", 22, 15)
+        running = self._ex("watch-rerun-2026-08-22-1", 22, 14, status="RUNNING")
+        cands, non_terminal = mod.chain_candidates(
+            [source, running], "2026-08-22",
+            source["executionArn"], source["startDate"],
+        )
+        assert cands == []
+        assert [e["name"] for e in non_terminal] == ["watch-rerun-2026-08-22-1"]
+
+    def test_a_far_older_cycle_is_out_of_the_window(self, mod):
+        source = self._ex("watch-rerun-2026-08-22-1", 22, 14)
+        old = self._ex("scheduled-prev-week", 15, 9)
+        cands, _ = mod.chain_candidates(
+            [source, old], "2026-08-22", source["executionArn"], source["startDate"]
+        )
+        assert cands == []
+
+
+# ---------------------------------------------------------------------------
+# alpha-engine-config-I8162 — no spot boot when no box stage survives
+# ---------------------------------------------------------------------------
+
+def _rule_matches(rule: dict, flags: dict) -> bool:
+    """Evaluate one Choice rule (nested And of IsPresent/BooleanEquals pairs,
+    or the bare IsPresent passthrough) against an execution input."""
+    if "And" in rule:
+        return all(_rule_matches(sub, flags) for sub in rule["And"])
+    var = rule["Variable"].removeprefix("$.")
+    if "IsPresent" in rule:
+        return (var in flags) is rule["IsPresent"]
+    if "BooleanEquals" in rule:
+        return flags.get(var) is rule["BooleanEquals"]
+    raise AssertionError(f"unhandled comparison in {rule}")
+
+
+def _dispatch_gate_next(state: dict, flags: dict) -> str:
+    for rule in state["Choices"]:
+        if _rule_matches(rule, flags):
+            return rule["Next"]
+    return state["Default"]
+
+
+class TestSpotDispatchOnlyWhenABoxStageSurvives:
+    """alpha-engine-config-I8162.
+
+    ``watch-rerun-2026-08-22-1`` spent 07:25:26 -> 07:29:29 PT — 4 of the run's
+    16 minutes — in ``DispatchWeeklyFreshnessSpot`` ->
+    ``WaitForWeeklyFreshnessSpotBootstrap``. Recovery is exactly when the skip
+    set is largest, so the most often-unnecessary stage was the one that always
+    ran.
+
+    The predicate is DERIVED from ``STAGES`` by reachability over the live
+    definition, never hand-listed in the SF: hand-listing drifts in the
+    asymmetric direction, where the pipeline denies a boot to a stage that then
+    SSM-invokes onto a box it does not have — which FAILS a run rather than
+    costing four minutes.
+    """
+
+    def test_the_sf_branch_is_exactly_the_derived_predicate(self, mod, sf_def):
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        assert gate["Choices"][1] == mod.spot_dispatch_bypass_rule(sf_def), (
+            "CheckSpotDispatchNeeded's bypass branch has drifted from "
+            "scripts/weekly_sf_rerun.py::spot_dispatch_bypass_rule — regenerate "
+            "it there rather than hand-editing the definition"
+        )
+
+    def test_the_passthrough_branch_and_default_are_unchanged(self, mod, sf_def):
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        assert gate["Choices"][0] == {
+            "Variable": "$.ec2_instance_id",
+            "IsPresent": True,
+            "Next": "NormalizeEc2InstanceId",
+        }
+        assert gate["Default"] == "DispatchWeeklyFreshnessSpot"
+        assert len(gate["Choices"]) == 2
+
+    def test_every_flag_in_the_branch_is_a_real_stage_flag(self, mod, sf_def):
+        flags = mod.box_dispatch_flags(sf_def)
+        assert set(flags) <= {s.flag for s in mod.STAGES}
+        assert flags, "the box-stage set cannot be empty — this SF runs on a box"
+
+    def test_skipping_every_box_stage_routes_past_the_dispatch(self, mod, sf_def):
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        flags = {f: True for f in mod.box_dispatch_flags(sf_def)}
+        assert _dispatch_gate_next(gate, flags) == mod.SPOT_DISPATCH_CONVERGENCE
+
+    @pytest.mark.parametrize("held_back", range(8))
+    def test_leaving_any_one_box_stage_unskipped_still_dispatches(
+        self, mod, sf_def, held_back
+    ):
+        """The asymmetric direction, one stage at a time: a run that still has
+        a box stage to execute must still get a box."""
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        derived = mod.box_dispatch_flags(sf_def)
+        if held_back >= len(derived):
+            pytest.skip("fewer box stages than the parametrization covers")
+        flags = {f: True for f in derived if f != derived[held_back]}
+        assert _dispatch_gate_next(gate, flags) == "DispatchWeeklyFreshnessSpot", (
+            f"{derived[held_back]} is unskipped — that stage SSM-invokes onto "
+            "$.ec2_instance_id and the run would fail without a box"
+        )
+
+    def test_the_predicate_is_sound_against_the_definition_itself(self, mod, sf_def):
+        """Not just 'the two files agree' — with the derived flags set, NO state
+        that dereferences $.ec2_instance_id is reachable past the gate, and
+        dropping any one of them puts at least one back."""
+        derived = mod.box_dispatch_flags(sf_def)
+        assert mod.box_states_needing_dispatch(
+            sf_def, {f: True for f in derived}
+        ) == set()
+        for flag in derived:
+            partial = {f: True for f in derived if f != flag}
+            assert mod.box_states_needing_dispatch(sf_def, partial), (
+                f"{flag} is redundant — box_dispatch_flags must not emit a "
+                "conjunct that carries no coverage"
+            )
+
+    def test_a_present_ec2_instance_id_still_wins(self, mod, sf_def):
+        """The rerun helper passes a still-live launcher box through verbatim;
+        that branch must keep precedence over the new bypass."""
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        flags = {f: True for f in mod.box_dispatch_flags(sf_def)}
+        flags["ec2_instance_id"] = "i-abc"
+        assert _dispatch_gate_next(gate, flags) == "NormalizeEc2InstanceId"


### PR DESCRIPTION
## What & why

Two recovery-path defects in the weekly freshness pipeline, both measured on `watch-rerun-2026-08-22-1`.

**`alpha-engine-config-I8161` — a chained recovery lost the original run's progress.** `weekly_sf_rerun.py` defaults to the LATEST failed execution, which after one recovery is the RERUN — whose history contains only the stages it did not skip, so everything the ORIGINAL run completed reads as not-completed. Measured: `skip_backtester`, `skip_predictor_backtest` and `skip_portfolio_optimizer_backtest` moved from `derived skips` (deriving from the scheduled run) to `dropped skips` (deriving from `watch-rerun-2026-08-22-1`). A second recovery would have re-burnt the backtester family — hours of spot compute — for stages that completed cleanly four hours earlier.

The completed set is a property of the **`run_date`**, not of one execution. The helper now enumerates every terminal execution of that `run_date` up to and including the source (the scheduled run plus every prior `watch-rerun-<run_date>-N`), classifies each history independently, and folds them **latest-attempt-wins**: completed in run 1 then failed in run 3 must re-run; completed in run 1 and never attempted again stays completed. Per-stage provenance names the execution that witnessed each verdict and the plan printer prints it — a derived skip whose evidence cannot be named is indistinguishable from an inherited flag, and auditability is the property that makes this script trustworthy at all.

Immunity to `alpha-engine-config-I7259` is **structural, not a rule the code has to remember**: the chain reads execution HISTORIES, never a previous input's `skip_*` keys, and a hand-added flag nobody's execution acted on leaves no trace in any history. An unreadable chain link **raises** rather than silently shrinking the chain — a dropped link can turn a stage that FAILED in a later run back into "completed" from an earlier one, which is the swallow the helper exists to prevent. Non-terminal executions in the window are excluded and **said out loud** rather than treated as partial evidence.

**`alpha-engine-config-I8162` — every recovery booted a spot instance for stages that were skipped.** `CheckSpotDispatchNeeded` asked only whether `$.ec2_instance_id` was already present, so the rerun spent 07:25:26 → 07:29:29 PT — 4 of its 16 minutes — in `DispatchWeeklyFreshnessSpot` → `WaitForWeeklyFreshnessSpotBootstrap`. Recovery is exactly when the skip set is largest, so the most often-unnecessary stage was the one that always ran. The state now carries a second branch: bypass the dispatch entirely when **every** stage that SSM-invokes onto `$.ec2_instance_id` is skipped by this execution's input, landing on the same `CheckShellRun` convergence with no instance id at all.

### Keeping the SF predicate and the `STAGES` table from drifting

The conjunction is **derived, never hand-listed in the SF**. `box_dispatch_flags()` in `scripts/weekly_sf_rerun.py`:

1. finds the box-addressing states by their reference to `$.ec2_instance_id` **in the definition** (no list of state names anywhere), measured from `CheckShellRun` so the boot machinery's own references are structurally excluded — that is how the box is acquired, never a reason to acquire it;
2. establishes ownership by **reachability** — a flag owns a box state when setting that flag alone makes the state unreachable — with `STAGES` supplying only the flag universe, which is already pinned against the definition by `TestStageTableLockstep`;
3. **proves the full conjunction sound** (with every stage flag set, zero box states reachable) and raises otherwise, so a new box stage behind no skip flag fails the build;
4. **minimises finest-to-coarsest**, dropping a flag only when re-running the reachability check proves the remainder still covers everything — which is what turns `skip_backtester_stage_only` plus four parity branch flags into the coarse `skip_backtester` a recovery plan actually emits.

`TestSpotDispatchOnlyWhenABoxStageSurvives` then pins `CheckSpotDispatchNeeded.Choices[1]` to `spot_dispatch_bypass_rule(sf_def)` byte-for-byte, and separately asserts the predicate is sound *against the definition itself* — not merely that the two files agree. The asymmetric direction (denying a boot to a stage that then SSM-invokes onto a box it does not have FAILS a run, where an unnecessary boot costs four minutes) is guarded one stage at a time: holding back any single conjunct must still dispatch.

Derived set (8 conjuncts): `skip_morning_enrich`, `skip_data_phase1`, `skip_rag_ingestion`, `skip_data_phase2`, `skip_predictor_training`, `skip_backtester`, `skip_evaluator`, `skip_post_eval`.

## SOTA and delta

SOTA for both: derive the fact from the artifact that already carries it, and guard the derivation rather than the transcription — the chain from execution histories (the only evidence immune to flag propagation), the dispatch predicate from the definition's own graph. No delta on either. The reachability walk deliberately **over-approximates** unknown branches, so its only possible error is booting a box that was not needed.

## Corrected premise in `alpha-engine-config-I8162` — and a gating follow-up

`I8162` states that on `watch-rerun-2026-08-22-1` "every stage that runs on the weekly spot instance was skipped". Read live, that is **wrong**: the execution entered `SaturdayHealthCheck` and `WeeklySubstrateHealthCheck`, both `ssm:sendCommand` onto `$.ec2_instance_id`. Two surviving stages used the box that was booted.

The fix is still correct and is the right layer, but it **cannot fire from a helper-generated recovery input today**: `skip_post_eval` is a required conjunct (it is the only flag covering the health checks) and the `post_eval` `STAGES` row carries `emit_skip=False` deliberately, per config#6054. Filed as **`alpha-engine-config-I8167`** (P1, `complexity:mid`) with the two decision-shaped options and a recommendation; deliberately not resolved here, because reversing config#6054's documented position is its own change with its own rationale.

## Merge order

**`nousergon-data-PR1508` first** (`fix/rerun-carries-cadence-skips-260822`, `alpha-engine-config-I8153`) — this branch is cut from it and carries its commit. Nothing from PR1508 is reverted or re-implemented: `cadence_declared_skips()`, `CadenceSkipsUnreadable`, `RerunPlan.cadence_skips`, the `cadence skips` printer line and `TestCadenceDeclaredSkipsAreCarried` are all untouched and still pass. If PR1508 merges first this rebases to nothing; merging this one first would land PR1508's diff under the wrong issue reference.

## Test plan

- Full suite **before** opening: `python3 -m pytest tests/ -q` → **6461 passed, 17 skipped** in 110s. No pre-existing failures surfaced.
- `tests/test_weekly_sf_rerun.py` → 85 passed (61 before, 24 added).
- **The new guards fail against the base branch**: checked out `origin/fix/rerun-carries-cadence-skips-260822`'s `scripts/weekly_sf_rerun.py` and `infrastructure/step_function.json` under the new tests → **23 failed, 1 passed**. The `I8161` guard the issue specifies (`test_a_second_recovery_still_skips_what_the_first_run_completed` — run 1 completes A and B then fails at C; run 2 skips A and B and fails at C; run 3's plan must skip A and B) is among them, and `test_the_source_alone_would_lose_them` keeps the pre-fix behaviour as the contrast.
- SF definition validated against AWS exactly as `deploy-infrastructure.sh` does: `aws stepfunctions validate-state-machine-definition --type STANDARD` → `{"result": "OK", "diagnostics": []}`. Existing SF lockstep/wiring/choice-guard suites green (`Choices[0]` and `Default` deliberately unchanged, so the states pinned by `test_sf_morning_enrich_split_wiring.py` and `test_sf_friday_shell_run_wiring.py` are untouched); each new conjunct is the repo's canonical `And[IsPresent, BooleanEquals]` pair per `test_sf_choice_guards.py`.
- **Live rehearsal, read-only**: `scripts/weekly_sf_rerun.py --dry-run --execution-arn ...:watch-rerun-2026-08-22-1` against production. It prints `chain : 1ed4d68f-...-63c393d65199 -> watch-rerun-2026-08-22-1` and now derives `skip_backtester`, `skip_predictor_backtest` and `skip_portfolio_optimizer_backtest`, each attributed to the scheduled run — the exact three flags the issue measured being lost. Nothing was started or mutated.

Rehearsal-path: tests/test_weekly_sf_rerun.py


---

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
