### PR TITLE
fix(weekly-sf-rerun): couple ReportCard to Director's rerun (alpha-engine-config-I8382)

### DIFF
--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -1355,6 +1355,49 @@ def derive_plan(
                 f"with its own skip flag set. Refusing (forbidden swallow)."
             )
 
+    # Director/ReportCard freshness coupling (alpha-engine-config-I8382,
+    # measured 2026-08-22 watch-rerun-2026-08-22-3). Director's input contract
+    # is a report_card.json produced by THIS execution — but report_card and
+    # director are independently-witnessed stages, and LATEST-ATTEMPT-WINS
+    # (resolve_chain, above) can legitimately witness report_card as
+    # "completed" from an EARLIER, possibly-failed chain link while director
+    # itself was never witnessed complete anywhere in the chain (its own
+    # failure is terminal — config#6408 — so DirectorComplete is never
+    # entered by a failing attempt, and the stage keeps re-running on every
+    # rerun until one succeeds). The two facts compose into a bug: a rerun
+    # skips ReportCard (reusing an old evaluator/{date}/report_card.json,
+    # possibly the very run whose Director hard-failed and whose upstream
+    # tiles were still degraded) while re-running Director fresh against that
+    # STALE card. Measured: watch-rerun-2026-08-22-3 graded a card written by
+    # the FAILED 02:00 execution (report_card.json at 07:04) with its freshly
+    # re-run Director (action_plan.json at 09:04) — a card with
+    # status:"partial", tiles_overall_status:"RED", degraded_attestation:true,
+    # scope_unknown:true, none of which reflect what the intervening reruns
+    # actually fixed upstream.
+    #
+    # Fix: whenever Director will actually RUN this rerun (skip_director is
+    # not True), ReportCard must run too — forcing a fresh card from THIS
+    # execution rather than letting Director grade one carried over from a
+    # different, earlier attempt. This is independent of the failed/degraded
+    # reachability guard above (report_card is neither failed nor degraded
+    # here — it is "completed", just stale relative to what Director is about
+    # to consume), so it is not covered by must_rerun / BACKTESTER_OVERSHADOWED
+    # and needs its own rule. The safe direction is to over-run (re-run a
+    # ReportCard that was actually still fine) rather than under-run (skip one
+    # that no longer reflects reality) — same reasoning _reachable_from uses
+    # for the spot-dispatch predicate.
+    director_will_run = not plan.skip_flags.get(STAGES_BY_NAME["director"].flag)
+    if director_will_run and plan.skip_flags.pop(STAGES_BY_NAME["report_card"].flag, None):
+        if "report_card" in plan.completed:
+            plan.completed.remove("report_card")
+        plan.notes.append(
+            "skip_report_card dropped: Director will run this rerun and its "
+            "input contract is a ReportCard produced by THIS execution — "
+            "skipping ReportCard would let Director grade a card written by "
+            "an earlier, possibly-stale attempt (alpha-engine-config-I8382, "
+            "measured 2026-08-22 watch-rerun-2026-08-22-3)."
+        )
+
     orig_role = original_input.get("pipeline_role")
     if orig_role != EMITTED_ROLE:
         plan.notes.append(

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -1307,6 +1307,74 @@ class TestChainedRecoveryKeepsTheOriginalRunsProgress:
         assert "rationale_clustering" not in plan.completed
 
 
+class TestDirectorReportCardFreshnessCoupling:
+    """alpha-engine-config-I8382, measured 2026-08-22 watch-rerun-2026-08-22-3.
+
+    Director's input contract is a report_card.json produced by THIS
+    execution. report_card and director are independently-witnessed stages,
+    so a rerun can legitimately witness report_card as "completed" (it ran to
+    completion in this or an earlier chain link) while director itself never
+    completes (its failure is terminal — config#6408 — so it keeps re-running
+    across chain links until one succeeds). Left alone, that composes into a
+    rerun that SKIPS ReportCard while RE-RUNNING Director against the stale
+    card ReportCard last wrote — measured live: a card written by the FAILED
+    02:00 execution graded by a Director that ran nearly two hours later.
+    """
+
+    # ReportCard runs and completes (witness: CheckSkipDirector + Director
+    # entered), then Director itself runs and fails terminally (Director is
+    # entered as WORK — detect_failure — but DirectorComplete never is).
+    _REPORT_CARD_COMPLETED_DIRECTOR_FAILED = [
+        "InitializeInput", "CheckSkipBacktester", "Backtester",
+        "CheckSkipPredictorBacktest", "PredictorBacktest",
+        "CheckSkipPortfolioOptimizerBacktest", "PortfolioOptimizerBacktest",
+        "CheckSkipParity", "CheckSkipEvaluator", "EvaluatorDiagnostics",
+        "CheckSkipPostEval", "SaturdayHealthCheck", "CheckShellRunNotify",
+        "CheckSkipReportCard", "ReportCard",
+        "CheckSkipDirector", "Director",
+        # no DirectorComplete: Director hard-failed (terminal, config#6408)
+    ]
+
+    def test_director_will_run_forces_report_card_to_rerun(self, mod):
+        plan = mod.derive_plan(
+            _chain_history(self._REPORT_CARD_COMPLETED_DIRECTOR_FAILED)
+        )
+        assert "director" in plan.failed
+        assert "skip_director" not in plan.skip_flags
+        assert "skip_report_card" not in plan.skip_flags, (
+            "Director will run this rerun, so ReportCard must run too — "
+            "skipping it lets Director grade a card from a different, "
+            "possibly-stale attempt"
+        )
+        assert "report_card" not in plan.completed
+        assert any(
+            "skip_report_card dropped" in n and "I8382" in n
+            for n in plan.notes
+        )
+
+    def test_the_dropped_flag_is_actually_reachable(self, mod, sf_def):
+        """The emitted input must not just OMIT skip_report_card — ReportCard's
+        work state must be reachable under the rest of the derived flags, or
+        this is a paper fix."""
+        plan = mod.derive_plan(
+            _chain_history(self._REPORT_CARD_COMPLETED_DIRECTOR_FAILED)
+        )
+        reachable = mod._simulate_reachable_works(plan.skip_flags, {})
+        assert "report_card" in reachable
+
+    def test_report_card_still_skips_when_director_also_completed(self, mod):
+        """Regression: the ordinary case (both witnessed complete) is
+        unaffected — nothing here should force an unnecessary ReportCard
+        re-run when Director genuinely does not need to run."""
+        entered = self._REPORT_CARD_COMPLETED_DIRECTOR_FAILED[:-1] + [
+            "DirectorComplete",
+        ]
+        plan = mod.derive_plan(_chain_history(entered))
+        assert plan.skip_flags.get("skip_director") is True
+        assert plan.skip_flags.get("skip_report_card") is True
+        assert "report_card" in plan.completed
+
+
 class TestChainMembership:
     """Which executions the chain is built FROM — pure, so the membership rule
     is testable without AWS."""


### PR DESCRIPTION
## Summary

`weekly_sf_rerun.py::derive_plan` derived `skip_report_card` and `skip_director` independently from their own stage witnesses. Director's contract is a `report_card.json` produced by **this execution** — but nothing coupled the two flags, so a rerun could skip ReportCard (an earlier chain link witnessed it complete) while re-running Director fresh against the stale card.

Fix: `derive_plan` now drops `skip_report_card` whenever `skip_director` is not set (Director will actually run this rerun) — forcing ReportCard to rerun fresh in the same execution. Confirmed reachable under `_simulate_reachable_works` (no topology change needed — `report_card` is already modeled as reachable whenever its flag is absent).

## Measured defect this addresses

Weekly execution `1ed4d68f-…` (02:00:49, 2026-08-22) FAILED at Director with `APITimeoutError`; ReportCard had already completed in that run, writing `evaluator/latest/report_card.json` at 07:04 (`status:"partial"`, `tiles_overall_status:"RED"`, `degraded_attestation:true`, `scope_unknown:true`). `watch-rerun-2026-08-22-1` and `-2` FAILED; `watch-rerun-2026-08-22-3` (08:53:30) SUCCEEDED — its entered-state sequence shows `CheckSkipReportCard → Director → DirectorComplete`, i.e. `ReportCard` itself was never entered (skipped) while Director ran fresh at 09:04, grading the 07:04 card from the failed original run rather than anything reflecting the intervening reruns.

Filed: `alpha-engine-config-I8382`.

## Sibling work this session (separate repos, no file overlap)

- `crucible-evaluator-PR268` — retries `krepis.llm.StreamIdleTimeoutError` by type in `_invoke_with_retry` (Defect 1: the Director APITimeoutError root cause and its streaming-era successor failure mode). Independent — no merge-order constraint with this PR.
- A sibling agent owns `nousergon-data/infrastructure/lambdas/weekly-run-scope/**` (not touched here) and `crucible-evaluator/grading/**` (not touched here).

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_weekly_sf_rerun.py -q` — 92 passed (3 new: `TestDirectorReportCardFreshnessCoupling`)
- [x] `.venv/bin/python -m pytest tests/ -q --ignore=tests/integration` — 6550 passed, 12 skipped (full non-integration suite; `tests/integration/` reaches real infra per this repo's `AGENTS.md`, not run)

Rehearsal-path: tests/test_weekly_sf_rerun.py

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
