### PR TITLE
feat(pause-reconcile): publish machine-readable declared-pause lane set

### DIFF
--- a/infrastructure/pause_reconcile.py
+++ b/infrastructure/pause_reconcile.py
@@ -79,10 +79,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
+import boto3
 import yaml
 
 HERE = Path(__file__).parent.resolve()
@@ -107,6 +110,16 @@ _AWS_MANAGED_PREFIX = "DO-NOT-DELETE-"
 CHECK_ID = "automation-pause-reconcile"
 CHECK_LABEL = "automation pause: manifest vs registry vs live AWS"
 CADENCE_MINUTES = 1440  # the daily sf-arn-drift-check sweep
+
+#: alpha-engine-config-I8189 — a machine-readable declared-pause set, so a
+#: cross-repo consumer (crucible-evaluator's groom tile) can render "declared
+#: off" instead of inferring "did not run or its writer broke" from absent
+#: artifacts. One producer of pause truth (this module, already running daily
+#: at 09:50 UTC), on the evaluator's existing S3 read path.
+PAUSED_LANES_KEY = "ops/checks/automation-pause-reconcile/paused_lanes.json"
+PAUSED_LANES_SCHEMA_VERSION = 1
+
+logger = logging.getLogger(__name__)
 
 
 # ── register 3: live AWS ─────────────────────────────────────────────────────
@@ -820,6 +833,55 @@ def publish_error(error: str, dry_run: bool = False) -> str | None:
     return fcr.emit(env, dry_run=dry_run)
 
 
+def publish_paused_lanes(manifest: dict | None = None, dry_run: bool = False) -> str | None:
+    """Publish the machine-readable declared-pause set (alpha-engine-config-I8189).
+
+    A DATA artifact, not this check's own status envelope — deliberately a
+    separate S3 key from `publish()`'s `fcr.emit` (which writes this check's
+    console row, not a fact other repos read). The evaluator's groom tile
+    (`crucible-evaluator/grading/tiles/groom.py`) reads this key to render a
+    declared-off state for the paused groom lanes instead of inferring
+    "groomer did not run or its writer broke" from absent artifacts —
+    `observability-policy.md` §8.3 forbids inferring DISABLED, and forbids the
+    symmetric failure of a declared pause rendering as an undeclared gap.
+
+    ``paused`` is exactly ``automation_pause.paused_names(manifest)`` — the
+    existing helper that already computes "every name for which DISABLED is
+    the intended live state" (``paused`` + ``pending`` blocks) — not
+    reimplemented here.
+
+    Never raises: a failed publish of this artifact must not fail the check
+    itself, the same posture `publish()`/`publish_error()` already take via
+    `fcr.emit`. On any exception this logs a warning and returns None.
+    """
+    generated_at = datetime.now(UTC).isoformat()
+    try:
+        paused = sorted(ap.paused_names(manifest))
+        body = {
+            "schema_version": PAUSED_LANES_SCHEMA_VERSION,
+            "generated_at": generated_at,
+            "paused": paused,
+        }
+        uri = f"s3://{REGISTRY_BUCKET}/{PAUSED_LANES_KEY}"
+        if dry_run:
+            logger.info("[dry-run] would publish %s (%d paused lane(s))", uri, len(paused))
+            return None
+        boto3.client("s3").put_object(
+            Bucket=REGISTRY_BUCKET, Key=PAUSED_LANES_KEY,
+            Body=json.dumps(body, indent=2).encode(),
+            ContentType="application/json",
+        )
+        return uri
+    except Exception:  # noqa: BLE001 — a failed publish must not fail the check
+        logger.warning(
+            "could not publish declared-pause lane set to s3://%s/%s — "
+            "cross-repo consumers (e.g. crucible-evaluator's groom tile) will "
+            "not see this run's paused-lane set until the next scheduled run",
+            REGISTRY_BUCKET, PAUSED_LANES_KEY, exc_info=True,
+        )
+        return None
+
+
 def main() -> int:
     ap_ = argparse.ArgumentParser(
         description="reconcile the pause manifest, the observability registry and live AWS")
@@ -866,6 +928,10 @@ def main() -> int:
         # a check must not go red because its telemetry did. The verdict below
         # is unaffected either way.
         publish(findings, checked=len(triggers), dry_run=args.dry_run, declared_gaps=gaps)
