### PR TITLE
fix(weekly-sf): run AggregateCosts after Director so cost.parquet can contain the pipeline's largest cost (alpha-engine-config-I7194)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2494,7 +2494,7 @@
                       "BooleanEquals": true
                     }
                   ],
-                  "Next": "CheckSkipAggregateCosts"
+                  "Next": "BranchAComplete"
                 }
               ],
               "Default": "Counterfactual"
@@ -2535,97 +2535,11 @@
                 }
               ],
               "ResultPath": "$.counterfactual_result",
-              "Next": "CheckSkipAggregateCosts"
+              "Next": "BranchAComplete"
             },
             "MarkCounterfactualDegraded": {
               "Type": "Pass",
               "Comment": "alpha-engine-config#6722: threads $.research_degraded_local=true onto Counterfactual's fail-open path without changing its continuation (still CheckSkipAggregateCosts).",
-              "Result": true,
-              "ResultPath": "$.research_degraded_local",
-              "Next": "CheckSkipAggregateCosts"
-            },
-            "CheckSkipAggregateCosts": {
-              "Type": "Choice",
-              "Comment": "Skip-gate. {\"skip_aggregate_costs\": true} bypasses the daily cost-telemetry aggregation Lambda (used for ad-hoc reruns where the cost parquet for the date is already current, or when iterating on the aggregator script). Standalone invocation of the Lambda is always available via the deploy.sh aggregate_costs target. Independent of skip_rationale_clustering / skip_replay_concordance / skip_counterfactual \u2014 the four are independent observability paths.",
-              "Choices": [
-                {
-                  "And": [
-                    {
-                      "Variable": "$.skip_aggregate_costs",
-                      "IsPresent": true
-                    },
-                    {
-                      "Variable": "$.skip_aggregate_costs",
-                      "BooleanEquals": true
-                    }
-                  ],
-                  "Next": "BranchAComplete"
-                }
-              ],
-              "Default": "AggregateCosts"
-            },
-            "AggregateCosts": {
-              "Type": "Task",
-              "Comment": "Daily cost-telemetry aggregation Lambda. Reads decision_artifacts/_cost_raw/{run_date}/*.jsonl and writes the daily parquet at decision_artifacts/_cost/{run_date}/cost.parquet, emits per-agent CW metrics under AlphaEngine/Cost, and asserts FAN-IN COVERAGE (config-I7179): the set of distinct producers under _cost_raw must contain every producer the `coverage.required_producers` map below declares for the stages this execution actually entered, and must contain nothing outside the declared/conditional/allowed sets. A COUNT cannot see this defect \u2014 five Think Tank files look exactly like healthy coverage, which is what they were mistaken for until 2026-08-13. This Comment previously claimed 'all LLM-emitting upstream states have written their cost JSONL rows by the time the aggregator runs' and named rationale-clustering and counterfactual among them; both are measured to make ZERO LLM calls, and the pipeline's single most expensive call (Director, `ultra` group) runs at the TOP LEVEL after this Parallel and is therefore NOT in this parquet at all. Correcting the aggregator's position is tracked separately. Failure is non-blocking (Catch routes to MarkAggregateCostsDegraded) \u2014 cost telemetry is observability, NOT a primary deliverable; a coverage breach must be loud without regressing the alpha pipeline. Status contract OK / SKIPPED / ERROR mirrors data #295 + L3277 audit.",
-              "Resource": "arn:aws:states:::lambda:invoke",
-              "Parameters": {
-                "FunctionName": "alpha-engine-research-aggregate-costs:live",
-                "Payload": {
-                  "date.$": "$.run_date",
-                  "dry_run_llm.$": "$.research_dry",
-                  "coverage": {
-                    "execution_arn.$": "$$.Execution.Id",
-                    "required_producers": {
-                      "ChallengerShadow": [
-                        "single-agent-quant"
-                      ],
-                      "EvalJudgeProcess": [
-                        "evaljudge-batch"
-                      ],
-                      "ReplayConcordance": [
-                        "replay-concordance"
-                      ]
-                    },
-                    "conditional_producers": {
-                      "EvalJudgeProcess": [
-                        "evaljudge-sync"
-                      ]
-                    },
-                    "allowed_producers": [
-                      "thinktank-*",
-                      "director-plan"
-                    ]
-                  }
-                }
-              },
-              "TimeoutSeconds": 270,
-              "Retry": [
-                {
-                  "ErrorEquals": [
-                    "Lambda.ServiceException",
-                    "Lambda.TooManyRequestsException"
-                  ],
-                  "MaxAttempts": 1,
-                  "IntervalSeconds": 60,
-                  "BackoffRate": 1.0
-                }
-              ],
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Comment": "Cost-telemetry aggregation is observability \u2014 failure must NOT halt the pipeline. The next Saturday SF will retry over a fresh _cost_raw partition; the prior week's parquet (or the manual-trigger fallback via scripts/aggregate_costs.py) remains available. alpha-engine-config#6722: this Catch matches sf-pipeline-policy.md \u00a75's NAMED cost-aggregation carve-out verbatim ('Health-check and cost-aggregation stages may fail-open ... They must still set a degraded flag') \u2014 previously routed straight to BranchAComplete with zero flag, a policy non-compliance on an explicit clause. Now routes through MarkAggregateCostsDegraded first.",
-                  "Next": "MarkAggregateCostsDegraded",
-                  "ResultPath": "$.aggregate_costs_error"
-                }
-              ],
-              "ResultPath": "$.aggregate_costs_result",
-              "Next": "BranchAComplete"
-            },
-            "MarkAggregateCostsDegraded": {
-              "Type": "Pass",
-              "Comment": "alpha-engine-config#6722: threads $.research_degraded_local=true onto AggregateCosts's fail-open path (the sf-pipeline-policy.md \u00a75 cost-aggregation carve-out's required flag) without changing its continuation (still BranchAComplete).",
               "Result": true,
               "ResultPath": "$.research_degraded_local",
               "Next": "BranchAComplete"
@@ -6126,7 +6040,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckShellRunNotify"
+          "Next": "CheckSkipAggregateCosts"
         }
       ],
       "Default": "CheckSkipSaturdayHealthCheck"
@@ -6527,6 +6441,108 @@
       "ResultPath": "$.director_result",
       "Next": "DirectorComplete"
     },
+    "CheckSkipAggregateCosts": {
+      "Type": "Choice",
+      "Comment": "Skip-gate. {\"skip_aggregate_costs\": true} bypasses the daily cost-telemetry aggregation Lambda (used for ad-hoc reruns where the cost parquet for the date is already current, or when iterating on the aggregator script). Standalone invocation of the Lambda is always available via the deploy.sh aggregate_costs target. POSITION (alpha-engine-config-I7194, 2026-08-25): this gate and the states behind it were the LAST states of ResearchPredictorParallel branch 0 until now. They sit at the TOP LEVEL, on the single edge every real-completion path takes into CheckShellRunNotify \u2014 after Director, the pipeline's most expensive LLM call. The entry point is this gate rather than DirectorComplete deliberately: DirectorComplete is entered ONLY via Director's success edge, so anchoring there would silently skip cost aggregation on {\"skip_director\": true}, on {\"skip_post_eval\": true} and on the ReportCard fail-open \u2014 exactly the reruns. Independent of skip_rationale_clustering / skip_replay_concordance / skip_counterfactual / skip_report_card / skip_director / skip_scanner_leaderboard / skip_post_eval: cost telemetry is not part of the post-eval advisory tail, and none of those flags has ever bypassed it.",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.skip_aggregate_costs",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.skip_aggregate_costs",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "CheckShellRunNotify"
+        }
+      ],
+      "Default": "AggregateCosts"
+    },
+    "AggregateCosts": {
+      "Type": "Task",
+      "Comment": "Daily cost-telemetry aggregation Lambda. Reads decision_artifacts/_cost_raw/{run_date}/*.jsonl and writes the daily parquet at decision_artifacts/_cost/{run_date}/cost.parquet, emits per-agent CW metrics under AlphaEngine/Cost, and asserts FAN-IN COVERAGE (config-I7179): the set of distinct producers under _cost_raw must contain every producer the `coverage.required_producers` map below declares for the stages this execution actually entered, and must contain nothing outside the declared/conditional/allowed sets. A COUNT cannot see this defect \u2014 five Think Tank files look exactly like healthy coverage, which is what they were mistaken for until 2026-08-13. POSITION (alpha-engine-config-I7194, 2026-08-25): this state ran as the last state of ResearchPredictorParallel branch 0 until now, which put it BEFORE Director \u2014 the single most expensive LLM call in the pipeline, `ultra` group, callsite director-plan \u2014 so cost.parquet structurally could not contain the pipeline's largest cost and AlphaEngine/Cost under-reported by an unbounded margin in the reassuring direction. It now runs at the top level on the single edge into CheckShellRunNotify, after Director AND after the ScannerLeaderboard leaf, so every state that can emit a cost row has emitted it before the prefix is read. Director is consequently promoted from allowed_producers to required_producers, and its SECOND callsite \u2014 director-retro-judge (crucible-evaluator director/retro.py, run best-effort by the SAME Lambda invocation and genuinely absent on the first cycle, when there is no prior plan, and when the invocation budget is exhausted) \u2014 is declared CONDITIONAL: undeclared, it would arrive as a present-but-undeclared producer the moment the Director's IAM grant lands (alpha-engine-config-I8152) and the aggregator would refuse it. Failure is non-blocking (Catch routes to MarkAggregateCostsDegraded) \u2014 cost telemetry is observability, NOT a primary deliverable; a coverage breach must be loud without regressing the alpha pipeline. Status contract OK / SKIPPED / ERROR mirrors data #295 + L3277 audit.",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "alpha-engine-research-aggregate-costs:live",
+        "Payload": {
+          "date.$": "$.run_date",
+          "dry_run_llm.$": "$.research_dry",
+          "coverage": {
+            "execution_arn.$": "$$.Execution.Id",
+            "required_producers": {
+              "ChallengerShadow": [
+                "single-agent-quant"
+              ],
+              "EvalJudgeProcess": [
+                "evaljudge-batch"
+              ],
+              "ReplayConcordance": [
+                "replay-concordance"
+              ],
+              "Director": [
+                "director-plan"
+              ]
+            },
+            "conditional_producers": {
+              "EvalJudgeProcess": [
+                "evaljudge-sync"
+              ],
+              "Director": [
+                "director-retro-judge"
+              ]
+            },
+            "allowed_producers": [
+              "thinktank-*"
+            ]
+          }
+        }
+      },
+      "TimeoutSeconds": 270,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "MaxAttempts": 1,
+          "IntervalSeconds": 60,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "Cost-telemetry aggregation is observability \u2014 failure must NOT halt the pipeline. The next Saturday SF will retry over a fresh _cost_raw partition; the prior week's parquet (or the manual-trigger fallback via scripts/aggregate_costs.py) remains available. alpha-engine-config#6722: this Catch matches sf-pipeline-policy.md \u00a75's NAMED cost-aggregation carve-out verbatim ('Health-check and cost-aggregation stages may fail-open ... They must still set a degraded flag'). alpha-engine-config-I7194: the flag it sets is now $.aggregate_costs_degraded, its own top-level family, because the branch-local $.research_degraded_local this path used to thread exists only inside the Parallel and is hoisted as branch_a_degraded \u2014 which would attribute a cost-aggregation failure to a Parallel that no longer contains the aggregator.",
+          "Next": "MarkAggregateCostsDegraded",
+          "ResultPath": "$.aggregate_costs_error"
+        }
+      ],
+      "ResultPath": "$.aggregate_costs_result",
+      "Next": "CheckShellRunNotify"
+    },
+    "MarkAggregateCostsDegraded": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7194: the SF-controlled visible flag CheckGateDegradedNotify reads, set BEFORE the summary so the flag is on the execution record whatever happens downstream. Shape mirrors ScannerLeaderboardDegraded / ReportCardDegraded exactly. Replaces the branch-local $.research_degraded_local this Catch path set while the aggregator lived inside ResearchPredictorParallel branch 0.",
+      "Result": true,
+      "ResultPath": "$.aggregate_costs_degraded",
+      "Next": "SetAggregateCostsDegradedSummary"
+    },
+    "SetAggregateCostsDegradedSummary": {
+      "Type": "Pass",
+      "Comment": "alpha-engine-config-I7194: mirrors SetScannerLeaderboardDegradedSummary. $.degraded_summary is what CheckDegradedOutcome reads to route to WriteCompletionMarkerDegraded \u2014 without it the run would end SUCCEEDED with no cost record for the cycle. Like every sibling Set*DegradedSummary in this definition it OVERWRITES an earlier stage's summary; the per-stage booleans survive independently. Deliberately carries NO stage_error: the sibling convention is uniform and a Choice path added later must not start throwing States.Runtime here (tests/test_degraded_terminal_derives_its_cause.py). Continuation is CheckShellRunNotify \u2014 the same edge the success and skip paths take, so a fail-open changes what the run SAYS, never where it goes.",
+      "Parameters": {
+        "degraded": true,
+        "reason": "weekly_aggregate_costs_fail_open",
+        "run_date.$": "$.run_date"
+      },
+      "ResultPath": "$.degraded_summary",
+      "Next": "CheckShellRunNotify"
+    },
     "CheckShellRunNotify": {
       "Type": "Choice",
       "Comment": "Consolidated Friday-PM shell-run result notify. Reuses the EXISTING NotifyComplete SNS-publish substrate (same alpha-engine-alerts topic, same arn:aws:states:::sns:publish Resource) with a shell_run-tagged Subject/Message so the operator can tell a Friday dry-pass result apart from a real Saturday SUCCESS in their inbox. shell_run absent/false \u2192 NotifyComplete (BYTE-IDENTICAL to pre-spine). shell_run=true \u2192 NotifyShellRunComplete. No new SNS topic / Lambda / infra \u2014 the consolidated per-state pass/fail report (ROADMAP design point 5) is a scoped follow-on; the spine delivers a single shell-run-tagged success signal by reusing NotifyComplete's pattern.",
@@ -6755,6 +6771,20 @@
           ],
           "Comment": "alpha-engine-config-I7813. LAST in the list on purpose: a run that also degraded a gate, a health check, the parity verdict, the report card or a Branch A fail-open matches one of the rules above and gets that (more consequential) notification, while the leaf's own PublishScannerLeaderboardDegraded alert has already named it. This rule exists so a run whose ONLY degradation is the observe-only board cannot reach NotifyComplete's \"All steps completed successfully\" while terminating in DegradedRun.",
           "Next": "NotifyCompleteScannerLeaderboardDegraded"
