### PR TITLE
fix(sf): a Parallel branch returns its outcome envelope, not its payload (alpha-engine-config-I8194)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -1076,7 +1076,7 @@
     },
     "ResearchPredictorParallel": {
       "Type": "Parallel",
-      "Comment": "Research and PredictorTraining are DATA-INDEPENDENT (no S3/db data flows between them \u2014 see CLAUDE.md Architecture). They previously ran sequentially ONLY to 'spread API load', a now-STALE rationale: predictor TRAINING (training/train_handler.py) reads ArcticDB + CPU LightGBM and makes NO Anthropic calls (the yfinance fallback was removed by predictor PR #6; train_handler yfinance docstrings are stale). Research's only heavy load is Anthropic. They do not contend on the rate-limited API, so they run in parallel here to decouple PredictorTraining from Research's variable <=75-min strict-retry runtime and shorten SF wall-clock. Branch A = the full Research-consuming chain (DataPhase2 + eval-judge chain + agent-justification triple), Branch B = the PredictorTraining quartet. PER-BRANCH ERROR ISOLATION: each branch ends in a branch-local Pass terminal (End:true) that records OK/FAILED as DATA \u2014 a branch NEVER throws, so SF Parallel's default cancel-all-siblings-on-error behaviour can never abandon or waste an in-flight (or completed+S3-promoted) sibling. The SF is failed AFTER the join by CheckBranchOutcomes if either branch recorded FAILED. The Parallel-level Catch is a defense-in-depth backstop for genuine SF-engine Parallel errors only (the branches themselves always succeed). (config#885: the Scanner\u2192RAGIngestion\u2192RegimeSubstrate\u2192RegimeRetrospectiveEval chain was relocated FROM top-level INTO Branch A's head so PredictorTraining (Branch B) now forks parallel to it directly after DataPhase1 \u2014 Predictor \u22a5 Scanner/RAG/Regime, all of which produce side-effect S3/ArcticDB artifacts, never SF-state JSON consumed by Branch B or any post-join state. Their in-branch error edges were rewired to the branch-fail path PublishResearchFailureImmediate\u2192BranchAFailed.)",
+      "Comment": "Research and PredictorTraining are DATA-INDEPENDENT (no S3/db data flows between them \u2014 see CLAUDE.md Architecture). They previously ran sequentially ONLY to 'spread API load', a now-STALE rationale: predictor TRAINING (training/train_handler.py) reads ArcticDB + CPU LightGBM and makes NO Anthropic calls (the yfinance fallback was removed by predictor PR #6; train_handler yfinance docstrings are stale). Research's only heavy load is Anthropic. They do not contend on the rate-limited API, so they run in parallel here to decouple PredictorTraining from Research's variable <=75-min strict-retry runtime and shorten SF wall-clock. Branch A = the full Research-consuming chain (DataPhase2 + eval-judge chain + agent-justification triple), Branch B = the PredictorTraining quartet. PER-BRANCH ERROR ISOLATION: each branch ends in a branch-local Pass terminal (End:true) that records OK/FAILED as DATA \u2014 a branch NEVER throws, so SF Parallel's default cancel-all-siblings-on-error behaviour can never abandon or waste an in-flight (or completed+S3-promoted) sibling. The SF is failed AFTER the join by CheckBranchOutcomes if either branch recorded FAILED. The Parallel-level Catch is a defense-in-depth backstop for genuine SF-engine Parallel errors only (the branches themselves always succeed). (config#885: the Scanner\u2192RAGIngestion\u2192RegimeSubstrate\u2192RegimeRetrospectiveEval chain was relocated FROM top-level INTO Branch A's head so PredictorTraining (Branch B) now forks parallel to it directly after DataPhase1 \u2014 Predictor \u22a5 Scanner/RAG/Regime, all of which produce side-effect S3/ArcticDB artifacts, never SF-state JSON consumed by Branch B or any post-join state. Their in-branch error edges were rewired to the branch-fail path PublishResearchFailureImmediate\u2192BranchAFailed.) alpha-engine-config-I8194: every branch terminal replaces its payload (Parameters/Result nested under the old ResultPath key, no ResultPath), so this Parallel's result is bounded by the number of branches rather than by branch state. tests/test_sf_parallel_branch_payload.py derives that invariant from the definition \u2014 do not reintroduce a ResultPath on a branch terminal.",
       "Branches": [
         {
           "StartAt": "InitResearchDegradedFlag",
@@ -2669,25 +2669,27 @@
             },
             "BranchAComplete": {
               "Type": "Pass",
-              "Comment": "Branch A (Scanner \u2192 RegimeSubstrate \u2192 SignalsEnvelope \u2192 ChallengerShadow \u2192 RAG chain \u2192 RegimeRetrospectiveEval \u2192 DataPhase2 \u2192 eval-judge chain \u2192 EvalRollingMean \u2192 RationaleClustering \u2192 ReplayConcordance \u2192 Counterfactual \u2192 AggregateCosts) completed (config-I2515 Phase B reorder \u2014 the multi-agent Research graph runner was removed). Records branch_a_status=OK so the post-join AggregateBranchOutcomes can decide whether to halt the SF. End:true so the Parallel branch SUCCEEDS \u2014 it must never throw, because a thrown branch would cancel the sibling PredictorTraining branch (default SF Parallel semantics). alpha-engine-config#6722: also hoists $.research_degraded_local (seeded false by InitResearchDegradedFlag, set true by any of Branch A's internal fail-open Mark*Degraded states) as branch_a_degraded \u2014 read by AggregateBranchOutcomes/CheckResearchPredictorDegraded post-join since a Parallel branch cannot write an outer-scope JSONPath directly.",
+              "Comment": "Branch A (Scanner \u2192 RegimeSubstrate \u2192 SignalsEnvelope \u2192 ChallengerShadow \u2192 RAG chain \u2192 RegimeRetrospectiveEval \u2192 DataPhase2 \u2192 eval-judge chain \u2192 EvalRollingMean \u2192 RationaleClustering \u2192 ReplayConcordance \u2192 Counterfactual \u2192 AggregateCosts) completed (config-I2515 Phase B reorder \u2014 the multi-agent Research graph runner was removed). Records branch_a_status=OK so the post-join AggregateBranchOutcomes can decide whether to halt the SF. End:true so the Parallel branch SUCCEEDS \u2014 it must never throw, because a thrown branch would cancel the sibling PredictorTraining branch (default SF Parallel semantics). alpha-engine-config#6722: also hoists $.research_degraded_local (seeded false by InitResearchDegradedFlag, set true by any of Branch A's internal fail-open Mark*Degraded states) as branch_a_degraded \u2014 read by AggregateBranchOutcomes/CheckResearchPredictorDegraded post-join since a Parallel branch cannot write an outer-scope JSONPath directly. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "branch_a_status": "OK",
-                "branch_a_degraded.$": "$.research_degraded_local",
-                "scanner_resource_kill.$": "$.scanner_resource_kill"
+                "branch_a": {
+                  "branch_a_status": "OK",
+                  "branch_a_degraded.$": "$.research_degraded_local",
+                  "scanner_resource_kill.$": "$.scanner_resource_kill"
+                }
               },
-              "ResultPath": "$.branch_a",
               "End": true
             },
             "BranchAFailed": {
               "Type": "Pass",
-              "Comment": "Branch A hard-failed (SignalsEnvelope failure \u2014 the LOAD-BEARING signals.json producer post config-I2515 Phase B \u2014 RAGIngestion failure, or DataPhase2 failure). Records branch_a_status=FAILED + the captured $.error as DATA and End:true \u2014 the branch SUCCEEDS in SF terms so the sibling PredictorTraining branch is NEVER abandoned by Parallel's cancel-siblings default. The SF is failed AFTER the join by CheckBranchOutcomes. Recovery: if Branch B completed + promoted weights to S3, the re-run uses {\"skip_predictor_training\": true} (weights are already live) and re-runs only Branch A. alpha-engine-config#6722: branch_a_degraded is fixed false here \u2014 a hard FAILED branch is reported via CheckBranchOutcomes' Or-gate before AggregateBranchOutcomes' degraded-fold is ever consulted, but the field must still exist unconditionally so that Parameters.$ extraction never throws States.Runtime. | alpha-engine-config-I7812: scanner_resource_kill is fixed false here for the same reason branch_a_degraded is \u2014 a hard FAILED branch is reported by CheckBranchOutcomes' Or-gate before the degraded fold is consulted, but AggregateBranchOutcomes' Parameters.$ extraction runs first and would throw States.Runtime on a missing field.",
+              "Comment": "Branch A hard-failed (SignalsEnvelope failure \u2014 the LOAD-BEARING signals.json producer post config-I2515 Phase B \u2014 RAGIngestion failure, or DataPhase2 failure). Records branch_a_status=FAILED + the captured $.error as DATA and End:true \u2014 the branch SUCCEEDS in SF terms so the sibling PredictorTraining branch is NEVER abandoned by Parallel's cancel-siblings default. The SF is failed AFTER the join by CheckBranchOutcomes. Recovery: if Branch B completed + promoted weights to S3, the re-run uses {\"skip_predictor_training\": true} (weights are already live) and re-runs only Branch A. alpha-engine-config#6722: branch_a_degraded is fixed false here \u2014 a hard FAILED branch is reported via CheckBranchOutcomes' Or-gate before AggregateBranchOutcomes' degraded-fold is ever consulted, but the field must still exist unconditionally so that Parameters.$ extraction never throws States.Runtime. | alpha-engine-config-I7812: scanner_resource_kill is fixed false here for the same reason branch_a_degraded is \u2014 a hard FAILED branch is reported by CheckBranchOutcomes' Or-gate before the degraded fold is consulted, but AggregateBranchOutcomes' Parameters.$ extraction runs first and would throw States.Runtime on a missing field. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "branch_a_status": "FAILED",
-                "branch_a_error.$": "$.error",
-                "branch_a_degraded": false,
-                "scanner_resource_kill": false
+                "branch_a": {
+                  "branch_a_status": "FAILED",
+                  "branch_a_error.$": "$.error",
+                  "branch_a_degraded": false,
+                  "scanner_resource_kill": false
+                }
               },
-              "ResultPath": "$.branch_a",
               "End": true
             },
             "InitRAGIngestionPollCount": {
@@ -2891,13 +2893,14 @@
             },
             "PredictorTrainingSkipped": {
               "Type": "Pass",
-              "Comment": "config#2253 branch-B skip terminal. Reads as a SUCCEEDED branch to AggregateBranchOutcomes/CheckBranchOutcomes \u2014 the join reads $.parallel_result[1].branch_b.branch_b_status (+ branch_b_degraded, alpha-engine-config#6722), and this records the identical branch_b_status=OK contract as BranchBComplete \u2014 plus an explicit skipped:true marker for execution-history forensics (no fabricated training payload beyond what routing requires). branch_b_degraded is fixed false: this path never reaches the model-zoo rotation (the skip claim is validated fresh weights, so there is nothing to rotate), and the field must exist unconditionally so AggregateBranchOutcomes' Parameters.$ extraction never throws States.Runtime. End:true so the sibling Research branch is never cancelled (the per-branch error-isolation invariant).",
+              "Comment": "config#2253 branch-B skip terminal. Reads as a SUCCEEDED branch to AggregateBranchOutcomes/CheckBranchOutcomes \u2014 the join reads $.parallel_result[1].branch_b.branch_b_status (+ branch_b_degraded, alpha-engine-config#6722), and this records the identical branch_b_status=OK contract as BranchBComplete \u2014 plus an explicit skipped:true marker for execution-history forensics (no fabricated training payload beyond what routing requires). branch_b_degraded is fixed false: this path never reaches the model-zoo rotation (the skip claim is validated fresh weights, so there is nothing to rotate), and the field must exist unconditionally so AggregateBranchOutcomes' Parameters.$ extraction never throws States.Runtime. End:true so the sibling Research branch is never cancelled (the per-branch error-isolation invariant). alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Result": {
-                "branch_b_status": "OK",
-                "skipped": true,
-                "branch_b_degraded": false
+                "branch_b": {
+                  "branch_b_status": "OK",
+                  "skipped": true,
+                  "branch_b_degraded": false
+                }
               },
-              "ResultPath": "$.branch_b",
               "End": true
             },
             "PredictorTraining": {
@@ -3659,23 +3662,25 @@
             },
             "BranchBComplete": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining quartet) completed (training success; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). The skip_predictor_training path terminates at its own PredictorTrainingSkipped terminal (config#2253) with the same branch_b_status=OK contract plus a skipped:true marker. Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch. alpha-engine-config#6722: also hoists $.research_degraded_local (seeded false by InitPredictorDegradedFlag, set true by MarkModelZooDegraded) as branch_b_degraded \u2014 read by AggregateBranchOutcomes/CheckResearchPredictorDegraded post-join since a Parallel branch cannot write an outer-scope JSONPath directly.",
+              "Comment": "Branch B (PredictorTraining quartet) completed (training success; the L4544 model-zoo rotation, if it ran, is best-effort and converges here regardless of outcome). The skip_predictor_training path terminates at its own PredictorTrainingSkipped terminal (config#2253) with the same branch_b_status=OK contract plus a skipped:true marker. Records branch_b_status=OK. End:true so the branch SUCCEEDS and never cancels the sibling Research branch. alpha-engine-config#6722: also hoists $.research_degraded_local (seeded false by InitPredictorDegradedFlag, set true by MarkModelZooDegraded) as branch_b_degraded \u2014 read by AggregateBranchOutcomes/CheckResearchPredictorDegraded post-join since a Parallel branch cannot write an outer-scope JSONPath directly. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "branch_b_status": "OK",
-                "branch_b_degraded.$": "$.research_degraded_local"
+                "branch_b": {
+                  "branch_b_status": "OK",
+                  "branch_b_degraded.$": "$.research_degraded_local"
+                }
               },
