### PR TITLE
feat(weekly-sf): the stage-coverage sweep gets a caller, and the marker names its claim (alpha-engine-config-I8214, I8186)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.10.2

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.10.2

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.15.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 krepis>=0.14.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/weekly-coverage-sweep/README.md
+++ b/infrastructure/lambdas/weekly-coverage-sweep/README.md
@@ -62,3 +62,15 @@ bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --apply-iam  # IAM o
 ```
 
 Managed outside CloudFormation, same rationale as `weekly-run-scope`.
+
+## Rehearsal path
+
+`infrastructure/lambdas/weekly-coverage-sweep/test_handler.py` — run pre-merge
+by `.github/workflows/ci.yml`'s `infrastructure/lambdas/*/test_handler.py` glob
+and pre-deploy by `_shared/run_handler_tests.sh`, so neither gate can drift from
+the other.
+
+Beyond the unit tests, the Friday-PM shell run is a live rehearsal: the SF
+threads `dry_run.$ = $.research_dry`, so the whole read path — client
+construction, every IAM grant the real run needs, the coverage derivation —
+executes against real infrastructure and writes nothing.

--- a/infrastructure/lambdas/weekly-coverage-sweep/README.md
+++ b/infrastructure/lambdas/weekly-coverage-sweep/README.md
@@ -1,0 +1,64 @@
+# alpha-engine-weekly-coverage-sweep
+
+The caller the stage-coverage sweep never had (`alpha-engine-config-I8214`,
+carrying `I8154` deliverable 4 and `I8186`'s state-machine half).
+
+## What it does
+
+Runs `nousergon_lib.pipeline_status`'s stage-coverage sweep over one weekly
+**cycle**, then:
+
+1. writes the sweep artifact to `_stage_coverage/_sweep/<pipeline>/<run_date>.json`
+   and publishes its metric,
+2. **augments the SF completion marker** at
+   `_sf_completion/<pipeline>/<run_date>.json` with the cycle's real shape —
+   which executions contributed, what each entered, what the union adds up to,
+3. pages (via `krepis.alerts`, deduped per pipeline + run date) when the sweep
+   finds a gap.
+
+## Why it exists
+
+The reader shipped in `nousergon-lib` and nothing called it, so it detected
+nothing. Meanwhile the completion marker's name was a claim the run could not
+support: on 2026-08-22 the marker was written by `watch-rerun-2026-08-22-3`,
+an execution that entered **1 of 16** declared spine stages. The SF now stamps
+`claim: sf_execution_terminal` and `cycle_verdict: unknown` on the object —
+what its own write actually asserts — and this handler is what upgrades that
+to a cycle verdict.
+
+## The three outcomes, and the one that matters
+
+| `outcome` | Meaning | SF terminal |
+|---|---|---|
+| `clean` | the sweep ran, no gap | `WeeklyCoverageSweepClean` |
+| `findings` | the sweep ran, found a gap, **already paged** | `WeeklyCoverageSweepFindings` |
+| `unavailable` | **the sweep did not run**, or ran and could not publish | `WeeklyCoverageSweepUnavailable` → SNS → `WeeklyCoverageSweepUnobserved` |
+
+`unavailable` is never collapsed into either of the others. "Found nothing"
+and "did not run" are different facts, and only the second means the coverage
+surface is unobserved (`principles.md` §2.7). The state machine pages for it
+because a handler that never started cannot page for itself.
+
+The handler **never raises**. It runs downstream of the pipeline's real success
+terminal, and an observe-only tail that fails a completed run is a worse defect
+than the one it was added to detect (`sf-pipeline-policy.md` §2.1).
+
+## Why a Lambda and not an SSM command
+
+This pipeline has no always-on box. `$.ec2_instance_id` is an ephemeral spot,
+and since `alpha-engine-config-I8162` a recovery run whose every box stage is
+skipped carries **no instance id at all** — which is precisely the run that
+most needs a coverage verdict. A sweep dereferencing it would throw
+`States.Runtime` one state after the pipeline's own success terminal. Mirrors
+`weekly-run-scope`, the sibling Lambda reading the same execution history for
+the same pipeline.
+
+## Deploy
+
+```
+bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --bootstrap  # first time
+bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh              # code only
+bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --apply-iam  # IAM only
+```
+
+Managed outside CloudFormation, same rationale as `weekly-run-scope`.

--- a/infrastructure/lambdas/weekly-coverage-sweep/deploy.sh
+++ b/infrastructure/lambdas/weekly-coverage-sweep/deploy.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# deploy.sh — create or update the alpha-engine-weekly-coverage-sweep Lambda.
+#
+# alpha-engine-config-I8214 (carrying I8154 d4 and I8186's state-machine half).
+# Runs nousergon_lib's stage-coverage sweep over one weekly CYCLE, publishes the
+# sweep artifact + metric, and augments the SF completion marker with the
+# cycle's real shape. See index.py's module docstring for why this is a Lambda
+# rather than an SSM command on the run's own box.
+#
+# INVOKED BY the weekly SF's `WeeklyCoverageSweep` state — there is no schedule
+# and no EventBridge wiring here, same as its sibling weekly-run-scope.
+#
+# Managed OUTSIDE CloudFormation — operator-deployed, narrow OIDC blast radius,
+# same rationale as weekly-run-scope / eod-backstop / crypto-balances.
+#
+# Usage:
+#   bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh             # update code only
+#   bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --bootstrap # first-time create
+#   bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --apply-iam # re-apply iam-policy.json only (config#2825)
+#   bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --dry-run   # show actions, do not apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
+
+FUNCTION_NAME="alpha-engine-weekly-coverage-sweep"
+ROLE_NAME="alpha-engine-weekly-coverage-sweep-role"
+POLICY_NAME="alpha-engine-weekly-coverage-sweep-policy"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT_ID="711398986525"
+
+BOOTSTRAP=false; DRY_RUN=false; APPLY_IAM=false
+for arg in "$@"; do
+  case "$arg" in
+    --bootstrap) BOOTSTRAP=true ;;
+    --dry-run) DRY_RUN=true ;;
+    --apply-iam) APPLY_IAM=true ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
+
+# ----- 0. Tests gate the deploy -------------------------------------------
+# The handler's outcome routing is exercised against stubs and needs no AWS,
+# so there is no reason for a deploy to be the first thing that runs it.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3
+
+# ----- 1. Package: pip install deps + zip handler ---------------------------
+# Unlike weekly-run-scope, this handler has a real dependency: the sweep itself
+# lives in nousergon-lib. Docker-based install (never bare `pip install -t` on
+# macOS) — see lambda_pip_install.sh for the arch/ownership rationale.
+PKG=$(mktemp -d)
+trap "rm -rf '$PKG'" EXIT
+echo "Installing deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${SCRIPT_DIR}/../lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
+cp "${SCRIPT_DIR}/index.py" "${PKG}/index.py"
+ZIP="${PKG}/function.zip"
+(cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")
+echo "Packaged ${ZIP} ($(wc -c < "${ZIP}") bytes)"
+
+TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+if $APPLY_IAM; then
+  echo "Applying IAM (role=${ROLE_NAME}, policy=${POLICY_NAME})..."
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  echo "  ✓ IAM applied. Nothing else was touched."
+  exit 0
+fi
+
+if $BOOTSTRAP; then
+  echo "Bootstrapping ${FUNCTION_NAME}..."
+  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+  ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" \
+        --query 'Configuration.FunctionName' --output text >/dev/null 2>&1; then
+    echo "  Creating Lambda: ${FUNCTION_NAME}"
+    run aws lambda create-function \
+      --function-name "${FUNCTION_NAME}" \
+      --runtime python3.12 \
+      --role "${ROLE_ARN}" \
+      --handler index.handler \
+      --zip-file "fileb://${ZIP}" \
+      --timeout 120 \
+      --memory-size 256 \
+      --environment 'Variables={LOG_LEVEL=INFO,RESEARCH_BUCKET=alpha-engine-research,PIPELINE=ne-weekly-freshness-pipeline}' \
+      --region "${REGION}" \
+      --query 'FunctionArn' --output text
+    verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
+    exit 0
+  fi
+  echo "  Lambda exists, code will be updated below"
+fi
+
+echo "Updating ${FUNCTION_NAME} code..."
+run aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file "fileb://${ZIP}" \
+  --region "${REGION}" \
+  --query 'LastModified' --output text
+
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
+

--- a/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
+++ b/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
@@ -1,0 +1,68 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Logs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-weekly-coverage-sweep:*"
+    },
+    {
+      "Sid": "ReadTheCyclesExecutions",
+      "Effect": "Allow",
+      "Action": [
+        "states:ListExecutions",
+        "states:DescribeExecution",
+        "states:GetExecutionHistory"
+      ],
+      "Resource": [
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        "arn:aws:states:us-east-1:711398986525:execution:ne-weekly-freshness-pipeline:*"
+      ]
+    },
+    {
+      "Sid": "ReadTheStageVerdictAndFreshnessSurfaces",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research",
+        "arn:aws:s3:::alpha-engine-research/_stage_coverage/*",
+        "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
+      ]
+    },
+    {
+      "Sid": "WriteTheSweepArtifact",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/_sweep/*"
+    },
+    {
+      "Sid": "AugmentTheCompletionMarker",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research/_sf_completion/*"
+    },
+    {
+      "Sid": "PublishSweepMetrics",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*"
+    },
+    {
+      "Sid": "PageWhenTheSweepFindsAGap",
+      "Effect": "Allow",
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-watchdog-alerts"
+    }
+  ]
+}

--- a/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
+++ b/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
@@ -48,9 +48,13 @@
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
+        "s3:ListBucket",
         "s3:PutObject"
       ],
-      "Resource": "arn:aws:s3:::alpha-engine-research/_sf_completion/*"
+      "Resource": [
+        "arn:aws:s3:::alpha-engine-research",
+        "arn:aws:s3:::alpha-engine-research/_sf_completion/*"
+      ]
     },
     {
       "Sid": "PublishSweepMetrics",

--- a/infrastructure/lambdas/weekly-coverage-sweep/index.py
+++ b/infrastructure/lambdas/weekly-coverage-sweep/index.py
@@ -1,0 +1,186 @@
+"""alpha-engine-weekly-coverage-sweep — the caller the stage-coverage sweep never had.
+
+Tracked as ``alpha-engine-config-I8214`` (carrying ``I8154`` deliverable 4 and
+``I8186``'s state-machine half).
+
+**What it answers.** Did this weekly CYCLE actually cover the stages it
+declares, and does the completion marker say so? ``nousergon_lib.pipeline_status``
+shipped the reader — the cycle's real shape, the union over its contributing
+executions, the coverage verdict against the artifact registry — and nothing
+called it on a schedule, so it detected nothing. This handler is its caller.
+
+**Why the marker needs it.** On 2026-08-22 the marker at
+``_sf_completion/ne-weekly-freshness-pipeline/2026-08-22.json`` was written by
+``watch-rerun-2026-08-22-3``, an execution that entered **1 of 16** declared
+spine stages. The marker's name is a claim the run could not support: the SF
+writes it on reaching its own terminal, which is a narrower fact than "the
+cycle completed". So the SF now stamps ``claim: sf_execution_terminal`` and
+``cycle_verdict: unknown`` on the object, and this handler AUGMENTS it with the
+cycle's real shape — which executions contributed, what each entered, what the
+union adds up to. A consumer reading the marker before this runs resolves to
+UNKNOWN, never to an implied pass (``sf-pipeline-policy.md`` §2.3a).
+
+**Why a Lambda and not an SSM command on the run's box.** The weekly SF has no
+always-on instance: ``$.ec2_instance_id`` is an ephemeral spot, and since
+``alpha-engine-config-I8162`` a recovery run whose every box stage is skipped
+carries **no instance id at all** — which is exactly the shape of the run that
+most needs a coverage verdict. A sweep that dereferences the instance id would
+throw ``States.Runtime`` on those runs, one state after the pipeline's own
+success terminal. The sweep reads Step Functions and S3 and writes S3 and one
+metric; it has no reason to need a box. Mirrors ``weekly-run-scope``, the
+sibling that reads the same execution history for the same pipeline.
+
+**Failure posture — fail-open, and never silent.** Three outcomes, and the
+third is the one that must not be collapsed into either of the others:
+
+- ``clean`` — the sweep ran and found no gap.
+- ``findings`` — the sweep ran and found a gap. It has already paged from
+  inside ``nousergon_lib`` (``krepis.alerts``, deduped per pipeline+run_date).
+- ``unavailable`` — **the sweep did not run.** "Found nothing" and "did not
+  run" are different facts and only the second means the surface is unobserved
+  (``principles.md`` §2.7). This handler returns it as its own outcome so the
+  SF can page for it, because a sweep that never ran cannot page for itself.
+
+It never raises: this state sits DOWNSTREAM of the pipeline's real success
+terminal, and an observe-only tail that fails a completed run is a worse defect
+than the one it was added to detect (``sf-pipeline-policy.md`` §2.1 blast
+radius). The outcome is carried in the return value instead, where the SF's
+Choice reads it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+BUCKET = os.environ.get("RESEARCH_BUCKET", "alpha-engine-research")
+PIPELINE = os.environ.get("PIPELINE", "ne-weekly-freshness-pipeline")
+
+#: The three outcomes, closed. The SF's Choice matches these literals; adding a
+#: fourth without a matching Choice branch lands on the Default, which is
+#: ``unavailable`` — the honest fall-through, never ``clean``.
+OUTCOME_CLEAN = "clean"
+OUTCOME_FINDINGS = "findings"
+OUTCOME_UNAVAILABLE = "unavailable"
+
+
+def handler(event, _context):
+    run_date = (event or {}).get("run_date") or ""
+    state_machine_arn = (event or {}).get("state_machine_arn") or ""
+    dry_run = bool((event or {}).get("dry_run"))
+
+    if not run_date:
+        # No cycle key means no cycle to sweep. Unobserved, not clean.
+        return {
+            "outcome": OUTCOME_UNAVAILABLE,
+            "reason": "no run_date supplied — there is no cycle key to sweep",
+            "run_date": run_date,
+        }
+
+    try:
+        import boto3
+        from krepis.aws_region import resolve_region
+        from nousergon_lib.pipeline_status.completion_marker import augment_marker
+        from nousergon_lib.pipeline_status.coverage import (
+            publish_sweep,
+            read_coverage_sweep,
+        )
+
+        region = resolve_region()
+        s3_client = boto3.client("s3", region_name=region)
+        sweep = read_coverage_sweep(
+            pipeline=PIPELINE,
+            run_date=run_date,
+            state_machine_arn=state_machine_arn or None,
+            bucket=BUCKET,
+            s3_client=s3_client,
+        )
+    except Exception as exc:  # noqa: BLE001 — a sweep that cannot run says so
+        # Deliberate broad catch with a named recording surface: the return
+        # value below IS the recording surface, and the SF pages on it. The
+        # failure class swallowed is "the sweep could not be performed"; the
+        # primary deliverable (the weekly run, already complete) is untouched.
+        logger.exception("coverage sweep could not run for %s", run_date)
+        return {
+            "outcome": OUTCOME_UNAVAILABLE,
+            "reason": f"{type(exc).__name__}: {exc}",
+            "run_date": run_date,
+        }
+
+    explanation = sweep.explain()
+    logger.info("coverage sweep %s: %s", run_date, explanation)
+
+    if dry_run:
+        # The Friday-PM shell run exercises the whole read path — client
+        # construction, every IAM grant the real run needs, the derivation —
+        # and writes nothing. The same dry contract every advisory producer on
+        # this pipeline honours.
+        return {
+            "outcome": OUTCOME_CLEAN,
+            "dry_run": True,
+            "run_date": run_date,
+            "explanation": explanation,
+        }
+
+    published = False
+    augmented = False
+    write_error: str | None = None
+    try:
+        import boto3
+
+        publish_sweep(
+            sweep,
+            s3_client=s3_client,
+            cloudwatch_client=boto3.client("cloudwatch", region_name=region),
+            bucket=BUCKET,
+        )
+        published = True
+        if sweep.cycle is not None:
+            augment_marker(sweep.cycle, s3_client=s3_client, bucket=BUCKET)
+            augmented = True
+        else:
+            logger.warning(
+                "the cycle could not be read, so the marker keeps its bare "
+                "envelope claim — a marker with no cycle block resolves to "
+                "UNKNOWN, never to a pass"
+            )
+    except Exception as exc:  # noqa: BLE001
+        # The sweep RAN; only its write failed. That is still an unobserved
+        # surface for every downstream reader of the artifact and the marker,
+        # so it reports as unavailable rather than as a clean sweep whose
+        # result nobody can read.
+        logger.exception("coverage sweep ran but could not publish for %s", run_date)
+        write_error = f"{type(exc).__name__}: {exc}"
+
+    if write_error is not None:
+        return {
+            "outcome": OUTCOME_UNAVAILABLE,
+            "reason": f"the sweep ran but could not publish its result: {write_error}",
+            "run_date": run_date,
+            "explanation": explanation,
+        }
+
+    if sweep.should_alert:
+        try:
+            from krepis import alerts
+
+            alerts.publish(
+                explanation,
+                severity="error",
+                source=f"stage-coverage-sweep/{PIPELINE}",
+                dedup_key=f"stage-coverage-sweep/{PIPELINE}/{run_date}",
+            )
+        except Exception:  # noqa: BLE001
+            # A failed page must not turn a real finding into a clean result.
+            # The outcome below still says findings, and the SF records it.
+            logger.exception("coverage sweep finding could not be paged")
+
+    return {
+        "outcome": OUTCOME_FINDINGS if sweep.should_alert else OUTCOME_CLEAN,
+        "run_date": run_date,
+        "explanation": explanation,
+        "published": published,
+        "marker_augmented": augmented,
+    }

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -8,6 +8,6 @@
 #     unconditional dependency of nousergon-lib, no extra needed)
 #
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
-# v0.124.85. A lower pin makes this handler fail its import and return
+# v0.124.86. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -1,0 +1,13 @@
+# nousergon-lib provides the whole sweep:
+#   - nousergon_lib.pipeline_status.coverage.read_coverage_sweep / publish_sweep
+#     — the stage-coverage reader and its artifact + metric publisher
+#   - nousergon_lib.pipeline_status.completion_marker.augment_marker
+#     — merges the cycle's real shape into the SF completion marker
+#     (alpha-engine-config-I8186)
+#   - krepis.alerts / krepis.aws_region come with it (krepis is an
+#     unconditional dependency of nousergon-lib, no extra needed)
+#
+# FLOOR, not a preference: coverage.py and completion_marker.py first exist in
+# v0.124.85. A lower pin makes this handler fail its import and return
+# outcome=unavailable every week — which pages honestly, but detects nothing.
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/lambdas/weekly-coverage-sweep/test_handler.py
+++ b/infrastructure/lambdas/weekly-coverage-sweep/test_handler.py
@@ -1,0 +1,201 @@
+"""The coverage-sweep handler's OUTCOME ROUTING, against stubbed lib calls.
+
+Named ``test_handler.py`` because that is the only filename either gate looks
+for: ``.github/workflows/ci.yml`` globs ``infrastructure/lambdas/*/test_handler.py``
+pre-merge, and ``_shared/run_handler_tests.sh`` returns 0 for a lambda that has
+none.
+
+**What is under test, and what deliberately is not.** The sweep itself —
+coverage derivation, the cycle union, the marker merge — is
+``nousergon_lib.pipeline_status``'s, tested there against captured live
+executions. What lives HERE and nowhere else is the mapping from what the
+sweep did to the three outcomes the state machine routes on, and that mapping
+has exactly one property worth pinning: **``unavailable`` is never collapsed
+into either of the others.** A sweep that could not run, and a sweep that ran
+and found nothing, are different facts; only the second means the coverage
+surface is observed. Every test below is that property from a different angle.
+
+The lib is stubbed via ``sys.modules`` rather than installed: the tests must
+run on a bare deploy runner that has not pulled the git-only dependency, and
+stubs take precedence over anything installed (``run_handler_tests.sh``).
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def _install_stubs(
+    *,
+    sweep=None,
+    read_raises: Exception | None = None,
+    publish_raises: Exception | None = None,
+    augment_raises: Exception | None = None,
+    alerts_raises: Exception | None = None,
+    calls: dict | None = None,
+):
+    """Stub boto3, krepis and nousergon_lib in sys.modules; return the module."""
+    calls = calls if calls is not None else {}
+
+    boto3 = types.ModuleType("boto3")
+    boto3.client = lambda *a, **k: object()
+    sys.modules["boto3"] = boto3
+
+    krepis = types.ModuleType("krepis")
+    region_mod = types.ModuleType("krepis.aws_region")
+    region_mod.resolve_region = lambda: "us-east-1"
+    alerts_mod = types.ModuleType("krepis.alerts")
+
+    def _publish(*a, **k):
+        calls["alerted"] = calls.get("alerted", 0) + 1
+        if alerts_raises:
+            raise alerts_raises
+
+    alerts_mod.publish = _publish
+    krepis.alerts = alerts_mod
+    krepis.aws_region = region_mod
+    sys.modules["krepis"] = krepis
+    sys.modules["krepis.alerts"] = alerts_mod
+    sys.modules["krepis.aws_region"] = region_mod
+
+    nl = types.ModuleType("nousergon_lib")
+    ps = types.ModuleType("nousergon_lib.pipeline_status")
+    cov = types.ModuleType("nousergon_lib.pipeline_status.coverage")
+    cm = types.ModuleType("nousergon_lib.pipeline_status.completion_marker")
+
+    def _read(**kwargs):
+        if read_raises:
+            raise read_raises
+        return sweep
+
+    def _publish_sweep(*a, **k):
+        calls["published"] = calls.get("published", 0) + 1
+        if publish_raises:
+            raise publish_raises
+
+    def _augment(*a, **k):
+        calls["augmented"] = calls.get("augmented", 0) + 1
+        if augment_raises:
+            raise augment_raises
+
+    cov.read_coverage_sweep = _read
+    cov.publish_sweep = _publish_sweep
+    cm.augment_marker = _augment
+    sys.modules["nousergon_lib"] = nl
+    sys.modules["nousergon_lib.pipeline_status"] = ps
+    sys.modules["nousergon_lib.pipeline_status.coverage"] = cov
+    sys.modules["nousergon_lib.pipeline_status.completion_marker"] = cm
+
+    sys.modules.pop("index", None)
+    import index
+
+    return index, calls
+
+
+class _Sweep:
+    def __init__(self, *, should_alert: bool, cycle=object()):
+        self.should_alert = should_alert
+        self.cycle = cycle
+
+    def explain(self):
+        return "sweep says so"
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    yield
+    for name in list(sys.modules):
+        if name.startswith(("nousergon_lib", "krepis")) or name in ("boto3", "index"):
+            sys.modules.pop(name, None)
+
+
+def test_a_clean_sweep_is_clean_and_augments_the_marker():
+    index, calls = _install_stubs(sweep=_Sweep(should_alert=False))
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_CLEAN
+    assert out["marker_augmented"] is True
+    assert calls.get("alerted") is None, "a clean sweep must not page"
+
+
+def test_a_finding_is_findings_and_pages_once():
+    index, calls = _install_stubs(sweep=_Sweep(should_alert=True))
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_FINDINGS
+    assert calls["alerted"] == 1
+
+
+def test_a_sweep_that_cannot_run_is_unavailable_never_clean():
+    """The whole point. A crash reading the cycle means the coverage surface is
+    UNOBSERVED for this run — rendering that as clean is principles.md §2.7's
+    'no data rendered green'."""
+    index, _ = _install_stubs(read_raises=RuntimeError("AccessDenied"))
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_UNAVAILABLE
+    assert "AccessDenied" in out["reason"]
+
+
+def test_a_sweep_that_ran_but_could_not_publish_is_unavailable():
+    """It ran, but nothing downstream can read what it found — including the
+    marker, which keeps its bare envelope claim. Unobserved, not clean."""
+    index, _ = _install_stubs(
+        sweep=_Sweep(should_alert=False), publish_raises=OSError("no such bucket")
+    )
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_UNAVAILABLE
+    assert "could not publish" in out["reason"]
+
+
+def test_a_missing_run_date_is_unavailable_not_clean():
+    index, _ = _install_stubs(sweep=_Sweep(should_alert=False))
+    out = index.handler({}, None)
+    assert out["outcome"] == index.OUTCOME_UNAVAILABLE
+
+
+def test_an_unreadable_cycle_leaves_the_marker_alone_and_still_reports():
+    """`--augment-marker` with no cycle: the marker keeps cycle_verdict unknown,
+    which resolves to UNKNOWN downstream. The sweep itself still ran, so the
+    outcome is its own finding — not unavailable."""
+    index, calls = _install_stubs(sweep=_Sweep(should_alert=False, cycle=None))
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_CLEAN
+    assert out["marker_augmented"] is False
+    assert calls.get("augmented") is None
+
+
+def test_a_failed_page_does_not_turn_a_finding_into_a_clean_result():
+    index, _ = _install_stubs(
+        sweep=_Sweep(should_alert=True), alerts_raises=RuntimeError("SNS down")
+    )
+    out = index.handler({"run_date": "2026-08-22"}, None)
+    assert out["outcome"] == index.OUTCOME_FINDINGS
+
+
+def test_dry_run_writes_nothing():
+    """The Friday-PM preflight exercises the read path and every IAM grant it
+    needs, and must not touch the marker or the artifact."""
+    index, calls = _install_stubs(sweep=_Sweep(should_alert=False))
+    out = index.handler({"run_date": "2026-08-22", "dry_run": True}, None)
+    assert out["dry_run"] is True
+    assert out["outcome"] == index.OUTCOME_CLEAN
+    assert calls.get("published") is None
+    assert calls.get("augmented") is None
+
+
+def test_the_handler_never_raises_on_any_stub_failure():
+    """An observe-only tail downstream of the success terminal must not be able
+    to fail a completed weekly run (sf-pipeline-policy §2.1)."""
+    for kwargs in (
+        {"read_raises": RuntimeError("boom")},
+        {"sweep": _Sweep(should_alert=False), "publish_raises": RuntimeError("boom")},
+        {"sweep": _Sweep(should_alert=False), "augment_raises": RuntimeError("boom")},
+        {"sweep": _Sweep(should_alert=True), "alerts_raises": RuntimeError("boom")},
+    ):
+        index, _ = _install_stubs(**kwargs)
+        out = index.handler({"run_date": "2026-08-22"}, None)
+        assert out["outcome"] in {
+            index.OUTCOME_CLEAN,
+            index.OUTCOME_FINDINGS,
+            index.OUTCOME_UNAVAILABLE,
+        }

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,4 +16,4 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -6879,7 +6879,7 @@
         "Bucket": "alpha-engine-research",
         "Key.$": "States.Format('_sf_completion/ne-weekly-freshness-pipeline/{}.json', $.run_date)",
         "ContentType": "application/json",
