### PR TITLE
fix(splice-guard): both split orientations, and a page that states what it evaluated (alpha-engine-config-I8374)

### DIFF
--- a/builders/daily_append.py
+++ b/builders/daily_append.py
@@ -1099,6 +1099,42 @@ _SPLICE_GUARD_REL_TOL = 0.15
 _SPLICE_GUARD_ALLOW_ENV = "DAILY_APPEND_SPLICE_GUARD_ALLOW"
 # Price fields scaled by a split factor (volume scales inversely).
 _SPLICE_PRICE_FIELDS = ("Open", "High", "Low", "Close", "VWAP")
+# Ex-date plausibility window used by the PURE-APPEND branch when asking the
+# registry whether a registered split sits at this boundary. Deliberately
+# tighter than ``registry._EX_DATE_MAX_AHEAD_DAYS`` (60): the classifier's
+# generous look-ahead is safe because it also demands an EXACT factor match,
+# and this branch cannot (see the comment at the call site). A discontinuity
+# two months before an ex date is not explained by it.
+_SPLICE_GUARD_EX_DATE_EARLY_DAYS = 3
+_SPLICE_GUARD_EX_DATE_AHEAD_DAYS = 10
+
+
+def _splice_ratio_matches(observed: float, expected: float) -> bool:
+    """Whether ``observed`` sits within ``_SPLICE_GUARD_REL_TOL`` of ``expected``."""
+    if expected <= 0:
+        return False
+    return abs(observed - expected) <= _SPLICE_GUARD_REL_TOL * expected
+
+
+def _splice_restate_bar(bar, price_scale: float):
+    """Return a copy of ``bar`` with prices scaled by ``price_scale`` and
+    volume scaled inversely (a split restates the two in opposite directions).
+    """
+    restated = bar.copy()
+    for fld in _SPLICE_PRICE_FIELDS:
+        try:
+            val = float(restated[fld])
+        except Exception:  # noqa: BLE001 - absent/NaN field, skip
+            continue
+        if np.isfinite(val):
+            restated[fld] = val * price_scale
+    try:
+        vol = float(restated["Volume"])
+        if np.isfinite(vol):
+            restated["Volume"] = round(vol / price_scale)
+    except Exception:  # noqa: BLE001 - absent/NaN volume, prices still restated
+        pass
+    return restated
 
 
 def _splice_basis_guard(
@@ -1117,10 +1153,19 @@ def _splice_basis_guard(
     all REAL single-day moves that overlap the 2:1-split ratio zone, so
     magnitude alone cannot refuse):
 
-      * A registered split with ``ex_date > row_date`` already applied to the
-        store explains a ``1/factor`` gap exactly → the row arrived on the
-        pre-action basis (polygon restates its aggregates only once the ex
-        date lands — the CRWD 2026-06-30 case). Deterministic: restate it.
+      * A registered split with ``ex_date > row_date`` puts the row and the
+        store on different bases, in EITHER of two orientations, and the
+        observed ratio plus the store's applied-state says which:
+          - STORE-LEADS (gap ``1/factor``, action already applied to the
+            store): the row arrived on the pre-action basis because polygon
+            restates its aggregates only once the ex date lands — the CRWD
+            2026-06-30 case.
+          - FEED-LEADS (gap ``factor``, action NOT yet applied): the vendor
+            retro-adjusted its history AHEAD of the ex date while the store
+            is still pre-action — the IESC 2026-08-21 case.
+        Deterministic either way: restate the incoming row onto the STORE's
+        current basis (the registry restatement path owns migrating the whole
+        history), and say which orientation it was.
       * A split-like disagreement with an ALREADY-STORED row for the SAME
         date whose value coheres with its own neighbors is NEVER a market
         move (same date, same market — the HON 2026-06-26 case: incoming
@@ -1158,10 +1203,30 @@ def _splice_basis_guard(
     if 1.0 / _SPLICE_GUARD_SOFT_RATIO < ratio < _SPLICE_GUARD_SOFT_RATIO:
         return bar, "ok"
 
-    # A registered split whose ex_date is AFTER this row's date and which is
-    # already folded into the stored history explains the gap exactly: the
-    # incoming row is pre-action basis, the store is post-action basis, and
-    # the observed ratio is 1/factor. Restate the row by the action's factor.
+    # A registered split whose ex_date is AFTER this row's date puts the
+    # incoming row and the stored history on DIFFERENT adjusted bases — in
+    # one of TWO orientations, and production produces both:
+    #
+    #   STORE-LEADS / feed lags: the action is already folded into the stored
+    #     history, the vendor still serves pre-action aggregates, so the row
+    #     sits 1/factor ABOVE the store (CRWD 2026-06-30). Restate the row by
+    #     ``factor``.
+    #   FEED-LEADS / store lags: the vendor retro-adjusted its history AHEAD
+    #     of the ex date while the store is still pre-action, so the row sits
+    #     at ``factor``, BELOW the store (IESC 2026-08-21). Restate the row by
+    #     ``1/factor``.
+    #
+    # Either way the guard's job is the same: put the incoming row on the
+    # STORE's CURRENT basis so the series stays continuous. Migrating the
+    # whole history to the new basis is the registry restatement path's job,
+    # and it runs over the pre-ex rows once the action is applied.
+    #
+    # ``is_applied`` is the evidence for WHICH orientation, so it is asserted
+    # per-orientation rather than as a shared precondition: load-bearing and
+    # TRUE for store-leads, and necessarily FALSE for feed-leads — the split
+    # not yet being applied is exactly why the store is stale. Requiring it
+    # for both made feed-leads structurally unreachable, on top of the ratio
+    # test only ever accepting 1/factor (alpha-engine-config-I8374).
     for a in actions:
         if getattr(a, "type", None) != "split":
             continue
@@ -1172,34 +1237,37 @@ def _splice_basis_guard(
             continue
         if factor <= 0 or ex_ts <= today_ts:
             continue
-        if registry is not None and not registry.is_applied(
-            _ca.STORE_ARCTICDB_UNIVERSE, a.action_id
-        ):
-            continue
-        expected_gap = 1.0 / factor
-        if abs(ratio - expected_gap) <= _SPLICE_GUARD_REL_TOL * expected_gap:
-            restated_bar = bar.copy()
-            for fld in _SPLICE_PRICE_FIELDS:
-                try:
-                    val = float(restated_bar[fld])
-                except Exception:  # noqa: BLE001 - absent/NaN field, skip
-                    continue
-                if np.isfinite(val):
-                    restated_bar[fld] = val * factor
-            try:
-                vol = float(restated_bar["Volume"])
-                if np.isfinite(vol):
-                    restated_bar["Volume"] = round(vol / factor)
-            except Exception:  # noqa: BLE001 - absent/NaN volume, skip
-                pass
-            log.warning(
-                "daily_append splice basis-guard: %s @ %s row arrived on the "
-                "PRE-action basis (ratio %.4f vs stored history; registered "
-                "%s, ex %s, already applied to the store) — restated the "
-                "incoming row by factor %.6g before splice",
-                ticker, today_ts.date(), ratio, a.human(), a.ex_date, factor,
+        # None = no registry to ask; neither orientation is then excluded on
+        # applied-state and the ratio alone decides.
+        applied = None
+        if registry is not None:
+            applied = registry.is_applied(_ca.STORE_ARCTICDB_UNIVERSE, a.action_id)
+        if applied is not False and _splice_ratio_matches(ratio, 1.0 / factor):
+            orientation, price_scale = "store-leads", factor
+            detail = (
+                "row arrived on the PRE-action basis while the store is "
+                "already post-action (registered %s, ex %s, applied to the "
+                "store) — restated the incoming row by factor %.6g onto the "
+                "store's basis" % (a.human(), a.ex_date, price_scale)
             )
-            return restated_bar, "restated"
+        elif applied is not True and _splice_ratio_matches(ratio, factor):
+            orientation, price_scale = "feed-leads", 1.0 / factor
+            detail = (
+                "the FEED has already restated its history for a split that "
+                "is NOT yet applied to the store (registered %s, ex %s) — "
+                "restated the incoming row by %.6g back onto the store's "
+                "pre-action basis; the registry restatement path migrates the "
+                "whole series when the action is applied"
+                % (a.human(), a.ex_date, price_scale)
+            )
+        else:
+            continue
+        log.warning(
+            "daily_append splice basis-guard: %s @ %s basis mismatch "
+            "orientation=%s (ratio %.4f vs stored history): %s",
+            ticker, today_ts.date(), orientation, ratio, detail,
+        )
+        return _splice_restate_bar(bar, price_scale), "restated"
 
     allow = {
         entry.strip()
@@ -1252,15 +1320,85 @@ def _splice_basis_guard(
             )
             return bar, "refused"
 
-    # Pure append with an unexplained split-like ratio: can be a genuine
-    # crash/pop (CAR −48%, KD −55% verified real) — write it, page loudly.
+    # Pure append with a split-like ratio: can be a genuine crash/pop
+    # (CAR −48%, KD −55% verified real) — write it either way. Whether it
+    # pages depends on ASKING the registry first, which the message below
+    # used to assert without doing (alpha-engine-config-I8374).
+    #
+    # The test here is EX-DATE PROXIMITY plus the LOOSE ``_SPLICE_GUARD_REL_TOL``
+    # magnitude check. Do NOT re-tighten it to an exact-factor match
+    # (``registry._SPLIT_RATIO_TOL`` = 0.005): the two closes compared here are
+    # on DIFFERENT trading days, so the observed ratio is the split factor
+    # multiplied by whatever the market did in between. IESC 2026-08-24:
+    # 324.12 vs the 08-21 close 685.04 = 0.4731 = the 0.5 factor × a genuine
+    # 5.4% interday move. A cross-date ratio can never equal the exact factor
+    # whenever the market also moved — which is essentially always.
+    scope_actions: dict = {}
+    for a in actions:
+        if getattr(a, "type", None) != "split":
+            continue
+        try:
+            ex_ts = pd.Timestamp(a.ex_date).normalize()
+        except Exception:  # noqa: BLE001 - malformed ex_date cannot place the
+            # action at this boundary; excluded from the evaluated scope, and
+            # the WARNING is the recording surface so the ERROR below is not
+            # silently narrowed.
+            log.warning(
+                "daily_append splice basis-guard: %s session action %s has an "
+                "unparseable ex_date %r — excluded from the boundary check",
+                ticker, getattr(a, "action_id", "?"), getattr(a, "ex_date", None),
+            )
+            continue
+        delta_days = (ex_ts - today_ts).days
+        if -_SPLICE_GUARD_EX_DATE_EARLY_DAYS <= delta_days <= _SPLICE_GUARD_EX_DATE_AHEAD_DAYS:
+            scope_actions[getattr(a, "action_id", id(a))] = a
+    scope = "session-detected splits only (no registry available)"
+    if registry is not None:
+        scope = "persisted registry + session-detected splits"
+        for a in registry.splits_near(
+            ticker,
+            today_ts,
+            early_leniency_days=_SPLICE_GUARD_EX_DATE_EARLY_DAYS,
+            max_ahead_days=_SPLICE_GUARD_EX_DATE_AHEAD_DAYS,
+        ):
+            scope_actions[getattr(a, "action_id", id(a))] = a
+    explaining = None
+    for a in sorted(scope_actions.values(), key=lambda x: str(x.ex_date)):
+        try:
+            factor = _ca.expected_factor(a)
+        except Exception:  # noqa: BLE001 - malformed action, can't explain
+            continue
+        if factor <= 0:
+            continue
+        if _splice_ratio_matches(ratio, factor) or _splice_ratio_matches(
+            ratio, 1.0 / factor
+        ):
+            explaining = a
+            break
+
+    if explaining is not None:
+        log.warning(
+            "daily_append splice basis-guard: %s @ %s incoming close %.4f vs "
+            "prior stored close %.4f (ratio %.4f) sits at the boundary of a "
+            "REGISTERED corporate action (%s, ex %s, action_id=%s) — an "
+            "expected basis discontinuity at an ex date, not an anomaly. "
+            "Writing; the restatement path flattens the pre-ex history when "
+            "the action is applied to the store",
+            ticker, today_ts.date(), bar_close, prior_close, ratio,
+            explaining.human(), explaining.ex_date, explaining.action_id,
+        )
+        return bar, "ok"
+
     log.error(
         "daily_append splice basis-guard: %s @ %s incoming close %.4f vs "
         "prior stored close %.4f (ratio %.4f) is split-like and NO registered "
-        "corporate action explains it. Writing (a genuine move is possible), "
-        "but if a corporate-action record lands later the restatement path "
-        "must flatten this boundary — verify the split calendar",
+        "corporate action explains it (evaluated: %s for %s with ex_date in "
+        "[%s -%dd, +%dd]). Writing (a genuine move is possible), but if a "
+        "corporate-action record lands later the restatement path must "
+        "flatten this boundary — verify the split calendar",
         ticker, today_ts.date(), bar_close, prior_close, ratio,
+        scope, ticker, today_ts.date(),
+        _SPLICE_GUARD_EX_DATE_EARLY_DAYS, _SPLICE_GUARD_EX_DATE_AHEAD_DAYS,
     )
     return bar, "ok"
 

--- a/corporate_actions/registry.py
+++ b/corporate_actions/registry.py
@@ -262,6 +262,77 @@ class CorporateActionRegistry:
         self._put_json(key, payload)
         return True
 
+    # ── candidate lookup shared by every discrepancy question ────────────
+    def _known_actions(self) -> dict:
+        """Persisted registry UNION this session's detections, by action_id.
+
+        Session detections win on id collision. A failed persisted load
+        degrades to session-only scope with a WARNING rather than raising —
+        the callers state the scope they actually evaluated, so a narrowed
+        scope never becomes a false "nothing explains this".
+        """
+        known: dict = {}
+        try:
+            known.update(self._ensure_loaded())
+        except Exception as exc:  # noqa: BLE001 - degrade to session-only scope
+            log.warning(
+                "corporate_actions registry: persisted-action load failed (%s) "
+                "— discrepancy classification degrades to session-detected scope",
+                exc,
+            )
+        known.update(self._session_actions)  # session wins on id collision
+        return known
+
+    def splits_near(
+        self,
+        ticker: str,
+        date,
+        *,
+        early_leniency_days: int = _EX_DATE_EARLY_LENIENCY_DAYS,
+        max_ahead_days: int = _EX_DATE_MAX_AHEAD_DAYS,
+    ) -> list:
+        """Registered SPLIT actions for ``ticker`` whose ``ex_date`` sits in the
+        plausibility window around ``date``, earliest ex_date first.
+
+        The ex-date half of :meth:`explains_discrepancy`, lifted out so a
+        caller that CANNOT use an exact-factor match can still ask the
+        registry the authoritative question "is there a registered split at
+        this boundary?". ``builders/daily_append._splice_basis_guard``'s
+        pure-append branch is that caller: the two closes it compares are on
+        DIFFERENT trading days, so the observed ratio is the split factor
+        multiplied by whatever the market did in between and can never equal
+        the exact factor (alpha-engine-config-I8374).
+
+        The window is a parameter, not a constant, because the answer differs
+        by question: the classifier's default look-ahead is generous, while a
+        caller asking "is this row AT the boundary" wants a tight one.
+        """
+        candidates = [
+            a
+            for a in self._known_actions().values()
+            if a.type == "split" and a.ticker == str(ticker)
+        ]
+        date_ts = pd.Timestamp(date).normalize()
+        out = []
+        for action in candidates:
+            try:
+                ex_ts = pd.Timestamp(action.ex_date).normalize()
+            except Exception:  # noqa: BLE001 - malformed ex_date, not a candidate
+                log.warning(
+                    "corporate_actions registry: action %s has an unparseable "
+                    "ex_date %r — excluded from splits_near(%s)",
+                    action.action_id, action.ex_date, ticker,
+                )
+                continue
+            if ex_ts < date_ts - timedelta(days=early_leniency_days):
+                continue
+            if ex_ts > date_ts + timedelta(days=max_ahead_days):
+                continue
+            out.append(action)
+        # Evaluate by ex_date ascending so the earliest plausible action wins.
+        out.sort(key=lambda a: a.ex_date)
+        return out
+
     # ── the authoritative discrepancy classifier ─────────────────────────
     def explains_discrepancy(self, ticker: str, date, prior: float, new: float):
         """Return the registered ``CorporateAction`` that explains an adjusted-
@@ -299,33 +370,9 @@ class CorporateActionRegistry:
         except Exception:
             return None
 
-        known: dict = {}
-        try:
-            known.update(self._ensure_loaded())
-        except Exception as exc:  # noqa: BLE001 - degrade to session-only scope
-            log.warning(
-                "corporate_actions registry: persisted-action load failed (%s) "
-                "— explains_discrepancy degrades to session-detected scope",
-                exc,
-            )
-        known.update(self._session_actions)  # session wins on id collision
-        candidates = [
-            a
-            for a in known.values()
-            if a.type == "split" and a.ticker == str(ticker)
-        ]
-        # Evaluate by ex_date ascending so the earliest plausible action wins.
-        candidates.sort(key=lambda a: a.ex_date)
-        for action in candidates:
-            try:
-                ex_ts = pd.Timestamp(action.ex_date).normalize()
-            except Exception:
-                continue
-            # ex_date plausibility window relative to the discrepancy date.
-            if ex_ts < date_ts - timedelta(days=_EX_DATE_EARLY_LENIENCY_DAYS):
-                continue
-            if ex_ts > date_ts + timedelta(days=_EX_DATE_MAX_AHEAD_DAYS):
-                continue
+        # ex_date plausibility window (``splits_near``) first, exact-factor
+        # match second — the two halves of a match, in that order.
+        for action in self.splits_near(ticker, date_ts):
             try:
                 expected = expected_factor(action)
             except (NotImplementedError, ValueError):

--- a/tests/test_daily_append_splice_guard.py
+++ b/tests/test_daily_append_splice_guard.py
@@ -95,6 +95,57 @@ class TestSpliceBasisGuard:
         assert float(out["Close"]) == pytest.approx(763.14 * 0.25)
         assert float(out["Volume"]) == pytest.approx(3_687_971 / 0.25, rel=1e-6)
 
+    def test_feed_leads_pre_adjusted_row_restated_onto_the_store_basis(self):
+        # IESC 2026-08-21 (alpha-engine-config-I8374): polygon retro-adjusted
+        # its history for the registered 1:2 (ex 2026-08-24) while ArcticDB was
+        # still on the pre-action basis. The incoming row then sits at
+        # ``factor`` BELOW the store — the MIRROR of the CRWD case — and
+        # ``is_applied`` is False BY DEFINITION, because the split not yet
+        # being applied is exactly why the store is stale. Both facts made this
+        # orientation structurally unreachable before I8374.
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        action = ca.CorporateAction.from_split("IESC", "2026-08-24", 1, 2)
+        reg.record_detected(action, run_id="r")  # detected, NOT applied
+
+        assert reg.is_applied(ca.STORE_ARCTICDB_UNIVERSE, action.action_id) is False
+
+        hist = _hist({"2026-08-19": 697.38, "2026-08-20": 683.27})
+        bar = _bar(342.52, volume=1_400_000)
+        out, verdict = _splice_basis_guard(
+            "IESC", bar, hist, pd.Timestamp("2026-08-21"), [action], reg
+        )
+        assert verdict == "restated"
+        # Restated ONTO THE STORE'S basis (×1/factor = ×2), not onto the feed's.
+        assert float(out["Close"]) == pytest.approx(342.52 * 2.0)
+        assert float(out["Volume"]) == pytest.approx(1_400_000 / 2.0, rel=1e-6)
+
+    def test_restatement_log_names_the_orientation(self, caplog):
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        action = ca.CorporateAction.from_split("IESC", "2026-08-24", 1, 2)
+        reg.record_detected(action, run_id="r")
+        hist = _hist({"2026-08-19": 697.38, "2026-08-20": 683.27})
+        with caplog.at_level(logging.WARNING):
+            _out, verdict = _splice_basis_guard(
+                "IESC", _bar(342.52), hist, pd.Timestamp("2026-08-21"),
+                [action], reg,
+            )
+        assert verdict == "restated"
+        assert any("orientation=feed-leads" in r.message for r in caplog.records)
+
+        caplog.clear()
+        reg2 = CorporateActionRegistry(_FakeS3(), "b")
+        crwd = ca.CorporateAction.from_split("CRWD", "2026-07-02", 1, 4)
+        reg2.record_detected(crwd, run_id="r")
+        reg2.mark_applied(crwd, ca.STORE_ARCTICDB_UNIVERSE, run_id="r")
+        hist2 = _hist({"2026-06-26": 175.27, "2026-06-29": 185.73})
+        with caplog.at_level(logging.WARNING):
+            _out, verdict = _splice_basis_guard(
+                "CRWD", _bar(763.14), hist2, pd.Timestamp("2026-06-30"),
+                [crwd], reg2,
+            )
+        assert verdict == "restated"
+        assert any("orientation=store-leads" in r.message for r in caplog.records)
+
     def test_unapplied_future_ex_action_does_not_restate(self):
         # The store is NOT yet on the post-action scale — a 1/factor gap is
         # then expected pre-basis continuity, not a mismatch to correct.
@@ -145,6 +196,58 @@ class TestSpliceBasisGuard:
         assert verdict == "ok"
         assert float(out["Close"]) == pytest.approx(10.59)
         assert any("NO registered corporate action" in r.message for r in caplog.records)
+
+    def test_pure_append_at_a_registered_ex_date_does_not_page(self, caplog):
+        # IESC 2026-08-24 (alpha-engine-config-I8374): the ex date itself. The
+        # compared closes are on DIFFERENT trading days (324.12 vs the 08-21
+        # close 685.04 = 0.4731 = the 0.5 factor × a genuine 5.4% interday
+        # move), so an EXACT-factor match cannot fire here — only ex-date
+        # proximity can. The old code asserted "NO registered corporate action
+        # explains it" while holding this very action.
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        action = ca.CorporateAction.from_split("IESC", "2026-08-24", 1, 2)
+        reg.record_detected(action, run_id="r")
+
+        hist = _hist({"2026-08-20": 683.27, "2026-08-21": 685.04})
+        with caplog.at_level(logging.WARNING):
+            out, verdict = _splice_basis_guard(
+                "IESC", _bar(324.12), hist, pd.Timestamp("2026-08-24"), [], reg
+            )
+        assert verdict == "ok"
+        assert float(out["Close"]) == pytest.approx(324.12)
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(
+            "REGISTERED corporate action" in r.message
+            and action.action_id in r.message
+            for r in caplog.records
+        )
+
+    def test_pure_append_page_states_the_scope_it_evaluated(self, caplog):
+        # A genuinely unexplained split-like append must still page — and the
+        # message must name what it actually asked (MRNA 2026-08-19: the
+        # registry holds no MRNA action at all, so the claim was true there).
+        reg = CorporateActionRegistry(_FakeS3(), "b")
+        hist = _hist({"2026-08-18": 61.10, "2026-08-19": 62.96})
+        with caplog.at_level(logging.ERROR):
+            out, verdict = _splice_basis_guard(
+                "MRNA", _bar(174.38), hist, pd.Timestamp("2026-08-20"), [], reg
+            )
+        assert verdict == "ok"
+        assert float(out["Close"]) == pytest.approx(174.38)
+        errs = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert len(errs) == 1
+        assert "NO registered corporate action explains it" in errs[0]
+        assert "evaluated: persisted registry + session-detected splits" in errs[0]
+
+    def test_pure_append_page_admits_a_narrowed_scope_without_a_registry(self, caplog):
+        hist = _hist({"2026-02-05": 22.07, "2026-02-06": 23.49})
+        with caplog.at_level(logging.ERROR):
+            _out, verdict = _splice_basis_guard(
+                "KD", _bar(10.59), hist, pd.Timestamp("2026-02-09"), [], None
+            )
+        assert verdict == "ok"
+        errs = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("session-detected splits only (no registry available)" in m for m in errs)
 
     def test_missing_prior_close_fails_open(self):
         out, verdict = _splice_basis_guard(


### PR DESCRIPTION
Tracker: `alpha-engine-config-I8374` (a closing keyword never works across repositories — that issue is closed by hand once this merges).

## What was wrong

`builders/daily_append.py::_splice_basis_guard` refused a correct incoming IESC row on 2026-08-21 and then, on 2026-08-24, paged at ERROR severity saying no corporate action explained the gap — while holding `4acdeb80383fb01a` (IESC 1:2, ex 2026-08-24), registered since 2026-08-18.

**Defect A — one orientation only.** The restatement branch tested `expected_gap = 1.0 / factor` and required `registry.is_applied(STORE_ARCTICDB_UNIVERSE, ...)`. That encodes a single story: the store leads, the feed lags (CRWD 2026-06-30). The opposite orientation — the vendor retro-adjusts its history AHEAD of the ex date while ArcticDB is still pre-action — was structurally unreachable for two independent reasons: the observed ratio is `factor` (BELOW), never `1/factor`; and `is_applied` is False BY DEFINITION there, because the split not yet being applied is exactly why the store is stale. IESC 2026-08-21: incoming 342.52 vs stored 683.27 = 0.5013, `expected_gap` tested 2.0, `is_applied` False — it fell through to the same-date refusal and kept the stale 685.04.

**Defect B — a claim nothing evaluated.** The terminal `log.error` emitted "is split-like and NO registered corporate action explains it" at paging severity. No code path reaching that line consulted the registry; `registry` was used in this function for exactly one thing, `is_applied()`.

## What changed

- **`_splice_basis_guard` is orientation-symmetric.** A candidate action now matches at `1/factor` (store-leads) or at `factor` (feed-leads), and the incoming row is restated onto the **store's current basis** in whichever direction matched — `×factor` for store-leads, `×1/factor` for feed-leads. Migrating the whole history to the new basis stays the registry restatement path's job.
- **`is_applied` is asserted per orientation, not as a shared precondition** — load-bearing and TRUE for store-leads, necessarily FALSE for feed-leads. A `None` registry excludes neither and the ratio alone decides, preserving today's behaviour where no registry is passed.
- **The log line names the orientation** (`orientation=store-leads` / `orientation=feed-leads`). A single "restated" verdict hid two situations with different downstream implications.
- **The terminal message asks before it claims.** New `CorporateActionRegistry.splits_near(ticker, date, *, early_leniency_days, max_ahead_days)` — the ex-date half of `explains_discrepancy`, lifted out and now shared by both (`explains_discrepancy` is unchanged in behaviour; it is `splits_near` + the exact-factor test). A split-like pure append at a registered ex date logs a WARNING naming the action and its `action_id`; a genuinely unexplained one still pages at ERROR, and now **names the scope it evaluated** (persisted registry + session detections, or session-only when no registry was available) and the window it searched.
- **The pure-append test is ex-date proximity plus the LOOSE `_SPLICE_GUARD_REL_TOL`, and the reason is a code comment** so the next reader does not re-tighten it: the two closes compared there are on DIFFERENT trading days, so the observed ratio is the split factor multiplied by whatever the market did in between. IESC 2026-08-24: 324.12 vs the 08-21 close 685.04 = 0.4731 = the 0.5 factor × a genuine 5.4% interday move. Against `_SPLIT_RATIO_TOL` = 0.005 an exact-factor match can never fire whenever the market also moved.
- The window for that branch is deliberately tighter (−3d/+10d) than the classifier's +60d, because the classifier's generous look-ahead is safe only in company with an exact-factor match.

## Tests

`tests/test_daily_append_splice_guard.py` — the absence of a feed-leads test is why this shipped:

- `test_feed_leads_pre_adjusted_row_restated_onto_the_store_basis` — IESC, `is_applied` False, must restate ×2.
- `test_restatement_log_names_the_orientation` — both orientations, both log lines.
- `test_pure_append_at_a_registered_ex_date_does_not_page` — IESC 08-24 cross-date ratio, must emit no ERROR and must name the action.
- `test_pure_append_page_states_the_scope_it_evaluated` — MRNA-shaped genuinely unexplained append still pages, message states its scope.
- `test_pure_append_page_admits_a_narrowed_scope_without_a_registry`.
- The existing store-leads (CRWD), same-date refusal (HON), allowlist and fail-open tests are unchanged and pass.

`python3 -m pytest tests -q`: 6569 passed. Two pre-existing failures are **stale local package installs on this laptop, not repo defects** — `nousergon-lib` 0.124.83 installed vs `v0.124.88` pinned (`test_pipeline_status_registry_source_check.py`; the three missing states are present in the published lib) and `krepis` 0.59.24 installed vs `0.59.33` pinned (`test_stage_coverage_run_date_contract.py`). CI installs from `requirements.txt`.

## Not in this PR

The 2026-08-24 logs also show `corporate_actions.apply` refusing to apply the IESC split with `orientation=none` — "NO corroborating price move on the raw close within the ex_date window" — while the feed had already restated its history. That is the same orientation blindness one layer up in the APPLY path's corroboration check. It self-healed on 2026-08-25 once the raw close moved past the ex date; recommended as a separate tracked follow-up rather than bundled here.

## Data

**No data fix is needed and none is performed.** The restatement path applied `4acdeb80383fb01a` at 2026-08-25T12:20:14Z (`applied/arcticdb_universe/4acdeb80383fb01a.json`); the ArcticDB series reads 08-19 348.690, 08-20 341.635, 08-21 342.520, 08-24 324.120, 08-25 313.230 — continuous, single post-split basis. This PR fixes the guard, not the data.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rxs8r7SsFn1xBQo4e5c2u6