-              "ResultPath": "$.branch_b",
               "End": true
             },
             "BranchBFailed": {
               "Type": "Pass",
-              "Comment": "Branch B (PredictorTraining) failed/timed-out (SSM non-Success normalized by ExtractPredictorError, or a Task Catch). Records branch_b_status=FAILED + $.error as DATA, End:true so the branch SUCCEEDS and the sibling Research branch runs to its own completion \u2014 a completed Research branch's signals.json / decision_artifacts are NOT silently discarded. The SF is failed AFTER the join by CheckBranchOutcomes. NOTE: if PredictorTraining promoted weights to S3 before failing a later poll, those weights persist; the recovery re-run skips the genuinely-completed branch. alpha-engine-config#6722: branch_b_degraded is fixed false here \u2014 a hard FAILED branch is reported via CheckBranchOutcomes' Or-gate before AggregateBranchOutcomes' degraded-fold is ever consulted, but the field must still exist unconditionally so Parameters.$ extraction never throws States.Runtime.",
+              "Comment": "Branch B (PredictorTraining) failed/timed-out (SSM non-Success normalized by ExtractPredictorError, or a Task Catch). Records branch_b_status=FAILED + $.error as DATA, End:true so the branch SUCCEEDS and the sibling Research branch runs to its own completion \u2014 a completed Research branch's signals.json / decision_artifacts are NOT silently discarded. The SF is failed AFTER the join by CheckBranchOutcomes. NOTE: if PredictorTraining promoted weights to S3 before failing a later poll, those weights persist; the recovery re-run skips the genuinely-completed branch. alpha-engine-config#6722: branch_b_degraded is fixed false here \u2014 a hard FAILED branch is reported via CheckBranchOutcomes' Or-gate before AggregateBranchOutcomes' degraded-fold is ever consulted, but the field must still exist unconditionally so Parameters.$ extraction never throws States.Runtime. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "branch_b_status": "FAILED",
-                "branch_b_error.$": "$.error",
-                "branch_b_degraded": false
+                "branch_b": {
+                  "branch_b_status": "FAILED",
+                  "branch_b_error.$": "$.error",
+                  "branch_b_degraded": false
+                }
               },