-        "Body.$": "States.Format('\\{\"sf\":\"ne-weekly-freshness-pipeline\",\"execution_arn\":\"{}\",\"status\":\"SUCCEEDED\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"substrate_relaunches\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, $.run_date, $.substrate_relaunch_attempts)"
+        "Body.$": "States.Format('\\{\"sf\":\"ne-weekly-freshness-pipeline\",\"execution_arn\":\"{}\",\"status\":\"SUCCEEDED\",\"claim\":\"sf_execution_terminal\",\"cycle_verdict\":\"unknown\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"substrate_relaunches\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, $.run_date, $.substrate_relaunch_attempts)"
       },
       "TimeoutSeconds": 60,
       "Retry": [
@@ -6893,7 +6893,7 @@
           "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
         }
       ],
-      "End": true
+      "Next": "WeeklyCoverageSweep"
     },
     "NotifyShellRunComplete": {
       "Type": "Task",
@@ -8505,6 +8505,110 @@
       "Type": "Succeed",
       "Comment": "alpha-engine-config-I6891: the clean Friday-PM preflight terminal. Byte-equivalent in outcome to the End: true NotifyShellRunComplete previously carried \u2014 a green preflight still ends SUCCEEDED and still writes no completion marker; only the degraded edge changed."
     },
+    "WeeklyCoverageSweep": {
+      "Comment": "WeeklyCoverageSweep (alpha-engine-config-I8214, carrying I8154 deliverable 4 and I8186's state-machine half) \u2014 runs nousergon_lib's stage-coverage sweep over THIS cycle and augments the completion marker the previous state just wrote with the cycle's real shape. WHY IT EXISTS: the sweep's READER shipped in nousergon-lib and nothing called it, so it detected nothing. This state is its caller. PLACEMENT: immediately after WriteCompletionMarker, deliberately \u2014 the marker must exist before it can be augmented. The marker the SF writes claims only 'this SF execution reached its terminal' (claim: sf_execution_terminal, cycle_verdict: unknown); this state is what upgrades that to a cycle verdict. On 2026-08-22 the marker was written by an execution that entered 1 of 16 declared stages and said nothing about it. WHY A LAMBDA AND NOT AN SSM COMMAND: this pipeline has no always-on box \u2014 $.ec2_instance_id is an ephemeral spot, and since alpha-engine-config-I8162 a recovery run whose every box stage is skipped carries NO instance id at all, which is exactly the run that most needs a coverage verdict. A sweep dereferencing it would throw States.Runtime one state after the pipeline's own success terminal. Mirrors weekly-run-scope, the sibling Lambda that reads the same execution history for the same pipeline. OBSERVE-ONLY TAIL, a design constraint not an omission: everything from here down is downstream of the real success terminal and must never turn a completed weekly run into a failure (sf-pipeline-policy \u00a72.1 blast radius). Every terminal below is a Succeed, and the Catch routes to the unobserved terminal rather than to a failure. THREE OUTCOMES AND 'DID NOT RUN' IS NOT ONE OF THE OTHER TWO: the handler returns outcome clean / findings / unavailable. Findings have ALREADY paged from inside the handler (krepis.alerts, deduped per pipeline+run_date), so nothing pages again here; 'unavailable' is the one case the sweep cannot page for itself, so the state machine does it. Collapsing unavailable into findings renders an unobserved surface as a detection, and collapsing it into clean renders it green (principles.md \u00a72.7). PREFLIGHT-AWARE: dry_run.$ = $.research_dry \u2014 the Friday-PM shell run exercises the whole read path and every IAM grant, and writes nothing. TIMEOUT: 90s, deliberately BELOW the Lambda's own 120s so the SF ceiling is the one that binds (tests/test_sf_lambda_timeout_ordering.py). DEGRADED PATH DELIBERATELY NOT WIRED: WriteCompletionMarkerDegraded must keep flowing straight into DegradedRun (a Fail state) or sf-telegram-notifier's 'Error: DegradedRun' consumer contract breaks (alpha-engine-config-I6891). A degraded cycle's coverage is swept out-of-band instead.",
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-weekly-coverage-sweep",
+        "Payload": {
+          "run_date.$": "$.run_date",
+          "dry_run.$": "$.research_dry",
+          "state_machine_arn.$": "$$.StateMachine.Id"
+        }
+      },
+      "TimeoutSeconds": 90,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException",
+            "Lambda.SdkClientException"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 5,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "A sweep that could not be INVOKED is the did-not-run case, and it is the one case the handler cannot report for itself because it never started. Routes to the unobserved terminal, which pages \u2014 never to the clean one.",
+          "Next": "WeeklyCoverageSweepUnavailable",
+          "ResultPath": "$.coverage_sweep_error"
+        }
+      ],
+      "ResultSelector": {
+        "outcome.$": "$.Payload.outcome",
+        "payload.$": "$.Payload"
+      },
+      "ResultPath": "$.coverage_sweep",
+      "Next": "CheckWeeklyCoverageSweepOutcome"
+    },
+    "CheckWeeklyCoverageSweepOutcome": {
+      "Type": "Choice",
+      "Comment": "The handler's outcome IS the verdict; each value gets its own named terminal so the execution history says which happened. $.coverage_sweep.outcome is safe to dereference un-guarded: the sole predecessor pins it via ResultSelector (config#2275 rule 3b). The Default is the UNOBSERVED terminal, not the clean one \u2014 an outcome this Choice does not recognise is an unknown state of the coverage surface, and unknown is never rendered green.",
+      "Choices": [
+        {
+          "Variable": "$.coverage_sweep.outcome",
+          "StringEquals": "clean",
+          "Next": "WeeklyCoverageSweepClean"
+        },
+        {
+          "Variable": "$.coverage_sweep.outcome",
+          "StringEquals": "findings",
+          "Next": "WeeklyCoverageSweepFindings"
+        }
+      ],
+      "Default": "WeeklyCoverageSweepUnavailable"
+    },
+    "WeeklyCoverageSweepClean": {
+      "Type": "Succeed",
+      "Comment": "outcome=clean: the sweep ran and found no coverage gap. The marker WriteCompletionMarker wrote a moment earlier now carries the cycle's real shape, so its cycle_verdict is no longer 'unknown'."
+    },
+    "WeeklyCoverageSweepFindings": {
+      "Type": "Succeed",
+      "Comment": "outcome=findings: the sweep ran and found a gap. It has ALREADY paged from inside the handler (krepis.alerts, dedup_key stage-coverage-sweep/<pipeline>/<run_date>) \u2014 no second publish here, which would render one finding as two incidents. Succeed rather than Fail because the weekly run itself completed: this terminal reports on the SWEEP, and failing the execution would retroactively mark a good run bad, which is the misattribution alpha-engine-config-I8045 is about."
+    },
+    "WeeklyCoverageSweepUnavailable": {
+      "Type": "Task",
+      "Comment": "outcome=unavailable, an unrecognised outcome, or an invoke failure: the sweep DID NOT RUN, or ran and could not publish what it found. This is the branch that must page from the state machine, because a handler that never started cannot page for itself, and 'found nothing' and 'did not run' are different facts (principles.md \u00a72.7). Fail-open to Succeed after publishing: the weekly run completed and its completion is not in question \u2014 what is unobserved is the coverage check over it.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekly Pipeline - stage-coverage sweep DID NOT RUN",
+        "Message.$": "States.Format('The weekly run for {} completed and wrote its completion marker, but the stage-coverage sweep did not run, or ran and could not publish its result. The marker therefore keeps its bare envelope claim - cycle_verdict unknown - and no coverage verdict exists for this cycle. This is an UNOBSERVED surface, not a clean result. Re-run it by invoking the alpha-engine-weekly-coverage-sweep Lambda with run_date {} and state_machine_arn arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline.', $.run_date, $.run_date)"
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 2,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 notifier convention: a failed notify must not fail the run.",
+          "Next": "WeeklyCoverageSweepUnobserved",
+          "ResultPath": "$.coverage_sweep_notify_error"
+        }
+      ],
+      "ResultPath": "$.coverage_sweep_notify_result",
+      "Next": "WeeklyCoverageSweepUnobserved"
+    },
+    "WeeklyCoverageSweepUnobserved": {
+      "Type": "Succeed",
+      "Comment": "Terminal for the did-not-run case, named for what is true \u2014 the coverage surface is unobserved for this cycle \u2014 rather than for the run, which completed."
+    },
     "WriteCompletionMarkerDegraded": {
       "Type": "Task",
       "Comment": "alpha-engine-config-I6891, the DEGRADED twin of WriteCompletionMarker (shape mirrored from step_function_daily.json per the shared-code rule). Writes the SAME key as the clean marker with status DEGRADED and the full $.degraded_summary embedded, so a marker reader (pipeline-watchdog, sf-telegram-notifier, weekly_sf_recovery_metric) can tell a run that really worked from one that only ended. Deliberately EXCLUDES the Friday-PM preflight paths for the same reason WriteCompletionMarker does. No swallow-all Catch, same as the clean twin: a marker that cannot be written means this execution's own completion is unverifiable, which is the ambiguity the feature exists to surface rather than mask. ResultPath is LOAD-BEARING, not hygiene (alpha-engine-config-I6891): a Task with no ResultPath defaults to $, so the putObject result REPLACES the whole state input and the DegradedRun terminal's CausePath dereference of $.degraded_summary.reason cannot resolve. The execution then fails with States.Runtime instead of DegradedRun \u2014 and Error: DegradedRun is a consumer contract: sf-telegram-notifier's _is_degraded_run() keys its DEGRADED rendering off exactly that string, so every honestly-degraded run rendered as an ordinary crash-red FAILED with a truncated cause. Shipped in both weekday definitions since config#6692/#6722; the weekly one inherited it by mirroring them and it is fixed in all three here.",
@@ -8513,7 +8617,7 @@
         "Bucket": "alpha-engine-research",
         "Key.$": "States.Format('_sf_completion/ne-weekly-freshness-pipeline/{}.json', $.run_date)",
         "ContentType": "application/json",
-        "Body.$": "States.Format('\\{\"sf\":\"ne-weekly-freshness-pipeline\",\"execution_arn\":\"{}\",\"status\":\"DEGRADED\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"degraded_summary\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, $.run_date, States.JsonToString($.degraded_summary))"
+        "Body.$": "States.Format('\\{\"sf\":\"ne-weekly-freshness-pipeline\",\"execution_arn\":\"{}\",\"status\":\"DEGRADED\",\"claim\":\"sf_execution_terminal\",\"cycle_verdict\":\"unknown\",\"started_at\":\"{}\",\"completed_at\":\"{}\",\"cycle_key\":\"{}\",\"degraded_summary\":{}\\}', $$.Execution.Id, $$.Execution.StartTime, $$.State.EnteredTime, $.run_date, States.JsonToString($.degraded_summary))"
       },
       "ResultPath": "$.degraded_marker_result",
       "TimeoutSeconds": 60,

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ arcticdb>=6.23.0
 # produced — the source-check is what tells you, and it stays RED until the
 # pin is right, which is the guard against merging the SF JSON ahead of the
 # registry entry.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.86
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ arcticdb>=6.23.0
 # produced — the source-check is what tells you, and it stays RED until the
 # pin is right, which is the guard against merging the SF JSON ahead of the
 # registry entry.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.83
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.85
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/sf_degraded_summary_helpers.py
+++ b/tests/sf_degraded_summary_helpers.py
@@ -121,5 +121,55 @@ def assert_completion_notifier_chain(states: dict, notifier: str) -> None:
     assert "Cause" not in states["DegradedRun"]
 
     clean_marker = states["WriteCompletionMarker"]