+        # alpha-engine-config-I8189: the declared-pause lane set, a separate
+        # data artifact for cross-repo consumers. Same dry_run handling, same
+        # never-raises posture as `publish()` above.
+        publish_paused_lanes(dry_run=args.dry_run)
 
     print(annotation(findings, len(triggers)))
     if args.markdown:

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -89,6 +89,16 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # alpha-engine-config-PR7225; pinned here so this repo's guard is honest
     # about the new PUT site either way.
     "validators/stage_output_sweep.py": 1,
+    # alpha-engine-config-I8189 — the declared-pause lane set,
+    # s3://alpha-engine-research/ops/checks/automation-pause-reconcile/paused_lanes.json.
+    # One PUT per daily pause-reconcile.yml run (09:50 UTC), from
+    # `publish_paused_lanes()`, called right after the existing `publish()`
+    # call in `main()`. Registered rather than grandfathered — a stale/absent
+    # copy silently reproduces I8189 in the consumer (crucible-evaluator's
+    # groom tile falls back to inferring "did not run" from absent
+    # artifacts). The row rides alpha-engine-config-PR8199; pinned here so
+    # this repo's guard is honest about the new PUT site either way.
+    "infrastructure/pause_reconcile.py": 1,
     # alpha-engine-config-I7249 — the daily all-stage --preflight-only sweep's
     # own outputs, written by AwsSurface.put_json/put_text from emit():
     #   _preflight_sweep/{run_id}/report.json   (the run's durable record)

--- a/tests/test_pause_reconcile.py
+++ b/tests/test_pause_reconcile.py
@@ -21,6 +21,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -603,3 +604,129 @@ def test_a_declared_gap_row_names_its_owner_and_expiry(mod):
     assert rows, "the justified entry must render as a declared gap"
     assert "alpha-engine-config-I6984" in rows[0]["detail"]
     assert "2999-01-01" in rows[0]["detail"]
