### PR TITLE
fix(weekly-run-scope): write run_scope.json under the trading day, not the calendar day

### DIFF
--- a/.github/workflows/deploy-weekly-run-scope.yml
+++ b/.github/workflows/deploy-weekly-run-scope.yml
@@ -1,0 +1,92 @@
+name: Deploy weekly-run-scope
+
+# Auto-deploy the alpha-engine-weekly-run-scope Lambda on merge to main.
+#
+# Why this exists: every other SF-invoked Lambda in this repo has its own
+# deploy-*.yml (freshness-monitor, weekly-preflight, etc.) so a change under
+# the lambda's directory actually goes live. This Lambda (alpha-engine-config-
+# I7620) had none — it was operator-deployed only, which is exactly the
+# codified-but-not-live drift class deploy-infrastructure.yml (deploys the SF,
+# not the lambdas) was built to avoid. Added alongside alpha-engine-config-
+# I8373: that fix vendors a NEW runtime dependency (krepis) into a lambda
+# whose zip previously carried none, so a merge-triggered deploy is the only
+# way the fix actually reaches the Lambda instead of sitting correct-on-main
+# and unreachable, same as the freshness-monitor open_orders gap this pattern
+# was built to close.
+#
+# Separation of concerns: this deploys the function CODE (deploy.sh default
+# path = update-function-code). weekly-run-scope/deploy.sh has no
+# `--code-only` flag (unlike freshness-monitor's — there is no registry here
+# to skip), so the plain default path is used, same as deploy-weekly-
+# preflight.yml.
+#
+# IAM: the github-actions-lambda-deploy role's LambdaUpdate grant covers
+# arn:aws:lambda:...:function:alpha-engine-* (including this function,
+# alpha-engine-weekly-run-scope) so this job needs no policy change.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/lambdas/weekly-run-scope/**'
+      - '.github/workflows/deploy-weekly-run-scope.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-weekly-run-scope-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy weekly-run-scope Lambda
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: alpha-engine-data
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12 (match Lambda runtime)
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Deploy weekly-run-scope
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/weekly-run-scope/deploy.sh
+
+      - name: Report deployed version
+        working-directory: alpha-engine-data
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          aws lambda get-function \
+            --function-name alpha-engine-weekly-run-scope \
+            --query "Configuration.[LastModified,CodeSha256]" \
+            --output text
+
+      - name: Append to system-wide deploy changelog
+        if: always()
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@8a904b7a817901f2520dd87131ff307ed97fee02 # main
+        with:
+          deploy_status: ${{ job.status == 'success' && 'success' || 'failure' }}
+          deploy_workflow: deploy-weekly-run-scope.yml
+
+  # Alert (Telegram) on genuine post-merge failure on the default branch.
+  # Reusable workflow + transport in nousergon-lib. config#1128.
+  notify-main-failure:
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/lambdas/weekly-run-scope/deploy.sh
+++ b/infrastructure/lambdas/weekly-run-scope/deploy.sh
@@ -46,14 +46,25 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # ----- 0. Tests gate the deploy -------------------------------------------
 # The derivation runs against captured real executions and needs no AWS, so
 # there is no reason for a deploy to be the first thing that exercises it.
+# alpha-engine-config-I8373: index.py now does a REAL `import krepis.dates`,
+# so the gate needs the lambda's own requirements.txt installed alongside
+# pytest — the same `-r requirements.txt` shape freshness-monitor/deploy.sh
+# uses, not the old bare `boto3` list (which never covered a real
+# `import krepis`).
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-run_handler_tests "${SCRIPT_DIR}" boto3
+run_handler_tests "${SCRIPT_DIR}" -r "${SCRIPT_DIR}/requirements.txt"
 
-# ----- 1. Package ----------------------------------------------------------
-# No pip install: requirements.txt is deliberately empty (boto3 comes from the
-# runtime), so the zip is index.py + run_scope.py and nothing else.
+# ----- 1. Package: pip install runtime deps into $PKG -----------------------
+# alpha-engine-config-I8373: requirements.txt now carries krepis (for
+# krepis.dates.resolve_trading_day), so the zip is built the same
+# Lambda-safe-Docker-pip way every other dependency-carrying lambda in this
+# tree is (see freshness-monitor/deploy.sh) — bare `cp` of the two source
+# files was correct only while requirements.txt was empty.
+LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PKG=$(mktemp -d)
 trap "rm -rf '$PKG'" EXIT
