### PR TITLE
roster: drop nousergon/symposion from BACKLOG_REPOS mirror

### DIFF
--- a/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/index.py
@@ -209,7 +209,7 @@ DEMAND_GATE_ENABLED = os.environ.get("GROOM_DEMAND_GATE_ENABLED", "true").lower(
 # change the roster, then mirror it here in the same change.
 BACKLOG_REPOS = (
     "nousergon/alpha-engine-config", "nousergon/metron-ops",
-    "nousergon/vires-ops", "nousergon/telos-ops", "nousergon/symposion",
+    "nousergon/vires-ops", "nousergon/telos-ops",
     "nousergon/claude-code-config", "nousergon/nousergon-console",
     "nousergon/oiax", "nousergon/scannerctl",
 )


### PR DESCRIPTION
## What & why

Drops `nousergon/symposion` from the `BACKLOG_REPOS` declared roster mirror in `infrastructure/lambdas/scheduled-groom-dispatcher/index.py`, per the symposion archive ruling, 2026-08-24: Brian ruled to archive `nousergon/symposion` (no near-term development, re-enablable later). GitHub archives repos read-only, so symposion can no longer accept PRs or issues — its roster roles go from `[backlog, code]` to `[]`. `alpha-engine-config/scripts/check_repo_roster_drift.py::check_mirrors` holds every declared mirror equal to its roster role including order, so the `backlog`-role mirror here must drop symposion once the roster does.

Order of all remaining `BACKLOG_REPOS` entries is preserved exactly; only the one entry was removed.

## Sibling PRs and merge order

This change is one leg of a coordinated set:

1. **symposion feature-removal PR** — merges FIRST
2. This PR (`nousergon-data`) and the `crucible-dashboard` mirror PR — merge second, either order
3. `alpha-engine-config` roster PR (`REPO_ROSTER.yaml`) — merges LAST

## Test plan

- `python3 -m pytest infrastructure/lambdas/scheduled-groom-dispatcher/test_handler.py -q` → 207 passed
- `python3 -m pytest tests/test_manifest_drift.py infrastructure/lambdas/_shared/test_hermetic_import_guard.py -q` → 14 passed
- Searched the Lambda directory and repo test tree for any test asserting `symposion` by name — none found; `test_handler.py` has no symposion-specific assertions to update.
- Verified `AGENTS.md`/`CLAUDE.md` remain gitignored (`git check-ignore -v`) and only the intended file is staged (`git status`).

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)