+
+
+
+
+# ── alpha-engine-config-I8189: machine-readable declared-pause lane set ─────
+#
+# The groom pause manifest lives in THIS repo; the evaluator (crucible-
+# evaluator's groom tile, a Lambda with no checkout) needs a machine-readable
+# fact instead of inferring "paused" from absent artifacts (forbidden by
+# observability-policy.md §8.3). This is the nousergon-data producer half —
+# `publish_paused_lanes` publishes the set `automation_pause.paused_names()`
+# already computes to a stable S3 key on the evaluator's existing read path.
+# The consumer half lands separately in crucible-evaluator.
+
+_KNOWN_GROOM_LANES = {
+    "alpha-engine-groom-lane-reconciler-5min",
+    "alpha-engine-groom-sweep-0000-daily",
+    "alpha-engine-groom-sweep-0800-daily",
+    "alpha-engine-groom-sweep-1600-daily",
+    "alpha-engine-scheduled-groom-0400-daily",
+    "alpha-engine-scheduled-groom-1200-daily",
+    "alpha-engine-scheduled-groom-2000-daily",
+    "alpha-engine-scheduled-groom-sun0900-weekly",
+}
+
+
+class _InMemoryS3:
+    """Minimal in-memory S3 mock (put_object only — this module never reads
+    this key back). No moto dep — mirrors
+    tests/test_daily_append_schema_drift.py::_InMemoryS3 /
+    tests/test_news_aggregates.py::_InMemoryS3, this repo's established
+    convention for S3-touching tests (deliberately no moto dependency)."""
+
+    def __init__(self) -> None:
+        self.puts: list[dict] = []
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.puts.append({"Bucket": Bucket, "Key": Key, "Body": Body, "ContentType": ContentType})
+        return {"ETag": "stub"}
+
+
+def test_publish_paused_lanes_writes_the_exact_contract_shape(mod, monkeypatch):
+    s3 = _InMemoryS3()
+    monkeypatch.setattr(mod, "boto3", MagicMock(client=lambda *a, **k: s3))
+
+    m = _manifest(
+        paused={name: "groom pause (alpha-engine-config-I6617)" for name in _KNOWN_GROOM_LANES},
+    )
+    uri = mod.publish_paused_lanes(m, dry_run=False)
+
+    assert uri == f"s3://{mod.REGISTRY_BUCKET}/{mod.PAUSED_LANES_KEY}"
+    assert len(s3.puts) == 1
+    put = s3.puts[0]
+    assert put["Bucket"] == mod.REGISTRY_BUCKET
+    assert put["Key"] == mod.PAUSED_LANES_KEY
+    assert put["ContentType"] == "application/json"
+
+    body = json.loads(put["Body"])
+    assert body["schema_version"] == 1
+    assert set(body.keys()) == {"schema_version", "generated_at", "paused"}
+    # generated_at parses as a UTC ISO8601 timestamp.
+    datetime.datetime.fromisoformat(body["generated_at"])
+    assert body["paused"] == sorted(body["paused"]), "paused list must be sorted"
+
+
+def test_publish_paused_lanes_matches_paused_names_including_the_eight_groom_lanes(mod, monkeypatch):
+    s3 = _InMemoryS3()
+    monkeypatch.setattr(mod, "boto3", MagicMock(client=lambda *a, **k: s3))
+
+    m = _manifest(
+        paused={name: "groom pause (alpha-engine-config-I6617)" for name in _KNOWN_GROOM_LANES},
+    )
+    mod.publish_paused_lanes(m, dry_run=False)
+
+    body = json.loads(s3.puts[0]["Body"])
+    assert set(body["paused"]) == mod.ap.paused_names(m)
+    assert _KNOWN_GROOM_LANES.issubset(set(body["paused"])), (
+        "all 8 known groom lanes must be present in the published paused set"
+    )
+
+
+def test_publish_paused_lanes_uses_the_live_manifest_by_default(mod, manifest):
+    """Sanity check against the real, checked-in manifest (not a synthetic
+    one): the 8 known groom lanes are actually paused there today."""
+    assert _KNOWN_GROOM_LANES.issubset(mod.ap.paused_names(manifest))
+
+
+def test_publish_paused_lanes_never_raises_on_a_publish_failure(mod, monkeypatch):
+    class _BrokenS3:
+        def put_object(self, **kw):
+            raise RuntimeError("S3 is down")
+
+    monkeypatch.setattr(mod, "boto3", MagicMock(client=lambda *a, **k: _BrokenS3()))
+
+    m = _manifest(paused={"tick": "x"})
+    result = mod.publish_paused_lanes(m, dry_run=False)  # must not raise
+    assert result is None
+
+
+def test_publish_paused_lanes_dry_run_does_not_write(mod, monkeypatch):
+    s3 = _InMemoryS3()
+    monkeypatch.setattr(mod, "boto3", MagicMock(client=lambda *a, **k: s3))
+
+    m = _manifest(paused={"tick": "x"})
+    result = mod.publish_paused_lanes(m, dry_run=True)
+    assert result is None
+    assert s3.puts == []
+
+
+def test_main_calls_publish_paused_lanes_after_publish(mod, monkeypatch):
+    """Wired into main() right after the existing publish() call, same
+    dry_run handling — verified by call order, not by re-testing publish()."""
+    calls: list[str] = []
+    monkeypatch.setattr(mod, "live_triggers", lambda: [])
+    monkeypatch.setattr(mod, "load_registry", lambda registry_dir=None: {})
+    monkeypatch.setattr(mod, "reconcile", lambda **kw: [])
+    monkeypatch.setattr(mod, "declared_alarm_gaps", lambda manifest=None: [])
+    monkeypatch.setattr(mod, "publish", lambda *a, **kw: calls.append("publish"))
+    monkeypatch.setattr(mod, "publish_paused_lanes", lambda *a, **kw: calls.append("publish_paused_lanes"))
+    monkeypatch.setattr(sys, "argv", ["pause_reconcile.py", "--check", "--publish", "--dry-run"])
+
+    mod.main()
+
+    assert calls == ["publish", "publish_paused_lanes"], (
+        "publish_paused_lanes must run right after publish(), same --publish/--dry-run gate"
+    )


### PR DESCRIPTION
## Summary

`alpha-engine-config-I8189`: four `crucible-evaluator` groom-tile components (`groom_completion_rate`, `groom_wet_per_completion`, `groom_comment_churn`, `groom_lost_chunks`) grade `N/A-MISSING-INPUT` with the reason "groomer did not run or its writer broke" when the groom was **deliberately** paused by Brian on 2026-08-07 (`alpha-engine-config-I6617`, tracked in `infrastructure/automation_pause.json`). `observability-policy.md` §8.3 requires DISABLED be DECLARED, never inferred — inferring "paused" from absent artifacts is exactly what the tile does today.