+echo "Installing runtime deps into ${PKG} (Lambda-safe Docker pip)..."
+bash "${LAMBDAS_DIR}/lambda_pip_install.sh" "${PKG}" "${SCRIPT_DIR}/requirements.txt"
 cp "${SCRIPT_DIR}/index.py" "${SCRIPT_DIR}/run_scope.py" "${PKG}/"
 ZIP="${PKG}/function.zip"
 (cd "${PKG}" && zip -qr "function.zip" . -x "function.zip")

--- a/infrastructure/lambdas/weekly-run-scope/index.py
+++ b/infrastructure/lambdas/weekly-run-scope/index.py
@@ -43,6 +43,7 @@ import logging
 import os
 
 import boto3
+from krepis.dates import resolve_trading_day
 
 from run_scope import build_run_scope
 
@@ -51,6 +52,22 @@ logger.setLevel(logging.INFO)
 
 BUCKET = os.environ.get("RESEARCH_BUCKET", "alpha-engine-research")
 KEY_TEMPLATE = "backtest/{run_date}/run_scope.json"
+
+
+class EmptyRunDateError(ValueError):
+    """Raised when the SF handed no ``run_date`` at all.
+
+    ``krepis.dates.resolve_trading_day`` is deliberately defensive — on a parse
+    failure it logs a WARNING and returns the input unchanged rather than
+    raising, which is right for its other callers but wrong here: an empty
+    string would sail through unchanged and produce ``backtest//run_scope.json``,
+    a key nothing has ever read from and nothing ever will. This module's own
+    ``handler`` already has a fail-open Catch (see the module docstring) that
+    routes any raised exception to a degraded, gradeless scope block — so
+    raising loudly here is free: it cannot fail the weekly run, and it turns a
+    silently-misplaced artifact into an honestly-absent one.
+    """
+
 
 #: Every ``skip_*`` key the SF understands is threaded in by the caller. Read
 #: only to EXPLAIN a NOT_REACHED row, never to decide a disposition — the
@@ -82,7 +99,7 @@ def _definition(client, state_machine_arn: str) -> dict:
 
 
 def handler(event, _context):
-    run_date = event.get("run_date") or ""
+    calendar_run_date = event.get("run_date") or ""
     execution_arn = event.get("execution_arn") or ""
     state_machine_arn = event.get("state_machine_arn") or ""
     dry_run = bool(event.get("dry_run"))
@@ -90,8 +107,29 @@ def handler(event, _context):
         key: value for key, value in (event.get("execution_input") or {}).items()
         if key.startswith(_FLAG_PREFIX)
     }
+    # Established before the try so the except branch always has a value to
+    # key the (possibly degraded) artifact by — even when the failure IS the
+    # resolution of `run_date` itself.
+    run_date = ""
 
     try:
+        # alpha-engine-config-I8373: `$.run_date` is the SF's CALENDAR date
+        # (`InitializeInput` sets it from `$$.Execution.StartTime` — a Saturday
+        # for this pipeline). Every artifact under `backtest/{key}/` is keyed by
+        # the TRADING day per DATE_CONVENTIONS, and the sole consumer
+        # (`crucible-evaluator/grading/handler.py::_resolve_run_date`) normalizes
+        # through this same shared primitive before reading. Writing under the
+        # raw calendar date put this artifact where nothing has ever looked —
+        # measured live, 2026-08-22: `backtest/2026-08-22/run_scope.json` sat
+        # alone while the cycle's ~49 other artifacts were under
+        # `backtest/2026-08-21/`.
+        if not calendar_run_date:
+            raise EmptyRunDateError(
+                "event['run_date'] was empty — refusing to write "
+                "backtest//run_scope.json"
+            )
+        run_date = resolve_trading_day(calendar_run_date)
+
         states = boto3.client("stepfunctions")
         definition = _definition(states, state_machine_arn)
         history = _history(states, execution_arn)
@@ -103,6 +141,11 @@ def handler(event, _context):
             state_machine_arn=state_machine_arn,
             input_flags=flags,
         )
+        # Both dates ride along: `run_date` stays the resolved trading day (the
+        # consumer's existing contract, unchanged), and the raw calendar date
+        # the execution actually started on is named explicitly so a reader can
+        # tell which execution produced this artifact without re-deriving it.
+        scope["calendar_run_date"] = calendar_run_date
     except Exception as exc:  # noqa: BLE001
         # Fail-open, and loudly. See the module docstring: the degraded block
         # grades NOTHING, so a consumer reading it cannot mistake this for a
