### PR TITLE
roster: enrol nousergon/scannerctl in BACKLOG_REPOS mirror (I8276 ruling)

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -211,7 +211,7 @@ BACKLOG_REPOS = (
     "nousergon/alpha-engine-config", "nousergon/metron-ops",
     "nousergon/vires-ops", "nousergon/telos-ops", "nousergon/symposion",
     "nousergon/claude-code-config", "nousergon/nousergon-console",
-    "nousergon/oiax",
+    "nousergon/oiax", "nousergon/scannerctl",
 )
 # config-I3227: the org this Lambda's PR enumeration searches org-wide. Never
 # a hardcoded repo list (config#2294 precedent — see alpha-engine-config's


### PR DESCRIPTION
## What & why

`alpha-engine-config-I8276`: `nousergon/scannerctl` (created 2026-08-24, public "Provider-neutral DLP scanning and egress-enforcement runtime") had no roster row, which has been failing the live half of `check-repo-roster-drift.yml` on `alpha-engine-config` main since 13:22Z today.

Brian ruled 2026-08-24 (`alpha-engine-config-I8276`): scannerctl carries roles `[backlog, code]`.

This repo declares one mirror of the roster's `backlog` role: `BACKLOG_REPOS` (qualified form, `nousergon/foo`) in `infrastructure/lambdas/scheduled-groom-dispatcher/index.py`. `alpha-engine-config/scripts/check_repo_roster_drift.py::check_mirrors` requires every declared mirror to equal its roster role INCLUDING ORDER, so `nousergon/scannerctl` is appended as the LAST entry to match the roster PR's append-last edit.

## Cross-repo siblings

- Roster PR (source of truth, appends scannerctl last in both role lists): `alpha-engine-config-PR8282` — https://github.com/nousergon/alpha-engine-config/pull/8282
- `symposion/server/decision-queue.mjs` mirror update — sibling PR in `nousergon/symposion` (in flight, number not yet visible from here)
- `crucible-dashboard/loaders/decision_queue_loader.py` mirror update — sibling PR in `nousergon/crucible-dashboard` (in flight, number not yet visible from here)

**Merge order:** `alpha-engine-config-PR8282` (roster) FIRST, then the three mirror PRs (this one, symposion, crucible-dashboard) in any order.

## Test plan

Ran the Lambda's own test suites in the worktree:

```
cd infrastructure/lambdas/scheduled-groom-dispatcher
python3 -m pytest test_handler.py test_attended_window_gate.py -q
```

Result: 217 passed, 0 failed. No pre-existing failures encountered.

## Scope

Only `infrastructure/lambdas/scheduled-groom-dispatcher/index.py` changed — one entry appended to `BACKLOG_REPOS`, no reordering or reformatting of existing entries. `AGENTS.md`/`CLAUDE.md` confirmed gitignored (`git check-ignore -v`) and not part of this commit.

---
Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