-              "ResultPath": "$.branch_b",
               "End": true
             },
             "InitPredictorPollCount": {
@@ -3876,7 +3881,7 @@
     },
     "AggregateBranchOutcomes": {
       "Type": "Pass",
-      "Comment": "Parallel join sync point. $.parallel_result is the 2-element array of each branch's final effective input (branch order matches the Branches array: [0]=Research branch, [1]=PredictorTraining branch). Each branch terminal wrote its status under $.branch_a / $.branch_b, so hoist both statuses to a flat path for the Choice. This is the natural Backtester sync point \u2014 Backtester needs BOTH Research signal history AND PredictorTraining weights. alpha-engine-config#6722: also hoists branch_a_degraded/branch_b_degraded \u2014 the branch-local $.research_degraded_local marker each branch threads through its own internal fail-open Catch routes (Branch A: Scanner/RegimeSubstrate/ChallengerShadow/RegimeRetrospectiveEval/ThinkTankDegraded/the eval-judge chain/AggregateCosts; Branch B: the model-zoo rotation group), folded here since a Parallel branch cannot write an outer-scope JSONPath directly \u2014 mirrors CheckParityBranchOutcomes' branch-status fold (alpha-engine-config#6030). Every branch terminal (BranchAComplete/BranchAFailed, BranchBComplete/BranchBFailed/PredictorTrainingSkipped) sets its *_degraded field unconditionally, so this Parameters.$ extraction never throws States.Runtime. | alpha-engine-config-I7812: also hoists scanner_resource_kill \u2014 set by ScannerResourceKill on the conditional fail-open path and seeded false by InitScannerResourceKillFlag, so this extraction is total.",
+      "Comment": "Parallel join sync point. $.parallel_result is the 2-element array of each branch's bounded outcome envelope (branch order matches the Branches array: [0]=Research branch, [1]=PredictorTraining branch). alpha-engine-config-I8194: each branch terminal replaces its payload rather than merging into it, so the array is a few hundred bytes regardless of how much state a branch accumulated \u2014 the 256 KB per-transition ceiling can no longer be reached through this join. The keys below are unchanged by that fix. Each branch terminal wrote its status under $.branch_a / $.branch_b, so hoist both statuses to a flat path for the Choice. This is the natural Backtester sync point \u2014 Backtester needs BOTH Research signal history AND PredictorTraining weights. alpha-engine-config#6722: also hoists branch_a_degraded/branch_b_degraded \u2014 the branch-local $.research_degraded_local marker each branch threads through its own internal fail-open Catch routes (Branch A: Scanner/RegimeSubstrate/ChallengerShadow/RegimeRetrospectiveEval/ThinkTankDegraded/the eval-judge chain/AggregateCosts; Branch B: the model-zoo rotation group), folded here since a Parallel branch cannot write an outer-scope JSONPath directly \u2014 mirrors CheckParityBranchOutcomes' branch-status fold (alpha-engine-config#6030). Every branch terminal (BranchAComplete/BranchAFailed, BranchBComplete/BranchBFailed/PredictorTrainingSkipped) sets its *_degraded field unconditionally, so this Parameters.$ extraction never throws States.Runtime. | alpha-engine-config-I7812: also hoists scanner_resource_kill \u2014 set by ScannerResourceKill on the conditional fail-open path and seeded false by InitScannerResourceKillFlag, so this extraction is total.",
       "Parameters": {
         "branch_a_status.$": "$.parallel_result[0].branch_a.branch_a_status",
         "branch_b_status.$": "$.parallel_result[1].branch_b.branch_b_status",
@@ -4532,7 +4537,7 @@
     },
     "ParityParallel": {
       "Type": "Parallel",
-      "Comment": "alpha-engine-config#6030 (Brian ruling 2026-08-01; sf-pipeline-policy \u00a72.1 atomic): the old Parity state bundled THREE logical stages (pit_parity lookahead pass ~13 min, pit_parity walkforward pass ~10 min, parity replay ~2.5 min) behind one spot_parity.sh invocation with internal skip flags \u2014 the prohibited pattern verbatim. None consumes another's output, yet all three died together (2026-08-01: SIGKILLed at the 2h bound with zero partial artifacts). Now each is an independent branch: its own spot instance, script, timeout, failure route and skip flag \u2014 one branch's failure never aborts its siblings (every branch converges on its own *Degraded terminal; the Parallel's Catch below is ONLY the backstop for a genuine SF-engine error, mirroring ResearchPredictorParallel's). The join (PitParityCompare) runs after ALL branches settle and emits the verdict \u2014 UNKNOWN when a pass artifact is missing (\u00a72.3a). The memory constraint that shaped the old design (two ~3 GB passes on one box, I6026) disappears: each pass gets its own instance.",
+      "Comment": "alpha-engine-config#6030 (Brian ruling 2026-08-01; sf-pipeline-policy \u00a72.1 atomic): the old Parity state bundled THREE logical stages (pit_parity lookahead pass ~13 min, pit_parity walkforward pass ~10 min, parity replay ~2.5 min) behind one spot_parity.sh invocation with internal skip flags \u2014 the prohibited pattern verbatim. None consumes another's output, yet all three died together (2026-08-01: SIGKILLed at the 2h bound with zero partial artifacts). Now each is an independent branch: its own spot instance, script, timeout, failure route and skip flag \u2014 one branch's failure never aborts its siblings (every branch converges on its own *Degraded terminal; the Parallel's Catch below is ONLY the backstop for a genuine SF-engine error, mirroring ResearchPredictorParallel's). The join (PitParityCompare) runs after ALL branches settle and emits the verdict \u2014 UNKNOWN when a pass artifact is missing (\u00a72.3a). The memory constraint that shaped the old design (two ~3 GB passes on one box, I6026) disappears: each pass gets its own instance. alpha-engine-config-I8194: every branch terminal replaces its payload (Parameters/Result nested under the old ResultPath key, no ResultPath), so this Parallel's result is bounded by the number of branches rather than by branch state. tests/test_sf_parallel_branch_payload.py derives that invariant from the definition \u2014 do not reintroduce a ResultPath on a branch terminal.",
       "Branches": [
         {
           "StartAt": "CheckSkipPitParityLookahead",
@@ -4723,29 +4728,32 @@
             },
             "PitParityLookaheadComplete": {
               "Type": "Pass",
-              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_pit_lookahead for AggregateParityBranchOutcomes.",
+              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_pit_lookahead for AggregateParityBranchOutcomes. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "OK"
+                "branch_pit_lookahead": {
+                  "status": "OK"
+                }
               },
-              "ResultPath": "$.branch_pit_lookahead",
               "End": true
             },
             "PitParityLookaheadSkipped": {
               "Type": "Pass",
-              "Comment": "Branch skip terminal ({\"skip_pit_parity_lookahead\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'.",
+              "Comment": "Branch skip terminal ({\"skip_pit_parity_lookahead\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "SKIPPED"
+                "branch_pit_lookahead": {
+                  "status": "SKIPPED"
+                }
               },
-              "ResultPath": "$.branch_pit_lookahead",
               "End": true
             },
             "PitParityLookaheadDegraded": {
               "Type": "Pass",
-              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.pit_parity_lookahead_poll / $.pit_parity_lookahead_error.",
+              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.pit_parity_lookahead_poll / $.pit_parity_lookahead_error. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "DEGRADED"
+                "branch_pit_lookahead": {
+                  "status": "DEGRADED"
+                }
               },
-              "ResultPath": "$.branch_pit_lookahead",
               "End": true
             },
             "PitParityLookaheadResourceKillCheck": {
@@ -4847,11 +4855,12 @@
             },
             "PitParityLookaheadResourceKill": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): PitParityLookahead was KILLED FOR RESOURCES (its own internal timeout), distinct from the generic PitParityLookaheadDegraded 'could not conclude' fail-open. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes reads this and routes the WHOLE SF to the hard-fail path (the shared hard-fail chokepoint) instead of the fail-open ParityDegraded continuation, so PitParityCompare/Evaluator/ReportCard/Director do not run this week and the failure is visible from get-execution-history alone.",
+              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): PitParityLookahead was KILLED FOR RESOURCES (its own internal timeout), distinct from the generic PitParityLookaheadDegraded 'could not conclude' fail-open. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes reads this and routes the WHOLE SF to the hard-fail path (the shared hard-fail chokepoint) instead of the fail-open ParityDegraded continuation, so PitParityCompare/Evaluator/ReportCard/Director do not run this week and the failure is visible from get-execution-history alone. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "RESOURCE_KILL"
+                "branch_pit_lookahead": {
+                  "status": "RESOURCE_KILL"
+                }
               },
-              "ResultPath": "$.branch_pit_lookahead",
               "End": true
             },
             "CheckPitParityLookaheadResourceKillCheckOutcome": {
@@ -5057,29 +5066,32 @@
             },
             "PitParityWalkforwardComplete": {
               "Type": "Pass",
-              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_pit_walkforward for AggregateParityBranchOutcomes.",
+              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_pit_walkforward for AggregateParityBranchOutcomes. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "OK"
+                "branch_pit_walkforward": {
+                  "status": "OK"
+                }
               },
-              "ResultPath": "$.branch_pit_walkforward",
               "End": true
             },
             "PitParityWalkforwardSkipped": {
               "Type": "Pass",
-              "Comment": "Branch skip terminal ({\"skip_pit_parity_walkforward\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'.",
+              "Comment": "Branch skip terminal ({\"skip_pit_parity_walkforward\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "SKIPPED"
+                "branch_pit_walkforward": {
+                  "status": "SKIPPED"
+                }
               },
-              "ResultPath": "$.branch_pit_walkforward",
               "End": true
             },
             "PitParityWalkforwardDegraded": {
               "Type": "Pass",
-              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.pit_parity_walkforward_poll / $.pit_parity_walkforward_error.",
+              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.pit_parity_walkforward_poll / $.pit_parity_walkforward_error. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "DEGRADED"
+                "branch_pit_walkforward": {
+                  "status": "DEGRADED"
+                }
               },
