### PR TITLE
fix(sf): introduce EXECUTION_RUN_DATE, a never-normalized run_date carrier (alpha-engine-config-I8155)

### DIFF
--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -582,11 +582,12 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "stage_coverage": _assert_stage_coverage(
             "RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot",
             started,
+            str(event.get("run_date", "")).strip() or None,
         ),
     }
 
 
-def _assert_stage_coverage(stage: str, started: datetime.datetime) -> dict:
+def _assert_stage_coverage(stage: str, started: datetime.datetime, run_date: str | None) -> dict:
     """Record this stage's own output verdict (alpha-engine-config-I7214).
 
     Both stages this Lambda backs are INFRASTRUCTURE/GATE stages: they
@@ -599,10 +600,21 @@ def _assert_stage_coverage(stage: str, started: datetime.datetime) -> dict:
     Never alters the handler's outcome. The ImportError branch is loud rather
     than silent because the nousergon-lib pin may predate the module, and an
     inert assertion must be distinguishable from a covered stage.
+
+    ``run_date`` comes from the state's ``Payload.run_date.$: "$.run_date"``
+    (alpha-engine-config-I8155 — DispatchWeeklyFreshnessSpot and
+    RelaunchWeeklyFreshnessSpot previously passed a narrow Payload with no
+    run_date at all, so this verdict has been writing under an empty
+    run_date since I7214 shipped). Never fabricated: a missing/blank
+    run_date is reported UNMEASURED rather than defaulting to any derived
+    date — inventing one here is exactly the defect I8155 fixes.
     """
+    if not run_date:
+        logger.error("stage-coverage assertion has no run_date for %s — event carried none", stage)
+        return {"stage": stage, "status": "UNMEASURED", "reason": "no run_date on state input"}
     try:
         from krepis.stage_coverage import assert_stage_coverage
     except ImportError as exc:
         logger.error("stage-coverage assertion unavailable for %s: %s", stage, exc)
         return {"stage": stage, "status": "UNMEASURED", "reason": str(exc)}
-    return assert_stage_coverage(stage, window_start=started)
+    return assert_stage_coverage(stage, window_start=started, run_date=run_date)

--- a/infrastructure/lambdas/weekly-preflight/index.py
+++ b/infrastructure/lambdas/weekly-preflight/index.py
@@ -139,11 +139,11 @@ def handler(event: dict, context) -> dict:
         "skip_count": len(skip_results),
         "ran_count": ran_count,
         "results": result_dicts,
-        "stage_coverage": _assert_stage_coverage("WeeklyPreflight", started),
+        "stage_coverage": _assert_stage_coverage("WeeklyPreflight", started, run_date),
     }
 
 
-def _assert_stage_coverage(stage: str, started: datetime) -> dict:
+def _assert_stage_coverage(stage: str, started: datetime, run_date: str | None) -> dict:
     """Record this stage's own output verdict (alpha-engine-config-I7214).
 
     `WeeklyPreflight` is an INFRASTRUCTURE/GATE stage: it positively declares
@@ -158,10 +158,22 @@ def _assert_stage_coverage(stage: str, started: datetime) -> dict:
     ImportError branch is loud rather than silent because the nousergon-lib
     pin may predate the module, and an inert assertion must be distinguishable
     from a covered stage.
+
+    ``run_date`` comes from the state input (``$.run_date`` — the SF Task
+    passes ``Payload.$="$"`` so ``event`` already carries it, alpha-engine-
+    config-I8155). Never fabricated: a missing/blank run_date is reported
+    UNMEASURED rather than defaulting to any derived date, because a stage
+    that invents its own timestamp is exactly the defect this mechanism
+    exists to catch (alpha-engine-config-I8155 — EXECUTION_RUN_DATE is
+    deliberately the ONLY carrier, never $RUN_DATE, which other launchers in
+    the fleet reassign to the trading day).
     """
+    if not run_date:
+        print(f"ERROR: stage-coverage assertion has no run_date for {stage} — event carried none")
+        return {"stage": stage, "status": "UNMEASURED", "reason": "no run_date on state input"}
     try:
         from krepis.stage_coverage import assert_stage_coverage
     except ImportError as exc:
         print(f"ERROR: stage-coverage assertion unavailable for {stage}: {exc}")
         return {"stage": stage, "status": "UNMEASURED", "reason": str(exc)}
-    return assert_stage_coverage(stage, window_start=started)
+    return assert_stage_coverage(stage, window_start=started, run_date=run_date)

--- a/infrastructure/spot_data_phase1.sh
+++ b/infrastructure/spot_data_phase1.sh
@@ -155,6 +155,12 @@ emit_heartbeat
 # See spot_morning_enrich.sh for the full rationale. OBSERVE MODE — the CLI
 # exits 0 for every verdict, and `|| echo ... >&2` rather than `|| true` keeps
 # an unreachable assertion distinguishable from a covered stage.
-"$LIB_PYTHON" -m krepis.stage_coverage assert --stage DataPhase1 --window-start "$_STAGE_WINDOW_START" || echo "WARNING: stage-coverage assertion did not run for DataPhase1 (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
+# --run-date is explicit ($EXECUTION_RUN_DATE, not $RUN_DATE): this launcher
+# never receives RUN_DATE at all, and even where RUN_DATE does exist elsewhere
+# in the fleet it is reassigned to the trading day by crucible-backtester's
+# infrastructure/_spot_common.sh — a carrier other code rewrites is exactly the
+# defect alpha-engine-config-I8155 fixes. EXECUTION_RUN_DATE is exported by
+# step_function.json from $.run_date and is never normalized by anything.
+"$LIB_PYTHON" -m krepis.stage_coverage assert --stage DataPhase1 --window-start "$_STAGE_WINDOW_START" --run-date "$EXECUTION_RUN_DATE" || echo "WARNING: stage-coverage assertion did not run for DataPhase1 (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
 
 echo "==> DataPhase1 complete."

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -1132,7 +1132,15 @@ PHASE2_ONLY
     # rather than `|| true` deliberately — a bare `|| true` would make an
     # unreachable assertion indistinguishable from a covered stage, which is
     # the exact silence this mechanism exists to remove.
-    "$LIB_PYTHON" -m krepis.stage_coverage assert --stage DataPhase2 --window-start "$_STAGE_WINDOW_START" || echo "WARNING: stage-coverage assertion did not run for DataPhase2 (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
+    #
+    # --run-date is explicit ($EXECUTION_RUN_DATE, not $RUN_DATE): this
+    # launcher never receives RUN_DATE at all, and even where RUN_DATE does
+    # exist elsewhere in the fleet it is reassigned to the trading day by
+    # crucible-backtester's infrastructure/_spot_common.sh — a carrier other
+    # code rewrites is exactly the defect alpha-engine-config-I8155 fixes.
+    # EXECUTION_RUN_DATE is exported by step_function.json from $.run_date
+    # and is never normalized by anything.
+    "$LIB_PYTHON" -m krepis.stage_coverage assert --stage DataPhase2 --window-start "$_STAGE_WINDOW_START" --run-date "$EXECUTION_RUN_DATE" || echo "WARNING: stage-coverage assertion did not run for DataPhase2 (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
     exit 0
 fi
 