+        },
+        {
+          "And": [
+            {
+              "Variable": "$.aggregate_costs_degraded",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.aggregate_costs_degraded",
+              "BooleanEquals": true
+            }
+          ],
+          "Comment": "alpha-engine-config-I7194. The sixth flag family, and the second one folded into the generic combined notifier rather than given a per-combination Task of its own \u2014 the generalization config#2276's comment predicted and config#6722 already applied to research_predictor_degraded. LAST in the list on purpose, for the same reason the scanner-leaderboard rule above it is: a run that also degraded a gate, a health check, the parity verdict, the report card, the leaf or a Branch A fail-open matches one of the rules above and gets that (more consequential) notification. This rule exists so a run whose ONLY degradation is the cost aggregation cannot reach NotifyComplete's \"All steps completed successfully\" while terminating in DegradedRun \u2014 which is what it would have done from the top level, where the branch-local $.research_degraded_local hoist that used to carry it does not reach.",
+          "Next": "NotifyCompleteMultipleDegraded"
         }
       ],
       "Default": "NotifyComplete"
@@ -6849,12 +6879,12 @@
     },
     "NotifyCompleteMultipleDegraded": {
       "Type": "Task",
-      "Comment": "config#6685 + alpha-engine-config-I6025 + alpha-engine-config#6722: SUCCESS notifier for a run where TWO OR MORE of the (now five) degraded-flag families fired together (pre-spend gates, tail health checks, report card advisory grading, parity verdict, ResearchPredictorParallel's internal fail-open routes) \u2014 OR research_predictor_degraded fired ALONE, which is deliberately folded here too rather than given its own single-flag notifier (it already covers 25+ distinct internal routes; a sixth per-combination axis would re-introduce the enumeration explosion this notifier exists to avoid). Folded (config#2276's own comment predicted a third flag family would need a data-driven notifier rather than a 7-way enumeration, and the same reasoning generalizes further): a single generic combined-degradation notifier, instead of enumerating every additional per-combination Task state. Deliberately does NOT assert which SPECIFIC families degraded in the constant Subject/Message (config#1819 forbids States.Format-ing the exact set into the text) \u2014 names all five categories generically and points at the execution record ($.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded) for the exact combination, which stays truthful regardless of which subset actually fired (including the single-family research_predictor_degraded-only case). Mirrors NotifyCompleteGatesDegraded's shape \u2014 constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819).",
+      "Comment": "config#6685 + alpha-engine-config-I6025 + alpha-engine-config#6722: SUCCESS notifier for a run where TWO OR MORE of the (now five) degraded-flag families fired together (pre-spend gates, tail health checks, report card advisory grading, parity verdict, ResearchPredictorParallel's internal fail-open routes) \u2014 OR research_predictor_degraded fired ALONE, which is deliberately folded here too rather than given its own single-flag notifier (it already covers 25+ distinct internal routes; a sixth per-combination axis would re-introduce the enumeration explosion this notifier exists to avoid). Folded (config#2276's own comment predicted a third flag family would need a data-driven notifier rather than a 7-way enumeration, and the same reasoning generalizes further): a single generic combined-degradation notifier, instead of enumerating every additional per-combination Task state. Deliberately does NOT assert which SPECIFIC families degraded in the constant Subject/Message (config#1819 forbids States.Format-ing the exact set into the text) \u2014 names all five categories generically and points at the execution record ($.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded) for the exact combination, which stays truthful regardless of which subset actually fired (including the single-family research_predictor_degraded-only case). Mirrors NotifyCompleteGatesDegraded's shape \u2014 constants-only Subject/Message, best-effort Catch to NotifyCompleteDegraded (config#1819). | alpha-engine-config-I7194: a SIXTH family, $.aggregate_costs_degraded, now folds here too \u2014 AggregateCosts left ResearchPredictorParallel branch 0 for the top level (so it runs AFTER Director, whose director-plan rows it could never see from inside the Parallel), and its fail-open flag can no longer ride $.research_degraded_local. Registered LAST in CheckGateDegradedNotify, so it selects this notifier only when nothing more consequential degraded.",
       "Resource": "arn:aws:states:::sns:publish",
       "Parameters": {
         "TopicArn.$": "$.sns_topic_arn",
         "Subject": "Alpha Engine Saturday Pipeline \u2014 DEGRADED: multiple (run terminates FAILED)",
-        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because one or more of the following degraded on this run: the pre-spend gates (LibPinDriftCheck/PipelineContractCheck/AcquireMutex), the tail health checks (SaturdayHealthCheck/WeeklySubstrateHealthCheck), the report card advisory grading (ReportCard Lambda), the Parity verdict (pit_parity/replay \u2014 absence of a verdict must NOT be read as a clean pass), and/or an internal ResearchPredictorParallel fail-open (Scanner/RegimeSubstrate/ChallengerShadow/ThinkTank/the eval-judge chain/cost aggregation/the model-zoo rotation). Exact combination is on the execution record: $.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded, with detail at $.report_card_error and (if set) $.health_check_error / $.substrate_check_error / $.parity_error / $.branch_outcomes. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
+        "Message": "Every WORK stage completed, and the run still terminates FAILED (config-I6891, sf-pipeline-policy.md \u00a72.3 Option A) because one or more of the following degraded on this run: the pre-spend gates (LibPinDriftCheck/PipelineContractCheck/AcquireMutex), the tail health checks (SaturdayHealthCheck/WeeklySubstrateHealthCheck), the report card advisory grading (ReportCard Lambda), the Parity verdict (pit_parity/replay \u2014 absence of a verdict must NOT be read as a clean pass), and/or an internal ResearchPredictorParallel fail-open (Scanner/RegimeSubstrate/ChallengerShadow/ThinkTank/the eval-judge chain/the model-zoo rotation), and/or the top-level cost aggregation (AggregateCosts, moved out of that Parallel by alpha-engine-config-I7194). Exact combination is on the execution record: $.gate_degraded / $.health_check_degraded / $.report_card_degraded / $.parity_degraded / $.research_predictor_degraded / $.aggregate_costs_degraded, with detail at $.report_card_error and (if set) $.health_check_error / $.substrate_check_error / $.parity_error / $.branch_outcomes. View pipeline status: https://dashboard.nousergon.ai/pipeline-status"
       },
       "ResultPath": "$.notify_result",
       "Catch": [
@@ -7975,7 +8005,7 @@
               "BooleanEquals": true
             }
           ],
