### PR TITLE
Give the Saturday health checks their own skip flag (I8167)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -6113,7 +6113,7 @@
     },
     "CheckSkipPostEval": {
       "Type": "Choice",
-      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator \u2014 bypassing the five full-run-only tail stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck \u2192 ReportCard \u2192 Director \u2192 ScannerLeaderboard, none of which previously had a skip gate; ScannerLeaderboard is the alpha-engine-config-I7813 observe-only board leaf) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester\u2192Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior.",
+      "Comment": "Post-Evaluator tail skip-gate (config#830). {\"skip_post_eval\": true} stops the run right after Evaluator \u2014 bypassing the five full-run-only tail stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck \u2192 ReportCard \u2192 Director \u2192 ScannerLeaderboard, none of which previously had a skip gate; ScannerLeaderboard is the alpha-engine-config-I7813 observe-only board leaf) and routing straight to CheckShellRunNotify so the SUCCESS SNS notify (and the shell-run-tagged variant) still fire. This is the one behavioral gap a standalone Backtester\u2192Evaluator SF used to cover; closing it here lets the weekly SF reproduce that shape via mode=backtest-eval with no forked state machine. The tail stages are advisory/observability only (health checks are non-blocking; ReportCard/Director are non-fatal advisories), so stopping before them is safe for a mid-week backtester/evaluator code rerun. Missing flag = run the full tail as normal, so scheduled Saturday runs are unaffected. Both inbound edges (CheckEvaluatorStatus Success and CheckSkipEvaluator skip) converge here, preserving the prior 'Evaluator-skipped still notifies' behavior. alpha-engine-config-I8167: skip_post_eval keeps this exact whole-tail meaning \u2014 the health-check-only bypass now lives one hop downstream at CheckSkipSaturdayHealthCheck, so a skip_post_eval=true run never reaches that gate at all.",
       "Choices": [
         {
           "And": [
@@ -6127,6 +6127,26 @@
             }
           ],
           "Next": "CheckShellRunNotify"
+        }
+      ],
+      "Default": "CheckSkipSaturdayHealthCheck"
+    },
+    "CheckSkipSaturdayHealthCheck": {
+      "Type": "Choice",
+      "Comment": "alpha-engine-config-I8167: health-check-only skip-gate, split out of the coarse CheckSkipPostEval span (config#6054 had already stopped emitting skip_post_eval for this purpose \u2014 see the post_eval Stage row's note in scripts/weekly_sf_rerun.py \u2014 but left no flag a mechanical recovery could actually set to reach the I8162 spot-dispatch bypass; skip_post_eval could not be reused because it also bypasses ReportCard/Director/ScannerLeaderboard, which I8162's bypass conjunction must not silently skip). {\"skip_saturday_health_check\": true} bypasses ONLY the two health-observe stages (SaturdayHealthCheck \u2192 WeeklySubstrateHealthCheck and their Wait/poll/Degraded satellites) and lands on RunScope \u2014 the same convergence point CheckSubstrateHealthCheckStatus's own Success edge and SetSubstrateHealthCheckDegradedSummary already use \u2014 so ReportCard, Director and ScannerLeaderboard are unaffected. Ruled 2026-08-24 (alpha-engine-config-I8167, operator decision (a)): the health checks are advisory and idempotent, which argues for a cheap re-run skip, not for booting a spot instance merely to re-run them. Missing flag = run both health checks as normal, so scheduled Saturday runs are unaffected. Sits strictly downstream of CheckSkipPostEval's Default so skip_post_eval=true (whole-tail) still short-circuits before ever reaching this gate.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_saturday_health_check",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_saturday_health_check",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "RunScope"
         }
       ],
       "Default": "SaturdayHealthCheck"