@@ -115,6 +158,7 @@ def handler(event, _context):
         )
         scope["degraded"] = True
         scope["degraded_reason"] = f"{type(exc).__name__}: {exc}"
+        scope["calendar_run_date"] = calendar_run_date
         scope["statement"] = (
             "SCOPE UNAVAILABLE — the run's own scope could not be derived, so "
             "NOTHING on this cycle is established as having been dispatched. "
@@ -129,6 +173,21 @@ def handler(event, _context):
         # construction, the two API grants, the derivation) and writes nothing —
         # the same dry contract every advisory producer on this pipeline honours.
         scope["dry_run"] = True
+        return scope
+
+    if not run_date:
+        # `run_date` never resolved (the EmptyRunDateError path, or a parse
+        # failure so total that `resolve_trading_day` itself couldn't return
+        # anything usable). Writing here would produce
+        # `backtest//run_scope.json` — a key nothing reads and everything after
+        # it would silently misinterpret as a real prefix. The Catch on the SF
+        # `RunScope` state already routes any raised exception to
+        # `CheckSkipReportCard` without failing the run, so an absent artifact
+        # here is the honest outcome, not a gap.
+        logger.error(
+            "run_date never resolved — not writing an artifact for this "
+            "execution (calendar_run_date=%r)", calendar_run_date,
+        )
         return scope
 
     key = KEY_TEMPLATE.format(run_date=run_date)

--- a/infrastructure/lambdas/weekly-run-scope/requirements.txt
+++ b/infrastructure/lambdas/weekly-run-scope/requirements.txt
@@ -11,4 +11,13 @@
 # NYSE holiday. 21 sibling lambdas already vendor krepis this way (see
 # freshness-monitor/requirements.txt + deploy.sh for the established pattern);
 # this mirrors it rather than inventing a parallel shortcut.
-krepis>=0.59.26
+#
+# Pinned, not floored — first-party/fast-moving deps are pinned, never
+# floored (alpha-engine-config-I7635, same convention as
+# crucible-evaluator/requirements.txt's `krepis[...]==` line). 0.59.38 is
+# krepis's released head at the time of this pin (verified: `git rev-parse
+# v0.59.38^{}` == `origin/main` on nousergon/krepis) and the exact version
+# this lambda's test_handler.py was run against (`pip install krepis==0.59.38`
+# into a clean venv, 28/28 passed) — not merely a floor assumed to resolve to
+# something tested.
+krepis==0.59.38

--- a/infrastructure/lambdas/weekly-run-scope/requirements.txt
+++ b/infrastructure/lambdas/weekly-run-scope/requirements.txt
@@ -1,4 +1,14 @@
-# No third-party dependencies. boto3 is provided by the Lambda runtime, and the
-# derivation in run_scope.py is pure stdlib by design — it is the module that
-# decides what the Director may grade, so it carries no dependency that could
-# fail to import on a cold start and take the scope block down with it.
+# CORRECTED alpha-engine-config-I8373 (was: "No third-party dependencies").
+# That rationale weighed a cold-start import risk against nothing — no
+# dependency meant nothing could fail to import. It never weighed the
+# dependency against the alternative that shipped instead: writing
+# run_scope.json to the wrong S3 prefix on EVERY run, where its only consumer
+# (crucible-evaluator) could never read it. An artifact landing somewhere
+# unreadable is a total failure of this Lambda's one job; a boto3-runtime-class
+# import risk is not. So: krepis, for krepis.dates.resolve_trading_day — the
+# SAME shared primitive the consumer already normalizes through, rather than
+# hand-rolling a "previous weekday" calculation here and drifting on the next
+# NYSE holiday. 21 sibling lambdas already vendor krepis this way (see
+# freshness-monitor/requirements.txt + deploy.sh for the established pattern);
+# this mirrors it rather than inventing a parallel shortcut.
+krepis>=0.59.26

--- a/infrastructure/lambdas/weekly-run-scope/test_handler.py
+++ b/infrastructure/lambdas/weekly-run-scope/test_handler.py
@@ -329,12 +329,19 @@ def _index(monkeypatch, *, definition=None, history=None, raises=None):
 def test_the_handler_writes_the_artifact_for_the_run_date(
     monkeypatch, definition, real_run_history
 ):
+    """``event['run_date']` is the SF's CALENDAR date — a Saturday for this
+    pipeline (`InitializeInput` sets it from `$$.Execution.StartTime`). The
+    written Key must land on the normalized TRADING day (Friday), the same
+    key the sole consumer (crucible-evaluator) reads — alpha-engine-config-
+    I8373: it previously landed on the raw Saturday, where nothing ever
+    read it.
+    """
     index, written = _index(
         monkeypatch, definition=definition, history=real_run_history
     )
     result = index.handler(
         {
-            "run_date": "2026-08-14",
+            "run_date": "2026-08-15",  # Saturday
             "execution_arn": "arn:x",
             "state_machine_arn": "arn:y",
             "execution_input": {"skip_parity": True, "sns_topic_arn": "arn:z"},
@@ -342,7 +349,60 @@ def test_the_handler_writes_the_artifact_for_the_run_date(
         None,
     )
     assert written["Key"] == "backtest/2026-08-14/run_scope.json"
+    assert result["run_date"] == "2026-08-14"
+    assert result["calendar_run_date"] == "2026-08-15"
     assert result["stages"]["Parity"]["disabled_by"] == "skip_parity"
+
+
+def test_a_saturday_run_date_normalizes_to_the_preceding_nyse_session(
+    monkeypatch, definition, all_skip_history
+):
+    """The real live case, alpha-engine-config-I8373: the 2026-08-22 weekly
+    execution wrote ``backtest/2026-08-22/run_scope.json`` while the cycle's
+    ~49 other artifacts were under ``backtest/2026-08-21/`` — the artifact
+    was written where its only consumer could never read it. 2026-08-22 is a
+    Saturday; 2026-08-21 is the preceding NYSE trading day (a Friday, no
+    intervening holiday).
+    """
+    index, written = _index(
+        monkeypatch, definition=definition, history=all_skip_history
+    )
+    result = index.handler(
+        {
+            "run_date": "2026-08-22",
+            "execution_arn": "arn:x",
+            "state_machine_arn": "arn:y",
+        },
+        None,
+    )
+    assert written["Key"] == "backtest/2026-08-21/run_scope.json"
+    assert result["run_date"] == "2026-08-21"
+    assert result["calendar_run_date"] == "2026-08-22"
+
+
+def test_an_empty_run_date_raises_rather_than_writing_a_double_slash_key(
+    monkeypatch, definition, all_skip_history
+):
+    """An empty ``run_date`` must never reach ``KEY_TEMPLATE.format`` — that
+    would silently write ``backtest//run_scope.json``, a key nothing reads
+    and every later listing of ``backtest/`` would misparse. The SF's own
+    Catch on the ``RunScope`` state routes any raised exception to
+    ``CheckSkipReportCard`` without failing the run (module docstring), so
+    raising here is free and turns a silently-misplaced artifact into an
+    honestly-absent one.
+    """
+    index, written = _index(
+        monkeypatch, definition=definition, history=all_skip_history
+    )
+    result = index.handler(
+        {"run_date": "", "execution_arn": "arn:x", "state_machine_arn": "arn:y"},
+        None,
+    )
+    assert result["degraded"] is True
+    assert "EmptyRunDateError" in result["degraded_reason"]
+    assert result["statement"].startswith("SCOPE UNAVAILABLE")
+    # Nothing was persisted — an absent artifact, not a misplaced one.
+    assert written == {}
 
 
 def test_only_skip_flags_are_carried_off_the_execution_input(


### PR DESCRIPTION
## Measured defect (alpha-engine-config-I8373)

The weekly SF's `RunScope` state (nousergon-data#1433, alpha-engine-config-I7620) passes `"run_date.$": "$.run_date"` — the CALENDAR date `InitializeInput` derives from `$$.Execution.StartTime` (a Saturday). `infrastructure/lambdas/weekly-run-scope/index.py` wrote `backtest/{run_date}/run_scope.json` with no trading-day normalization.

The sole consumer, `crucible-evaluator/grading/handler.py::_resolve_run_date`, normalizes the same raw calendar date through `krepis.dates.resolve_trading_day` before reading `backtest/{trading_day}/`.

**Live proof, 2026-08-22 run:** `s3://alpha-engine-research/backtest/2026-08-22/run_scope.json` (14483 bytes, 08:58) sat ALONE in that prefix while the entire cycle's ~49 artifacts were under `backtest/2026-08-21/`. Consequence: the 2026-08-21 report card carried `run_scope.present=false`, `scope_unknown=true`; contamination stayed UNKNOWN instead of NOT_IN_SCOPE; the Director withheld `issue_filing` and `loop_verification`.

## Fix

1. Normalize through `krepis.dates.resolve_trading_day` — the same shared primitive the consumer already uses, not a hand-rolled "previous weekday" calc (NYSE holidays are why the primitive exists).
2. `requirements.txt` now carries `krepis==0.59.38` — **pinned exact**, not floored: first-party/fast-moving deps are pinned per alpha-engine-config-I7635 (same convention as `crucible-evaluator/requirements.txt`'s `krepis[...]==` line). 0.59.38 is krepis's released head (verified `git rev-parse v0.59.38^{}` == `origin/main`) and the exact version this lambda's tests were run against. Rewrote the old "no third-party dependencies" rationale in place: an artifact written where nothing reads it is a total failure, strictly worse than a cold-start import risk.
3. `deploy.sh` now vendors the dependency via `lambda_pip_install.sh` (it previously shipped none — bare `cp` of the two source files) and gates the deploy with `-r requirements.txt` in `run_handler_tests`, mirroring `freshness-monitor/deploy.sh`.
4. **New: `.github/workflows/deploy-weekly-run-scope.yml`** — this Lambda had no merge-triggered deploy (deploy.sh was operator-run only). Per `pull-request-policy.md`, a PR must be deployable by the merge button alone; a post-merge command in a PR body/return message is not one of the three legal forms. Mirrors `deploy-weekly-preflight.yml`'s shape (this `deploy.sh` has no `--code-only`, unlike freshness-monitor's) with `deploy-freshness-monitor.yml`'s `get-function` verification step (this Lambda publishes no alias/version, same as freshness-monitor). Path filter `infrastructure/lambdas/weekly-run-scope/**` covers a `requirements.txt`-only change. IAM: `github-actions-lambda-deploy`'s `LambdaUpdate` grant already covers `arn:...:function:alpha-engine-*` — verified against `nous-ergon-ops/infrastructure/iam/github-actions-lambda-deploy/github-actions-lambda-deploy-policy.json` — so no new grant is needed.
5. The written body keeps `run_date` as the resolved trading day (consumer contract unchanged) and adds `calendar_run_date` so a reader can tell which execution produced it.
6. An empty/unparseable `run_date` now raises `EmptyRunDateError` rather than writing `backtest//run_scope.json`. The SF's `Catch` on `RunScope` already routes any exception to `CheckSkipReportCard` without failing the run — so this trades a silently-misplaced artifact for an honestly-absent one.

## Test plan (run locally before pushing)

- `infrastructure/lambdas/weekly-run-scope/test_handler.py`: 28 passed — including a Saturday `run_date` normalizing to the preceding NYSE session, the real 2026-08-22 → 2026-08-21 case, and an empty `run_date` raising and writing nothing. Existing Key-asserting tests updated.
- Ran the 28 tests a second time in a **clean venv with `krepis==0.59.38` installed via `pip install`** (not the ambient checkout) — confirms the pin is verified, not assumed.
- `tests/test_run_scope_wiring.py`: 8 passed (SF wiring unaffected).
- `tests/test_sf_lambda_timeout_ordering.py` + `tests/test_sf_global_timeout.py`: 22 passed, 1 skipped.
- `deploy.sh --dry-run` run end-to-end against the pinned version: Docker-based `lambda_pip_install.sh` install + test gate + packaging all succeeded (24MB zip); the AWS call itself was the only step skipped (dry-run).
- Full `nousergon-data` suite (`.venv/bin/python3 -m pytest tests/ -q`): **6570 passed, 17 skipped** (pre-existing skips, unrelated to this change).
- `krepis.dates` cold import measured at ~13ms (`python3 -X importtime`) — negligible against the existing 15s margin between the Lambda's 60s timeout and the SF state's 45s `TimeoutSeconds`. That ordering still holds.

## Tracking

`alpha-engine-config-I8373` — not closed by this PR (no cross-repo closing keyword works across repos; closing needs a manual comment after deploy + the first live weekly run's `NOT_IN_SCOPE` attestation, tracked separately as `alpha-engine-config-I7737`).

## Deploy

Merge-button-deployable: `deploy-weekly-run-scope.yml` fires on merge for any change under `infrastructure/lambdas/weekly-run-scope/**`, deploys code, and reports the deployed `CodeSha256`. No operator step required. (Manual re-run if ever needed: `bash infrastructure/lambdas/weekly-run-scope/deploy.sh`.)

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)