--- a/infrastructure/spot_morning_enrich.sh
+++ b/infrastructure/spot_morning_enrich.sh
@@ -159,6 +159,13 @@ emit_heartbeat
 # assertion indistinguishable from a covered stage, which is the exact silence
 # this mechanism exists to remove. Promotion to enforcing is one flag
 # (`--enforce`), guarded by tests/test_spot_stage_coverage_assertions.py.
-"$LIB_PYTHON" -m krepis.stage_coverage assert --stage MorningEnrich --window-start "$_STAGE_WINDOW_START" || echo "WARNING: stage-coverage assertion did not run for MorningEnrich (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
+#
+# --run-date is explicit ($EXECUTION_RUN_DATE, not $RUN_DATE): this launcher
+# never receives RUN_DATE at all, and even where RUN_DATE does exist elsewhere
+# in the fleet it is reassigned to the trading day by crucible-backtester's
+# infrastructure/_spot_common.sh — a carrier other code rewrites is exactly the
+# defect alpha-engine-config-I8155 fixes. EXECUTION_RUN_DATE is exported by
+# step_function.json from $.run_date and is never normalized by anything.
+"$LIB_PYTHON" -m krepis.stage_coverage assert --stage MorningEnrich --window-start "$_STAGE_WINDOW_START" --run-date "$EXECUTION_RUN_DATE" || echo "WARNING: stage-coverage assertion did not run for MorningEnrich (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
 
 echo "==> Morning-enrich complete."

--- a/infrastructure/spot_rag_ingestion.sh
+++ b/infrastructure/spot_rag_ingestion.sh
@@ -210,6 +210,13 @@ emit_heartbeat
 # product is rows in the pgvector corpus, which is not an S3 key; the registry
 # declares its two registerable artifacts (rag_corpus_freshness,
 # rag_ingestion_progress) and this asserts exactly those. OBSERVE MODE.
-"$LIB_PYTHON" -m krepis.stage_coverage assert --stage RAGIngestion --window-start "$_STAGE_WINDOW_START" || echo "WARNING: stage-coverage assertion did not run for RAGIngestion (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
+#
+# --run-date is explicit ($EXECUTION_RUN_DATE, not $RUN_DATE): this launcher
+# never receives RUN_DATE at all, and even where RUN_DATE does exist elsewhere
+# in the fleet it is reassigned to the trading day by crucible-backtester's
+# infrastructure/_spot_common.sh — a carrier other code rewrites is exactly the
+# defect alpha-engine-config-I8155 fixes. EXECUTION_RUN_DATE is exported by
+# step_function.json from $.run_date and is never normalized by anything.
+"$LIB_PYTHON" -m krepis.stage_coverage assert --stage RAGIngestion --window-start "$_STAGE_WINDOW_START" --run-date "$EXECUTION_RUN_DATE" || echo "WARNING: stage-coverage assertion did not run for RAGIngestion (rc=$?) — observe mode, stage NOT failed (config-I7214)" >&2
 
 echo "==> RAG ingestion complete."

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -43,7 +43,8 @@
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
         "Payload": {
-          "action": "check_weekly_run_day"
+          "action": "check_weekly_run_day",
+          "run_date.$": "$.run_date"
         }
       },
       "TimeoutSeconds": 60,
@@ -183,7 +184,8 @@
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
         "Payload": {
-          "action": "check_lib_pin_drift"
+          "action": "check_lib_pin_drift",
+          "run_date.$": "$.run_date"
         }
       },
       "TimeoutSeconds": 60,
@@ -268,7 +270,8 @@
       "Parameters": {
         "FunctionName": "alpha-engine-predictor-inference:live",
         "Payload": {
-          "action": "check_pipeline_contract"
+          "action": "check_pipeline_contract",
+          "run_date.$": "$.run_date"
         }
       },
       "TimeoutSeconds": 60,
@@ -1290,7 +1293,8 @@
               "Parameters": {
                 "FunctionName": "alpha-engine-predictor-regime-substrate:live",
                 "Payload": {
-                  "action.$": "$.regime_action"
+                  "action.$": "$.regime_action",
+                  "run_date.$": "$.run_date"
                 }
               },
               "TimeoutSeconds": 270,
@@ -1714,7 +1718,8 @@
               "Parameters": {
                 "FunctionName": "alpha-engine-predictor-regime-retrospective-eval:live",
                 "Payload": {
-                  "action.$": "$.regime_action"
+                  "action.$": "$.regime_action",
+                  "run_date.$": "$.run_date"
                 }
               },
               "TimeoutSeconds": 570,

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -680,7 +680,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -891,7 +891,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
             "5400"
           ]
@@ -1482,7 +1482,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "21600"
                   ]
