### PR TITLE
[P1/low] feat(overseer): register the research:weekly_ledger alert class (alpha-engine-config-I8264)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -900,6 +900,24 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: research_weekly_ledger_alerts
+    # alpha-engine-config-I8264 static-chokepoint registration. Emitted by
+    # crucible-research/lambda/scanner_handler.py after
+    # scoring/weekly_ledger.py::record_completed_week reports a week that
+    # CLOSED and could not be recorded (`unmeasurable`, or an unhandled
+    # error). The universe-cut slot's ledger is append-only and forward-only:
+    # a run records the one week that just ended, and no later run can go back
+    # and fill it, so an unrecorded week is permanently unrecorded. The write
+    # is observe-only and never reds the Scanner run, which is exactly why the
+    # failure needs a surface with a consumer rather than a WARN
+    # (ARCHITECTURE §61(a); champion-challenger-policy.md §7.2 — an
+    # unmeasurable result must not render as an empty success). A week that
+    # simply did not close is `skipped` and does NOT alert.
+    # The call site publishes with explicit severity="ERROR".
+    source: "research:weekly_ledger"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: research_corpus_stats_alerts
     # alpha-engine-config-I7896 static-chokepoint registration. Emitted by
     # crucible-research/lambda/aggregate_costs_handler.py::_refresh_corpus_stats


### PR DESCRIPTION
## Deploy mechanism

**Deploy-mechanism:** N/A — a data-only row in a registry file; no deploy-triggering path is touched.

## What

One row in `infrastructure/overseer/playbooks.yaml::alert_classes` for the alert source `research:weekly_ledger`.

## Why

`alpha-engine-config-I8264` adds a `publish_observe_alert(source="research:weekly_ledger")` call site in `crucible-research/lambda/scanner_handler.py`, wiring the universe-cut slot's weekly ledger into the scanner run. The ledger is append-only and **forward-only**: a run records the one week that just closed, and no later run revisits it, so a week it could not record is permanently unrecorded. The write is observe-only and must never red a Scanner run — which is precisely why its failure needs a surface with a consumer rather than a WARN (`ARCHITECTURE` §61(a); `champion-challenger-policy.md` §7.2: an unmeasurable result must fail loud, not render as an empty success).

A week that simply did not close is reported `skipped` and does **not** alert.

Without this row, `crucible-research`'s own `alert-class-pr-guard` fails on the new source, and the `alpha-engine-config` push-to-main fleet sweep would surface the gap days later on a third repo's main.

## Test plan

`yaml.safe_load` parses the edited file cleanly. The row mirrors `research_cut_promotion_alerts` immediately below it — same emitter Lambda, same fail-soft-plus-alarmed posture, same explicit `severity="ERROR"` at the call site — so `severities: [error]`, `intake: bus`, `response: drain-queue` carry over unchanged.

## Cross-repo

- **`crucible-research-PR738`** — the wiring, and the only consumer of this row.
- **Merge order: either.** The guard is satisfied by an OPEN PR carrying the row, so neither blocks the other, and nothing in this repo depends on the research PR.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)