-    assert clean_marker["End"] is True
     assert '"status":"SUCCEEDED"' in clean_marker["Parameters"]["Body.$"]
+    # alpha-engine-config-I8214: the clean marker no longer ENDS the execution;
+    # it hands off to the observe-only stage-coverage sweep, which augments the
+    # marker it just wrote with the cycle's real shape. The property the old
+    # `End is True` line stood for — a clean run terminates SUCCEEDED, never
+    # Fail — is asserted below over the whole tail, which is strictly more than
+    # the line it replaced: an observe-only tail that could fail a completed run
+    # would be the exact defect I8214's own comment forbids.
+    assert "End" not in clean_marker
+    assert clean_marker["Next"] == "WeeklyCoverageSweep"
+    assert_observe_only_tail(states, "WeeklyCoverageSweep")
+
+
+def assert_observe_only_tail(states: dict, entry: str) -> None:
+    """Every path out of `entry` reaches a Succeed, and none reaches a Fail.
+
+    An observe-only tail sits downstream of a pipeline's real success terminal.
+    It may page, it may write, it may find nothing — but it may not turn a
+    completed run into a failed one (sf-pipeline-policy §2.1 blast radius). A
+    reachability walk rather than a hand-listed set of terminals, so a state
+    added to the tail later is covered by this assertion existing.
+    """
+    seen: set[str] = set()
+    stack = [entry]
+    terminals: set[str] = set()
+    while stack:
+        name = stack.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        st = states[name]
+        assert st["Type"] != "Fail", (
+            f"{name} is reachable from the observe-only tail at {entry} and is a "
+            "Fail state — a tail downstream of the success terminal must never "
+            "fail a run that already completed"
+        )
+        nexts = []
+        if "Next" in st:
+            nexts.append(st["Next"])
+        for choice in st.get("Choices", []) or []:
+            nexts.append(choice["Next"])
+        if st.get("Default"):
+            nexts.append(st["Default"])
+        for catch in st.get("Catch", []) or []:
+            nexts.append(catch["Next"])
+        if not nexts:
+            assert st["Type"] == "Succeed" or st.get("End") is True, (
+                f"{name} terminates the tail without being a Succeed"
+            )
+            terminals.add(name)
+        stack.extend(nexts)
+    assert terminals, f"no terminal reachable from {entry}"