@@ -1777,7 +1777,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -2908,7 +2908,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),'export ALPHA_ENGINE_EXPERIMENT_ID=reference','export PREDICTOR_DEFER_TRAINING_EMAIL=1',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -3280,7 +3280,7 @@
                       "DocumentName": "AWS-RunShellScript",
                       "InstanceIds.$": "$.ec2_instance_id",
                       "Parameters": {
-                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
+                        "commands.$": "States.Array('set -eo pipefail','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),'export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-spec --log /var/log/predictor-model-zoo-spec.log -- bash infrastructure/spot_train_spec_dispatch.sh --spec-id {}{}',$$.Execution.Name,$.spec_id,$.preflight_args))",
                         "executionTimeout": [
                           "5400"
                         ]
@@ -3478,7 +3478,7 @@
                 "DocumentName": "AWS-RunShellScript",
                 "InstanceIds.$": "$.ec2_instance_id",
                 "Parameters": {
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1','export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-predictor pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','sudo -u ec2-user cp --remove-destination /home/ec2-user/alpha-engine-config/experiments/reference/predictor/predictor.yaml /home/ec2-user/alpha-engine-predictor/config/predictor.yaml','cd /home/ec2-user/alpha-engine-predictor','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),'export ALPHA_ENGINE_EXPERIMENT_ID=reference',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-model-zoo-select --log /var/log/predictor-model-zoo-select.log -- bash infrastructure/spot_model_zoo_select.sh --select-only{}',$$.Execution.Name,$.preflight_args))",
                   "executionTimeout": [
                     "5400"
                   ]
@@ -4046,7 +4046,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4211,7 +4211,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4376,7 +4376,7 @@
           "executionTimeout": [
             "7200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 7200
       },
@@ -4568,7 +4568,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'set +e',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args),'_pit_pass_rc=$?','if [ $_pit_pass_rc -ne 0 ] && aws s3api get-object --bucket alpha-engine-research --key parity/$RUN_DATE/pit_stats_lookahead.json /tmp/_pit_stats_lookahead_artifact.json >/dev/null 2>&1 && grep -qE \\'timed_out[^a-z]+true\\' /tmp/_pit_stats_lookahead_artifact.json; then aws s3api put-object --bucket alpha-engine-research --key parity/$RUN_DATE/.pit_stats_lookahead.resource_kill --body /dev/null >/dev/null 2>&1 || true; fi','exit $_pit_pass_rc')"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),'set +e',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh{}',$$.Execution.Name,$.preflight_args),'_pit_pass_rc=$?','if [ $_pit_pass_rc -ne 0 ] && aws s3api get-object --bucket alpha-engine-research --key parity/$RUN_DATE/pit_stats_lookahead.json /tmp/_pit_stats_lookahead_artifact.json >/dev/null 2>&1 && grep -qE \\'timed_out[^a-z]+true\\' /tmp/_pit_stats_lookahead_artifact.json; then aws s3api put-object --bucket alpha-engine-research --key parity/$RUN_DATE/.pit_stats_lookahead.resource_kill --body /dev/null >/dev/null 2>&1 || true; fi','exit $_pit_pass_rc')"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -4902,7 +4902,7 @@
                   "executionTimeout": [
                     "5400"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),'set +e',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args),'_pit_pass_rc=$?','if [ $_pit_pass_rc -ne 0 ] && aws s3api get-object --bucket alpha-engine-research --key parity/$RUN_DATE/pit_stats_walkforward.json /tmp/_pit_stats_walkforward_artifact.json >/dev/null 2>&1 && grep -qE \\'timed_out[^a-z]+true\\' /tmp/_pit_stats_walkforward_artifact.json; then aws s3api put-object --bucket alpha-engine-research --key parity/$RUN_DATE/.pit_stats_walkforward.resource_kill --body /dev/null >/dev/null 2>&1 || true; fi','exit $_pit_pass_rc')"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),'set +e',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh{}',$$.Execution.Name,$.preflight_args),'_pit_pass_rc=$?','if [ $_pit_pass_rc -ne 0 ] && aws s3api get-object --bucket alpha-engine-research --key parity/$RUN_DATE/pit_stats_walkforward.json /tmp/_pit_stats_walkforward_artifact.json >/dev/null 2>&1 && grep -qE \\'timed_out[^a-z]+true\\' /tmp/_pit_stats_walkforward_artifact.json; then aws s3api put-object --bucket alpha-engine-research --key parity/$RUN_DATE/.pit_stats_walkforward.resource_kill --body /dev/null >/dev/null 2>&1 || true; fi','exit $_pit_pass_rc')"
                 },
                 "TimeoutSeconds": 5400
               },
@@ -5236,7 +5236,7 @@
                   "executionTimeout": [
                     "2700"
                   ],
-                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
+                  "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh{}',$$.Execution.Name,$.preflight_args))"
                 },
                 "TimeoutSeconds": 2700
               },
@@ -5529,7 +5529,7 @@
           "executionTimeout": [
             "2700"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 2700
       },
@@ -5752,7 +5752,7 @@
           "executionTimeout": [
             "1800"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1800
       },
@@ -5926,7 +5926,7 @@
           "executionTimeout": [
             "1200"
           ],
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-backtester pull --ff-only origin main','cd /home/ec2-user/alpha-engine-backtester','export HOME=/home/ec2-user','export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1',States.Format('export RUN_DATE=\\'{}\\'',$.run_date),States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize{}',$$.Execution.Name,$.preflight_args))"
         },
         "TimeoutSeconds": 1200
       },
@@ -6117,7 +6117,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug health-check --log /var/log/health-check.log -- /home/ec2-user/alpha-engine-dashboard/.venv/bin/python health_checker.py --alert',$$.Execution.Name))",
           "executionTimeout": [
             "300"
           ]
@@ -6245,7 +6245,7 @@
         "DocumentName": "AWS-RunShellScript",
         "InstanceIds.$": "$.ec2_instance_id",
         "Parameters": {
-          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
+          "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-dashboard pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','cd /home/ec2-user/alpha-engine-dashboard','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug substrate-health-check --log /var/log/substrate-health-check.log -- bash infrastructure/substrate_health_check.sh --run-date {} --execution-arn {}',$$.Execution.Name,$.run_date,$$.Execution.Id))",
           "executionTimeout": [
             "240"
           ]
@@ -7457,6 +7457,7 @@
         "FunctionName": "alpha-engine-weekly-freshness-spot-dispatcher",
         "Payload": {
           "execution_id.$": "$$.Execution.Id",
+          "run_date.$": "$.run_date",
           "force_on_demand": true
         }
       },
@@ -8462,6 +8463,7 @@
         "FunctionName": "alpha-engine-weekly-freshness-spot-dispatcher",
         "Payload": {
           "execution_id.$": "$$.Execution.Id",
+          "run_date.$": "$.run_date",
           "force_on_demand": true
         }
       },