-              "ResultPath": "$.branch_pit_walkforward",
               "End": true
             },
             "PitParityWalkforwardResourceKillCheck": {
@@ -5181,11 +5193,12 @@
             },
             "PitParityWalkforwardResourceKill": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): PitParityWalkforward was KILLED FOR RESOURCES (its own internal timeout), distinct from the generic PitParityWalkforwardDegraded 'could not conclude' fail-open. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes reads this and routes the WHOLE SF to the hard-fail path (the shared hard-fail chokepoint) instead of the fail-open ParityDegraded continuation, so PitParityCompare/Evaluator/ReportCard/Director do not run this week and the failure is visible from get-execution-history alone.",
+              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): PitParityWalkforward was KILLED FOR RESOURCES (its own internal timeout), distinct from the generic PitParityWalkforwardDegraded 'could not conclude' fail-open. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes reads this and routes the WHOLE SF to the hard-fail path (the shared hard-fail chokepoint) instead of the fail-open ParityDegraded continuation, so PitParityCompare/Evaluator/ReportCard/Director do not run this week and the failure is visible from get-execution-history alone. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "RESOURCE_KILL"
+                "branch_pit_walkforward": {
+                  "status": "RESOURCE_KILL"
+                }
               },
-              "ResultPath": "$.branch_pit_walkforward",
               "End": true
             },
             "CheckPitParityWalkforwardResourceKillCheckOutcome": {
@@ -5396,38 +5409,42 @@
             },
             "ParityReplayComplete": {
               "Type": "Pass",
-              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_parity_replay for AggregateParityBranchOutcomes.",
+              "Comment": "Branch success terminal \u2014 the witness state scripts/weekly_sf_rerun.py keys on ('entered => completed'). Writes the branch status under $.branch_parity_replay for AggregateParityBranchOutcomes. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "OK"
+                "branch_parity_replay": {
+                  "status": "OK"
+                }
               },
-              "ResultPath": "$.branch_parity_replay",
               "End": true
             },
             "ParityReplaySkipped": {
               "Type": "Pass",
-              "Comment": "Branch skip terminal ({\"skip_parity_replay\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'.",
+              "Comment": "Branch skip terminal ({\"skip_parity_replay\": true}) \u2014 recorded distinctly from OK/DEGRADED so the aggregate and the rerun helper can tell 'ran clean' from 'operator skipped'. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "SKIPPED"
+                "branch_parity_replay": {
+                  "status": "SKIPPED"
+                }
               },
-              "ResultPath": "$.branch_parity_replay",
               "End": true
             },
             "ParityReplayDegraded": {
               "Type": "Pass",
-              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.parity_replay_poll / $.parity_replay_error.",
+              "Comment": "THE BRANCH-LEVEL FAIL-OPEN MARKER (alpha-engine-config#6030). Every non-success path of this branch converges here \u2014 send/poll Catch, terminal non-Success command status, poll-budget exhaustion \u2014 and the branch ENDS SUCCESS with status DEGRADED so the SF Parallel never kills the sibling branches (\u00a74 blast radius; mirrors ThinkTankDegraded's fail-open shape). The degradation is NOT silent: CheckParityBranchOutcomes folds any DEGRADED branch into the existing $.parity_degraded flag family (ParityDegraded \u2192 PublishParityDegraded pages immediately; CheckGateDegradedNotify carries it to the terminal notification per \u00a72.3), and the PitParityCompare join emits the parity verdict as UNKNOWN when this branch's artifact is consequently absent (\u00a72.3a \u2014 absence of a verdict is never a pass). Specifics on the execution record: $.parity_replay_poll / $.parity_replay_error. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "DEGRADED"
+                "branch_parity_replay": {
+                  "status": "DEGRADED"
+                }
               },
-              "ResultPath": "$.branch_parity_replay",
               "End": true
             },
             "ParityReplayResourceKill": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): ParityReplay's captured StandardErrorContent carried krepis.ssm_log_capture's RESOURCE KILL classification (alpha-engine-config-I7258) \u2014 the replay was killed for resources, not merely unable to conclude. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes routes the WHOLE SF to the hard-fail path instead of the fail-open ParityDegraded continuation.",
+              "Comment": "alpha-engine-config-I7267 (Brian's 2026-08-13 ruling, sf-pipeline-policy \u00a73 SFP-3): ParityReplay's captured StandardErrorContent carried krepis.ssm_log_capture's RESOURCE KILL classification (alpha-engine-config-I7258) \u2014 the replay was killed for resources, not merely unable to conclude. Branch still ends SUCCESS (sibling-isolation, \u00a74 blast radius, unchanged) but with status RESOURCE_KILL \u2014 CheckParityBranchOutcomes routes the WHOLE SF to the hard-fail path instead of the fail-open ParityDegraded continuation. alpha-engine-config-I8194 (States.DataLimitExceeded on ParityParallel, measured on friday-shell-2026-08-14-validate-i7386): this terminal no longer carries ResultPath, so the branch's OUTPUT is exactly this envelope instead of the branch's whole ~108 KB effective input with the envelope merged in. The keys are unchanged \u2014 the envelope is nested under the same key the old ResultPath wrote to \u2014 so every post-join JSONPath resolves exactly as before. The branch's substantive result is an S3 artifact the join reads (artifact-by-reference), never SF state.",
               "Parameters": {
-                "status": "RESOURCE_KILL"
+                "branch_parity_replay": {
+                  "status": "RESOURCE_KILL"
+                }
               },
-              "ResultPath": "$.branch_parity_replay",
               "End": true
             }
           }