--- a/tests/test_sf_completion_marker_wiring.py
+++ b/tests/test_sf_completion_marker_wiring.py
@@ -63,7 +63,18 @@ def test_marker_state_shape(weekly_states):
     assert "ne-weekly-freshness-pipeline" in body
     assert "$$.Execution.Id" in body
     assert "$.run_date" in body
-    assert st["End"] is True
+    # I8214: the marker hands off to the observe-only coverage sweep instead of
+    # ending the execution. The sweep augments the object this state just wrote.
+    assert "End" not in st
+    assert st["Next"] == "WeeklyCoverageSweep"
+    assert '"claim":"sf_execution_terminal"' in body, (
+        "the marker must name what its write actually asserts — the SF execution "
+        "reached its terminal — rather than implying the cycle completed"
+    )
+    assert '"cycle_verdict":"unknown"' in body, (
+        "a consumer reading the marker BEFORE the sweep augments it must resolve "
+        "to UNKNOWN, never to an implied pass (sf-pipeline-policy §2.3a)"
+    )
     # Deliberate: no swallow-all Catch (unlike the SNS notifiers) — a marker
     # that genuinely cannot be written should surface as a real failure,
     # not be silently swallowed the way a non-fatal notify is.

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -74,6 +74,14 @@ _FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
     # infrastructure/lambdas/weekly-run-scope/deploy.sh; a generous ceiling here
     # would let an advisory state hold the tail of the weekly run.
     "alpha-engine-weekly-run-scope": 60,