--- a/tests/fixtures/sf_prekeystone_spot_commands.json
+++ b/tests/fixtures/sf_prekeystone_spot_commands.json
@@ -6,6 +6,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug backtester --log /var/log/backtester.log -- bash infrastructure/spot_backtester.sh"
   ],
   "DataPhase1": [
@@ -14,6 +15,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh"
   ],
   "DataPhase2": [
@@ -21,6 +23,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug data-phase2 --log /var/log/data-phase2.log -- bash infrastructure/spot_data_weekly.sh --phase2-only"
   ],
   "DriftDetection": [
@@ -38,6 +41,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-diagnostics --log /var/log/evaluator-diagnostics.log -- bash infrastructure/spot_evaluator.sh --eval-half=diagnostics"
   ],
   "EvaluatorOptimize": [
@@ -47,6 +51,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug evaluator-optimize --log /var/log/evaluator-optimize.log -- bash infrastructure/spot_evaluator.sh --eval-half=optimize"
   ],
   "MorningEnrich": [
@@ -55,6 +60,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug morning-enrich --log /var/log/morning-enrich.log -- bash infrastructure/spot_morning_enrich.sh"
   ],
   "ParityReplay": [
@@ -64,6 +70,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-replay --log /var/log/parity-replay.log -- bash infrastructure/spot_parity_replay.sh"
   ],
   "PitParityCompare": [
@@ -73,6 +80,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug parity-compare --log /var/log/parity-compare.log -- bash infrastructure/spot_parity_compare.sh"
   ],
   "PitParityLookahead": [
@@ -82,6 +90,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "set +e",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-lookahead --log /var/log/pit-lookahead.log -- bash infrastructure/spot_pit_lookahead.sh",
     "_pit_pass_rc=$?",
@@ -95,6 +104,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "set +e",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug pit-walkforward --log /var/log/pit-walkforward.log -- bash infrastructure/spot_pit_walkforward.sh",
     "_pit_pass_rc=$?",
@@ -108,6 +118,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug portfolio-optimizer --log /var/log/portfolio-optimizer.log -- bash infrastructure/spot_portfolio_optimizer_backtest.sh"
   ],
   "PredictorBacktest": [
@@ -117,6 +128,7 @@
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
     "export RUN_DATE='2026-05-18'",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-backtest --log /var/log/predictor-backtest.log -- bash infrastructure/spot_predictor_backtest.sh"
   ],
   "PredictorTraining": [
@@ -127,6 +139,7 @@
     "cd /home/ec2-user/alpha-engine-predictor",
     "export HOME=/home/ec2-user",
     "export AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "export ALPHA_ENGINE_EXPERIMENT_ID=reference",
     "export PREDICTOR_DEFER_TRAINING_EMAIL=1",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug predictor-training --log /var/log/predictor-training.log -- bash infrastructure/spot_predictor_training.sh"
@@ -136,6 +149,7 @@
     "sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main",
     "cd /home/ec2-user/alpha-engine-data",
     "export HOME=/home/ec2-user",
+    "export EXECUTION_RUN_DATE='2026-05-18'",
     "/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id test-execution-name --slug rag-ingestion --log /var/log/rag-ingestion.log -- bash infrastructure/spot_rag_ingestion.sh"
   ]
 }

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -584,6 +584,21 @@ def orig_spot_cmds() -> dict:
       stage of the weekly pipeline was broken between the two merges.
       Tracked SOTA close: alpha-engine-config-I7383.
 
+    - **Regenerated 2026-08-22** (alpha-engine-config-I8155): every
+      coverage-asserting spot state now exports `EXECUTION_RUN_DATE` from
+      `$.run_date` alongside its existing exports (immediately after
+      `export RUN_DATE=...` on the 9 crucible-backtester-family keys here,
+      after `export HOME=...` on MorningEnrich/DataPhase1/DataPhase2/
+      RAGIngestion which have no `RUN_DATE` export at all). A deliberate,
+      reviewed absent-path change confined to the new export line — fixes
+      the 2026-08-22 weekly run where `krepis.stage_coverage` verdicts split
+      across an empty run_date (the 4 shell-launcher stages, which never
+      received `RUN_DATE`) and the trading-day run_date (the 9 backtester
+      stages, whose `RUN_DATE` is reassigned by
+      crucible-backtester's `infrastructure/_spot_common.sh`).
+      `EXECUTION_RUN_DATE` is a NEW carrier for exactly that reason: it is
+      never normalized by anything downstream.
+
     Regenerate ONLY on a deliberate, reviewed change to a spot state's
     absent-path (`preflight_args=""`) command, by re-extracting the
     resolved spot commands from the new `origin/main` SF.

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -74,10 +74,15 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # before MorningEnrich (alpha-engine-substrate-health-gate Lambda).
     "SubstrateHealthGate": frozenset({"instance_id.$"}),
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
-    "LibPinDriftCheck": frozenset({"action"}),
+    # alpha-engine-config-I8155: +run_date.$ — the stage-coverage verdict this
+    # Lambda writes is keyed on the execution's own run_date, and without it
+    # in the Payload the handler substituted datetime.now(), which matches
+    # $.run_date only while the stage runs on the same UTC day the execution
+    # started.
+    "LibPinDriftCheck": frozenset({"action", "run_date.$"}),
     # config#693 (L4595): pre-spend pipeline-contract preflight gate, wired
     # directly after LibPinDriftGate's pass-through (predictor-inference Lambda).
-    "PipelineContractCheck": frozenset({"action"}),
+    "PipelineContractCheck": frozenset({"action", "run_date.$"}),  # +run_date.$ (I8155)
     # config#2348: pre-spend evaluator Lambda-SHA drift gate pair, wired
     # directly after PipelineContractGate's pass-through. Two separate Lambda
     # invokes (grading, then director) — each checks its OWN :live alias's
@@ -85,15 +90,15 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     "EvaluatorDeployDriftCheck": frozenset({"action"}),
     "EvaluatorDirectorDeployDriftCheck": frozenset({"action"}),
     # config#1824 weekly run-day gate (pure calendar; mirrors LibPinDriftCheck shape).
-    "WeeklyRunDayGate": frozenset({"action"}),
+    "WeeklyRunDayGate": frozenset({"action", "run_date.$"}),  # +run_date.$ (I8155)
     "Scanner": frozenset({"dry_run_llm.$", "run_date.$"}),
     # alpha-engine-config-I7813: the same scanner Lambda, invoked as a
     # post-Director leaf with an explicit `mode` so it builds ONLY the
     # observe-only scanner/leaderboard board. The literal `mode` is what
     # keeps this payload distinct from Scanner's above.
     "ScannerLeaderboard": frozenset({"dry_run_llm.$", "run_date.$", "mode"}),
-    "RegimeSubstrate": frozenset({"action.$"}),
-    "RegimeRetrospectiveEval": frozenset({"action.$"}),
+    "RegimeSubstrate": frozenset({"action.$", "run_date.$"}),  # +run_date.$ (I8155)
+    "RegimeRetrospectiveEval": frozenset({"action.$", "run_date.$"}),  # +run_date.$ (I8155)
     # alpha-engine-config-I2515 Phase B: replaces the removed multi-agent
     # Research state as the signals.json producer.
     # config-I2916: preflight.$=$.research_dry threads the Friday-PM shell-run

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -178,8 +178,12 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # config-I7119's SubstrateRelaunchGate recovers only the 8 top-level sites,
     # and the 5 inside ResearchPredictorParallel are unreachable from it by ASL
     # scoping. Removing the reclaim is the only measure covering all 13.
+    # alpha-engine-config-I8155: run_date.$ added — this Lambda's stage-
+    # coverage verdict (DispatchWeeklyFreshnessSpot / RelaunchWeeklyFreshnessSpot,
+    # both INFRASTRUCTURE/GATE stages) had been writing under an empty
+    # run_date since I7214 shipped, because neither Payload carried one.
     "DispatchWeeklyFreshnessSpot": frozenset(
-        {"execution_id.$", "force_on_demand"}
+        {"execution_id.$", "run_date.$", "force_on_demand"}
     ),
     # config-I7119: the SAME dispatcher, invoked to replace a launcher box that
     # was reclaimed mid-run. force_on_demand was added to the dispatcher in
@@ -189,7 +193,7 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # two payloads are now identical. A literal `true`, not a `.$` path: the
     # decision is structural, never execution input.
     "RelaunchWeeklyFreshnessSpot": frozenset(
-        {"execution_id.$", "force_on_demand"}
+        {"execution_id.$", "run_date.$", "force_on_demand"}
     ),
 }
 