@@ -7432,7 +7452,7 @@
     },
     "CheckSpotDispatchNeeded": {
       "Type": "Choice",
-      "Comment": "config#2248 (root-cause fix for the always-on dashboard box SPOF): the 14 downstream sendCommand/Lambda states (MorningEnrich through WeeklySubstrateHealthCheck, plus SubstrateHealthGate's Payload) all key off $.ec2_instance_id. That field is no longer a hardcoded literal in the SaturdayTrigger EventBridge Input or the Friday shell-run trigger Lambda (both stripped by config#2248) — it is populated HERE, either by an already-present operator/rerun value (this Choice's first branch: scripts/weekly_sf_rerun.py's rerun_input() passes the ORIGINAL failed execution's ec2_instance_id through verbatim, so a watch-rerun reuses the same still-live launcher box instead of paying for a second spot launch) or by a fresh ephemeral spot this Choice's Default branch dispatches via DispatchWeeklyFreshnessSpot. Sits where CheckMutexRole's cadence-acquire path (via AcquireMutex) AND its bypass Default (operator/recovery/non-cadence roles, which skip the mutex entirely) BOTH converge -- so every execution passes through this gate exactly once, regardless of pipeline_role, never burning a spot launch on a mutex conflict -- and BEFORE CheckShellRun / any of the 14 consumer states (nothing may reference $.ec2_instance_id before this gate resolves it). alpha-engine-config-I8162 adds the SECOND branch: bypass the dispatch entirely when EVERY stage that SSM-invokes onto $.ec2_instance_id is skipped by this execution's input, landing straight on the same CheckShellRun convergence with no ec2_instance_id at all (nothing downstream dereferences it once all of those stages are gated off). Recovery is exactly when the skip set is largest, so the most often-unnecessary stage was the one that always ran: watch-rerun-2026-08-22-1 spent 4 of its 16 minutes in DispatchWeeklyFreshnessSpot -> WaitForWeeklyFreshnessSpotBootstrap. The conjunction is NOT hand-maintained here: it is DERIVED from scripts/weekly_sf_rerun.py's STAGES table by reachability over this definition (box_dispatch_flags) and pinned to this state by tests/test_weekly_sf_rerun.py::TestSpotDispatchOnlyWhenABoxStageSurvives. Edit it there, never here — the two drifting in the other direction denies a boot to a stage that then SSM-invokes onto a box it does not have, which FAILS a run rather than costing four minutes.",
+      "Comment": "config#2248 (root-cause fix for the always-on dashboard box SPOF): the 14 downstream sendCommand/Lambda states (MorningEnrich through WeeklySubstrateHealthCheck, plus SubstrateHealthGate's Payload) all key off $.ec2_instance_id. That field is no longer a hardcoded literal in the SaturdayTrigger EventBridge Input or the Friday shell-run trigger Lambda (both stripped by config#2248) — it is populated HERE, either by an already-present operator/rerun value (this Choice's first branch: scripts/weekly_sf_rerun.py's rerun_input() passes the ORIGINAL failed execution's ec2_instance_id through verbatim, so a watch-rerun reuses the same still-live launcher box instead of paying for a second spot launch) or by a fresh ephemeral spot this Choice's Default branch dispatches via DispatchWeeklyFreshnessSpot. Sits where CheckMutexRole's cadence-acquire path (via AcquireMutex) AND its bypass Default (operator/recovery/non-cadence roles, which skip the mutex entirely) BOTH converge -- so every execution passes through this gate exactly once, regardless of pipeline_role, never burning a spot launch on a mutex conflict -- and BEFORE CheckShellRun / any of the 14 consumer states (nothing may reference $.ec2_instance_id before this gate resolves it). alpha-engine-config-I8162 adds the SECOND branch: bypass the dispatch entirely when EVERY stage that SSM-invokes onto $.ec2_instance_id is skipped by this execution's input, landing straight on the same CheckShellRun convergence with no ec2_instance_id at all (nothing downstream dereferences it once all of those stages are gated off). Recovery is exactly when the skip set is largest, so the most often-unnecessary stage was the one that always ran: watch-rerun-2026-08-22-1 spent 4 of its 16 minutes in DispatchWeeklyFreshnessSpot -> WaitForWeeklyFreshnessSpotBootstrap. The conjunction is NOT hand-maintained here: it is DERIVED from scripts/weekly_sf_rerun.py's STAGES table by reachability over this definition (box_dispatch_flags) and pinned to this state by tests/test_weekly_sf_rerun.py::TestSpotDispatchOnlyWhenABoxStageSurvives. Edit it there, never here — the two drifting in the other direction denies a boot to a stage that then SSM-invokes onto a box it does not have, which FAILS a run rather than costing four minutes. alpha-engine-config-I8167 (operator decision (a), 2026-08-24): the deriver's 8th conjunct is now skip_saturday_health_check rather than skip_post_eval, because skip_post_eval could never be reached from a mechanical recovery's Director-only input without also silently disabling ReportCard/Director/ScannerLeaderboard — see CheckSkipSaturdayHealthCheck.",
       "Choices": [
         {
           "Variable": "$.ec2_instance_id",
@@ -7528,11 +7548,11 @@
             {
               "And": [
                 {
-                  "Variable": "$.skip_post_eval",
+                  "Variable": "$.skip_saturday_health_check",
                   "IsPresent": true
                 },
                 {
-                  "Variable": "$.skip_post_eval",
+                  "Variable": "$.skip_saturday_health_check",
                   "BooleanEquals": true
                 }
               ]

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -570,32 +570,55 @@ STAGES: tuple[Stage, ...] = (
         # rerun derived from one of those must still attribute the failure.
         historical_work=frozenset({"Evaluator"}),
     ),
-    # config#6054: the coarse post_eval span is SPLIT. The two health checks
-    # keep no flag of their own — they are advisory, idempotent, and cheap,
-    # so a tail rerun simply re-runs them (their degraded markers are carried
-    # by the post_eval alias row below, informationally; a health-check
-    # degradation alone never forces a ReportCard re-run, which is why they
-    # are NOT in report_card's degraded_witness). skip_post_eval survives in
-    # the DEFINITION as a deprecated whole-tail alias (CheckSkipPostEval)
-    # for in-flight inputs; the deriver no longer emits it — it emits the
-    # per-stage flags below.
+    # config#6054: the coarse post_eval span is SPLIT — ReportCard/Director
+    # got their own rows below. alpha-engine-config-I8167 splits it FURTHER:
+    # the two health checks now sit behind their OWN gate
+    # (CheckSkipSaturdayHealthCheck / skip_saturday_health_check, this row),
+    # reached one hop downstream of the deprecated whole-tail
+    # CheckSkipPostEval alias (the post_eval row right below). Root cause:
+    # skip_post eval could never be the flag the I8162 spot-dispatch bypass
+    # emits, because setting it ALSO bypasses ReportCard/Director/
+    # ScannerLeaderboard — flags a mechanical recovery must never silently
+    # set. This row owns emission (emit_skip=True, the default): a recovery
+    # chain that witnessed both health checks complete (RunScope entered)
+    # emits skip_saturday_health_check=true, the flag CheckSpotDispatchNeeded's
+    # bypass conjunction now tests instead of skip_post_eval.
     Stage(
-        "post_eval", "skip_post_eval",
-        "CheckSkipPostEval", "SaturdayHealthCheck",
-        frozenset({"CheckShellRunNotify"}),
-        # Health-check degraded routes only (config#2276) — ReportCard's
-        # and Director's moved to their own rows below (config#6054).
+        "saturday_health_check", "skip_saturday_health_check",
+        "CheckSkipSaturdayHealthCheck", "SaturdayHealthCheck",
+        frozenset({"RunScope"}),
+        # Same degraded routes the coarse post_eval row used to own — a
+        # health-check degradation is fail-open and continues to RunScope,
+        # so entering one of these must still force a re-run rather than
+        # read as "completed" (I6055). Ownership moved here from post_eval;
+        # never duplicate a degraded route across two rows
+        # (test_every_degraded_state_is_mapped enforces exactly one owner).
         degraded_witness=frozenset({
             "SaturdayHealthCheckDegraded", "SetSaturdayHealthCheckDegradedSummary",
             "SubstrateHealthCheckDegraded", "SetSubstrateHealthCheckDegradedSummary",
         }),
+    ),
+    Stage(
+        "post_eval", "skip_post_eval",
+        "CheckSkipPostEval", "SaturdayHealthCheck",
+        frozenset({"CheckShellRunNotify"}),
         emit_skip=False,
+        # detect_failure=False (alpha-engine-config-I8167): shares its `work`
+        # state with "saturday_health_check" above, which now owns
+        # completion/failure/degraded detection for the physical
+        # SaturdayHealthCheck/WeeklySubstrateHealthCheck pair — same shared-work
+        # convention as "backtester_stage_only" sharing "backtester"'s work.
+        # A second row detecting the same work state would double-count it
+        # without changing any outcome.
+        detect_failure=False,
         note=(
-            "skip_post_eval is a DEPRECATED whole-tail alias (config#6054): "
-            "the deriver emits skip_report_card / skip_director instead; the "
-            "health checks re-run on any tail rerun (advisory + idempotent). "
-            "Remove the alias once a full cycle has passed on the split "
-            "flags."
+            "skip_post_eval is a DEPRECATED whole-tail alias (config#6054, "
+            "config-I8167): the deriver emits skip_report_card / "
+            "skip_director / skip_saturday_health_check instead. Kept in "
+            "the DEFINITION only for in-flight inputs that still set it — "
+            "its meaning (bypass the entire post-Evaluator tail, including "
+            "ReportCard/Director/ScannerLeaderboard) is UNCHANGED. Remove "
+            "the alias once a full cycle has passed on the split flags."
         ),
     ),
     Stage(
@@ -658,6 +681,7 @@ STAGES: tuple[Stage, ...] = (
 )
 
 STAGES_BY_NAME = {s.name: s for s in STAGES}
+STAGES_BY_FLAG = {s.flag: s for s in STAGES}
 BRANCH_A_STAGES = frozenset({
     # alpha-engine-config-I2515 Phase B: "research" removed (the
     # multi-agent Research state — and its skip_research flag /
@@ -865,6 +889,28 @@ def box_dispatch_flags(sm_def: dict) -> tuple:
         trial = [f for f in kept if f != flag]
         if not box_states_needing_dispatch(sm_def, {f: True for f in trial}):
             kept = trial
+    # alpha-engine-config-I8167: every surviving conjunct must be a flag this
+    # SCRIPT can actually set — a conjunct backed only by a stage with
+    # emit_skip=False is a predicate no producer emits, which reads as live
+    # in the definition (CheckSpotDispatchNeeded's Choice tests it) while
+    # being permanently unreachable from any input this script derives. This
+    # is exactly the shape I8162 shipped: skip_post_eval was the sole
+    # coverer of the health-check span and carried emit_skip=False, so the
+    # bypass could never fire from a mechanical recovery's derived input.
+    # Fail the build here rather than let it recur silently.
+    non_emittable = [f for f in kept if not STAGES_BY_FLAG[f].emit_skip]
+    if non_emittable:
+        raise SystemExit(
+            f"FATAL: CheckSpotDispatchNeeded's bypass conjunction would "
+            f"include {non_emittable}, whose STAGES row(s) carry "
+            "emit_skip=False — this script's deriver can never SET that "
+            "flag, so the bypass predicate reads as live but is dead code "
+            "for every input derive_plan() produces (alpha-engine-config-"
+            "I8162 / I8167). Either give the stage that uniquely covers "
+            "this span its own emit_skip=True STAGES row, or prove it "
+            "genuinely redundant (drop it) so the minimization above "
+            "removes it instead."
+        )
     return tuple(kept)
 
 
@@ -1081,12 +1127,15 @@ def _simulate_reachable_works(flags: dict, original_input: dict) -> set:
         run_linear(["backtester", "predictor_backtest", "portfolio_optimizer_backtest"])
         run_parity_family()
     # config#6054 split the coarse post_eval span: post_eval survives as the
-    # deprecated whole-tail alias (its health checks re-run on any tail rerun)
-    # while report_card / director are now independently gated. All three are
-    # modeled here so the degraded-aware reachability guard (which now folds
-    # DEGRADED stages into must_rerun) can see post_eval — its health-check
-    # degraded_witness — as reachable when a tail rerun re-runs the span.
-    run_linear(["evaluator", "post_eval", "report_card", "director"])
+    # deprecated whole-tail alias while report_card / director are
+    # independently gated. alpha-engine-config-I8167 split it further —
+    # saturday_health_check now owns the two health-check states behind its
+    # own gate, one hop downstream of post_eval's (still-live) whole-tail
+    # alias. All four are modeled here so the degraded-aware reachability
+    # guard (which folds DEGRADED stages into must_rerun) can see
+    # saturday_health_check — its health-check degraded_witness — as
+    # reachable when a tail rerun re-runs the span.
+    run_linear(["evaluator", "saturday_health_check", "post_eval", "report_card", "director"])
     return ran
 
 

--- a/tests/test_run_scope_wiring.py
+++ b/tests/test_run_scope_wiring.py
@@ -71,6 +71,11 @@ def test_it_runs_after_every_work_stage_and_before_the_report_card(states):
     assert predecessors == {
         "CheckSubstrateHealthCheckStatus",
         "SetSubstrateHealthCheckDegradedSummary",
+        # alpha-engine-config-I8167: CheckSkipSaturdayHealthCheck's bypass
+        # route (skip_saturday_health_check=true) lands here directly,
+        # bypassing SaturdayHealthCheck/WeeklySubstrateHealthCheck entirely
+        # — a third route into the post-eval tail, alongside the two above.
+        "CheckSkipSaturdayHealthCheck",
     }
 
 

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -212,7 +212,11 @@ class TestSkipBacktesterPreservesEvalJudge:
             == "CheckSkipPostEval"
         )
         # The tail gate defaults to the full health-check tail (normal run).
-        assert states["CheckSkipPostEval"]["Default"] == "SaturdayHealthCheck"
+        # alpha-engine-config-I8167: the tail gate now defaults one hop
+        # downstream, to the new health-check-only skip gate — which itself
+        # defaults to SaturdayHealthCheck on a normal run.
+        assert states["CheckSkipPostEval"]["Default"] == "CheckSkipSaturdayHealthCheck"
+        assert states["CheckSkipSaturdayHealthCheck"]["Default"] == "SaturdayHealthCheck"
 
 
 class TestSkipEvalJudge:
@@ -920,4 +924,8 @@ class TestJudgeChainBeforePredictor:
             == "CheckSkipPostEval"
         )
         # The tail gate defaults to the full health-check tail on a normal run.
-        assert states["CheckSkipPostEval"]["Default"] == "SaturdayHealthCheck"
+        # alpha-engine-config-I8167: the tail gate now defaults one hop
+        # downstream, to the new health-check-only skip gate — which itself
+        # defaults to SaturdayHealthCheck on a normal run.
+        assert states["CheckSkipPostEval"]["Default"] == "CheckSkipSaturdayHealthCheck"
+        assert states["CheckSkipSaturdayHealthCheck"]["Default"] == "SaturdayHealthCheck"

--- a/tests/test_sf_evaluator_wiring.py
+++ b/tests/test_sf_evaluator_wiring.py
@@ -267,7 +267,11 @@ class TestHalfOrdering:
         success = next(c for c in chk["Choices"]
                        if c.get("StringEquals") == "Success")
         assert success["Next"] == "CheckSkipPostEval"
-        assert states["CheckSkipPostEval"]["Default"] == "SaturdayHealthCheck"
+        # alpha-engine-config-I8167: the tail gate now defaults one hop
+        # downstream, to the new health-check-only skip gate — which itself
+        # defaults to SaturdayHealthCheck on a normal run.
+        assert states["CheckSkipPostEval"]["Default"] == "CheckSkipSaturdayHealthCheck"
+        assert states["CheckSkipSaturdayHealthCheck"]["Default"] == "SaturdayHealthCheck"
 
 
 # ── Poll loop, per half ───────────────────────────────────────────────────

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -157,6 +157,12 @@ _EXPECTED_SKIPS = {
     # and Director independently.
     "skip_report_card",
     "skip_director",
+    # alpha-engine-config-I8167: health-check-only gate, one hop downstream
+    # of skip_post_eval's (still-live) whole-tail alias — bypasses only
+    # SaturdayHealthCheck/WeeklySubstrateHealthCheck, leaving ReportCard/
+    # Director/ScannerLeaderboard unaffected. emit_skip=True in STAGES, so
+    # this is the flag a mechanical recovery's derived input actually sets.
+    "skip_saturday_health_check",
     # alpha-engine-config-I7813: the observe-only scanner leaderboard leaf,
     # placed after Director. Its own gate so a rerun that already produced
     # the board does not pay a second ~904-symbol closes-panel read.

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -298,9 +298,15 @@ class TestDerivePlan:
         backward compatibility with pre-fix execution histories — new
         executions never enter it."""
         plan = mod.derive_plan(_events("director_degraded"))
-        # the degraded tail must re-run — never skipped, never "completed"
-        assert "post_eval" in plan.degraded
-        assert "post_eval" not in plan.completed
+        # the degraded tail must re-run — never skipped, never "completed".
+        # alpha-engine-config-I8167: ownership of the health-check degraded
+        # routes moved from the deprecated "post_eval" alias row to the new
+        # "saturday_health_check" row (emit_skip=True) — post_eval no longer
+        # carries a degraded_witness at all.
+        assert "saturday_health_check" in plan.degraded
+        assert "saturday_health_check" not in plan.completed
+        assert "skip_saturday_health_check" not in plan.skip_flags
+        assert "post_eval" not in plan.degraded
         assert "skip_post_eval" not in plan.skip_flags
         # the degradation must be surfaced in the derivation notes
         # (PublishDirectorDegraded retained in degraded_witness for backward compat)
@@ -1260,8 +1266,15 @@ class TestChainedRecoveryKeepsTheOriginalRunsProgress:
             )],
             source_label="watch-rerun-2026-08-22-1",
         )
-        assert "post_eval" in plan.degraded
-        assert "post_eval" not in plan.completed
+        # alpha-engine-config-I8167: degraded-route ownership moved to the
+        # new "saturday_health_check" row. "post_eval" (the deprecated,
+        # emit_skip=False whole-tail alias) still reads "completed" from the
+        # prior link's witness (CheckShellRunNotify) — informational only,
+        # since emit_skip=False means it never emits skip_post_eval.
+        assert "saturday_health_check" in plan.degraded
+        assert "saturday_health_check" not in plan.completed
+        assert "post_eval" not in plan.degraded
+        assert "skip_post_eval" not in plan.skip_flags
 
     def test_the_chain_reads_histories_never_a_previous_inputs_flags(self, mod):
         """Immunity to alpha-engine-config-I7259 is structural, not a rule the
@@ -1446,3 +1459,109 @@ class TestSpotDispatchOnlyWhenABoxStageSurvives:
         flags = {f: True for f in mod.box_dispatch_flags(sf_def)}
         flags["ec2_instance_id"] = "i-abc"
         assert _dispatch_gate_next(gate, flags) == "NormalizeEc2InstanceId"
+
+    def test_every_conjunct_is_emittable(self, mod, sf_def):
+        """alpha-engine-config-I8167: every flag CheckSpotDispatchNeeded's
+        bypass conjunction tests must be a flag derive_plan() can actually
+        SET (emit_skip=True) — a conjunct backed only by an emit_skip=False
+        stage reads as live in the definition but is dead code for every
+        input this script derives. This is a direct assertion pinning
+        box_dispatch_flags' own I8167 guard against the live definition, not
+        just a unit test of the guard in isolation (see the two tests
+        below for that)."""
+        for flag in mod.box_dispatch_flags(sf_def):
+            stage = mod.STAGES_BY_FLAG[flag]
+            assert stage.emit_skip, (
+                f"{flag} ({stage.name}) is in the bypass conjunction but "
+                "its STAGES row carries emit_skip=False — no input "
+                "derive_plan() emits can ever satisfy the bypass. Give the "
+                "stage its own emit_skip=True row (skip_saturday_health_check "
+                "did this for the health-check span) or prove it redundant."
+            )
+
+    def test_skip_saturday_health_check_is_emit_skip_true(self, mod):
+        """Pins the specific I8167 fix: the health-check span's flag is
+        emittable, replacing the old skip_post_eval conjunct (emit_skip=False,
+        a deliberately DEPRECATED alias — see its STAGES row's note)."""
+        assert mod.STAGES_BY_NAME["saturday_health_check"].emit_skip is True
+        assert mod.STAGES_BY_NAME["post_eval"].emit_skip is False
+
+    def test_a_non_emittable_sole_coverer_fails_the_build(
+        self, mod, sf_def, monkeypatch
+    ):
+        """Regression guard reproducing the exact I8162 defect shape this
+        issue fixes: a box-addressing span whose ONLY covering STAGES row
+        carries emit_skip=False must fail box_dispatch_flags() loudly,
+        never silently ship a dead conjunct. Simulated by removing the
+        (emittable) saturday_health_check row from STAGES so skip_post_eval
+        — emit_skip=False — becomes, once again, the sole flag the
+        reachability minimization can find to cover the health-check span
+        against the REAL, unmodified step_function.json."""
+        trimmed = tuple(
+            s for s in mod.STAGES if s.name != "saturday_health_check"
+        )
+        monkeypatch.setattr(mod, "STAGES", trimmed)
+        monkeypatch.setattr(
+            mod, "STAGES_BY_NAME", {s.name: s for s in trimmed}
+        )
+        monkeypatch.setattr(
+            mod, "STAGES_BY_FLAG", {s.flag: s for s in trimmed}
+        )
+        with pytest.raises(SystemExit, match="emit_skip=False"):
+            mod.box_dispatch_flags(sf_def)
+
+    def test_a_helper_generated_director_only_recovery_satisfies_the_bypass(
+        self, mod, sf_def
+    ):
+        """alpha-engine-config-I8167 closes-when: a recovery whose chain
+        witnessed every box stage complete (everything but Director) derives
+        an input that SATISFIES CheckSpotDispatchNeeded's bypass conjunction.
+        Before this fix the bypass was unreachable from any input
+        derive_plan() could produce — its sole health-check conjunct
+        (skip_post_eval) carried emit_skip=False, so no derived input ever
+        set it. Synthesized minimally: one stateEnteredEventDetails per
+        witness state for each of the 8 box-conjunct stages, plus Director's
+        own work state entered-but-not-completed (the recovery target)."""
+        events = [
+            {
+                "type": "ExecutionStarted",
+                "executionStartedEventDetails": {
+                    "input": json.dumps({
+                        "pipeline_role": "watch-rerun",
+                        "run_date": "2026-08-24",
+                    }),
+                },
+            },
+            *[
+                {"type": "TaskStateEntered", "stateEnteredEventDetails": {"name": n}}
+                for n in [
+                    "CheckSkipDataPhase1",               # morning_enrich witness
+                    "ResearchPredictorParallel",          # data_phase1 witness
+                    "CheckSkipRegimeRetrospectiveEval",   # rag_ingestion witness
+                    "CheckSkipEvalJudge",                 # data_phase2 witness
+                    "ResolveZooSpecs",                    # predictor_training witness
+                    "CheckSkipPredictorBacktest",         # backtester witness
+                    "CheckSkipPostEval",                  # evaluator witness
+                    "RunScope",                           # saturday_health_check witness (I8167)
+                    "Director",                           # director's WORK state: entered, unfinished
+                ]
+            ],
+        ]
+        plan = mod.derive_plan(events)
+        assert "director" in plan.failed
+
+        derived_box_flags = set(mod.box_dispatch_flags(sf_def))
+        assert derived_box_flags <= set(plan.skip_flags), (
+            f"missing box-conjunct flags: {derived_box_flags - set(plan.skip_flags)}"
+        )
+        assert all(plan.skip_flags[f] is True for f in derived_box_flags)
+        # skip_saturday_health_check specifically — not the old, non-emittable
+        # skip_post_eval conjunct — is what got emitted.
+        assert plan.skip_flags.get("skip_saturday_health_check") is True
+
+        gate = sf_def["States"]["CheckSpotDispatchNeeded"]
+        assert _dispatch_gate_next(gate, plan.skip_flags) == mod.SPOT_DISPATCH_CONVERGENCE, (
+            "a helper-generated Director-only recovery input must take the "
+            "spot-dispatch bypass, not boot a box to re-run advisory, "
+            "idempotent health checks"
+        )


### PR DESCRIPTION
## What & why

Implements `alpha-engine-config-I8167`, operator decision **(a)** (2026-08-24): give the Saturday/substrate health checks their own emittable skip flag rather than ruling that a box is genuinely needed on every recovery. The health checks are advisory and idempotent, which argues for a cheap re-run skip, not for booting a spot instance merely to re-run them. (b) was explicitly rejected in the ruling and is not implemented here.

Root cause: `I8162` shipped a spot-dispatch bypass so a Director-only mechanical recovery skips booting a spot box, gated by `skip_post_eval` among 7 other conjuncts. `skip_post_eval` can never fire from a mechanical recovery's derived input — `scripts/weekly_sf_rerun.py`'s `STAGES` row for it carries `emit_skip=False` (config#6054: it's a deprecated whole-tail alias), so no input `derive_plan()` produces ever sets it. The bypass read as live in the definition but was permanently unreachable from any real recovery.

## What changed

1. **`infrastructure/step_function.json`** — new `CheckSkipSaturdayHealthCheck` Choice gate, keyed on a new `skip_saturday_health_check` flag, inserted between `CheckSkipPostEval`'s `Default` and `SaturdayHealthCheck`. Covers exactly `SaturdayHealthCheck`, `WaitForSaturdayHealthCheck`, `WeeklySubstrateHealthCheck`, `WaitForWeeklySubstrateHealthCheck` (and their Wait/poll/Degraded satellites) and converges on `RunScope` — the same convergence point the health-check pair's own success/degraded paths already use — so `ReportCard`/`Director`/`ScannerLeaderboard` are unaffected. `skip_post_eval` keeps its exact existing whole-tail meaning (still bypasses the entire post-Evaluator tail, unchanged). `CheckSpotDispatchNeeded`'s bypass conjunction now tests `skip_saturday_health_check` instead of `skip_post_eval` (the 8th conjunct, 1:1 swap).

2. **`scripts/weekly_sf_rerun.py`** — new `STAGES` row `saturday_health_check` / `skip_saturday_health_check` (`emit_skip=True`, the default) owns completion/failure/degraded-witness detection for the physical health-check pair; the deprecated `post_eval` row keeps its whole-tail-alias meaning but no longer owns `detect_failure` or a `degraded_witness` (shared-work convention, mirrors `backtester_stage_only`/`backtester`). `_simulate_reachable_works` updated to model the new stage.

   **Most important part**: `box_dispatch_flags()` now raises `SystemExit` if any conjunct it derives is backed by a `STAGES` row with `emit_skip=False` — the exact defect class this issue exists to close ("a predicate conjunct no producer emits") can no longer recur silently, for this gate or any future one.

3. Verified via a synthetic test that a helper-generated Director-only recovery input (every box stage witnessed complete, only Director remaining) derives a skip set that satisfies `CheckSpotDispatchNeeded`'s bypass conjunction end-to-end against the live definition.

## Judgment call (stated assumption)

The ruling text lists "`SubstrateHealthGate`'s payload" as part of the new gate's span alongside the four health-check states. `SubstrateHealthGate` (the box-readiness Lambda gate, config#2249) runs *before* `MorningEnrich`, gated by `skip_morning_enrich` — structurally unrelated to the post-Evaluator health-check tail, and already unreachable once `skip_morning_enrich` is set (confirmed: `box_dispatch_flags()` succeeds without the "uncovered state" FATAL). I read this phrase as inherited from `CheckSpotDispatchNeeded`'s own comment, which lists "`SubstrateHealthGate`'s Payload" among the general population of `$.ec2_instance_id`-referencing states relevant to *that* gate's derivation (deliverable 3) — not an instruction to re-gate `SubstrateHealthGate` itself behind the new flag, which would be a structural error (it would block box readiness checks even on runs where `MorningEnrich` still needs the box). Did not touch `SubstrateHealthGate`.

## Test plan

- `python3 -m pytest tests/test_weekly_sf_rerun.py -q` — 89 passed (13 new/updated).
- `python3 -m pytest tests/ -q` — 6545 passed, 17 skipped, **2 pre-existing failures**, both reproduced identically on `main` (confirmed via a scratch worktree) and unrelated to this change — not touched here:
  - `tests/test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday-json_path0]` (missing `WeeklyCoverageSweep`/`WeeklyCoverageSweepUnavailable` registry entries)
  - `tests/test_stage_coverage_run_date_contract.py::test_stage_verdict_requires_the_execution_run_date_for_its_exact_s3_key`
- Did not run `aws stepfunctions validate-state-machine-definition` locally (no scoped credentials in this session) — relying on the `sf-definition-validate` CI job, which runs the same preflight `deploy-infrastructure.sh --validate-only` uses.
- Did not deploy the state machine or start any execution.

## Closes-when

`weekly_sf_rerun.py --dry-run` on a recovery whose chain witnessed every box stage complete emits an input satisfying `CheckSpotDispatchNeeded`'s bypass conjunction — demonstrated by `TestSpotDispatchOnlyWhenABoxStageSurvives::test_a_helper_generated_director_only_recovery_satisfies_the_bypass`.

## Tracker

`alpha-engine-config-I8167`. A closing keyword does not work across repos (the tracker lives in `nousergon/alpha-engine-config`, this PR is in `nousergon-data`) — the issue is closed by hand once this merges and the property is verified on `main`.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)

---

Rehearsal-path: tests/test_weekly_sf_rerun.py

The gated behaviour is reachable without waiting for a Saturday. `tests/test_weekly_sf_rerun.py` exercises it three ways, and the third is the end-to-end rehearsal of exactly the case this PR exists for:

- `test_a_helper_generated_director_only_recovery_satisfies_the_bypass` — builds a helper-generated Director-only recovery input and asserts it satisfies `CheckSpotDispatchNeeded`'s live bypass conjunction, read from `infrastructure/step_function.json` itself rather than from a restated copy. This is the `Closes-when` condition, executed in CI on every push.
- `test_every_conjunct_is_emittable` — asserts every conjunct of the live bypass predicate is backed by a `STAGES` row with `emit_skip=True`.
- `test_a_non_emittable_sole_coverer_fails_the_build` — reproduces the original `I8162` shape by removing the new stage row, and confirms the guard fires. The regression is rehearsed, not just the fix.

`sf-definition-validate` (the AWS ASL validator) passed on this branch, so the state-machine edit is structurally valid as well as behaviourally tested.