### PR TITLE
feat(overseer): register the eval_rolling_mean producer-failure alert class (alpha-engine-config-I8177)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -822,6 +822,19 @@ alert_classes:
     response: drain-queue
 
   # ── research (crucible-research) ──
+  # alpha-engine-config-I8177 (crucible-research-PR724). The weekly
+  # eval_rolling_mean Lambda hangs four best-effort aggregations off the
+  # rolling-mean run (calibration_kappa, control_bands, agent_quality,
+  # producer_leaderboard). Their failure must not sink the primary deliverable
+  # — but recording it only in a WARN log and an unread return field is how the
+  # agent_quality producer stayed broken for two months while eight report-card
+  # components read N/A. All four now publish here at ERROR, deduped per
+  # producer per ISO week.
+  - class: research_eval_rolling_mean_producer_failure
+    source: "crucible-research/eval_rolling_mean_handler"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: research_score_aggregator_gap
     source: "research:score_aggregator"
     severities: [warning]


### PR DESCRIPTION
## What

Adds one `alert_classes` row to `infrastructure/overseer/playbooks.yaml`:

```yaml
- class: research_eval_rolling_mean_producer_failure
  source: "crucible-research/eval_rolling_mean_handler"
  severities: [error]
  intake: bus
  response: drain-queue
```

## Why

Companion to `crucible-research-PR724`. That PR puts the four best-effort aggregations hung off the weekly `eval_rolling_mean` Lambda — `calibration_kappa`, `control_bands`, `agent_quality`, `producer_leaderboard` — onto the machine-readable alert bus at ERROR severity, deduped per producer per ISO week.

Each was wrapped in `except Exception` so a failure could not sink the rolling mean (the primary deliverable). That carve-out is legitimate. Recording the failure **only** in a `logger.warning` and a `{"status": "ERROR"}` field of the handler's return value that nothing consumes is not: a human-only notification is invisible (`observability-policy.md` §7.3) — the response plane cannot see it and nothing owns follow-through.

The cost was measured. The `agent_quality` producer raised `'str' object has no attribute 'isoformat'` on every weekly run from 2026-06-23 to 2026-08-22 — two months — while `backtest/{date}/agent_quality.json` existed on no date anywhere in the bucket and eight report-card components graded `N/A-MISSING-INPUT`. Nothing paged, because the only trace was a WARN line reading "(non-fatal)".

`intake: bus` / `response: drain-queue`: a producer that stopped producing is real work for the drain queue, not an operator-only notice.

## SOTA and delta

SOTA is that every notification also emits onto the machine-readable bus, and every publishing source carries a registry row so coverage is derivable rather than hand-known (`observability-policy.md` §2.2, §7.3). This is that row. No delta.

## Test plan

Full suite run in this worktree **before** opening: `python3 -m pytest -q -p no:randomly` → **6437 passed, 17 skipped** in 106.5s. No failures, pre-existing or otherwise.

Includes `tests/test_alert_class_pr_guard.py`, `tests/test_alert_class_registry_drift.py` and `tests/test_overseer_playbook_registry.py` (108 assertions across the three), which are the checks that validate this row's shape.

## Merge order

**Either PR first, in either direction.** The `crucible-research` guard re-reads this registry on every run and treats an open `nousergon-data` PR carrying the row as satisfying it, so this PR turns that check green without waiting to merge. Nothing here is blocked by `crucible-research-PR724`, so the two cannot deadlock.

## Related

- Tracking issue with the full 47-component register: `alpha-engine-config-I8177`
- `crucible-research-PR724` — the change this row registers
- `nous-ergon-ops-PR842`, `crucible-evaluator-PR254` — siblings in the same arc

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)