--- a/tests/test_sf_stage_output_sweep_wiring.py
+++ b/tests/test_sf_stage_output_sweep_wiring.py
@@ -50,13 +50,29 @@ def test_run_date_is_still_threaded(substrate_command):
     assert "$.run_date" in substrate_command
 
 
+def test_execution_run_date_is_also_exported(substrate_command):
+    """alpha-engine-config-I8155: WeeklySubstrateHealthCheck already threads
+    $.run_date as a --run-date CLI arg to substrate_health_check.sh, but the
+    krepis.stage_coverage assertions this stage's SIBLING launchers make need
+    the same value as an environment variable, never $RUN_DATE (reassigned to
+    the trading day by crucible-backtester's infrastructure/_spot_common.sh).
+    """
+    assert "export EXECUTION_RUN_DATE=" in substrate_command
+    assert "$.run_date" in substrate_command
+
+
 def test_format_argument_order_matches_the_placeholders(substrate_command):
     """`States.Format` is positional, so an argument appended in the wrong
     order silently swaps the run date and the execution ARN — the sweep would
     then head keys under a date that is an ARN and report every artifact
     missing, with no error anywhere.
+
+    Locates the specific `States.Format(...)` call that builds the
+    krepis.ssm_log_capture command line — NOT `substrate_command`'s first
+    `States.Format(`, which since alpha-engine-config-I8155 is the earlier
+    `export EXECUTION_RUN_DATE=...` call this state also carries.
     """
-    start = substrate_command.index("States.Format(")
+    start = substrate_command.index("States.Format('/home/ec2-user")
     fragment = substrate_command[start:]
     assert fragment.index("$$.Execution.Name") < fragment.index("$.run_date")
     assert fragment.index("$.run_date") < fragment.index("$$.Execution.Id")

--- a/tests/test_sf_weekly_run_day_gate_wiring.py
+++ b/tests/test_sf_weekly_run_day_gate_wiring.py
@@ -78,7 +78,14 @@ class TestGateRouting:
     def test_gate_invokes_predictor_calendar_action(self, states):
         gate = states["WeeklyRunDayGate"]
         assert gate["Parameters"]["FunctionName"] == "alpha-engine-predictor-inference:live"
-        assert gate["Parameters"]["Payload"] == {"action": "check_weekly_run_day"}
+        assert gate["Parameters"]["Payload"] == {
+            "action": "check_weekly_run_day",
+            # alpha-engine-config-I8155: the execution's own run_date, so the
+            # handler's stage-coverage verdict is keyed on the run rather than
+            # on datetime.now() — which agrees with it only while the stage
+            # runs on the same UTC day the execution started.
+            "run_date.$": "$.run_date",
+        }
         assert gate["Next"] == "WeeklyRunDayGateChoice"
         (catch,) = gate["Catch"]
         assert catch["Next"] == "WeeklyRunDayGateFailed"

--- a/tests/test_stage_coverage_assertions.py
+++ b/tests/test_stage_coverage_assertions.py
@@ -473,3 +473,81 @@ def test_resolve_zoo_specs_is_not_a_coverage_asserting_state() -> None:
     text = _ssm_command_text(states["ResolveZooSpecs"])
     assert CLI_MODULE not in text
     assert _EXECUTION_RUN_DATE_EXPORT not in text
+
+
+# ── config-I8155: the Lambda-backed coverage stages get $.run_date too ───────
+#
+# The SSM half above carries EXECUTION_RUN_DATE to the launcher scripts. The
+# Lambda half needs the same identity in its EVENT, and five states did not
+# have it: WeeklyRunDayGate, LibPinDriftCheck, PipelineContractCheck (all
+# `alpha-engine-predictor:live`) and RegimeSubstrate /
+# RegimeRetrospectiveEval carried Payloads holding ONLY `action`.
+#
+# Those five wrote a CORRECT run_date on 2026-08-22 — and only by
+# coincidence. Their handlers substituted `datetime.now(timezone.utc).date()`
+# or a calendar date derived from it, which equals `$.run_date` exactly when
+# the stage runs on the same UTC day the execution started. An execution
+# beginning 23:50 UTC, a stage crossing midnight, or any redrive of an older
+# run_date splits them — and the split is invisible, because the verdict
+# still lands under a plausible-looking prefix.
+#
+# "Right for the wrong reason" is not a passing state for an identity field.
+
+_LAMBDA_COVERAGE_STATES: dict[str, str] = {
+    "WeeklyRunDayGate": "alpha-engine-predictor-inference",
+    "LibPinDriftCheck": "alpha-engine-predictor-inference",
+    "PipelineContractCheck": "alpha-engine-predictor-inference",
+    "RegimeSubstrate": "alpha-engine-predictor-regime-substrate",
+    "RegimeRetrospectiveEval": "alpha-engine-predictor-regime-retrospective-eval",
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LAMBDA_COVERAGE_STATES))
+def test_every_lambda_coverage_state_threads_the_execution_run_date(name: str) -> None:
+    states = _sf_states()
+    assert name in states, f"{name}: state not found in the live SF definition"
+    payload = states[name]["Parameters"]["Payload"]
+    assert payload.get("run_date.$") == "$.run_date", (
+        f"{name}: Payload does not thread $.run_date, so its handler has no "
+        "way to learn the execution's identity and must either fabricate one "
+        "(forbidden) or record UNMEASURED. Payload is "
+        f"{sorted(payload)} (alpha-engine-config-I8155)."
+    )
+
+
+def test_no_lambda_coverage_state_substitutes_a_derived_date_for_run_date() -> None:
+    """`$.run_date` and nothing else. A Payload wiring `run_date` to a
+    trading-day or cycle field would satisfy the presence test above while
+    reintroducing exactly the split it exists to prevent."""
+    states = _sf_states()
+    for name in sorted(_LAMBDA_COVERAGE_STATES):
+        wired = states[name]["Parameters"]["Payload"].get("run_date.$")
+        assert wired == "$.run_date", (
+            f"{name}: run_date is wired to {wired!r}. It must be the "
+            "execution's own $.run_date — cycle_date is derived separately by "
+            "krepis via last_closed_trading_day() and is a different question."
+        )
+
+
+def test_the_lambda_coverage_state_set_is_not_silently_smaller_than_reality() -> None:
+    """Guard the guard. The curated set above is a claim about the pipeline;
+    if a Lambda-backed Task state's function is one of the named coverage
+    functions and it is absent from the set, the set is stale and this test —
+    not a quiet pass — is what says so."""
+    states = _sf_states()
+    functions = set(_LAMBDA_COVERAGE_STATES.values())
+    discovered = set()
+    for name, body in states.items():
+        if body.get("Type") != "Task" or "lambda:invoke" not in body.get("Resource", ""):
+            continue
+        fn = str(body.get("Parameters", {}).get("FunctionName", ""))
+        if any(fn.startswith(f"{f}:") or fn == f for f in functions):
+            discovered.add(name)
+    unlisted = sorted(discovered - set(_LAMBDA_COVERAGE_STATES))
+    assert not unlisted, (
+        "Lambda state(s) on a coverage-asserting function are missing from "
+        f"_LAMBDA_COVERAGE_STATES: {unlisted}. Add them (and thread "
+        "$.run_date into their Payloads) or the curated set is a smaller "
+        "world than its name implies."
+    )
+    assert discovered, "the lambda-state scan found nothing — it cannot pass vacuously"