-          "Next": "CheckShellRunNotify"
+          "Next": "CheckSkipAggregateCosts"
         }
       ],
       "Default": "ScannerLeaderboard"
@@ -8038,7 +8068,7 @@
     "ScannerLeaderboardComplete": {
       "Type": "Pass",
       "Comment": "alpha-engine-config-I7813: success-only witness for the rerun deriver (scripts/weekly_sf_rerun.py), exactly the DirectorComplete pattern and for the same reason \u2014 the success edge and every bypass path would otherwise converge on CheckShellRunNotify, leaving no state that uniquely witnesses 'the leaf actually completed' (the I6055 trap).",
-      "Next": "CheckShellRunNotify"
+      "Next": "CheckSkipAggregateCosts"
     },
     "ScannerLeaderboardDegraded": {
       "Type": "Pass",
@@ -8094,10 +8124,10 @@
           ],
           "Comment": "Best-effort alert \u2014 a publish failure must not block the non-fatal path this alert decorates. $.degraded_summary is already set, so the run still terminates DEGRADED.",
           "ResultPath": "$.scanner_leaderboard_degraded_notify_error",
-          "Next": "CheckShellRunNotify"
+          "Next": "CheckSkipAggregateCosts"
         }
       ],
-      "Next": "CheckShellRunNotify"
+      "Next": "CheckSkipAggregateCosts"
     },
     "NotifyCompleteScannerLeaderboardDegraded": {
       "Type": "Task",

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -396,17 +396,12 @@ STAGES: tuple[Stage, ...] = (
     Stage(
         "counterfactual", "skip_counterfactual",
         "CheckSkipCounterfactual", "Counterfactual",
-        frozenset({"CheckSkipAggregateCosts"}),
-        degraded_witness=frozenset({"MarkCounterfactualDegraded"}),
-    ),
-    Stage(
-        "aggregate_costs", "skip_aggregate_costs",
-        "CheckSkipAggregateCosts", "AggregateCosts",
+        # alpha-engine-config-I7194: was CheckSkipAggregateCosts until the
+        # aggregator left this branch for the top level. Counterfactual is now
+        # the last work state of Branch A, so its success edge, its Catch fold
+        # and the skip route all land on BranchAComplete.
         frozenset({"BranchAComplete"}),
-        # alpha-engine-config#6722: matches sf-pipeline-policy.md §5's named
-        # cost-aggregation carve-out, which REQUIRES a degraded flag —
-        # MarkAggregateCostsDegraded now provides it.
-        degraded_witness=frozenset({"MarkAggregateCostsDegraded"}),
+        degraded_witness=frozenset({"MarkCounterfactualDegraded"}),
     ),
     # --- ResearchPredictorParallel branch B -------------------------------
     Stage(
@@ -601,7 +596,12 @@ STAGES: tuple[Stage, ...] = (
     Stage(
         "post_eval", "skip_post_eval",
         "CheckSkipPostEval", "SaturdayHealthCheck",
-        frozenset({"CheckShellRunNotify"}),
+        # alpha-engine-config-I7194: was CheckShellRunNotify. The whole-tail
+        # skip route now lands one state earlier, on the cost-aggregation
+        # gate — skip_post_eval bypasses the post-Evaluator ADVISORIES and
+        # has never bypassed cost telemetry, which carries its own
+        # skip_aggregate_costs flag.
+        frozenset({"CheckSkipAggregateCosts"}),
         emit_skip=False,
         # detect_failure=False (alpha-engine-config-I8167): shares its `work`
         # state with "saturday_health_check" above, which now owns
@@ -616,8 +616,9 @@ STAGES: tuple[Stage, ...] = (
             "config-I8167): the deriver emits skip_report_card / "
             "skip_director / skip_saturday_health_check instead. Kept in "
             "the DEFINITION only for in-flight inputs that still set it — "
-            "its meaning (bypass the entire post-Evaluator tail, including "
-            "ReportCard/Director/ScannerLeaderboard) is UNCHANGED. Remove "
+            "its meaning (bypass the entire post-Evaluator advisory tail, "
+            "including ReportCard/Director/ScannerLeaderboard, but NOT the "
+            "cost aggregation behind its own gate) is UNCHANGED. Remove "
             "the alias once a full cycle has passed on the split flags."
         ),
     ),
@@ -678,6 +679,28 @@ STAGES: tuple[Stage, ...] = (
             "SetScannerLeaderboardResourceKillSummary",
         }),
     ),
+    Stage(
+        "aggregate_costs", "skip_aggregate_costs",
+        "CheckSkipAggregateCosts", "AggregateCosts",
+        # alpha-engine-config-I7194: this row modeled a Branch A stage until
+        # the aggregator moved to the top level so it could see Director's
+        # director-plan cost rows. It is now the LAST gate before the terminal
+        # notify, and its success edge, its fail-open and its skip route all
+        # land on CheckShellRunNotify — the ordinary skip-lands-in-witness
+        # convention, exactly as the shared BranchAComplete witness worked
+        # before the move, NOT director's/scanner_leaderboard's inverted one.
+        frozenset({"CheckShellRunNotify"}),
+        # alpha-engine-config#6722: matches sf-pipeline-policy.md §5's named
+        # cost-aggregation carve-out, which REQUIRES a degraded flag. I7194
+        # splits that flag into its own top-level family, so the summary Pass
+        # is a second degraded witness (the ReportCard/ScannerLeaderboard
+        # shape) — the branch-local $.research_degraded_local fold it used
+        # does not exist outside the Parallel.
+        degraded_witness=frozenset({
+            "MarkAggregateCostsDegraded",
+            "SetAggregateCostsDegradedSummary",
+        }),
+    ),
 )
 
 STAGES_BY_NAME = {s.name: s for s in STAGES}
@@ -694,7 +717,10 @@ BRANCH_A_STAGES = frozenset({
     "scanner", "regime_substrate", "signals_envelope", "challenger_shadow",
     "rag_ingestion", "regime_retrospective_eval",
     "data_phase2", "eval_judge", "rationale_clustering",
-    "replay_concordance", "counterfactual", "aggregate_costs",
+    "replay_concordance", "counterfactual",
+    # alpha-engine-config-I7194: aggregate_costs left this set when the
+    # aggregator moved out of ResearchPredictorParallel branch 0 to the
+    # top-level tail — it is modeled with the other tail stages below.
 })
 # Stages whose gate is only reachable THROUGH CheckSkipBacktester's run path
 # (the skip route overshoots them — see Stage("backtester").note).
@@ -1135,7 +1161,13 @@ def _simulate_reachable_works(flags: dict, original_input: dict) -> set:
     # guard (which folds DEGRADED stages into must_rerun) can see
     # saturday_health_check — its health-check degraded_witness — as
     # reachable when a tail rerun re-runs the span.
-    run_linear(["evaluator", "saturday_health_check", "post_eval", "report_card", "director"])
+    # alpha-engine-config-I7194: aggregate_costs joins the tail — it now runs
+    # after Director, on the single edge every real-completion path takes
+    # into CheckShellRunNotify.
+    run_linear([
+        "evaluator", "saturday_health_check", "post_eval", "report_card",
+        "director", "aggregate_costs",
+    ])
     return ran
 
 

--- a/tests/fixtures/weekly_sf_rerun/tail_stage_failure.json
+++ b/tests/fixtures/weekly_sf_rerun/tail_stage_failure.json
@@ -693,24 +693,6 @@
       "timestamp": "2026-07-11T09:00:00Z"
     },
     {
-      "type": "ChoiceStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "CheckSkipAggregateCosts",
-        "input": "{}"
-      },
-      "id": 74,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
-      "type": "TaskStateEntered",
-      "stateEnteredEventDetails": {
-        "name": "AggregateCosts",
-        "input": "{}"
-      },
-      "id": 75,
-      "timestamp": "2026-07-11T09:00:00Z"
-    },
-    {
       "type": "TaskStateExited",
       "stateExitedEventDetails": {
         "name": "AggregateCosts",

--- a/tests/test_sf_aggregate_costs_wiring.py
+++ b/tests/test_sf_aggregate_costs_wiring.py
@@ -5,18 +5,32 @@ companion alpha-engine-research PR adds the
 ``alpha-engine-research-aggregate-costs:live`` Lambda; this test only
 asserts the SF wiring.
 
-Pin the chain end of Branch A:
+Pin the tail of the weekly definition:
 
-    ... Counterfactual → CheckSkipAggregateCosts → AggregateCosts
-                                                 → BranchAComplete
+    ... DirectorComplete ─┐
+        CheckSkipDirector ┤
+        Publish/Complete  ├→ CheckSkipAggregateCosts → AggregateCosts
+        of the leaf       ┘                          → CheckShellRunNotify
 
-The aggregator must sit AFTER the entire LLM chain (Research /
-eval-judge / rationale-clustering / replay-concordance / counterfactual)
-so every upstream LLM-emitting state has finished writing its
-``_cost_raw/{date}/*.jsonl`` rows by the time the aggregator runs.
-Catches regressions like: a future SF refactor that drops the new
-state, or reroutes Counterfactual back to BranchAComplete bypassing
-the aggregator.
+The aggregator must sit AFTER every LLM-emitting state so all of their
+``_cost_raw/{run_date}/*.jsonl`` rows exist by the time it reads the
+prefix. **alpha-engine-config-I7194 (2026-08-25)** moved it out of
+``ResearchPredictorParallel`` branch 0, where it ran BEFORE ``Director``
+— the pipeline's single most expensive call — so ``cost.parquet``
+structurally could not contain the pipeline's largest cost and
+``AlphaEngine/Cost`` under-reported by an unbounded margin in the
+reassuring direction.
+
+It is anchored on the SHARED edge into ``CheckShellRunNotify`` rather
+than on ``DirectorComplete``: that witness is entered only via
+``Director``'s success edge, so anchoring there would silently skip cost
+aggregation under ``skip_director``, under ``skip_post_eval`` and after
+a ``ReportCard`` fail-open — exactly the reruns — turning an incomplete
+parquet into a missing one.
+
+Catches regressions like: a future SF refactor that drops a state, that
+reroutes the tail past the aggregator, or that puts it back upstream of
+an LLM call.
 """
 
 from __future__ import annotations
@@ -97,13 +111,12 @@ class TestLambdaTarget:
 
 
 class TestFailureIsolation:
-    def test_catch_routes_to_branch_a_complete(self, states):
+    def test_catch_routes_through_the_degraded_flag(self, states):
         # Cost telemetry is observability — aggregator failure must NOT
-        # halt the pipeline. Mirrors the rationale-clustering Catch.
-        # alpha-engine-config#6722: this Catch matches sf-pipeline-policy.md
-        # §5's NAMED cost-aggregation carve-out, which REQUIRES a degraded
-        # flag — now routes through MarkAggregateCostsDegraded before
-        # converging on BranchAComplete exactly as before.
+        # halt the pipeline. alpha-engine-config#6722: this Catch matches
+        # sf-pipeline-policy.md §5's NAMED cost-aggregation carve-out,
+        # which REQUIRES a degraded flag, so it routes through
+        # MarkAggregateCostsDegraded rather than straight to the notify.
         catches = states["AggregateCosts"]["Catch"]
         assert len(catches) >= 1
         assert any(
@@ -111,7 +124,59 @@ class TestFailureIsolation:
             and "States.ALL" in c["ErrorEquals"]
             for c in catches
         )
-        assert states["MarkAggregateCostsDegraded"]["Next"] == "BranchAComplete"
+
+    def test_the_degraded_flag_is_its_own_top_level_family(self, states):
+        """alpha-engine-config-I7194. Inside the Parallel this path wrote
+        the branch-local ``$.research_degraded_local``, hoisted as
+        ``branch_a_degraded`` and folded into
+        ``$.research_predictor_degraded``. That fold does not exist at the
+        top level, and reusing the name would attribute a cost-aggregation
+        failure to a Parallel that no longer contains the aggregator — so
+        the flag is its own family, in the ReportCard / ScannerLeaderboard
+        shape: boolean first, then the summary the terminal reads."""
+        flag = states["MarkAggregateCostsDegraded"]
+        assert flag["Type"] == "Pass"
+        assert flag["Result"] is True
+        assert flag["ResultPath"] == "$.aggregate_costs_degraded"
+        assert flag["Next"] == "SetAggregateCostsDegradedSummary"
+
+        summary = states["SetAggregateCostsDegradedSummary"]
+        assert summary["Type"] == "Pass"
+        assert summary["ResultPath"] == "$.degraded_summary"
+        assert summary["Parameters"]["degraded"] is True
+        assert summary["Parameters"]["reason"]
+        # A Choice path added later must not throw on an absent error key.
+        assert "stage_error.$" not in summary["Parameters"]
+        # The fail-open changes what the run SAYS, never where it goes.
+        assert summary["Next"] == "CheckShellRunNotify"
+
+    def test_a_degraded_aggregation_can_never_report_a_clean_success(self, states):
+        """Without a rule of its own in CheckGateDegradedNotify a run whose
+        only degradation is the cost aggregation falls through to
+        NotifyComplete — "All steps completed successfully" — while
+        terminating in DegradedRun. Folded into the generic combined
+        notifier rather than given a per-combination Task, the
+        disposition config#6722 already applied to
+        ``$.research_predictor_degraded``; registered LAST, so anything
+        more consequential reports itself instead."""
+        gate = states["CheckGateDegradedNotify"]
+        matching = [
+            c
+            for c in gate["Choices"]
+            if any(
+                cond.get("Variable") == "$.aggregate_costs_degraded"
+                for cond in (c.get("And") or [c])
+            )
+        ]
+        assert len(matching) == 1
+        assert matching[0]["Next"] == "NotifyCompleteMultipleDegraded"
+        assert gate["Choices"][-1] is matching[0]
+        assert gate["Default"] == "NotifyComplete"
+        # The notifier's constant Message must name the flag it now covers —
+        # config#1819 forbids formatting the live set into the text, so the
+        # enumeration IS the contract with the operator reading it.
+        message = states["NotifyCompleteMultipleDegraded"]["Parameters"]["Message"]
+        assert "$.aggregate_costs_degraded" in message
 
     def test_retry_only_on_lambda_service_errors(self, states):
         # Same shape as rationale-clustering — service-level retries
@@ -130,57 +195,85 @@ class TestFailureIsolation:
 
 
 class TestEdges:
-    def test_counterfactual_routes_to_check_skip_aggregate_costs(self, states):
-        # Default path (success) — Counterfactual's Next must hit the
-        # new skip-gate, NOT BranchAComplete directly.
-        cf = states["Counterfactual"]
-        assert cf["Next"] == "CheckSkipAggregateCosts"
+    def test_the_aggregator_is_a_top_level_state(self, sf):
+        """alpha-engine-config-I7194. Not a stylistic point: ASL gives a
+        state in a Parallel branch no ordering relationship with anything
+        outside that Parallel, so an aggregator inside one can never be
+        ordered after Director."""
+        for name in (
+            "CheckSkipAggregateCosts",
+            "AggregateCosts",
+            "MarkAggregateCostsDegraded",
+            "SetAggregateCostsDegradedSummary",
+        ):
+            assert name in sf["States"], f"{name} is not a top-level state"
+        for st in sf["States"].values():
+            if st.get("Type") != "Parallel":
+                continue
+            for branch in st["Branches"]:
+                assert "AggregateCosts" not in branch["States"]
 
-    def test_counterfactual_catch_routes_to_check_skip_aggregate_costs(self, states):
-        # Counterfactual failure must STILL run the aggregator —
-        # upstream LLM cost rows are independent of counterfactual's
-        # success. (The aggregator's own Catch routes to
-        # BranchAComplete so a downstream failure-of-failure can't
-        # ladder back into the failed counterfactual error path.)
-        # alpha-engine-config#6722: routes through MarkCounterfactualDegraded
-        # before converging on CheckSkipAggregateCosts exactly as before.
-        cf = states["Counterfactual"]
-        catches = cf["Catch"]
-        assert any(
-            c["Next"] == "MarkCounterfactualDegraded"
-            for c in catches
+    def test_every_edge_into_the_notify_gate_passes_the_aggregator_first(self, sf):
+        """The load-bearing property. The aggregator is anchored on the
+        tail's single convergence point, so no completion path can reach
+        the terminal notify without it — which is what an anchor on
+        DirectorComplete (a success-ONLY witness) would have allowed
+        under skip_director, under skip_post_eval and after a ReportCard
+        fail-open."""
+        allowed = {
+            "CheckSkipAggregateCosts",  # the skip route
+            "AggregateCosts",           # the success route
+            "SetAggregateCostsDegradedSummary",  # the fail-open route
+        }
+        offenders = []
+        for name, st in sf["States"].items():
+            if name in allowed:
+                continue
+            targets = [st.get("Next"), st.get("Default")]
+            targets += [c.get("Next") for c in st.get("Choices", []) or []]
+            targets += [c.get("Next") for c in st.get("Catch", []) or []]
+            if "CheckShellRunNotify" in targets:
+                offenders.append(name)
+        assert not offenders, (
+            f"{offenders} reach CheckShellRunNotify without passing the "
+            f"cost-aggregation gate — their cost rows would never be "
+            f"aggregated (alpha-engine-config-I7194)"
         )
-        assert states["MarkCounterfactualDegraded"]["Next"] == "CheckSkipAggregateCosts"
 
-    def test_check_skip_counterfactual_default_unchanged(self, states):
-        # CheckSkipCounterfactual's Default → Counterfactual stays
-        # unchanged; only the SKIP branch is rerouted to the new
-        # CheckSkipAggregateCosts.
-        skip = states["CheckSkipCounterfactual"]
-        assert skip["Default"] == "Counterfactual"
+    def test_the_leaf_and_the_director_hand_off_to_the_gate(self, states):
+        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckSkipAggregateCosts"
+        assert states["CheckSkipScannerLeaderboard"]["Choices"][0]["Next"] == (
+            "CheckSkipAggregateCosts"
+        )
+        assert states["PublishScannerLeaderboardDegraded"]["Next"] == (
+            "CheckSkipAggregateCosts"
+        )
+        # The coarse deprecated whole-tail alias too: skip_post_eval bypasses
+        # the advisories, and never bypassed cost telemetry.
+        assert states["CheckSkipPostEval"]["Choices"][0]["Next"] == (
+            "CheckSkipAggregateCosts"
+        )
 
-    def test_check_skip_counterfactual_skip_routes_to_aggregate_costs_gate(
-        self, states,
-    ):
-        # When operator skips counterfactual, the flow MUST still hit
-        # the aggregator gate (an operator skipping counterfactual is
-        # NOT also skipping cost-telemetry — those are independent
-        # skip flags per the comment on CheckSkipAggregateCosts).
-        skip = states["CheckSkipCounterfactual"]
-        skip_choices = skip["Choices"]
-        assert len(skip_choices) == 1
-        assert skip_choices[0]["Next"] == "CheckSkipAggregateCosts"
+    def test_branch_a_no_longer_routes_through_the_aggregator(self, states):
+        """Counterfactual is Branch A's last work state again. All three
+        of its exits land on the branch terminal."""
+        assert states["Counterfactual"]["Next"] == "BranchAComplete"
+        assert states["MarkCounterfactualDegraded"]["Next"] == "BranchAComplete"
+        assert states["CheckSkipCounterfactual"]["Default"] == "Counterfactual"
+        assert states["CheckSkipCounterfactual"]["Choices"][0]["Next"] == (
+            "BranchAComplete"
+        )
 
-    def test_aggregate_costs_success_routes_to_branch_a_complete(self, states):
-        assert states["AggregateCosts"]["Next"] == "BranchAComplete"
+    def test_aggregate_costs_success_routes_to_the_notify_gate(self, states):
+        assert states["AggregateCosts"]["Next"] == "CheckShellRunNotify"
 
-    def test_check_skip_aggregate_costs_skip_routes_to_branch_a_complete(
+    def test_check_skip_aggregate_costs_skip_routes_to_the_notify_gate(
         self, states,
     ):
         skip = states["CheckSkipAggregateCosts"]
         skip_choices = skip["Choices"]
         assert len(skip_choices) == 1
-        assert skip_choices[0]["Next"] == "BranchAComplete"
+        assert skip_choices[0]["Next"] == "CheckShellRunNotify"
 
     def test_check_skip_aggregate_costs_default_is_aggregate_costs(self, states):
         assert states["CheckSkipAggregateCosts"]["Default"] == "AggregateCosts"

--- a/tests/test_sf_cost_fanin_coverage.py
+++ b/tests/test_sf_cost_fanin_coverage.py
@@ -63,21 +63,34 @@ def states(sf) -> dict:
 
 
 @pytest.fixture(scope="module")
-def branch_a(sf) -> dict:
-    """The branch AggregateCosts itself lives in.
+def scopes(sf) -> dict:
+    """Every scope in the definition, keyed by the top-level state that
+    contains it: the top level itself under ``None``, and each Parallel
+    branch under the Parallel's own state name.
 
-    Reachability is only meaningful inside one branch: a stage in a
-    sibling branch of the same Parallel, or at the top level after it,
-    has no ordering relationship with the aggregator that the aggregator
-    can rely on.
+    Reachability is only meaningful WITHIN one scope — ASL gives a state
+    in one Parallel branch no ordering relationship with a state in a
+    sibling branch. Between scopes the ordering that IS guaranteed is the
+    Parallel's own: a Parallel completes before its ``Next``, so every
+    state inside it precedes every state reachable after it.
     """
-    for st in sf["States"].values():
-        if st.get("Type") != "Parallel":
-            continue
-        for branch in st["Branches"]:
-            if "AggregateCosts" in branch["States"]:
-                return branch["States"]
-    raise AssertionError("AggregateCosts is not inside a Parallel branch")
+    out: dict = {None: sf["States"]}
+    for name, st in sf["States"].items():
+        if st.get("Type") == "Parallel":
+            for branch in st["Branches"]:
+                out.setdefault(name, {}).update(branch["States"])
+    return out
+
+
+def _enclosing(stage: str, scopes: dict) -> str | None:
+    """The top-level state that contains ``stage`` — ``None`` when the
+    stage IS a top-level state."""
+    if stage in scopes[None]:
+        return None
+    for parallel, states in scopes.items():
+        if parallel is not None and stage in states:
+            return parallel
+    raise AssertionError(f"{stage} is in no scope of the definition")
 
 
 @pytest.fixture(scope="module")
@@ -165,29 +178,79 @@ class TestDeclaredStagesAreReal:
 class TestDeclaredStagesCanActuallyBeSeen:
     """The ordering half — the failure that was live when this was written.
 
-    ``Director`` makes the pipeline's single most expensive call and runs
-    at the TOP LEVEL, after the Parallel that contains ``AggregateCosts``.
-    Its rows cannot be in the parquet the aggregator writes, so demanding
-    them would make the coverage check fail on every healthy run. It is
-    listed under ``allowed_producers`` instead, and moving the aggregator
-    is tracked separately. This test is what stops a later edit from
-    quietly promoting a post-aggregator stage into ``required_producers``.
+    ``Director`` makes the pipeline's single most expensive call
+    (``ultra`` group, callsite ``director-plan``) and runs at the TOP
+    LEVEL. ``AggregateCosts`` ran as the last state of
+    ``ResearchPredictorParallel`` branch 0, so the Director's rows landed
+    in ``_cost_raw`` AFTER the parquet for that date was written and
+    could never be in it — ``cost.parquet`` structurally excluded the
+    pipeline's largest cost, and ``AlphaEngine/Cost`` under-reported by
+    an unbounded margin in the reassuring direction. Fixed by
+    ``alpha-engine-config-I7194``: the aggregator moved to the top-level
+    tail, on the single edge every real-completion path takes into
+    ``CheckShellRunNotify``, and ``Director`` is required rather than
+    merely allowed.
+
+    The reachability rule below is stated over SCOPES rather than over
+    one hard-coded branch, so it keeps holding wherever the aggregator
+    sits — that generality is the whole point: the branch-local version
+    of this test could only ever have said "the aggregator cannot see
+    Director", never "it must".
     """
 
-    def test_every_required_stage_precedes_the_aggregator(self, coverage, branch_a):
+    def test_every_required_stage_precedes_the_aggregator(self, coverage, scopes):
+        agg_scope = _enclosing("AggregateCosts", scopes)
         for stage in coverage["required_producers"]:
-            assert stage in branch_a, (
-                f"{stage} is required to have emitted cost rows before "
-                f"AggregateCosts runs, but it is not in the aggregator's own "
-                f"Parallel branch — the aggregator cannot see its rows"
+            stage_scope = _enclosing(stage, scopes)
+            if stage_scope == agg_scope:
+                # Same scope — the ordinary intra-scope walk.
+                assert _reaches(stage, "AggregateCosts", scopes[agg_scope]), (
+                    f"{stage} cannot reach AggregateCosts, so its cost rows "
+                    f"are not guaranteed to exist when the aggregator reads "
+                    f"the prefix"
+                )
+                continue
+            # Different scopes. The only ordering ASL guarantees across a
+            # Parallel boundary is the Parallel's own: everything inside it
+            # finishes before its Next. So the stage's enclosing Parallel
+            # must reach the aggregator's scope at the top level, and the
+            # aggregator must not itself be inside a Parallel the stage is
+            # not in (a sibling branch has no ordering at all).
+            assert agg_scope is None, (
+                f"{stage} is in {stage_scope or 'the top level'} and "
+                f"AggregateCosts is inside {agg_scope} — a Parallel branch "
+                f"has no ordering relationship with anything outside it, so "
+                f"the aggregator cannot rely on seeing {stage}'s rows"
             )
-            assert _reaches(stage, "AggregateCosts", branch_a), (
-                f"{stage} cannot reach AggregateCosts, so its cost rows are "
-                f"not guaranteed to exist when the aggregator reads the prefix"
+            assert stage_scope is not None
+            assert _reaches(stage_scope, "AggregateCosts", scopes[None]), (
+                f"{stage} runs inside {stage_scope}, which does not reach "
+                f"AggregateCosts at the top level — its cost rows are not "
+                f"guaranteed to exist when the aggregator reads the prefix"
             )
 
     def test_the_aggregator_does_not_require_itself(self, coverage):
         assert "AggregateCosts" not in coverage["required_producers"]
+
+    def test_the_aggregator_runs_after_the_director(self, sf, scopes):
+        """The I7194 defect, stated as the property rather than as a
+        position. Anchored on Director's SKIP gate, not on Director or
+        DirectorComplete: DirectorComplete is entered only on Director's
+        success edge, so an aggregator anchored there would silently not
+        run under ``skip_director`` or after a ReportCard fail-open —
+        exactly the reruns — and the parquet would be missing entirely
+        rather than merely incomplete."""
+        assert _enclosing("AggregateCosts", scopes) is None, (
+            "AggregateCosts must be a top-level state: Director is one, and "
+            "a Parallel branch cannot be ordered after it"
+        )
+        top = scopes[None]
+        assert _reaches("Director", "AggregateCosts", top)
+        assert _reaches("CheckSkipDirector", "AggregateCosts", top)
+        assert not _reaches("AggregateCosts", "Director", top), (
+            "the aggregator must not be able to precede the Director on any "
+            "path — that is the whole defect"
+        )
 
 
 class TestKnownProducersStayDeclared:
@@ -220,6 +283,29 @@ class TestKnownProducersStayDeclared:
         detector that cries wolf is turned off."""
         assert coverage["conditional_producers"]["EvalJudgeProcess"] == [
             "evaljudge-sync"
+        ]
+
+    def test_director_plan_is_required(self, coverage):
+        """alpha-engine-config-I7194: the pipeline's most expensive call.
+        It was ``allowed`` — never required — only because the aggregator
+        ran before it, which is exactly the defect. Demoting it back to
+        ``allowed`` would restore a coverage check that passes when the
+        largest cost in the pipeline is missing."""
+        assert coverage["required_producers"]["Director"] == ["director-plan"]
+        assert "director-plan" not in coverage["allowed_producers"]
+
+    def test_director_retro_judge_is_conditional_not_required(self, coverage):
+        """The SAME Lambda invocation makes a second call —
+        ``crucible-evaluator`` ``director/retro.py::grade_prior_plan``,
+        callsite ``director-retro-judge`` — which genuinely does not fire
+        on every run: ``_run_retro_best_effort`` returns ``skipped`` on
+        the first cycle (no prior plan) and on an exhausted invocation
+        budget, and swallows its own failure because the plan is already
+        persisted. Requiring it would make the detector cry wolf; leaving
+        it undeclared would make the aggregator refuse it as a
+        present-but-undeclared producer the first time it does fire."""
+        assert coverage["conditional_producers"]["Director"] == [
+            "director-retro-judge"
         ]
 
     def test_thinktank_is_allowed_but_never_required(self, coverage):

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -744,7 +744,7 @@ class TestReplayConcordance:
 
 
 class TestSkipCounterfactual:
-    def test_skip_flag_bypasses_to_aggregate_costs_gate(self, states):
+    def test_skip_flag_bypasses_to_branch_terminal(self, states):
         """Skipping Counterfactual now lands on the AggregateCosts
         skip-gate (ROADMAP L1146 — SF-wired daily cost aggregator
         added 2026-05-25), not directly on BranchAComplete. The cost
@@ -755,9 +755,11 @@ class TestSkipCounterfactual:
         run. The four observability skip flags (skip_counterfactual /
         skip_rationale_clustering / skip_replay_concordance /
         skip_aggregate_costs) are independent. Pre-L1146 this assertion
-        pinned ``BranchAComplete``; the L1146 wire-up reroutes through
-        ``CheckSkipAggregateCosts`` which transitively reaches the
-        Branch-A terminal."""
+        pinned ``BranchAComplete``; the L1146 wire-up rerouted through
+        ``CheckSkipAggregateCosts``, and alpha-engine-config-I7194 moved
+        that gate to the TOP LEVEL — so the branch terminal is once again
+        the direct target, and cost aggregation now runs AFTER Director
+        instead of before it."""
         skip = states["CheckSkipCounterfactual"]
         choice = skip["Choices"][0]
         and_clauses = choice["And"]
@@ -766,7 +768,7 @@ class TestSkipCounterfactual:
             and c.get("BooleanEquals") is True
             for c in and_clauses
         )
-        assert choice["Next"] == "CheckSkipAggregateCosts"
+        assert choice["Next"] == "BranchAComplete"
 
     def test_default_runs_counterfactual(self, states):
         assert states["CheckSkipCounterfactual"]["Default"] == "Counterfactual"
@@ -794,17 +796,17 @@ class TestCounterfactual:
         # across 8 weeks of corpus).
         assert states["Counterfactual"]["TimeoutSeconds"] == 600
 
-    def test_success_exits_to_aggregate_costs_gate(self, states):
-        # Counterfactual is now the SECOND-to-last load-bearing state in
-        # Branch A — the L1146 wire-up (2026-05-25) inserted the
-        # AggregateCosts cost-telemetry aggregator after it. Success now
-        # exits to CheckSkipAggregateCosts, which transitively reaches
-        # BranchAComplete (End:true). Persisted S3 artifacts are still
-        # available to the downstream Evaluator, which runs AFTER the
-        # Parallel join. Pre-L1146: Counterfactual.Next == BranchAComplete.
-        assert states["Counterfactual"]["Next"] == "CheckSkipAggregateCosts"
+    def test_success_exits_to_branch_terminal(self, states):
+        # Counterfactual is Branch A's LAST load-bearing state again: the
+        # L1146 wire-up (2026-05-25) inserted AggregateCosts after it, and
+        # alpha-engine-config-I7194 moved that aggregator to the top level
+        # so it runs after Director (whose director-plan rows it could
+        # never see from inside this Parallel). Persisted S3 artifacts are
+        # still available to the downstream Evaluator, which runs AFTER
+        # the Parallel join.
+        assert states["Counterfactual"]["Next"] == "BranchAComplete"
 
-    def test_catch_routes_to_aggregate_costs_gate_not_failure(self, states):
+    def test_catch_routes_to_branch_terminal_not_failure(self, states):
         # Same Catch posture as the rest of the agent-justification
         # triple — Counterfactual is observability, not load-bearing, so
         # failures fall through to the next observability step (the cost
@@ -816,12 +818,13 @@ class TestCounterfactual:
         # observability layer with its own Catch routing to
         # BranchAComplete.
         # alpha-engine-config#6722: routes through MarkCounterfactualDegraded
-        # before converging on CheckSkipAggregateCosts exactly as before.
+        # first. alpha-engine-config-I7194: that fold now converges on
+        # BranchAComplete, the aggregator having moved to the top level.
         catch = states["Counterfactual"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
         assert catch["Next"] == "MarkCounterfactualDegraded"
         assert catch["Next"] != "HandleFailure"
-        assert states["MarkCounterfactualDegraded"]["Next"] == "CheckSkipAggregateCosts"
+        assert states["MarkCounterfactualDegraded"]["Next"] == "BranchAComplete"
 
     def test_retries_on_transient_lambda_errors(self, states):
         retry = states["Counterfactual"]["Retry"][0]
@@ -877,35 +880,33 @@ class TestJudgeChainBeforePredictor:
             == "CheckSkipEvalJudge"
         )
 
-    def test_counterfactual_exits_to_aggregate_costs_gate(self, states):
+    def test_counterfactual_exits_to_branch_terminal(self, states):
         """Counterfactual's three exit edges (Next + Catch + the
-        skip-gate above it) all converge on the AggregateCosts skip-gate
-        added by ROADMAP L1146 (2026-05-25). The Evaluator-sees-judge-
+        skip-gate above it) all converge on BranchAComplete
+        (alpha-engine-config-I7194 moved the AggregateCosts skip-gate that
+        ROADMAP L1146 inserted here to the top-level tail). The Evaluator-sees-judge-
         artifacts ordering invariant is still satisfied because
         Evaluator runs AFTER the Parallel join, by which point Branch A
         (including the inserted cost-aggregator step) has completed and
         its S3 artifacts are landed. Edge target history:
         pre-2026-05-07 SaturdayHealthCheck → 2026-05-07→05-16
         CheckSkipPredictorTraining → 2026-05-16→05-25 BranchAComplete →
-        post-L1146 CheckSkipAggregateCosts. The transitive reach to
-        BranchAComplete is preserved (CheckSkipAggregateCosts.Default →
-        AggregateCosts.Next → BranchAComplete; CheckSkipAggregateCosts's
-        skip-branch → BranchAComplete directly)."""
-        # alpha-engine-config#6722: the Catch edge now detours through
-        # MarkCounterfactualDegraded, still transitively reaching
-        # CheckSkipAggregateCosts.
-        assert states["Counterfactual"]["Next"] == "CheckSkipAggregateCosts"
+        L1146 CheckSkipAggregateCosts → alpha-engine-config-I7194
+        (2026-08-25) BranchAComplete again."""
+        # alpha-engine-config#6722: the Catch edge detours through
+        # MarkCounterfactualDegraded, still reaching BranchAComplete.
+        assert states["Counterfactual"]["Next"] == "BranchAComplete"
         assert (
             states["Counterfactual"]["Catch"][0]["Next"]
             == "MarkCounterfactualDegraded"
         )
         assert (
             states["MarkCounterfactualDegraded"]["Next"]
-            == "CheckSkipAggregateCosts"
+            == "BranchAComplete"
         )
         assert (
             states["CheckSkipCounterfactual"]["Choices"][0]["Next"]
-            == "CheckSkipAggregateCosts"
+            == "BranchAComplete"
         )
 
     def test_evaluator_exits_directly_to_health_check(self, states):

--- a/tests/test_sf_friday_shell_run_wiring.py
+++ b/tests/test_sf_friday_shell_run_wiring.py
@@ -1102,11 +1102,14 @@ class TestConsolidatedNotify:
         # Director → DirectorComplete (success-only rerun witness) →
         # CheckSkipScannerLeaderboard → ScannerLeaderboard →
         # ScannerLeaderboardComplete (success-only rerun witness) →
-        # CheckShellRunNotify. alpha-engine-config-I7813 inserted the last three:
-        # the observe-only scanner board is a leaf AFTER the advisories, and
-        # every path that previously reached CheckShellRunNotify from this tail
-        # — ReportCard's degraded route, Director's skip route, Director's
-        # success — now passes through its gate first.
+        # CheckSkipAggregateCosts → AggregateCosts → CheckShellRunNotify.
+        # alpha-engine-config-I7813 inserted the scanner-leaderboard trio;
+        # alpha-engine-config-I7194 then appended the cost-aggregation gate as
+        # the tail's LAST stage, so the aggregator runs after Director and its
+        # director-plan rows are in the parquet. Every path that previously
+        # reached CheckShellRunNotify from this tail — ReportCard's degraded
+        # route, Director's skip route, Director's success, the leaf's three
+        # routes — now passes through that gate first.
         assert substrate_success["Next"] == "RunScope"
         assert states["RunScope"]["Next"] == "CheckSkipReportCard"
         assert states["CheckSkipReportCard"]["Default"] == "ReportCard"
@@ -1127,7 +1130,7 @@ class TestConsolidatedNotify:
         assert states["CheckSkipScannerLeaderboard"]["Default"] == "ScannerLeaderboard"
         leaf = states["ScannerLeaderboard"]
         assert leaf["Next"] == "ScannerLeaderboardComplete"
-        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
+        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckSkipAggregateCosts"
         # alpha-engine-config-I7812: a resource kill forks one state earlier so
         # the terminal cause can name it; both routes set the same
         # $.scanner_leaderboard_degraded flag and converge on the same alert.
@@ -1138,7 +1141,12 @@ class TestConsolidatedNotify:
         assert_degraded_continuation(
             states, "ScannerLeaderboardDegraded", "PublishScannerLeaderboardDegraded"
         )
-        assert states["PublishScannerLeaderboardDegraded"]["Next"] == "CheckShellRunNotify"
+        assert states["PublishScannerLeaderboardDegraded"]["Next"] == "CheckSkipAggregateCosts"
+        # alpha-engine-config-I7194: the cost-aggregation gate is the tail's
+        # last stage and the sole entry into the terminal notify.
+        assert states["CheckSkipAggregateCosts"]["Default"] == "AggregateCosts"
+        assert states["AggregateCosts"]["Next"] == "CheckShellRunNotify"
+        assert states["CheckSkipAggregateCosts"]["Choices"][0]["Next"] == "CheckShellRunNotify"
 
     def test_advisory_tail_runs_dry_on_preflight(self, states):
         """ROADMAP L4504: ReportCard + Director were added after the shell-run

--- a/tests/test_sf_research_predictor_degraded_wiring.py
+++ b/tests/test_sf_research_predictor_degraded_wiring.py
@@ -126,8 +126,14 @@ _BRANCH_A_MARK_STATES = {
     "MarkEvalRollingMeanDegraded": "CheckSkipRationaleClustering",
     "MarkRationaleClusteringDegraded": "CheckSkipReplayConcordance",
     "MarkReplayConcordanceDegraded": "CheckSkipCounterfactual",
-    "MarkCounterfactualDegraded": "CheckSkipAggregateCosts",
-    "MarkAggregateCostsDegraded": "BranchAComplete",
+    # alpha-engine-config-I7194: Counterfactual is Branch A's last work state
+    # now that the aggregator runs at the top level, so this fold lands on the
+    # branch terminal directly. MarkAggregateCostsDegraded left this table with
+    # the aggregator — it no longer writes $.research_degraded_local, because
+    # the branch-local fold does not exist outside the Parallel; its top-level
+    # replacement writes $.aggregate_costs_degraded and is pinned by
+    # tests/test_sf_aggregate_costs_wiring.py.
+    "MarkCounterfactualDegraded": "BranchAComplete",
 }
 
 
@@ -155,7 +161,6 @@ def test_branch_a_mark_state_shape(branch_a, name, next_target):
         "RationaleClustering",
         "ReplayConcordance",
         "Counterfactual",
-        "AggregateCosts",
     ],
 )
 def test_branch_a_owner_catch_routes_through_a_mark_state(branch_a, owner):

--- a/tests/test_sf_scanner_leaderboard_leaf.py
+++ b/tests/test_sf_scanner_leaderboard_leaf.py
@@ -158,9 +158,14 @@ def test_a_leaf_failure_degrades_the_run_loudly_and_never_silently(states):
     assert alert["Resource"] == "arn:aws:states:::sns:publish"
     assert "ScannerLeaderboard" in alert["Parameters"]["Subject"]
     # Best-effort: the alert can fail without changing the outcome it reports.
-    assert alert["Next"] == "CheckShellRunNotify"
+    # alpha-engine-config-I7194: the tail's convergence point is now the
+    # cost-aggregation gate, which every real-completion path enters before
+    # CheckShellRunNotify — the aggregator runs AFTER Director so it can see
+    # the director-plan cost rows. The leaf's own routing is unchanged in
+    # meaning: one hop, best-effort, no fork.
+    assert alert["Next"] == "CheckSkipAggregateCosts"
     for catch in alert["Catch"]:
-        assert catch["Next"] == "CheckShellRunNotify"
+        assert catch["Next"] == "CheckSkipAggregateCosts"
 
     # $.degraded_summary is what CheckDegradedOutcome routes on.
     outcome = states["CheckDegradedOutcome"]
@@ -190,9 +195,16 @@ def test_the_terminal_notify_can_never_call_a_degraded_leaf_a_success(states):
     ]
     assert len(matching) == 1
     assert matching[0]["Next"] == "NotifyCompleteScannerLeaderboardDegraded"
-    # LAST before the clean default: a run that ALSO degraded something
-    # consequential must report that instead.
-    assert gate["Choices"][-1] is matching[0]
+    # Second-to-last before the clean default: a run that ALSO degraded
+    # something consequential must report that instead. alpha-engine-config-I7194
+    # appended one further rule after this one — $.aggregate_costs_degraded,
+    # the tail's sixth and least consequential family — so the property this
+    # pins is "after every more consequential family", not "physically last".
+    assert gate["Choices"].index(matching[0]) == len(gate["Choices"]) - 2
+    assert any(
+        cond.get("Variable") == "$.aggregate_costs_degraded"
+        for cond in (gate["Choices"][-1].get("And") or [gate["Choices"][-1]])
+    )
     assert gate["Default"] == "NotifyComplete"
     assert states["NotifyCompleteScannerLeaderboardDegraded"]["Next"] == "CheckDegradedOutcome"
 
@@ -200,14 +212,17 @@ def test_the_terminal_notify_can_never_call_a_degraded_leaf_a_success(states):
 def test_the_leaf_is_skippable_and_witnessed_for_rerun(states):
     """sf-pipeline-policy.md §2.5: recovery is one mechanical command, which
     needs (a) a skip flag the rerun deriver can emit and (b) a success-ONLY
-    witness. Witnessing on the shared CheckShellRunNotify would mark a bypassed
-    leaf complete and skip it on the rerun — the I6055 trap."""
+    witness. Witnessing on the shared tail convergence point would mark a
+    bypassed leaf complete and skip it on the rerun — the I6055 trap.
+    alpha-engine-config-I7194 moved that convergence point one state earlier,
+    to CheckSkipAggregateCosts; it is still shared by the skip and success
+    routes, so the witness still has to be the leaf's own Pass."""
     gate = states["CheckSkipScannerLeaderboard"]
     assert gate["Default"] == "ScannerLeaderboard"
-    assert {c["Next"] for c in gate["Choices"]} == {"CheckShellRunNotify"}
+    assert {c["Next"] for c in gate["Choices"]} == {"CheckSkipAggregateCosts"}
     assert states["ScannerLeaderboard"]["Next"] == "ScannerLeaderboardComplete"
     assert states["ScannerLeaderboardComplete"]["Type"] == "Pass"
-    assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
+    assert states["ScannerLeaderboardComplete"]["Next"] == "CheckSkipAggregateCosts"
     # Only the leaf's success edge enters the witness.
     enterers = [
         name for name, body in states.items()

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -273,6 +273,14 @@ _DEGRADED_FLAG_JSONPATHS: dict[str, frozenset[str]] = {
             # leaf's own flag. Read LAST in CheckGateDegradedNotify, so a run
             # that also degraded something consequential still reports that.
             "$.scanner_leaderboard_degraded",
+            # alpha-engine-config-I7194: AggregateCosts moved out of
+            # ResearchPredictorParallel branch 0 onto the top-level tail (so it
+            # runs AFTER Director, whose director-plan rows it could never see
+            # from inside the Parallel). Its fail-open can no longer ride the
+            # branch-local $.research_degraded_local fold, so it gets its own
+            # family — also read LAST, folded into the generic combined
+            # notifier rather than given a per-combination Task of its own.
+            "$.aggregate_costs_degraded",
         }
     ),
     "step_function_daily.json": frozenset({"$.degraded_summary"}),
@@ -528,18 +536,10 @@ _DEGRADED_FLAG_EXEMPT: dict[str, dict[str, str]] = {
         ),
         "ResearchPredictorParallel.Counterfactual": (
             "Same fold as Scanner (routes through MarkCounterfactualDegraded) "
-            "before continuing to CheckSkipAggregateCosts unchanged."
-        ),
-        "ResearchPredictorParallel.AggregateCosts": (
-            "FIXED (alpha-engine-config#6722): matched sf-pipeline-policy.md "
-            "§5's NAMED cost-aggregation carve-out verbatim ('Health-check "
-            "and cost-aggregation stages may fail-open ... They must still "
-            "set a degraded flag') without complying — Catch routed "
-            "straight to BranchAComplete with zero flag. Now routes through "
-            "MarkAggregateCostsDegraded (same branch-local fold as Scanner) "
-            "before continuing to BranchAComplete unchanged — the §5 "
-            "clause's flag requirement is now met, verified by "
-            "tests/test_sf_research_predictor_degraded_wiring.py."
+            "before continuing to BranchAComplete unchanged "
+            "(alpha-engine-config-I7194: was CheckSkipAggregateCosts until the "
+            "aggregator left this branch — Counterfactual is now Branch A's "
+            "last work state)."
         ),
         "ResearchPredictorParallel.ResolveZooSpecs": (
             "FIXED, not directly walker-visible (alpha-engine-config#6722, "

--- a/tests/test_sf_substrate_check_wiring.py
+++ b/tests/test_sf_substrate_check_wiring.py
@@ -132,7 +132,11 @@ class TestChainOrdering:
         assert states["Director"]["Next"] == "DirectorComplete"
         assert states["DirectorComplete"]["Next"] == "CheckSkipScannerLeaderboard"
         assert states["CheckSkipScannerLeaderboard"]["Default"] == "ScannerLeaderboard"
-        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckShellRunNotify"
+        # alpha-engine-config-I7194: the leaf now hands off to the
+        # cost-aggregation gate, the tail's last stage, which runs the
+        # aggregator AFTER Director and then enters the notify gate.
+        assert states["ScannerLeaderboardComplete"]["Next"] == "CheckSkipAggregateCosts"
+        assert states["AggregateCosts"]["Next"] == "CheckShellRunNotify"
         assert all(
             c["Next"] == "NormalizeFailureContext" for c in states["Director"]["Catch"]
         )

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -133,7 +133,16 @@ class TestDerivePlan:
             "skip_rationale_clustering",
             "skip_replay_concordance",
             "skip_counterfactual",
-            "skip_aggregate_costs",
+            # skip_aggregate_costs is NOT here (alpha-engine-config-I7194):
+            # the aggregator left Branch A for the top-level tail, where it
+            # runs AFTER Director — so a run that failed at Evaluator never
+            # reached it, and a stage the run never attempted must not be
+            # skipped on the rerun. The fixture was trimmed to match: it is a
+            # pre-move history, and the two events it carried for those
+            # states cannot occur under this topology. A REAL pre-move
+            # history replayed after this change derives aggregate_costs as
+            # failed rather than complete, which re-runs an idempotent
+            # Lambda — the safe direction, same as director's inversion.
             "skip_predictor_training",
             "skip_backtester_stage_only",
             "skip_predictor_backtest",
@@ -561,11 +570,14 @@ class TestStageTableLockstep:
                 # alpha-engine-config-I7813: same inverted convention as
                 # director, and for the same I6055 reason — the witness is the
                 # success-only ScannerLeaderboardComplete Pass, while the skip
-                # route lands on CheckShellRunNotify, which every bypass path
-                # also enters. An original run that skipped the leaf yields a
+                # route lands on the tail's shared convergence point, which
+                # every bypass path also enters. alpha-engine-config-I7194
+                # moved that point one state earlier — from CheckShellRunNotify
+                # to CheckSkipAggregateCosts — so the aggregator runs after
+                # Director. An original run that skipped the leaf yields a
                 # rerun that re-runs it: the safe direction for an observe-only
                 # board that costs one Lambda invocation.
-                assert skip_targets == {"CheckShellRunNotify"}
+                assert skip_targets == {"CheckSkipAggregateCosts"}
                 assert "ScannerLeaderboardComplete" not in skip_targets
                 continue
             if stage.name == "backtester_stage_only":


### PR DESCRIPTION
Closes the topology half of `alpha-engine-config-I7194` — https://github.com/nousergon/alpha-engine-config/issues/7194

## The defect

`AggregateCosts` was the last state of `ResearchPredictorParallel` branch 0. `Director` — the single most expensive LLM call in the weekly pipeline (`ultra` group, callsite `director-plan`) — runs at the **top level, after that Parallel**. Its cost rows land in `decision_artifacts/_cost_raw/{date}/` after `cost.parquet` for that date has already been written, so the parquet **structurally could not** contain the pipeline's largest single cost, and `AlphaEngine/Cost` under-reported by an unbounded margin **in the reassuring direction**.

## Topology chosen, and why

**Chosen:** move `CheckSkipAggregateCosts` / `AggregateCosts` / `MarkAggregateCostsDegraded` to the top level, anchored on the tail's **single convergence point** — every edge that reached `CheckShellRunNotify` now enters `CheckSkipAggregateCosts` first, and the gate's three routes (skip / success / fail-open) are the only edges into `CheckShellRunNotify`. Five edges were repointed: `CheckSkipPostEval`'s whole-tail skip, `CheckSkipScannerLeaderboard`'s skip, `ScannerLeaderboardComplete`, and `PublishScannerLeaderboardDegraded`'s `Next` + `Catch`. Branch 0's three edges into the old gate (`Counterfactual`.Next, `MarkCounterfactualDegraded`, `CheckSkipCounterfactual`'s skip) now go straight to `BranchAComplete`, restoring `Counterfactual` as Branch A's last work state.

**Rejected — anchor on `DirectorComplete`** (the issue's literal deliverable 1). `DirectorComplete` is entered **only** via `Director`'s success edge; `skip_director`, the deprecated whole-tail `skip_post_eval`, and `ReportCard`'s fail-open all bypass it. Anchoring there would silently skip cost aggregation on exactly the reruns — turning an incomplete parquet into a **missing** one. Stated assumption, written per the engagement protocol: deliverable 1's intent is "after Director on every path", and the convergence point is the only placement that delivers it.

**Rejected — a second aggregation pass.** The issue forbids it directly, and it is right to: the aggregator is idempotent so it would work, and it would leave two states with the same name doing different jobs, one silently redundant.

**Rejected — anchor after `WriteCompletionMarker`.** That tail is observe-only and downstream of the run's success terminal; a stage there cannot set `$.degraded_summary`, so a fail-open could not reach an honest terminal.

**SOTA:** cost aggregation runs at the pipeline's last convergence point, after every state that can emit a cost row, with fan-in coverage asserted against a declaration the pipeline itself owns. **Delta: none** — that is what this lands.

## Preserved semantics

`skip_aggregate_costs` gate · the `States.ALL` Catch to `MarkAggregateCostsDegraded` (`sf-pipeline-policy` §5's named cost-aggregation fail-open carve-out, which **requires** the degraded flag) · the `Retry` on `Lambda.ServiceException` / `TooManyRequestsException` only · `ResultPath` keys (`$.aggregate_costs_result` / `$.aggregate_costs_error`) · `TimeoutSeconds: 270` (still strictly below the Lambda's own 300s, so the declared budget is the one that fires).

## Degraded-flag plumbing (issue deliverable 5)

Inside the Parallel, `MarkAggregateCostsDegraded` wrote the branch-local `$.research_degraded_local`, hoisted by `BranchAComplete` as `branch_a_degraded` and folded into `$.research_predictor_degraded`. **That fold does not exist at the top level**, and reusing the name would attribute a cost-aggregation failure to a Parallel that no longer contains the aggregator. So the flag becomes its own family, in the `ReportCard` / `ScannerLeaderboard` shape:

`AggregateCosts` --Catch--> `MarkAggregateCostsDegraded` (`$.aggregate_costs_degraded = true`) → `SetAggregateCostsDegradedSummary` (`$.degraded_summary`, reason `weekly_aggregate_costs_fail_open`) → `CheckShellRunNotify`.

`CheckDegradedOutcome` therefore still routes a degraded run to `WriteCompletionMarkerDegraded` → `DegradedRun` (Option A, §2.3). `CheckGateDegradedNotify` gains one rule, **registered last**, folding the sixth family into `NotifyCompleteMultipleDegraded` — the disposition `config#6722` already applied to `$.research_predictor_degraded`, rather than a seventh per-combination Task. That notifier's constant `Message` is updated in the same commit: it listed "cost aggregation" among `ResearchPredictorParallel`'s internal fail-opens, which is no longer true, and now names `$.aggregate_costs_degraded` in its enumeration.

**Not included, deliberately:** an immediate `sns:publish` on this fail-open path, matching `PublishReportCardDegraded` / `PublishScannerLeaderboardDegraded`. The old path did not page either, so this is parity, not a regression — and a new `Task` state would require a companion `nousergon-lib` `STATE_TO_ARCHIVE_PAGE` entry plus a pin bump, dragging a cross-repo dependency into a change the issue split out specifically to stage on its own. Filed as `alpha-engine-config-I8336`, which also carries the detection blindness behind it: `tests/test_degraded_paths_page_immediately.py` enforces §5's paging half over `step_function_daily.json` and `step_function_eod.json` only, never the weekly definition.

## `coverage.allowed_producers` (issue deliverable 2 / item 3)

`director-plan` is **removed** from `allowed_producers` and promoted to `required_producers` — the declaration is now obsolete, exactly as the issue anticipated.

**A second producer had to be declared with it, and this is the one non-obvious finding.** The Director Lambda makes **two** LLM calls in one invocation: `director-plan` (`crucible-evaluator` `director/agent.py`) and `director-retro-judge` (`director/retro.py::grade_prior_plan`, called by `handler.py::_run_retro_best_effort`). The retro genuinely does not fire on every run — `skipped` on the first cycle (no prior plan) and on an exhausted invocation budget, and its own failure is swallowed because the plan is already persisted. Left undeclared it would arrive as a **present-but-undeclared** producer and the aggregator would refuse it the first time it fired. Declared as `conditional_producers.Director`, the `evaljudge-sync` precedent.

`tests/test_sf_cost_fanin_coverage.py::test_every_required_stage_precedes_the_aggregator` is **not deleted** — it is generalised from the hard-coded `branch_a` fixture to a scope-aware walk (top level under `None`, each Parallel branch under its Parallel's name), which encodes the only ordering ASL actually guarantees across a Parallel boundary: everything inside a Parallel finishes before its `Next`, and sibling branches have no ordering at all. A new test, `test_the_aggregator_runs_after_the_director`, pins the defect as a property rather than a position — including `not _reaches("AggregateCosts", "Director")`.

## Class check (issue item 3 / deliverable 4)

**Checked, and the class is now closed.** Enumerated every `callsite_id` literal across `crucible-research` and `crucible-evaluator` (`nousergon-lib`, `crucible-predictor` and `crucible-backtester` contain **no** `LLMClient` construction and no `callsite_id` at all): `director-plan`, `director-retro-judge`, `evaljudge-sync`, `evaljudge-shadow`, `evaljudge-batch`, `thinktank-*`, and `live-validate-openrouter-judge` (a validation script, not an SF stage). Of the states reachable after the aggregator's **old** position:

- `Director` — **two** call sites, both now declared (above).
- `ReportCard` (`alpha-engine-evaluator:live`, `grading/`) — no `LLMClient`, zero LLM calls. Confirms the issue's 2026-08-13 measurement.
- `ScannerLeaderboard` (`alpha-engine-research-scanner:live`, `mode=scanner_leaderboard`) — no `LLMClient` in `lambda/scanner_handler.py` or `scanner/`. `dry_run_llm` is threaded into it, which is a red herring the fan-in module already documents.
- `Backtester`, `PredictorBacktest`, `PortfolioOptimizerBacktest`, `PitParityCompare`, `EvaluatorDiagnostics`, `EvaluatorOptimize`, `SaturdayHealthCheck`, `WeeklySubstrateHealthCheck`, `SubstrateHealthGate`, `RunScope`, `WeeklyCoverageSweep` — no LLM call sites in their repos.

No other LLM-emitting state runs after the aggregator's new position: the only states downstream of it are the terminal notifiers, `WriteCompletionMarker(Degraded)` and the observe-only `WeeklyCoverageSweep` tail.

**Out-of-scope finding, named not fixed (`alpha-engine-config-I8335`):** `evaljudge-shadow` (`crucible-research` `evals/judge.py`) is declared **nowhere** in the coverage block — not required, not conditional, not allowed. It is upstream of the aggregator in both the old and the new topology, so this change neither creates nor worsens it; it belongs to the declaration-completeness work of `alpha-engine-config-I7179`. Filed rather than bundled.

## This fix is necessary but NOT sufficient — `alpha-engine-config-I8152`

`alpha-engine-evaluator-role` grants no `s3:PutObject` on `decision_artifacts/*`, so the Director has **never** successfully written a cost row (`aws s3 ls .../decision_artifacts/_cost_raw/ --recursive | grep -ci director` returns 0 across all 354 objects). That IAM gap is `alpha-engine-config-I8152`, fixed separately in `nous-ergon-ops`. **Both changes are required for the Director's cost to actually appear in `cost.parquet`; neither is sufficient alone.** Until I8152 lands, `Director` in `required_producers` will make the fan-in check report a declared-but-absent producer — which is the honest reading (the stage ran and emitted nothing) and routes through the fail-open, not through a pipeline halt.

## Rerun deriver (`scripts/weekly_sf_rerun.py`)

The `aggregate_costs` `Stage` row moves out of `BRANCH_A_STAGES` and into the tail: gate `CheckSkipAggregateCosts`, witness `CheckShellRunNotify` (the ordinary skip-lands-in-witness convention, exactly as the shared `BranchAComplete` witness worked before — not `director`'s / `scanner_leaderboard`'s inverted one), degraded witnesses `MarkAggregateCostsDegraded` + `SetAggregateCostsDegradedSummary`. `counterfactual`'s witness returns to `BranchAComplete`; `post_eval`'s and `scanner_leaderboard`'s skip routes land one state earlier.

**Known, accepted:** a **pre-move** execution history replayed by the deriver after this merges has `AggregateCosts` entered inside branch 0 and never enters `CheckShellRunNotify`, so it derives `aggregate_costs` as *failed* rather than *complete* and the rerun re-runs an idempotent Lambda. That is the safe direction, the same trade `director`'s inverted convention already accepts. `tests/fixtures/weekly_sf_rerun/tail_stage_failure.json` was trimmed of the two events it carried for those states, because they cannot occur under this topology.

## Validation

`.venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration` → **6528 passed, 12 skipped, 0 failed**.

Two failures surfaced on the first run and were **environment, not code**: `test_pipeline_status_registry_source_check` and `test_stage_coverage_run_date_contract` failed against a stale local venv (`nousergon-lib` 0.124.83 vs the pinned v0.124.87; `krepis` 0.59.12 vs the pinned 0.59.33). Installing the declared pins cleared both with no source change — CI installs from `requirements.txt` and never saw them.

Guards that had to be updated with the topology, each pinning a real property: `test_sf_structural_contract` (`$.aggregate_costs_degraded` registered as a flag family; the branch-local `ResearchPredictorParallel.AggregateCosts` exemption **deleted**, because the walker can now see the flag directly), `test_sf_cost_fanin_coverage`, `test_sf_aggregate_costs_wiring`, `test_sf_eval_judge_wiring`, `test_sf_research_predictor_degraded_wiring`, `test_sf_scanner_leaderboard_leaf`, `test_sf_friday_shell_run_wiring`, `test_sf_substrate_check_wiring`, `test_weekly_sf_rerun`.

Rehearsal-path: infrastructure/run_weekly_offcycle.sh — the Friday-PM shell run (`shell_run=true`, `research_dry=true`) passes no `skip_aggregate_costs`, no `skip_director` and no `skip_post_eval`, so it walks the exact new tail end-to-end against the live definition: `ReportCard` → `Director` (its no-Opus / no-write probe) → `ScannerLeaderboard` → `CheckSkipAggregateCosts` → `AggregateCosts` (dry, no parquet write) → `CheckShellRunNotify`. `sf-pipeline-policy` §7.2's conditional is satisfied — it exercises **that exact definition path**, not an approximation.

**Merge sequencing (a recommendation to the reviewer, not a post-merge step):** the issue asks that this land behind a green weekly run rather than ahead of one, and the Friday shell run is the cheapest confirmation. There is **nothing to run after merging** — `deploy-infrastructure.yml` re-stamps and redeploys the definition on push to `main`, and the change is complete at that point.

## Follow-ups filed

- `alpha-engine-config-I8335` — `evaljudge-shadow` declared nowhere in the coverage block (belongs to `alpha-engine-config-I7179`; upstream of the aggregator in both topologies).
- `alpha-engine-config-I8336` — no immediate `sns:publish` on the weekly cost-aggregation fail-open path (`sf-pipeline-policy` §5's paging half), plus the detection blindness behind it: `tests/test_degraded_paths_page_immediately.py` covers only the two weekday definitions.

## Deploy mechanism
**Deploy-mechanism:** `deploy-infrastructure.yml` (re-stamps and redeploys `infrastructure/step_function.json` on push to `main`).

---

**Prepared by:** claude-opus-5 via [Claude Code](https://claude.com/claude-code)