@@ -5448,7 +5465,7 @@
     },
     "AggregateParityBranchOutcomes": {
       "Type": "Pass",
-      "Comment": "Parallel join sync point (mirrors AggregateBranchOutcomes). $.parity_parallel_result is the 3-element array of each branch's final effective input (branch order matches the Branches array: [0]=PitParityLookahead, [1]=PitParityWalkforward, [2]=ParityReplay). Each branch terminal wrote its status (OK | DEGRADED | SKIPPED) under $.branch_pit_lookahead / $.branch_pit_walkforward / $.branch_parity_replay \u2014 hoist all three to a flat path for the Choice.",
+      "Comment": "Parallel join sync point (mirrors AggregateBranchOutcomes). $.parity_parallel_result is the 3-element array of each branch's bounded outcome envelope (branch order matches the Branches array: [0]=PitParityLookahead, [1]=PitParityWalkforward, [2]=ParityReplay). alpha-engine-config-I8194: this join FAILED the run with States.DataLimitExceeded on friday-shell-2026-08-14-validate-i7386 \u2014 all three branches SUCCEEDED and each returned its whole ~108 KB effective input, 323,876 bytes of array against a 262,144-byte ceiling. Each branch terminal now replaces its payload instead of merging into it, so the array is a few hundred bytes and the parity passes' substantive results are read from S3 (parity/{run_date}/pit_stats_*.json) by PitParityCompare, never carried in SF state. The three JSONPaths below are unchanged by that fix. Each branch terminal wrote its status (OK | DEGRADED | SKIPPED) under $.branch_pit_lookahead / $.branch_pit_walkforward / $.branch_parity_replay \u2014 hoist all three to a flat path for the Choice.",
       "Parameters": {
         "pit_lookahead_status.$": "$.parity_parallel_result[0].branch_pit_lookahead.status",
         "pit_walkforward_status.$": "$.parity_parallel_result[1].branch_pit_walkforward.status",

--- a/tests/test_sf_backtest_parity_split_wiring.py
+++ b/tests/test_sf_backtest_parity_split_wiring.py
@@ -413,8 +413,13 @@ class TestChainOrdering:
             st = b[terminal]
             assert st["Type"] == "Pass"
             assert st.get("End") is True, f"{terminal} must End the branch"
-            assert st["Parameters"] == {"status": status}
-            assert st["ResultPath"] == f"$.{branch_key}"
+            # alpha-engine-config-I8194: the status envelope is nested
+            # under branch_key INSIDE Parameters and ResultPath is gone,
+            # so the branch returns ~40 bytes instead of its whole
+            # effective input. $.parity_parallel_result[i].{branch_key}
+            # .status still resolves exactly as before.
+            assert st["Parameters"] == {branch_key: {"status": status}}
+            assert "ResultPath" not in st
 
     def test_backtest_reachable_strictly_before_parity(self, sf, states):
         """Walk the HAPPY path from StartAt and assert Backtester (backtest

--- a/tests/test_sf_parallel_branch_payload.py
+++ b/tests/test_sf_parallel_branch_payload.py
@@ -1,0 +1,296 @@
+"""A Parallel state may never forward an unbounded branch payload
+(alpha-engine-config-I8194).
+
+2026-08-14 — the weekly SF FAILED with ``States.DataLimitExceeded``: "the
+state/task 'ParityParallel' returned a result with a size exceeding the
+maximum number of bytes service limit" (execution
+``friday-shell-2026-08-14-validate-i7386``, event 1403). Every one of the
+three parity branches SUCCEEDED. The failure was purely the shape of the
+join: each branch terminal was a ``Pass`` with a ``ResultPath``, so its
+output was the branch's whole *effective input* — 107,962 / 107,939 /
+107,895 bytes as measured in that execution's history — with a 40-byte
+status envelope merged into it. The Parallel's result array was 323,876
+bytes against the 262,144-byte per-transition ceiling.
+
+It was invisible for eight days because ``skip_parity: true`` on all three
+automatic triggers routes ``CheckSkipParity`` straight past ``ParityParallel``,
+so the only path that reaches the defect is one no scheduled run takes. That
+is the reason this file exists rather than a fix alone: the class is not
+reachable by running the pipeline, so it has to be reachable by reading the
+definition.
+
+The sibling guard for the OTHER half of this class is
+``tests/test_sf_poll_resultselector.py`` — SSM stdout accumulating inside a
+branch, which tripped the identical error on ``ResearchPredictorParallel`` on
+2026-06-06 and again on 2026-06-19. That guard bounds what a branch *carries*;
+this one bounds what a branch *returns*. Both are needed: the 2026-08-14
+payload was already stdout-free.
+
+**Derived from the definition, never from a list of state names.** A
+hand-kept list of Parallel or terminal state names is exactly what drifts
+when the next branch is added — the 2026-06-19 recurrence was a guard that
+enumerated only the three states in the first incident's path.
+
+The bounded shape, which is also the fleet's artifact-by-reference
+convention: a branch writes its substantive result to S3 and its terminal
+``Pass`` **replaces** the payload with a small outcome envelope (``Parameters``
+or ``Result``, and no ``ResultPath``), so the branch's return size is a
+constant. The join reads the envelope for routing and reads S3 for content.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_SF_FILES = {
+    "saturday": _INFRA / "step_function.json",
+    "weekday": _INFRA / "step_function_daily.json",
+    "eod": _INFRA / "step_function_eod.json",
+    "groom": _INFRA / "step_function_groom.json",
+}
+
+# The Step Functions per-transition payload quota, in bytes.
+_PAYLOAD_LIMIT = 256 * 1024
+
+# What a `<key>.$` field is charged when bounding a worst-case envelope: its
+# value is a JSONPath into branch state, so its size is not knowable from the
+# definition. 4 KB is generous for the only such fields that exist today
+# (normalized `$.error` contexts and boolean degraded flags).
+_JSONPATH_FIELD_ALLOWANCE = 4 * 1024
+
+# A Parallel result must stay a rounding error against the quota, not merely
+# fit under it: the result is merged into the state's input, which on the
+# 2026-08-14 execution was itself 105,971 bytes.
+_ENVELOPE_BUDGET = _PAYLOAD_LIMIT // 8
+
+
+def _walk_states(states: dict, prefix: str = ""):
+    for name, st in states.items():
+        if not isinstance(st, dict):
+            continue
+        yield prefix + name, st
+        for sub in ("Iterator", "ItemProcessor"):
+            inner = st.get(sub)
+            if isinstance(inner, dict) and isinstance(inner.get("States"), dict):
+                yield from _walk_states(inner["States"], f"{prefix}{name}/")
+        for i, b in enumerate(st.get("Branches", []) or []):
+            if isinstance(b, dict) and isinstance(b.get("States"), dict):
+                yield from _walk_states(b["States"], f"{prefix}{name}[{i}]/")
+
+
+def _parallel_states():
+    """Yield (sf, name, state, definition) for every Parallel in every SF."""
+    for sf, path in _SF_FILES.items():
+        if not path.exists():
+            continue
+        definition = json.loads(path.read_text())
+        for name, st in _walk_states(definition["States"]):
+            if st.get("Type") == "Parallel":
+                yield sf, name, st, definition
+
+
+def _branch_terminals(branch: dict):
+    """Yield (name, state) for every state that ends a branch.
+
+    A branch ends at `End: true` or at a `Succeed`/`Fail` state. `Fail`
+    produces no output at all, so it is never a payload carrier.
+
+    Only the branch's OWN states count. A `Map` iterator or a nested `Parallel`
+    inside the branch has its own terminals, and those end an iteration rather
+    than the branch — a nested Parallel is discovered and checked in its own
+    right by `_parallel_states`.
+    """
+    for name, st in branch["States"].items():
+        if not isinstance(st, dict):
+            continue
+        if st.get("Type") == "Fail":
+            continue
+        if st.get("End") is True or st.get("Type") == "Succeed":
+            yield name, st
+
+
+def _replaces_its_payload(st: dict) -> bool:
+    """True when this terminal's output is its own projection, not its input.
+
+    A `Pass` writes its projection to `ResultPath`, defaulting to `$` — the
+    whole payload. Any other `ResultPath` means "merge into the input I was
+    handed", which is precisely the unbounded forward.
+    """
+    if st.get("Type") != "Pass":
+        return False
+    if "Parameters" not in st and "Result" not in st:
+        return False
+    return st.get("ResultPath", "$") == "$"
+
+
+def _projects_its_result(parallel: dict) -> bool:
+    """True when the Parallel itself projects the branch array away.
+
+    A `ResultSelector` is evaluated on the raw branch array before the state's
+    output is measured, so projecting there bounds the result even when the
+    branches return everything. It is the alternative satisfying shape, not
+    the preferred one — the branch-terminal shape keeps the bound where the
+    payload is produced.
+    """
+    selector = parallel.get("ResultSelector")
+    if not isinstance(selector, dict) or not selector:
+        return False
+    return all(not isinstance(v, (dict, list)) for v in selector.values())
+
+
+def _outcome_envelope(st: dict) -> dict:
+    return st.get("Parameters") if "Parameters" in st else st.get("Result", {})
+
+
+def _flat_keys(obj):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield k
+            yield from _flat_keys(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _flat_keys(v)
+
+
+def _terminal_cases():
+    cases = []
+    for sf, name, st, _ in _parallel_states():
+        if _projects_its_result(st):
+            continue
+        for i, branch in enumerate(st.get("Branches", [])):
+            for tname, tst in _branch_terminals(branch):
+                cases.append(
+                    pytest.param(sf, name, i, tname, tst, id=f"{sf}-{name}[{i}]-{tname}")
+                )
+    return cases
+
+
+def _parallel_cases():
+    return [
+        pytest.param(sf, name, st, definition, id=f"{sf}-{name}")
+        for sf, name, st, definition in _parallel_states()
+    ]
+
+
+def test_the_definitions_contain_parallel_states_to_guard():
+    """A guard that silently matches nothing is not a guard.
+
+    If every Parallel is ever removed this fails loudly rather than passing
+    vacuously — the failure mode the fleet keeps re-finding in detectors that
+    report a true number about a smaller world than their name implies.
+    """
+    assert list(_parallel_states()), "no Parallel state found in any SF definition"
+    assert _terminal_cases(), "no Parallel branch terminal discovered to check"
+
+
+@pytest.mark.parametrize("sf,parallel,branch,tname,tst", _terminal_cases())
+def test_every_parallel_branch_terminal_replaces_its_payload(
+    sf, parallel, branch, tname, tst
+):
+    """The 2026-08-14 defect, stated as an invariant.
+
+    `ResultPath: "$.branch_x"` on a branch terminal means the branch returns
+    everything it accumulated plus a status. Nest the envelope under that same
+    key inside `Parameters`/`Result` and drop `ResultPath` instead: every
+    post-join JSONPath resolves identically and the branch's return size stops
+    depending on how much state it walked through.
+    """
+    assert _replaces_its_payload(tst), (
+        f"{sf}: {parallel} branch {branch} terminal {tname} forwards its branch "
+        f"payload (Type={tst.get('Type')!r}, ResultPath={tst.get('ResultPath')!r}). "
+        "A Parallel branch terminal must be a Pass carrying Parameters/Result with "
+        "no ResultPath, so the branch returns a bounded outcome envelope and its "
+        "substantive result is read from S3 by the join (alpha-engine-config-I8194)."
+    )
+
+
+@pytest.mark.parametrize("sf,parallel,st,definition", _parallel_cases())
+def test_worst_case_parallel_result_is_a_rounding_error_against_the_quota(
+    sf, parallel, st, definition
+):
+    """Bound the join's result from the definition, in bytes.
+
+    The structural test above says the shape is right; this one says the shape
+    actually buys the headroom. On 2026-08-14 this number was 323,876 for
+    ParityParallel.
+    """
+    if _projects_its_result(st):
+        pytest.skip(f"{parallel} projects its result with a scalar ResultSelector")
+    total = 2 + 2 * len(st.get("Branches", []))  # brackets and separators
+    for i, branch in enumerate(st.get("Branches", [])):
+        sizes = []
+        for _, tst in _branch_terminals(branch):
+            envelope = _outcome_envelope(tst)
+            charged = sum(
+                _JSONPATH_FIELD_ALLOWANCE if k.endswith(".$") else 0
+                for k in _flat_keys(envelope)
+            )
+            sizes.append(len(json.dumps(envelope)) + charged)
+        assert sizes, f"{parallel} branch {i} has no terminal"
+        total += max(sizes)
+    assert total < _ENVELOPE_BUDGET, (
+        f"{sf}: {parallel}'s worst-case branch array is {total} bytes, over the "
+        f"{_ENVELOPE_BUDGET}-byte envelope budget ({_PAYLOAD_LIMIT}-byte SF quota, "
+        "which the state's own input also has to fit inside)."
+    )
+
+
+@pytest.mark.parametrize("sf,parallel,st,definition", _parallel_cases())
+def test_every_post_join_path_resolves_against_every_branch_terminal(
+    sf, parallel, st, definition
+):
+    """Shrinking the payload must not drop what the join reads.
+
+    Derived both ways: the paths come from every JSONPath in the definition
+    that reads the Parallel's own ResultPath, and the fields come from the
+    branch terminals themselves. A projection that omits a field some
+    downstream `Parameters.$` reads throws `States.Runtime` at the join — the
+    same class the branch-terminal comments already warn about, now enforced.
+    """
+    result_path = st.get("ResultPath")
+    if not result_path or not result_path.startswith("$."):
+        pytest.skip(f"{parallel} does not store its result under a named path")
+    root = result_path[2:]
+    text = json.dumps(definition)
+    branches = st.get("Branches", [])
+
+    pattern = re.compile(r"\$\." + re.escape(root) + r"\[(\d+)\]((?:\.[A-Za-z0-9_]+)+)")
+    seen = set()
+    for m in pattern.finditer(text):
+        idx, rest = int(m.group(1)), m.group(2)
+        seen.add((idx, rest))
+        assert idx < len(branches), (
+            f"{sf}: {parallel} is read at index {idx} but has {len(branches)} branches"
+        )
+        keys = rest.lstrip(".").split(".")
+        for tname, tst in _branch_terminals(branches[idx]):
+            node = _outcome_envelope(tst)
+            trail = []
+            for key in keys:
+                trail.append(key)
+                assert isinstance(node, dict), (
+                    f"{sf}: {parallel}[{idx}] terminal {tname} — "
+                    f"$.{root}[{idx}].{'.'.join(trail)} is read downstream but the "
+                    "envelope is not an object at that level"
+                )
+                if key in node:
+                    node = node[key]
+                elif f"{key}.$" in node:
+                    node = {}
+                else:
+                    raise AssertionError(
+                        f"{sf}: {parallel}[{idx}] terminal {tname} does not provide "
+                        f"$.{root}[{idx}].{'.'.join(trail)}, which the definition "
+                        "reads after the join. Every terminal a branch can end at "
+                        "must set every field the join extracts, or Parameters.$ "
+                        "throws States.Runtime on whichever path ran."
+                    )
+    assert seen, (
+        f"{sf}: nothing in the definition reads $.{root} — a Parallel whose result "
+        "no state consumes is either dead weight or a missing join"
+    )

--- a/tests/test_sf_parity_degraded_wiring.py
+++ b/tests/test_sf_parity_degraded_wiring.py
@@ -44,6 +44,17 @@ _BRANCH_VARS = {
     "ParityReplay": "parity_replay",
 }
 
+# alpha-engine-config-I8194: the key each branch terminal nests its outcome
+# envelope under. It used to be the terminal's ResultPath; the terminal now
+# replaces its payload instead of merging into it, so the same name is the
+# sole top-level key of Parameters and $.parity_parallel_result[i].<key>
+# .status resolves unchanged.
+_BRANCH_ENVELOPE_KEYS = {
+    "PitParityLookahead": "branch_pit_lookahead",
+    "PitParityWalkforward": "branch_pit_walkforward",
+    "ParityReplay": "branch_parity_replay",
+}
+
 
 @pytest.fixture(scope="module")
 def states() -> dict:
@@ -92,7 +103,12 @@ def test_branch_degraded_terminal_ends_branch_success(branches, base):
     st = branches[base][f"{base}Degraded"]
     assert st["Type"] == "Pass"
     assert st.get("End") is True
-    assert st["Parameters"] == {"status": "DEGRADED"}
+    # alpha-engine-config-I8194: envelope nested under the branch key,
+    # no ResultPath — the branch returns the envelope, not its payload.
+    assert st["Parameters"] == {
+        _BRANCH_ENVELOPE_KEYS[base]: {"status": "DEGRADED"}
+    }
+    assert "ResultPath" not in st
 
 
 @pytest.mark.parametrize("base", _BRANCH_BASES)

--- a/tests/test_sf_parity_resource_kill_halt_i7267.py
+++ b/tests/test_sf_parity_resource_kill_halt_i7267.py
@@ -178,8 +178,14 @@ def test_resource_kill_terminal_ends_branch_success_with_resource_kill_status(br
     resource_kill = branches[base][f"{base}ResourceKill"]
     assert resource_kill["Type"] == "Pass"
     assert resource_kill.get("End") is True
-    assert resource_kill["Parameters"] == {"status": "RESOURCE_KILL"}
-    assert resource_kill["ResultPath"] == degraded["ResultPath"]
+    # alpha-engine-config-I8194: both terminals now nest their envelope
+    # under the same branch key and carry no ResultPath; the mirror
+    # assertion is on that key rather than on ResultPath.
+    assert resource_kill["Parameters"] == {
+        next(iter(degraded["Parameters"])): {"status": "RESOURCE_KILL"}
+    }
+    assert "ResultPath" not in resource_kill
+    assert set(resource_kill["Parameters"]) == set(degraded["Parameters"])
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +243,10 @@ def test_timed_out_true_execution_history_reaches_the_hard_fail_terminal(states,
     assert success_next == f"{base}ResourceKill"
 
     terminal = b[f"{base}ResourceKill"]
-    assert terminal["Parameters"]["status"] == "RESOURCE_KILL"
+    # alpha-engine-config-I8194: envelope nested under the branch key.
+    assert list(terminal["Parameters"].values()) == [
+        {"status": "RESOURCE_KILL"}
+    ]
     assert terminal.get("End") is True  # branch ends SUCCESS — siblings unaffected
 
     # Post-join: simulate the aggregate/fold reading this branch's status.
@@ -295,7 +304,9 @@ def test_non_timeout_failure_execution_history_still_reaches_compare(states, bra
     assert outcome["Default"] == f"{base}Degraded"
 
     degraded = b[f"{base}Degraded"]
-    assert degraded["Parameters"] == {"status": "DEGRADED"}
+    # alpha-engine-config-I8194: envelope nested under the branch key.
+    assert list(degraded["Parameters"].values()) == [{"status": "DEGRADED"}]
+    assert "ResultPath" not in degraded
     assert degraded.get("End") is True
 
     cbo = states["CheckParityBranchOutcomes"]
@@ -337,8 +348,15 @@ def test_parity_replay_resource_kill_classified_from_standard_error_content(bran
     terminal = b["ParityReplayResourceKill"]
     assert terminal["Type"] == "Pass"
     assert terminal.get("End") is True
-    assert terminal["Parameters"] == {"status": "RESOURCE_KILL"}
-    assert terminal["ResultPath"] == b["ParityReplayDegraded"]["ResultPath"]
+    # alpha-engine-config-I8194: envelope nested under the branch key,
+    # ResultPath gone; the mirror assertion moves to the key.
+    assert terminal["Parameters"] == {
+        "branch_parity_replay": {"status": "RESOURCE_KILL"}
+    }
+    assert "ResultPath" not in terminal
+    assert set(terminal["Parameters"]) == set(
+        b["ParityReplayDegraded"]["Parameters"]
+    )
 
     cbo_choice_vars = {
         c["Variable"] for c in

--- a/tests/test_sf_research_predictor_degraded_wiring.py
+++ b/tests/test_sf_research_predictor_degraded_wiring.py
@@ -232,32 +232,38 @@ def test_mark_model_zoo_degraded_shape(branch_b):
 
 def test_branch_a_complete_hoists_local_flag(branch_a):
     st = branch_a["BranchAComplete"]
-    assert st["Parameters"]["branch_a_status"] == "OK"
-    assert st["Parameters"]["branch_a_degraded.$"] == "$.research_degraded_local"
+    assert st["Parameters"]["branch_a"]["branch_a_status"] == "OK"
+    assert (
+        st["Parameters"]["branch_a"]["branch_a_degraded.$"]
+        == "$.research_degraded_local"
+    )
 
 
 def test_branch_a_failed_sets_degraded_false(branch_a):
     st = branch_a["BranchAFailed"]
-    assert st["Parameters"]["branch_a_status"] == "FAILED"
-    assert st["Parameters"]["branch_a_degraded"] is False
+    assert st["Parameters"]["branch_a"]["branch_a_status"] == "FAILED"
+    assert st["Parameters"]["branch_a"]["branch_a_degraded"] is False
 
 
 def test_branch_b_complete_hoists_local_flag(branch_b):
     st = branch_b["BranchBComplete"]
-    assert st["Parameters"]["branch_b_status"] == "OK"
-    assert st["Parameters"]["branch_b_degraded.$"] == "$.research_degraded_local"
+    assert st["Parameters"]["branch_b"]["branch_b_status"] == "OK"
+    assert (
+        st["Parameters"]["branch_b"]["branch_b_degraded.$"]
+        == "$.research_degraded_local"
+    )
 
 
 def test_branch_b_failed_sets_degraded_false(branch_b):
     st = branch_b["BranchBFailed"]
-    assert st["Parameters"]["branch_b_status"] == "FAILED"
-    assert st["Parameters"]["branch_b_degraded"] is False
+    assert st["Parameters"]["branch_b"]["branch_b_status"] == "FAILED"
+    assert st["Parameters"]["branch_b"]["branch_b_degraded"] is False
 
 
 def test_predictor_training_skipped_sets_degraded_false(branch_b):
     st = branch_b["PredictorTrainingSkipped"]
-    assert st["Result"]["branch_b_status"] == "OK"
-    assert st["Result"]["branch_b_degraded"] is False
+    assert st["Result"]["branch_b"]["branch_b_status"] == "OK"
+    assert st["Result"]["branch_b"]["branch_b_degraded"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sf_research_predictor_parallel_wiring.py
+++ b/tests/test_sf_research_predictor_parallel_wiring.py
@@ -475,24 +475,33 @@ class TestBranchBContents:
         skipped = branch_b["PredictorTrainingSkipped"]
         assert skipped["Type"] == "Pass"
         assert skipped["End"] is True
-        assert skipped["ResultPath"] == "$.branch_b"
-        assert skipped["Result"]["branch_b_status"] == "OK"
-        assert skipped["Result"]["skipped"] is True
+        # alpha-engine-config-I8194: the envelope moved INSIDE Parameters
+        # under the key the old ResultPath named, and ResultPath is gone —
+        # a branch terminal must REPLACE its payload, not merge into it, or
+        # the branch returns its whole ~108 KB effective input and the join
+        # trips States.DataLimitExceeded. Every post-join JSONPath is
+        # unchanged. tests/test_sf_parallel_branch_payload.py owns the
+        # definition-derived form of this invariant.
+        assert "ResultPath" not in skipped
+        assert set(skipped["Result"]) == {"branch_b"}
+        assert skipped["Result"]["branch_b"]["branch_b_status"] == "OK"
+        assert skipped["Result"]["branch_b"]["skipped"] is True
         # Exactly the success contract + the marker + the degraded field
         # (alpha-engine-config#6722: fixed false — this path never reaches
         # the model-zoo rotation, and the field must exist unconditionally
         # so AggregateBranchOutcomes' Parameters.$ extraction never throws).
-        assert set(skipped["Result"]) == {
+        assert set(skipped["Result"]["branch_b"]) == {
             "branch_b_status", "skipped", "branch_b_degraded",
         }
-        assert skipped["Result"]["branch_b_degraded"] is False
+        assert skipped["Result"]["branch_b"]["branch_b_degraded"] is False
         # Contract equivalence with the real success terminal.
         complete = branch_b["BranchBComplete"]
         assert (
-            skipped["Result"]["branch_b_status"]
-            == complete["Parameters"]["branch_b_status"]
+            skipped["Result"]["branch_b"]["branch_b_status"]
+            == complete["Parameters"]["branch_b"]["branch_b_status"]
         )
-        assert skipped["ResultPath"] == complete["ResultPath"]
+        assert set(skipped["Result"]) == set(complete["Parameters"])
+        assert "ResultPath" not in complete
 
     # test_validation_head_object_key_is_iam_granted was ported to
     # nous-ergon-ops — the SF role policy
@@ -742,25 +751,40 @@ class TestPerBranchErrorIsolation:
         # alpha-engine-config#6722: BranchAComplete moved from a bare
         # Result to Parameters so it can also hoist branch_a_degraded.$
         # from the branch-local $.research_degraded_local marker.
-        ok = branch_a["BranchAComplete"]
-        assert ok["Parameters"]["branch_a_status"] == "OK"
-        assert ok["Parameters"]["branch_a_degraded.$"] == "$.research_degraded_local"
-        assert ok["ResultPath"] == "$.branch_a"
-        bad = branch_a["BranchAFailed"]
-        assert bad["Parameters"]["branch_a_status"] == "FAILED"
-        assert bad["Parameters"]["branch_a_error.$"] == "$.error"
-        assert bad["Parameters"]["branch_a_degraded"] is False
-        assert bad["ResultPath"] == "$.branch_a"
+        # alpha-engine-config-I8194: the envelope moved INSIDE Parameters
+        # under the key the old ResultPath named, and ResultPath is gone —
+        # a branch terminal must REPLACE its payload, not merge into it, or
+        # the branch returns its whole ~108 KB effective input and the join
+        # trips States.DataLimitExceeded. Every post-join JSONPath is
+        # unchanged. tests/test_sf_parallel_branch_payload.py owns the
+        # definition-derived form of this invariant.
+        ok = branch_a["BranchAComplete"]["Parameters"]["branch_a"]
+        assert ok["branch_a_status"] == "OK"
+        assert ok["branch_a_degraded.$"] == "$.research_degraded_local"
+        assert "ResultPath" not in branch_a["BranchAComplete"]
+        bad = branch_a["BranchAFailed"]["Parameters"]["branch_a"]
+        assert bad["branch_a_status"] == "FAILED"
+        assert bad["branch_a_error.$"] == "$.error"
+        assert bad["branch_a_degraded"] is False
+        assert "ResultPath" not in branch_a["BranchAFailed"]
 
     def test_branch_b_records_status(self, branch_b):
-        ok = branch_b["BranchBComplete"]
-        assert ok["Parameters"]["branch_b_status"] == "OK"
-        assert ok["Parameters"]["branch_b_degraded.$"] == "$.research_degraded_local"
-        assert ok["ResultPath"] == "$.branch_b"
-        bad = branch_b["BranchBFailed"]
-        assert bad["Parameters"]["branch_b_status"] == "FAILED"
-        assert bad["Parameters"]["branch_b_error.$"] == "$.error"
-        assert bad["Parameters"]["branch_b_degraded"] is False
+        # alpha-engine-config-I8194: the envelope moved INSIDE Parameters
+        # under the key the old ResultPath named, and ResultPath is gone —
+        # a branch terminal must REPLACE its payload, not merge into it, or
+        # the branch returns its whole ~108 KB effective input and the join
+        # trips States.DataLimitExceeded. Every post-join JSONPath is
+        # unchanged. tests/test_sf_parallel_branch_payload.py owns the
+        # definition-derived form of this invariant.
+        ok = branch_b["BranchBComplete"]["Parameters"]["branch_b"]
+        assert ok["branch_b_status"] == "OK"
+        assert ok["branch_b_degraded.$"] == "$.research_degraded_local"
+        assert "ResultPath" not in branch_b["BranchBComplete"]
+        bad = branch_b["BranchBFailed"]["Parameters"]["branch_b"]
+        assert bad["branch_b_status"] == "FAILED"
+        assert bad["branch_b_error.$"] == "$.error"
+        assert bad["branch_b_degraded"] is False
+        assert "ResultPath" not in branch_b["BranchBFailed"]
 
     def test_no_branch_state_routes_to_top_level_handle_failure(
         self, parallel
@@ -1215,9 +1239,9 @@ class TestNoDanglingTargetsAnywhere:
         error-isolation contract). Branch B gained a third terminal in
         config#2253: PredictorTrainingSkipped (validated-skip success)."""
         expected = [
-            ("$.branch_a", {"BranchAComplete", "BranchAFailed"}),
+            ("branch_a", {"BranchAComplete", "BranchAFailed"}),
             (
-                "$.branch_b",
+                "branch_b",
                 {
                     "BranchBComplete",
                     "BranchBFailed",
@@ -1229,8 +1253,15 @@ class TestNoDanglingTargetsAnywhere:
             ends = {
                 k for k, v in b["States"].items() if v.get("End") is True
             }
-            result_path, names = expected[bi]
+            envelope_key, names = expected[bi]
             assert ends == names, (bi, ends)
             for k in ends:
-                assert b["States"][k]["Type"] == "Pass", (bi, k)
-                assert b["States"][k]["ResultPath"] == result_path, (bi, k)
+                st = b["States"][k]
+                assert st["Type"] == "Pass", (bi, k)
+                # alpha-engine-config-I8194: the terminal REPLACES the
+                # branch payload — the envelope key that used to be the
+                # ResultPath is now the sole top-level key of
+                # Parameters/Result, and ResultPath is absent.
+                assert "ResultPath" not in st, (bi, k)
+                body = st.get("Parameters", st.get("Result"))
+                assert set(body) == {envelope_key}, (bi, k)

--- a/tests/test_sf_scanner_resource_kill_i7812.py
+++ b/tests/test_sf_scanner_resource_kill_i7812.py
@@ -241,10 +241,17 @@ def test_the_kill_marker_is_seeded_both_polarities_and_hoisted_out_of_the_branch
     assert '"scanner_resource_kill":false' in floor
     assert branch_a["ScannerResourceKill"]["ResultPath"] == "$.scanner_resource_kill"
     assert branch_a["ScannerResourceKill"]["Result"] is True
-    assert branch_a["BranchAComplete"]["Parameters"]["scanner_resource_kill.$"] == (
-        "$.scanner_resource_kill"
+    # alpha-engine-config-I8194: the hoisted fields moved one level down,
+    # inside the branch_a envelope that Parameters now IS (no ResultPath).
+    assert branch_a["BranchAComplete"]["Parameters"]["branch_a"][
+        "scanner_resource_kill.$"
+    ] == "$.scanner_resource_kill"
+    assert (
+        branch_a["BranchAFailed"]["Parameters"]["branch_a"][
+            "scanner_resource_kill"
+        ]
+        is False
     )
-    assert branch_a["BranchAFailed"]["Parameters"]["scanner_resource_kill"] is False
     assert states["AggregateBranchOutcomes"]["Parameters"]["scanner_resource_kill.$"] == (
         "$.parallel_result[0].branch_a.scanner_resource_kill"
     )


### PR DESCRIPTION
## What & why — `alpha-engine-config-I8194`

`ParityParallel` failed the weekly SF with `States.DataLimitExceeded` on execution `friday-shell-2026-08-14-validate-i7386` (event 1403), with **all three parity branches SUCCEEDED**. The failure was the shape of the join, not the work.

**Measured from that execution's history**, not assumed:

| | bytes |
|---|---|
| `PitParityLookaheadComplete` output | 107,962 |
| `PitParityWalkforwardComplete` output | 107,939 |
| `ParityReplayComplete` output | 107,934 |
| Parallel result array | **323,876** |
| SF per-transition quota | 262,144 |
| `ParityParallel` input (merged with the array at `ResultPath`) | 105,971 |

Each terminal was a `Pass` with a `ResultPath`, so its ~40-byte status envelope was **merged into** the branch payload instead of replacing it — the branch returned its whole effective input. Nothing about the branches' work was large; the ~108 KB is the execution state each branch inherits.

It has been invisible since 2026-08-14 because `skip_parity: true` on all three automatic triggers routes `CheckSkipParity` past `ParityParallel`. It fires on the first re-enabled run. Not touched here: `skip_parity` stays on every automatic trigger — that is `I7309`'s decision, and this fix is correct while parity remains disabled.

## The change

Every branch terminal in **both** Parallel states (17 in total) nests its envelope under the key its `ResultPath` used to name, and carries no `ResultPath`:

```
-  "Parameters": { "status": "OK" },
-  "ResultPath": "$.branch_pit_lookahead",
+  "Parameters": { "branch_pit_lookahead": { "status": "OK" } },
```

The branch's return size becomes a constant, and **every post-join JSONPath resolves unchanged** — `$.parity_parallel_result[0].branch_pit_lookahead.status`, `$.parallel_result[0].branch_a.branch_a_status`, `$.parallel_result[0].branch_a.scanner_resource_kill` and `ExtractParallelBranchError`'s whole-object `$.parallel_result[1].branch_b` all read exactly what they read before. Worst-case array after the change: **170 bytes** for `ParityParallel`.

`ResearchPredictorParallel` carries the identical defect (77,559 bytes of array today — latent, not firing) and is fixed with it. Fixing only the branch that failed would be fixing the instance, not the class.

## SOTA and delta

**SOTA: artifact-by-reference** — the branch writes its result to S3 and returns a small verdict envelope; the join reads what it needs from S3. That is already true here: `PitParityCompare` reads `parity/{run_date}/pit_stats_{lookahead,walkforward}.json`, and the parity verdict lands in `backtest/{run_date}/pit_parity.json`. The SF never carried the substantive result — only the payload it forgot to drop. So the fix is to stop forwarding, not to introduce a new artifact.

`policy-shared-code`: the shape mirrors the repo's existing guard for the *other* half of this class, `tests/test_sf_poll_resultselector.py`, which bounds what a branch **carries** (SSM stdout, the 2026-06-06 and 2026-06-19 instances of the same 256 KB error). This bounds what a branch **returns**. Both are needed — the 2026-08-14 payload was already stdout-free.

Considered and not taken: a `ResultSelector` on the Parallel. It bounds the state's output but leaves each branch free to return everything, so the bound sits away from where the payload is produced and the next branch added inherits nothing. The new guard accepts a scalar-only `ResultSelector` as a satisfying shape, so that route stays open where it is the right one.

**Delta: none.** No consumer loses a field, no new artifact, no new stage.

## The detector — `sf-pipeline-policy` §2.2

"A failure class that has broken a live run once becomes a preflight assertion (or an equivalent merge-blocking contract test) before the next run."

`tests/test_sf_parallel_branch_payload.py` (new, 22 cases) runs in the required `test` check. It is **derived from the definitions, never from a list of state names** — the 2026-06-19 recurrence of this class was a guard that enumerated only the three states in the first incident's path:

1. `test_every_parallel_branch_terminal_replaces_its_payload` — discovers every `Parallel` in all four SF JSONs, every branch, every terminal, and requires a payload-replacing `Pass`.
2. `test_worst_case_parallel_result_is_a_rounding_error_against_the_quota` — bounds the join's result in bytes from the definition (`.$` fields charged 4 KB), against 1/8 of the quota, because the result is merged into an input that was itself 105,971 bytes.
3. `test_every_post_join_path_resolves_against_every_branch_terminal` — the "don't drop what a consumer reads" half: regexes every `$.<result_path>[i].…` read out of the definition and asserts every terminal that branch can end at provides it, so a projection that omits a field cannot pass.
4. `test_the_definitions_contain_parallel_states_to_guard` — the guard fails rather than passing vacuously if it ever matches nothing.

Verified **red on the pre-fix definition** (19 failures, including all four `ParityParallel` branch-2 terminals) and green after — the property the issue asks for: the failure is now reachable without a live parity run.

## Merge order

No semantic dependency on the in-flight `nousergon-data` PRs. `nousergon-data-PR1510` (`EXECUTION_RUN_DATE`) and `nousergon-data-PR1509` (recovery chain) both edit `infrastructure/step_function.json`, but on disjoint state objects — `commands.$` / Lambda `Payload` params and `CheckEc2InstanceId` respectively, none of them a Parallel branch terminal. **Land 1509 and 1510 first if they are ready**; this branch rebases cleanly behind either. If this lands first, both rebase cleanly onto it.

## Test plan

Run **before** opening this PR, in a dedicated worktree:

- `python3 -m pytest tests/ -q` → **6459 passed, 17 skipped, 0 failed** (baseline 6437; +22 from the new guard). 105s.
- The 23 existing wiring assertions that pinned the old terminal shape were **updated, not deleted** — each still asserts the invariant it was written for (branch ends success, records its status, hoists its degraded / resource-kill flag unconditionally); only the location of the envelope moved. Files: `test_sf_backtest_parity_split_wiring.py`, `test_sf_parity_degraded_wiring.py`, `test_sf_parity_resource_kill_halt_i7267.py`, `test_sf_research_predictor_degraded_wiring.py`, `test_sf_research_predictor_parallel_wiring.py`, `test_sf_scanner_resource_kill_i7812.py`.
- `aws stepfunctions validate-state-machine-definition --type STANDARD --severity ERROR` on the edited definition → `{"result": "OK", "diagnostics": []}`.
- New guard run against `origin/main`'s definition → 19 failed / 3 passed; against this branch → 22 passed.

Rehearsal-path: tests/test_sf_parallel_branch_payload.py

The 256 KB ceiling is a property of the definition, and this PR's guard evaluates it from the definition — a live Saturday adds no information a green `test` check does not already carry.

## Closes-when (unchanged, and NOT claimed by this PR)

`I8194` closes when `ParityParallel` completes on an operator `StartExecution` carrying `{"skip_parity": false}` and `backtest/{run_date}/pit_parity.json` is written with both passes reporting. No production execution was started here — inspection was read-only.

Prepared by: Claude Opus 5 via [Claude Code](https://claude.com/claude-code)