The pause manifest lives in this repo; the evaluator runs as a Lambda with no checkout. This PR implements option (a) from the issue (preferred): the pause reconciler, which already runs daily at 09:50 UTC and already publishes its own console row, also publishes a machine-readable declared-pause lane set to a stable S3 key on the evaluator's existing read path.

## Changes

- `infrastructure/pause_reconcile.py`:
  - New `publish_paused_lanes(manifest=None, dry_run=False)`, called from `main()` immediately after the existing `publish()` call, under the same `if args.publish:` gate (same `--dry-run` handling).
  - Publishes `{"schema_version": 1, "generated_at": "<UTC ISO8601>", "paused": [...]}` to `s3://alpha-engine-research/ops/checks/automation-pause-reconcile/paused_lanes.json`.
  - `paused` is exactly `sorted(automation_pause.paused_names(manifest))` — the existing helper (every trigger for which DISABLED is the intended live state, across `paused` + `pending`), not reimplemented.
  - Never raises: wrapped in try/except, same posture as `publish()`/`publish_error()`'s use of `fcr.emit` — a failed publish of this artifact must not fail the check itself. Logs a warning and returns `None` on any exception.
  - `boto3` promoted to a module-level import (previously absent from this file) to match this repo's established test-patching convention (`monkeypatch.setattr(mod, "boto3", ...)`, e.g. `test_dlq_redrive.py`).

- `tests/test_pause_reconcile.py`: new tests asserting (1) the exact JSON contract shape and sort order, (2) the published set matches `automation_pause.paused_names()` output and is a superset of the 8 currently-paused groom lanes (`alpha-engine-groom-lane-reconciler-5min`, `alpha-engine-groom-sweep-{0000,0800,1600}-daily`, `alpha-engine-scheduled-groom-{0400,1200,2000}-daily`, `alpha-engine-scheduled-groom-sun0900-weekly` — verified against the live checked-in manifest, not just a synthetic one), (3) a publish failure never propagates, (4) `dry_run=True` writes nothing, (5) `main()` calls `publish_paused_lanes` immediately after `publish()` under the same flags.

  Uses an in-memory S3 mock (`unittest.mock.MagicMock` + a stub `put_object`), not moto — this repo's measured, established convention (`test_daily_append_schema_drift.py::_InMemoryS3`, `test_news_aggregates.py::_InMemoryS3`, both explicitly "no moto dep"), not the moto approach named in the original brief.

- `tests/test_artifact_registry_coverage.py`: pinned the new PUT site (`infrastructure/pause_reconcile.py: 1`) per this repo's producer-file coverage guard — the artifact is registered (not grandfathered) in `alpha-engine-config-PR8199` (draft, opened this session): a stale/absent copy would silently reproduce I8189 in the consumer.

## Test plan

Run before opening this PR:

```
.venv/bin/python3 -m pytest tests/test_pause_reconcile.py -q
45 passed in 0.52s

.venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration
6421 passed, 12 skipped, 420 warnings in 101.00s
```

Deployable by the merge button alone: the reconciler's next scheduled 09:50 UTC run publishes the artifact automatically, no post-merge step.

## Sibling PRs

- `alpha-engine-config-PR8199` (draft): registers the new artifact in `ARTIFACT_REGISTRY.yaml` — required by this PR's own coverage guard, opened first this session.
- `crucible-evaluator` PR (not yet known): the consumer half — the groom tile reading this key — opened separately this same arc by a peer working from this exact contract.
- Sibling in this arc, unrelated defect, separate worktree/branch: `fix/i8185-universe-returns-dead-columns` (`alpha-engine-config-I8185`), PR #1512.
- Not related to / does not conflict with in-flight `nousergon-data` PRs #1509, #1510, #1511 (verified via `gh pr diff --name-only` — none touch `infrastructure/pause_reconcile.py` or `infrastructure/automation_pause.py`).

Closes: none in this repo (tracker is `alpha-engine-config`) — addresses the nousergon-data producer half of `alpha-engine-config-I8189`.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)