+    # alpha-engine-config-I8214. ListExecutions + one DescribeExecution and
+    # GetExecutionHistory per contributing execution, a prefix listing, one
+    # PUT and one marker read-modify-write. Bounded by the cycle's execution
+    # count (single digits), not by the ticker universe. Matches the
+    # --bootstrap timeout in
+    # infrastructure/lambdas/weekly-coverage-sweep/deploy.sh; the SF state's
+    # 90s ceiling is deliberately below it so the SF is the one that binds.
+    "alpha-engine-weekly-coverage-sweep": 120,
     "alpha-engine-predictor-regime-retrospective-eval": 600,
     "alpha-engine-predictor-regime-substrate": 300,
     "alpha-engine-replay-concordance": 900,

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -73,6 +73,12 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # config#2249: fast pre-dispatch substrate health gate, immediately
     # before MorningEnrich (alpha-engine-substrate-health-gate Lambda).
     "SubstrateHealthGate": frozenset({"instance_id.$"}),
+    # alpha-engine-config-I8214: the stage-coverage sweep at the tail of the
+    # run. Deliberately NOT threading execution_arn: the sweep reads the whole
+    # CYCLE (every contributing execution for this run_date), not this one
+    # execution — passing an execution arn would invite a handler that reads
+    # only its own caller, which is the 1-of-16 reading I8186 is about.
+    "WeeklyCoverageSweep": frozenset({"run_date.$", "dry_run.$", "state_machine_arn.$"}),
     # L4517: preventive cross-repo lib-pin drift gate (predictor-inference Lambda).
     # alpha-engine-config-I8155: +run_date.$ — the stage-coverage verdict this
     # Lambda writes is keyed on the execution's own run_date, and without it

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -393,6 +393,18 @@ _NOTIFY_RESOURCE = "arn:aws:states:::sns:publish"
 #     needing its own tracker issue, not a leftover.
 _DEGRADED_FLAG_EXEMPT: dict[str, dict[str, str]] = {
     "step_function.json": {
+        # alpha-engine-config-I8214: the coverage sweep runs AFTER
+        # WriteCompletionMarker — after the pipeline's real success terminal.
+        # A degraded flag exists to make a fail-open visible in the RUN's own
+        # outcome; this run's outcome is already decided and written, and the
+        # sweep may not change it (sf-pipeline-policy §2.1 blast radius), so
+        # the flag would have no reader. The fail-open is made visible the
+        # only way that is honest here: its own SNS page from
+        # WeeklyCoverageSweepUnavailable, into a terminal named
+        # WeeklyCoverageSweepUnobserved — which says the coverage SURFACE, not
+        # the run, is the thing without a verdict.
+        "WeeklyCoverageSweep": "observe-only tail downstream of the success terminal — pages via its own SNS state; a degraded flag would have no reader, the run's outcome being already written",
+
         "RunScope": (
             "alpha-engine-config-I7620. The fail-open is VISIBLE on the "
             "consumer surface rather than through an SF flag, which is why no "


### PR DESCRIPTION
## What and why

The stage-coverage sweep's **reader** shipped in `nousergon-lib` and nothing called it, so it detected nothing. Meanwhile the weekly completion marker's name was a claim the run could not support: on 2026-08-22 `_sf_completion/ne-weekly-freshness-pipeline/2026-08-22.json` was written by `watch-rerun-2026-08-22-3`, an execution that entered **1 of 16** declared spine stages. `WriteCompletionMarker` sits downstream of `Director`, so any execution reaching Director writes it — the report card knew the cycle was incomplete and the marker did not.

Tracker: `alpha-engine-config-I8214` (carrying `I8154` d4 and `I8186`'s state-machine half).

## Changes

| Change | Why |
|---|---|
| Both markers stamp `claim: sf_execution_terminal` and `cycle_verdict: unknown` | names what the SF's write actually asserts; a consumer reading before the sweep resolves to UNKNOWN, never an implied pass (§2.3a) |
| New `alpha-engine-weekly-coverage-sweep` Lambda | runs the sweep over the CYCLE, publishes artifact + metric, augments the marker with the cycle's real shape |
| `WeeklyCoverageSweep` SF state + `CheckWeeklyCoverageSweepOutcome` + 4 terminals | the caller the sweep never had, at the tail of the run |
| lib pin `v0.124.83` → `v0.124.85`, 31 sites | `coverage.py`/`completion_marker.py` first exist in `.85`; lockstep requires all sites move together |

The marker is **not** gated on the work verdict — `I8186` explicitly forbids making it unreachable from a legitimate recovery.

## Why a Lambda and not an SSM command on the run's own box

`I8214`'s sketch assumed SSM. That is unsound here, and the reason is the point: **this pipeline has no always-on box.** `$.ec2_instance_id` is an ephemeral spot, and since `alpha-engine-config-I8162` a recovery run whose every box stage is skipped carries **no instance id at all** — exactly the run that most needs a coverage verdict. A sweep dereferencing it would throw `States.Runtime` one state after the pipeline's own success terminal. Mirrors `weekly-run-scope`, the sibling Lambda reading the same execution history for the same pipeline.

## The tail is observe-only, and that is a constraint

Everything from `WeeklyCoverageSweep` down sits downstream of the real success terminal, so it must never turn a completed weekly run into a failure (`sf-pipeline-policy.md` §2.1). Every terminal is a `Succeed`, the handler never raises, and `assert_observe_only_tail` **walks the tail and proves no `Fail` state is reachable from it** — strictly more than the `End is True` assertion it replaces.

## Three outcomes, and "did not run" is not one of the other two

`clean` / `findings` / `unavailable`. Findings have already paged from inside the handler (deduped per pipeline+run_date), so nothing pages twice. `unavailable` is the one case the sweep cannot report for itself, so `WeeklyCoverageSweepUnavailable` publishes to SNS and terminates at `WeeklyCoverageSweepUnobserved` — named for what is true: the coverage **surface** has no verdict, not the run. The Choice's `Default` is that terminal, so an unrecognised outcome lands on unobserved rather than on clean.

## Test plan — run before opening

- `python3 -m pytest tests/ -q` → **6541 passed, 17 skipped**, one failure: `test_pipeline_status_registry_source_check`, which requires the two new state names in `nousergon-lib`'s `STATE_TO_ARCHIVE_PAGE` **first**. That entry is in `nousergon-lib-PR350`; this PR pins the release carrying it.
- `aws stepfunctions validate-state-machine-definition` → `OK`, zero diagnostics.
- 9 new handler tests, each an angle on one property: `unavailable` is never collapsed into `clean` or `findings`.

## Cross-repo merge order

1. **`nousergon-lib-PR350`** — the `_extract_run_date` third source (`I8216`) and the two registry entries.
2. **this PR** — pin re-pointed to the tag PR350 produces before it leaves draft.
3. `alpha-engine-config` — the `pipeline_stages` ARTIFACT_REGISTRY row (separate PR).

Held as a **draft** until (1) merges, because the pin is not yet the tag that carries the `I8216` cycle-key fix — merging before that would ship a sweep whose cycle read drops every scheduled execution, which is the defect one layer up.

## Rehearsal path

Rehearsal-path: infrastructure/lambdas/weekly-coverage-sweep/test_handler.py

Also `.github/workflows/ci.yml` (the `infrastructure/lambdas/*/test_handler.py` glob), plus the Friday-PM shell run: `dry_run.$ = $.research_dry` exercises the whole read path and every IAM grant the real run needs, and writes nothing.

## Post-merge

The Lambda's first-time `--bootstrap` is an operator step, per the standing convention every operator-deployed Lambda in this repo follows (`weekly-run-scope`, `eod-backstop`, `crypto-balances`) — the merge itself only ever reaches a code-only path, and no workflow here can create or rewire infrastructure. Until it runs, the SF state's invoke fails and routes to `WeeklyCoverageSweepUnavailable`, which pages by design rather than failing the run or reading clean. The exact command is in the handover.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AygZVwiCP6oFM1S7EEx9bT