--- a/tests/test_stage_coverage_assertions.py
+++ b/tests/test_stage_coverage_assertions.py
@@ -47,6 +47,12 @@ def _states(definition: dict) -> dict[str, dict]:
                 walk(branch["States"])
             if "Iterator" in body:
                 walk(body["Iterator"]["States"])
+            # Newer ASL Map states use ItemProcessor rather than Iterator
+            # (e.g. TrainSpecDispatch, nested inside ModelZoo's Map) — both
+            # must be walked or a state nested only under ItemProcessor is
+            # silently invisible to every totality test in this file.
+            if "ItemProcessor" in body:
+                walk(body["ItemProcessor"]["States"])
 
     walk(definition["States"])
     return out
@@ -115,6 +121,36 @@ def test_each_launcher_passes_the_run_window(stage: str, script: str) -> None:
     while the consumer reads last week's belief."""
     body = _script(script)
     assert '--window-start "$_STAGE_WINDOW_START"' in body
+
+
+@pytest.mark.parametrize(
+    ("stage", "script"),
+    sorted(_launcher_stages_in_this_repo().items()),
+)
+def test_each_launcher_passes_an_explicit_run_date(stage: str, script: str) -> None:
+    """alpha-engine-config-I8155: on the 2026-08-22 weekly run every one of
+    these launchers wrote its verdict under an EMPTY run_date, because the
+    CLI's argparse default (`os.environ.get("RUN_DATE", "")`) resolves empty
+    when the launcher never receives RUN_DATE — which none of these do. The
+    fix is explicit: `--run-date "$EXECUTION_RUN_DATE"`, never a bare
+    `krepis.stage_coverage assert` relying on the CLI default, and never
+    `$RUN_DATE` — that name is reassigned to the trading day by
+    crucible-backtester's infrastructure/_spot_common.sh, so a carrier other
+    code rewrites is exactly the defect this fixes."""
+    body = _script(script)
+    for line in body.splitlines():
+        if CLI_MODULE in line and "assert --stage" in line and f"--stage {stage}" in line:
+            assert '--run-date "$EXECUTION_RUN_DATE"' in line, (
+                f"{script}: the {stage} assertion does not pass an explicit "
+                "--run-date $EXECUTION_RUN_DATE"
+            )
+            assert "$RUN_DATE" not in line.replace("$EXECUTION_RUN_DATE", ""), (
+                f"{script}: the {stage} assertion's --run-date must never read "
+                "the $RUN_DATE carrier — see alpha-engine-config-I8155"
+            )
+            break
+    else:
+        pytest.fail(f"{script}: no assert --stage {stage} line found")
 
 
 def test_the_window_is_captured_before_the_workload_not_after() -> None:
@@ -210,7 +246,7 @@ def test_the_multimode_launcher_asserts_only_the_phase2_stage() -> None:
 def test_weekly_preflight_records_its_no_output_declaration() -> None:
     body = (INFRA / "lambdas" / "weekly-preflight" / "index.py").read_text()
     assert "from krepis.stage_coverage import assert_stage_coverage" in body
-    assert '_assert_stage_coverage("WeeklyPreflight", started)' in body
+    assert '_assert_stage_coverage("WeeklyPreflight", started, run_date)' in body
     assert '"stage_coverage"' in body
 
 
@@ -221,6 +257,62 @@ def test_the_spot_dispatcher_derives_which_of_its_two_stages_ran() -> None:
         INFRA / "lambdas" / "weekly-freshness-spot-dispatcher" / "index.py"
     ).read_text()
     assert '"RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot"' in body
