### PR TITLE
fix(dispatcher): derive BACKLOG_REPOS from REPO_ROSTER.yaml (alpha-engine-config-I8197)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -195,9 +195,23 @@ GROOM_MAX_DISPATCHES_DAILY = int(os.environ.get("GROOM_MAX_DISPATCHES_DAILY", "4
 # anti-starvation escape valve (they contributed ZERO demand), so they only
 # ever got worked when unrelated issue demand happened to launch a run.
 DEMAND_GATE_ENABLED = os.environ.get("GROOM_DEMAND_GATE_ENABLED", "true").lower() == "true"
+# ── declared roster mirror (alpha-engine-config-I8197) ───────────────────────
+# The `backlog` role from alpha-engine-config/private-docs/REPO_ROSTER.yaml, the
+# single declaration of which org repos hold a groomed backlog. This repo is
+# public and the Lambda deploy artifact is bundled without that private file, so
+# this list is a DECLARED MIRROR: it is registered in the roster's `mirrors:`
+# block and `check_repo_roster_drift.py --live` fails whenever it stops matching
+# the role. A mirror is legal; a mirror that drifts is a CI failure.
+#
+# It had drifted by four repos — symposion, claude-code-config, nousergon-console
+# and oiax were groomed backlogs that this dispatcher's demand gate could not
+# see, so their demand counted as zero toward every tier floor. Do not hand-edit:
+# change the roster, then mirror it here in the same change.
 BACKLOG_REPOS = (
     "nousergon/alpha-engine-config", "nousergon/metron-ops",
-    "nousergon/vires-ops", "nousergon/telos-ops",
+    "nousergon/vires-ops", "nousergon/telos-ops", "nousergon/symposion",
+    "nousergon/claude-code-config", "nousergon/nousergon-console",
+    "nousergon/oiax",
 )
 # config-I3227: the org this Lambda's PR enumeration searches org-wide. Never
 # a hardcoded repo list (config#2294 precedent — see alpha-engine-config's


### PR DESCRIPTION
## What & why

`scheduled-groom-dispatcher`'s demand gate enumerated **four** backlog repos. The roster declares **eight**: `symposion`, `claude-code-config`, `nousergon-console` and `oiax` are groomed backlogs this dispatcher could not see, so their demand counted as **zero** toward every tier floor and toward the anti-starvation escape valve. Work on those four repos only ever got dispatched when unrelated demand happened to launch a run.

`BACKLOG_REPOS` now matches `alpha-engine-config/private-docs/REPO_ROSTER.yaml`'s `backlog` role: 4 → 8.

This repo is public and the Lambda artifact is bundled without the private roster, so the list stays a literal — but it is now a **declared mirror**, registered in the roster's new `mirrors:` block, with `check_repo_roster_drift.py --live` failing whenever it stops matching the role. That guard ships in `alpha-engine-config-PR8215`.

### Behaviour change, named

Per-tier demand totals rise, so runs that previously fell below a tier floor may now launch. **That is the correction, not a side effect** — the floor was being computed over half the backlog.

## In-flight overlap — read before merging

`nousergon-data-PR1129` (`groom/config-4989-spot-pool-anti-affinity`) also touches `infrastructure/lambdas/scheduled-groom-dispatcher/index.py`. I read its diff before branching:

- It does **not** touch `BACKLOG_REPOS`. Its nearest hunk starts at line 207; this change is at line 198.
- It is a **draft**, `mergeStateStatus: DIRTY`, carrying `gate:dependency` + `blocked:gate`, and has not been updated since 2026-08-01.

Since it is gate-blocked and does not touch the same symbol, this landed as a separate PR rather than an extension. **This PR should merge first** — it is six lines and unblocked; #1129 is blocked on its gate and will need a rebase regardless of ordering. I have not touched #1129, its branch, or its labels.

## Cross-repo change — merge order

One change across four repos (`alpha-engine-config-I8197`). **The three mirror PRs merge BEFORE the guard**, or the guard lands red against mirrors it is about to fix:

1. `symposion-PR123`
2. `crucible-dashboard-PR764`
3. `nousergon-data-PR1515` (this PR)
4. `alpha-engine-config-PR8215` — the guard and the detector, **last**

## Test plan — run before opening

```
python3 -m pytest infrastructure/lambdas/scheduled-groom-dispatcher/ -q
```

217 passed, 0 failed — on this branch, and identical on unmodified `origin/main`. No pre-existing failures in this path.

Mirror equality verified directly against the roster loader before commit: `BACKLOG_REPOS` MATCHES.

---

Prepared by: claude-opus-5 via [Claude Code](https://claude.com/claude-code)