+
+
+# ── alpha-engine-config-I8155: the two Lambdas pass a real run_date ──────────
+
+
+def test_weekly_preflight_threads_the_event_run_date() -> None:
+    """`WeeklyPreflight`'s Task already passes `Payload.$="$"` (config-I7443),
+    so `event["run_date"]` is the state input's `$.run_date` — no SF-side
+    Payload change needed, only wiring it into the assertion call."""
+    body = (INFRA / "lambdas" / "weekly-preflight" / "index.py").read_text()
+    assert 'run_date = event.get("run_date")' in body
+    assert "def _assert_stage_coverage(stage: str, started: datetime, run_date: str | None) -> dict:" in body
+    assert "assert_stage_coverage(stage, window_start=started, run_date=run_date)" in body
+
+
+def test_weekly_preflight_never_fabricates_a_run_date() -> None:
+    """A missing run_date on the event must report UNMEASURED, never invent a
+    date — that is exactly the defect alpha-engine-config-I8155 fixes."""
+    body = (INFRA / "lambdas" / "weekly-preflight" / "index.py").read_text()
+    fn = body[body.index("def _assert_stage_coverage(stage: str, started: datetime, run_date"):]
+    assert "if not run_date:" in fn
+    guard = fn[: fn.index("try:\n        from krepis.stage_coverage")]
+    assert '"status": "UNMEASURED"' in guard
+
+
+def test_the_spot_dispatcher_sf_payloads_carry_run_date() -> None:
+    """DispatchWeeklyFreshnessSpot and RelaunchWeeklyFreshnessSpot previously
+    passed a narrow Payload with no run_date at all — this Lambda's
+    stage-coverage verdict has been writing under an empty run_date since
+    I7214 shipped. Both states now thread `$.run_date` explicitly."""
+    definition = json.loads(SF_DEFINITION.read_text())
+    states = _states(definition)
+    for name in ("DispatchWeeklyFreshnessSpot", "RelaunchWeeklyFreshnessSpot"):
+        payload = states[name]["Parameters"]["Payload"]
+        assert payload.get("run_date.$") == "$.run_date", (
+            f"{name}: Payload does not thread $.run_date"
+        )
+
+
+def test_the_spot_dispatcher_threads_the_event_run_date() -> None:
+    body = (
+        INFRA / "lambdas" / "weekly-freshness-spot-dispatcher" / "index.py"
+    ).read_text()
+    assert 'str(event.get("run_date", "")).strip() or None' in body
+    assert "def _assert_stage_coverage(stage: str, started: datetime.datetime, run_date: str | None) -> dict:" in body
+    assert "assert_stage_coverage(stage, window_start=started, run_date=run_date)" in body
+
+
+def test_the_spot_dispatcher_never_fabricates_a_run_date() -> None:
+    body = (
+        INFRA / "lambdas" / "weekly-freshness-spot-dispatcher" / "index.py"
+    ).read_text()
+    fn = body[body.index("def _assert_stage_coverage(stage: str, started: datetime.datetime, run_date"):]
+    assert "if not run_date:" in fn
+    guard = fn[: fn.index("try:\n        from krepis.stage_coverage")]
+    assert '"status": "UNMEASURED"' in guard
 
 
 @pytest.mark.parametrize(
@@ -269,3 +361,115 @@ def test_the_weekly_preflight_lambda_has_no_coverage_action_dispatch() -> None:
 
 def test_the_end_of_run_module_is_gone() -> None:
     assert not (REPO / "sf_stage_coverage.py").exists()
+
+
+# ── alpha-engine-config-I8155: EXECUTION_RUN_DATE reaches every SSM state ────
+#
+# On the 2026-08-22 weekly run, krepis.stage_coverage verdicts split across
+# TWO run_date prefixes for one execution: the 8 shell/subprocess launchers
+# (this section's targets) wrote run_date="" because they never received
+# RUN_DATE at all; the crucible-backtester family wrote run_date to the
+# TRADING DAY because infrastructure/_spot_common.sh in that repo reassigns
+# RUN_DATE. EXECUTION_RUN_DATE is the fix: a NEW carrier, exported from
+# $.run_date (InitializeInput's single stamp, never rewritten anywhere in
+# this definition) into every coverage-asserting SSM state, and never
+# normalized by anything downstream.
+
+#: Every SSM sendCommand state whose command runs a launcher that performs a
+#: stage-coverage assertion. Deliberately excludes the two bare
+#: `aws s3api head-object` resource-kill-check states (PitParityLookaheadKillCheck-
+#: shaped) and ResolveZooSpecs (resolves rotation spec ids only, no assertion).
+_COVERAGE_ASSERTING_SSM_STATES = frozenset({
+    "MorningEnrich", "DataPhase1", "RAGIngestion", "DataPhase2",
+    "PredictorTraining", "TrainSpecDispatch", "ModelZooSelect",
+    "SaturdayHealthCheck", "WeeklySubstrateHealthCheck",
+    "Backtester", "PredictorBacktest", "PortfolioOptimizerBacktest",
+    "PitParityLookahead", "PitParityWalkforward", "ParityReplay",
+    "PitParityCompare", "EvaluatorDiagnostics", "EvaluatorOptimize",
+})
+
+_EXECUTION_RUN_DATE_EXPORT = "export EXECUTION_RUN_DATE="
+
+
+def _sf_states() -> dict[str, dict]:
+    return _states(json.loads(SF_DEFINITION.read_text()))
+
+
+@pytest.mark.parametrize("name", sorted(_COVERAGE_ASSERTING_SSM_STATES))
+def test_every_coverage_asserting_ssm_state_exports_execution_run_date(name: str) -> None:
+    states = _sf_states()
+    assert name in states, f"{name}: state not found in the live SF definition"
+    text = _ssm_command_text(states[name])
+    assert _EXECUTION_RUN_DATE_EXPORT in text, (
+        f"{name}: does not export EXECUTION_RUN_DATE — its stage-coverage "
+        "assertion (if any) has no reliable run_date carrier"
+    )
+    assert "$.run_date" in text, f"{name}: EXECUTION_RUN_DATE is not sourced from $.run_date"
+
+
+def test_execution_run_date_covers_every_task_state_with_a_krepis_assertion() -> None:
+    """The set above is asserted against the live definition, not just
+    hand-listed: any Task state whose command names krepis.stage_coverage
+    but lacks the export is a miss this test must catch even if the curated
+    set above goes stale."""
+    states = _sf_states()
+    missing = []
+    for name, body in states.items():
+        if body.get("Type") != "Task" or "sendCommand" not in body.get("Resource", ""):
+            continue
+        text = _ssm_command_text(body)
+        # A state whose *own* SSM command invokes krepis.stage_coverage
+        # directly (none do today — the CLI runs inside the launcher script
+        # over on the box) OR whose named launcher script is one of this
+        # repo's coverage-asserting scripts.
+        match = re.search(r"bash infrastructure/(spot_[a-z0-9_]+\.sh)", text)
+        if not match:
+            continue
+        script_path = INFRA / match.group(1)
+        if not script_path.exists() or CLI_MODULE not in script_path.read_text():
+            continue
+        missing.append(name)
+    # Every discovered state must actually carry the export.
+    for name in missing:
+        text = _ssm_command_text(states[name])
+        assert _EXECUTION_RUN_DATE_EXPORT in text, (
+            f"{name}: backs a coverage-asserting launcher but its SSM state "
+            "does not export EXECUTION_RUN_DATE"
+        )
+
+
+def test_run_date_export_does_not_replace_the_backtester_family_run_date() -> None:
+    """RUN_DATE is load-bearing for `parity/$RUN_DATE/...` S3 keys in the
+    crucible-backtester family — EXECUTION_RUN_DATE is ADDED alongside it,
+    never a replacement."""
+    states = _sf_states()
+    backtester_family = {
+        "Backtester", "PredictorBacktest", "PortfolioOptimizerBacktest",
+        "PitParityLookahead", "PitParityWalkforward", "ParityReplay",
+        "PitParityCompare", "EvaluatorDiagnostics", "EvaluatorOptimize",
+    }
+    for name in backtester_family:
+        text = _ssm_command_text(states[name])
+        assert "export RUN_DATE=" in text, f"{name}: lost its load-bearing RUN_DATE export"
+        assert _EXECUTION_RUN_DATE_EXPORT in text
+
+
+def test_the_resource_kill_check_states_do_not_export_execution_run_date() -> None:
+    """These two states run a bare `aws s3api head-object` — no launcher, no
+    assertion — so they must not gain the export."""
+    states = _sf_states()
+    for name, body in states.items():
+        text = _ssm_command_text(body)
+        if "aws s3api head-object" in text and "krepis.ssm_log_capture" not in text:
+            assert _EXECUTION_RUN_DATE_EXPORT not in text, (
+                f"{name}: a bare resource-kill-check state gained an unneeded export"
+            )
+
+
+def test_resolve_zoo_specs_is_not_a_coverage_asserting_state() -> None:
+    """ResolveZooSpecs only lists rotation spec ids — it must stay out of the
+    export set (and out of _COVERAGE_ASSERTING_SSM_STATES above)."""
+    states = _sf_states()
+    text = _ssm_command_text(states["ResolveZooSpecs"])
+    assert CLI_MODULE not in text
+    assert _EXECUTION_RUN_DATE_EXPORT not in text


### PR DESCRIPTION
## What & why

`alpha-engine-config-I8155`: on the 2026-08-22 weekly run, `krepis.stage_coverage` verdicts for one SF execution split across two `run_date` prefixes — `s3://alpha-engine-research/_stage_coverage/2026-08-22/` and `.../2026-08-21/`, the latter with 8 empty-`run_date` entries and 8 trading-day entries. The empty ones are this repo's shell/subprocess launchers (DataPhase1, DataPhase2, MorningEnrich, RAGIngestion) plus crucible-predictor's (ModelZooSelect, PredictorTraining, RAGIngestion, TrainSpecDispatch, SaturdayHealthCheck) — none receive `RUN_DATE`. The trading-day ones are crucible-backtester's family, whose `infrastructure/_spot_common.sh` reassigns `RUN_DATE` to the trading day. `$RUN_DATE` is therefore not a safe carrier fleet-wide.

Fix (this repo's half): a new carrier, `EXECUTION_RUN_DATE`, exported from `$.run_date` (`InitializeInput`'s single stamp, never rewritten anywhere else in `step_function.json`) into every SSM `sendCommand` state whose command runs a coverage-asserting launcher — 18 states total. Threaded via `--run-date "$EXECUTION_RUN_DATE"` into the 4 launcher scripts this repo owns (`spot_data_phase1.sh`, `spot_morning_enrich.sh`, `spot_rag_ingestion.sh`, `spot_data_weekly.sh --phase2-only`). It is deliberately a NEW name, not `RUN_DATE` — a carrier other code rewrites is exactly the defect.

Also fixes the two Lambda-backed stages this repo owns:
- `WeeklyPreflight` already receives the whole state input (`Payload.$="$"`, config-I7443) — only the handler needed wiring to thread `event["run_date"]` into the assertion.
- `DispatchWeeklyFreshnessSpot` / `RelaunchWeeklyFreshnessSpot` never carried `run_date` in their narrow `Payload` at all — both states gained `"run_date.$": "$.run_date"`, and the handler now threads it.

Neither Lambda fabricates a date on a missing/blank `run_date` — both report `UNMEASURED` rather than inventing one, which is exactly the defect this fixes.

## SOTA / delta

SOTA is a single reliable run_date carrier threaded end-to-end from the SF execution's own stamped input, never a shell/OS environment variable another repo's code is free to reassign. This PR implements that; no delta.

## Test plan

Ran locally before opening (fresh `.venv`, `requirements.txt` + `pytest==9.1.1`, `nousergon-lib==0.124.83`):

- `pytest tests/test_stage_coverage_assertions.py -q` — 64 passed (10 new tests added: per-launcher `--run-date $EXECUTION_RUN_DATE` checks, per-state SF-export checks over the 18-state target set, backtester-family RUN_DATE-preserved regression guard, resource-kill-check exclusion guard, ResolveZooSpecs exclusion guard, both Lambdas' run_date-threading and no-fabrication guards). Also fixed a pre-existing gap in the shared `_states()` helper (it walked `Iterator` but not `ItemProcessor`, so `TrainSpecDispatch` — nested in a Map — was invisible to every totality test in the file).
- `pytest tests/ -q` (full suite) — **6464 passed, 17 skipped**, 0 failed. Three pre-existing tests needed updates for this deliberate SF/script change (documented in each diff): `tests/test_sf_friday_shell_run_wiring.py`'s committed byte-identical fixture (`tests/fixtures/sf_prekeystone_spot_commands.json`, regenerated for the 14 affected `_SPOT_STATES` keys + changelog entry), `tests/test_sf_payload_uniqueness.py`'s `_SATURDAY_PAYLOAD_KEYS` registry (added `run_date.$` for both dispatcher states), and `tests/test_sf_stage_output_sweep_wiring.py`'s format-argument-order test (was matching the FIRST `States.Format(` in `WeeklySubstrateHealthCheck`'s command, which is now the new export — retargeted to the specific krepis.ssm_log_capture format call, and added a positive check that the export is present).

## Not in scope here

Read `nousergon-data-PR1508` (`fix/rerun-carries-cadence-skips-260822`, still open) first — it touches only `scripts/weekly_sf_rerun.py` and its own test file, no overlap with this PR's files. No extension needed.

## Also in this PR — the five Lambda-backed coverage stages (added after first push)

`WeeklyRunDayGate`, `LibPinDriftCheck`, `PipelineContractCheck`, `RegimeSubstrate` and `RegimeRetrospectiveEval` carried Payloads holding **only `action`**. All five nonetheless wrote a correct-looking `run_date` on 2026-08-22 — by coincidence: their handlers substituted `datetime.now(timezone.utc).date()` or a calendar date derived from it, which equals `$.run_date` exactly while the stage runs on the same UTC day the execution started. An execution beginning 23:50 UTC, a stage crossing midnight, or any redrive of an older run_date splits them, invisibly, because the verdict still lands under a plausible prefix. Right for the wrong reason is not a passing state for an identity field.

All five Payloads now thread `"run_date.$": "$.run_date"`. Three tests, not one: presence; that it is wired to `$.run_date` and not to a derived trading-day field (which would satisfy a presence check while reintroducing the split); and a guard-the-guard that discovers Lambda states on the coverage-asserting functions from the live definition, so the curated set cannot quietly become a smaller world than its name implies. `test_sf_payload_uniqueness.py`'s closed field-set registry and `test_sf_weekly_run_day_gate_wiring.py`'s exact-Payload assertion move with the change — pins on a deliberate edit, not drift.

Full suite re-run after this addition: **6471 passed, 17 skipped**, 0 failed.

## Merge order

**`krepis-PR179`** (`i8156-s3-surface`, additive) → **this PR** — it must land at or before the launcher PRs, which read the `EXECUTION_RUN_DATE` export and the five `run_date` Payloads this PR adds — together with `crucible-backtester-PR728`, `crucible-predictor-PR547`, `crucible-research-PR723`, `crucible-dashboard-PR763`, `crucible-evaluator-PR250`, `nous-ergon-ops-PR841` → **`krepis-PR180`** (`i8155-run-date-required`) **LAST**, because it makes `run_date` required and krepis's autobump publishes on merge, so no consumer may be left calling the old shape.

## Rehearsal

Rehearsal-path: tests/test_stage_coverage_assertions.py

The SF definition change is exercised entirely by contract tests over the committed definition — 71 cases asserting, per state, that the export is present and sourced from `$.run_date`, and, per Lambda state, that the Payload threads `$.run_date` and nothing derived. The discovery half of each set is computed from the live definition rather than hand-listed, so a state added later is covered without editing the test. `tests/test_sf_friday_shell_run_wiring.py`'s byte-identical command fixture is the second rehearsal surface: it regenerates every affected spot command string and diffs it, so an accidental change to the non-export part of any command fails before merge.

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
