### PR TITLE
fix(freshness-monitor): gate owning-item resolution on relevance (config-I8680)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -2211,25 +2211,88 @@ def _github_search_open_issues(term: str, pat: str) -> list[dict]:
     return [i for i in items if isinstance(i, dict) and i.get("number")]
 
 
+def _artifact_id_variants(artifact_id: str) -> list[str]:
+    """The spellings a human or a machine might use for one artifact_id.
+
+    The verbatim id is what the registry row and a machine-filed item use.
+    The hyphen/space variants exist because a HUMAN writes the condition in
+    prose — #6562's title says `director-retro-judge`, which an exact
+    `director_retro` match misses entirely, and missing it is the measured
+    defect that motivated the variants.
+    """
+    out = [artifact_id]
+    for variant in (artifact_id.replace("_", "-"), artifact_id.replace("_", " ")):
+        if variant not in out:
+            out.append(variant)
+    return out
+
+
+def _dedated_key(canonical_key: str) -> str:
+    """``canonical_key`` with date-shaped path segments removed.
+
+    ``predictor/2026-08-25/self_test.json`` → ``predictor/self_test.json``.
+    Used as a RELEVANCE signal only (an item that names the S3 path instead
+    of the artifact_id), never as a search term — it costs a query and
+    almost never appears verbatim in a title.
+    """
+    segments = [
+        s for s in (canonical_key or "").split("/")
+        if s and not s[:1].isdigit()
+    ]
+    return "/".join(segments)
+
+
 def _search_terms(artifact_id: str, canonical_key: str) -> list[str]:
     """Search terms derived from the alert's own §7.2 signature.
 
-    The artifact_id verbatim is the exact key both the registry row and a
-    machine-filed item use. The hyphen/space variants exist because a HUMAN
-    writes the condition in prose — #6562's title says `director-retro-judge`,
-    which an exact `director_retro` match misses entirely, and missing it is
-    the whole measured defect. The canonical key's own directory prefix
-    catches items that name the S3 path instead of the artifact.
+    The artifact_id and its prose variants — and NOTHING ELSE.
+
+    config-I8680: this used to also emit the canonical key's bare first path
+    segment (`trades`, `predictor`, `backtest`). GitHub's issue search is
+    full-text, so a single common word returned twenty-to-thirty open issues
+    that had nothing to do with the artifact, and `_rank_key` — which scores
+    no relevance at all — then handed ownership to whichever of them was the
+    oldest P0. Measured 2026-08-26: `open_orders_latest` was reported as
+    owned by alpha-engine-config#4500, "Groom/alert-drain boxes run egress
+    proxy v2.0.0 without auto-redaction", whose body matches neither
+    `open_orders` nor `trades/`.
+
+    That is not merely a cosmetic misattribution. `_alert_decision` replaces
+    the miss-count ladder with the owning item's AGE whenever an item
+    resolves, so a wrongly-attributed 30-day-old P0 makes
+    `age_days >= sla_days` trivially true and the row pages CRITICAL on its
+    FIRST confirmed miss — with `WARNING_ESCALATION_RUNS` bypassed. #4500
+    also carries `gate:dependency`, so its age only grows: the misattribution
+    was a PERMANENT critical-on-first-miss pin.
+
+    The path prefix is not lost, only demoted: it survives as a relevance
+    signal via :func:`_dedated_key`, where it can confirm an already-matched
+    candidate but can never be the sole basis for one.
     """
-    terms = [artifact_id]
-    for variant in (artifact_id.replace("_", "-"), artifact_id.replace("_", " ")):
-        if variant not in terms:
-            terms.append(variant)
-    prefix = (canonical_key or "").split("/", 1)[0]
-    # A date-shaped or empty first segment is not a stable identifier.
-    if prefix and not prefix[:1].isdigit() and prefix not in terms:
-        terms.append(prefix)
-    return terms
+    return _artifact_id_variants(artifact_id)
+
+
+def _is_relevant(
+    issue: dict, artifact_id: str, canonical_key: str,
+) -> bool:
+    """Whether this issue may own ``artifact_id`` AT ALL (config-I8680).
+
+    The bar is deliberately concrete: the artifact_id — in one of its prose
+    variants — or the de-dated S3 key appears in the issue's title or body.
+    An item that merely came back from a full-text search is NOT a candidate.
+
+    This is a FILTER, not a rank term, because a relevance score that only
+    reorders still lets an irrelevant item own the cause whenever it is the
+    only result. When nothing passes, `_resolve_owning_item` returns
+    `owning_item=None` and the miss-count ladder stays in force — which is
+    the correct clock for a condition that is genuinely undiagnosed.
+    """
+    haystack = f"{issue.get('title') or ''}\n{issue.get('body') or ''}".lower()
+    for variant in _artifact_id_variants(artifact_id):
+        if variant.lower() in haystack:
+            return True
+    dedated = _dedated_key(canonical_key)
+    return bool(dedated) and dedated.lower() in haystack
 
 
 def _priority_of(issue: dict) -> str | None:
@@ -2274,6 +2337,13 @@ def _summarize_issue(
     }
 
 
+# Sentinel for "names no registry artifact at all" in `_rank_key`'s
+# specificity term. Any value above the largest plausible `n_artifacts_named`
+# works; it is named rather than inline so the intent (sort LAST) cannot be
+# misread as a count.
+_UNSPECIFIC_RANK = 10 ** 6
+
+
 def _rank_key(item: dict[str, Any]) -> tuple:
     """Deterministic cause-ownership order (§7.4a's many-items-one-cause
     rule): highest priority first, then the NARROWEST claim, then the
@@ -2282,7 +2352,14 @@ def _rank_key(item: dict[str, Any]) -> tuple:
     the owner."""
     return (
         _PRIORITY_RANK.get(item["priority"], 9),
-        item["n_artifacts_named"] if item["n_artifacts_named"] else 99,
+        # config-I8680: this was `... if n else 99`, which sorted an item
+        # naming ZERO registry artifacts — i.e. maximally irrelevant — into
+        # the same bucket as every other zero-namer, collapsing the whole
+        # sort to "oldest of the highest priority wins". Zero now sorts
+        # LAST, where it belongs. With `_is_relevant` filtering upstream a
+        # zero-namer can still appear (it may match on the de-dated S3 key
+        # rather than the artifact_id), so the branch is live, not dead.
+        item["n_artifacts_named"] or _UNSPECIFIC_RANK,
         item["created_at"] or "",
         item["number"],
     )
@@ -2319,6 +2396,7 @@ def _resolve_owning_item(
     by_number: dict[int, dict] = {}
     errors: list[str] = []
     ran_any = False
+    n_filtered = 0
     for term in _search_terms(artifact_id, canonical_key):
         if state["queries"] >= OWNING_ITEM_LOOKUP_MAX_QUERIES:
             errors.append("lookup_budget_exhausted")
@@ -2334,6 +2412,15 @@ def _resolve_owning_item(
         state["queries"] += 1
         try:
             for issue in _github_search_open_issues(term, pat):
+                # config-I8680 relevance gate. Full-text search is a
+                # RECALL mechanism; it decides what to look at, never what
+                # owns the cause. An item that does not name this artifact
+                # (or its de-dated S3 key) is discarded here rather than
+                # ranked, because a rank can still crown an irrelevant item
+                # when it is the only result.
+                if not _is_relevant(issue, artifact_id, canonical_key):
+                    n_filtered += 1
+                    continue
                 by_number.setdefault(int(issue["number"]), issue)
             ran_any = True
         except Exception as exc:  # noqa: BLE001 — a single failed query degrades that term only; recording surfaces: `errors` → degraded_reason on the page and in check_results.json, plus the OwningItemLookupDegraded CW metric
@@ -2348,6 +2435,13 @@ def _resolve_owning_item(
         (_summarize_issue(i, now, known_artifact_ids) for i in by_number.values()),
         key=_rank_key,
     )
+    if not ranked:
+        logger.info(
+            "owning-item lookup: %s matched %d open issue(s) by full-text "
+            "search, none of which name the artifact or its key — no owning "
+            "item; the miss-count ladder stays in force (config-I8680)",
+            artifact_id, n_filtered,
+        )
     resolution = {
         "resolved": True,
         # A PARTIAL search still resolved something, but the operator is
@@ -2357,6 +2451,10 @@ def _resolve_owning_item(
         "owning_item": ranked[0] if ranked else None,
         "members": ranked[1:],
         "n_candidates": len(ranked),
+        # How many full-text hits the relevance gate discarded. Recorded so
+        # a gate that is silently rejecting everything is visible as a
+        # number rather than as an absence (principles.md §2.7).
+        "n_filtered_irrelevant": n_filtered,
     }
     state["cache"][artifact_id] = resolution
     return resolution

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -3242,10 +3242,178 @@ def test_search_terms_cover_the_human_prose_variant():
     assert "director_retro" in terms
     assert "director-retro" in terms
     assert "director retro" in terms
-    assert "director" in terms
-    # A date-shaped first path segment is not a stable identifier.
+
+
+def test_search_terms_no_longer_emit_the_bare_path_prefix():
+    """config-I8680. The bare first path segment used to be a search term.
+
+    GitHub issue search is full-text, so one common word (`trades`,
+    `predictor`, `director`) returned twenty-to-thirty unrelated open
+    issues, and `_rank_key` scores no relevance — so ownership fell to
+    whichever of them was the oldest P0. It is now a relevance signal only,
+    never a query.
+    """
+    import index
+    assert "director" not in index._search_terms(
+        "director_retro", "director/2026-08-13/retro.json")
+    assert "trades" not in index._search_terms(
+        "open_orders_latest", "trades/open_orders/latest.json")
+    # And a date-shaped segment was never a stable identifier either.
     assert "2026-08-13" not in index._search_terms(
         "x_y", "2026-08-13/retro.json")
+
+
+# ── config-I8680: the relevance gate ───────────────────────────────────────
+#
+# The measured 2026-08-26 misattribution, verbatim from the CRITICAL page:
+#
+#   artifact_id=open_orders_latest ... escalated_from=warning
+#   escalation_basis=owning_item_age after_consecutive_miss_runs=1
+#   owning_item=#4500 owning_item_priority=P0 owning_item_age_days=30.02
+#   owning_item_sla_days=1 owning_item_members_total=20
+#   owning_item_title='Groom/alert-drain boxes run egress proxy v2.0.0
+#   without auto-redaction — hard-blocks where the laptop redacts'
+#
+# #4500's body matches neither `open_orders` nor `trades/` (verified live via
+# `gh issue view 4500 --json body`). It won ownership on priority and age
+# alone. Because `_alert_decision` swaps the miss-count ladder for the owning
+# item's AGE the moment an item resolves, `30.02 >= 1` made a warning row page
+# CRITICAL on its FIRST miss — and #4500 carries `gate:dependency`, so its age
+# only grows.
+
+_OPEN_ORDERS_KEY = "trades/open_orders/latest.json"
+
+_IRRELEVANT_OLD_P0 = {
+    "number": 4500,
+    "html_url": "https://x/4500",
+    "created_at": "2026-07-27T13:31:07Z",
+    "title": ("Groom/alert-drain boxes run egress proxy v2.0.0 without "
+              "auto-redaction — hard-blocks where the laptop redacts"),
+    "body": "the groom box's proxy build predates auto-redaction",
+    "labels": [{"name": "P0"}, {"name": "gate:dependency"}],
+}
+
+_RELEVANT_YOUNGER_P2 = {
+    "number": 8000,
+    "html_url": "https://x/8000",
+    "created_at": "2026-08-24T00:00:00Z",
+    "title": "executor daemon stopped writing open_orders_latest",
+    "body": "no write to trades/open_orders/latest.json since the restart",
+    "labels": [{"name": "P2"}],
+}
+
+
+def test_irrelevant_old_p0_can_never_own_a_row(monkeypatch):
+    """The live defect: #4500 is the ONLY search result, so a relevance
+    RANK would still crown it. The gate must discard it and leave the row
+    unowned, which puts the miss-count ladder back in force."""
+    import index
+    monkeypatch.setattr(index, "_cached_github_pat", lambda state: "pat")
+    monkeypatch.setattr(index, "_github_search_open_issues",
+                        lambda term, pat: [_IRRELEVANT_OLD_P0])
+    res = index._resolve_owning_item(
+        "open_orders_latest", _OPEN_ORDERS_KEY, {"open_orders_latest"},
+        datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc),
+        index._new_lookup_state(),
+    )
+    assert res["resolved"] is True
+    assert res["owning_item"] is None
+    assert res["members"] == []
+    assert res["n_candidates"] == 0
+    # Recorded as a number, not as an absence.
+    assert res["n_filtered_irrelevant"] >= 1
+
+
+def test_relevance_outranks_priority_and_age(monkeypatch):
+    """A P2 filed two days ago that NAMES the artifact owns the cause over a
+    P0 filed a month ago that does not. Priority and age order candidates;
+    they do not create them."""
+    import index
+    monkeypatch.setattr(index, "_cached_github_pat", lambda state: "pat")
+    monkeypatch.setattr(
+        index, "_github_search_open_issues",
+        lambda term, pat: [_IRRELEVANT_OLD_P0, _RELEVANT_YOUNGER_P2],
+    )
+    res = index._resolve_owning_item(
+        "open_orders_latest", _OPEN_ORDERS_KEY, {"open_orders_latest"},
+        datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc),
+        index._new_lookup_state(),
+    )
+    assert res["owning_item"]["number"] == 8000
+    assert [m["number"] for m in res["members"]] == []
+
+
+def test_relevance_accepts_the_dedated_s3_key(monkeypatch):
+    """An item that names the S3 path instead of the artifact_id is still
+    the owner — that recall is what the path prefix used to buy, kept here
+    without buying twenty irrelevant candidates alongside it."""
+    import index
+    by_key = {
+        "number": 8100,
+        "html_url": "https://x/8100",
+        "created_at": "2026-08-20T00:00:00Z",
+        "title": "predictor/self_test.json has not been rewritten",
+        "body": "the weekly training run did not emit it",
+        "labels": [{"name": "P1"}],
+    }
+    monkeypatch.setattr(index, "_cached_github_pat", lambda state: "pat")
+    monkeypatch.setattr(index, "_github_search_open_issues",
+                        lambda term, pat: [by_key])
+    res = index._resolve_owning_item(
+        "predictor_self_test", "predictor/2026-08-25/self_test.json",
+        {"predictor_self_test"},
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+        index._new_lookup_state(),
+    )
+    assert res["owning_item"]["number"] == 8100
+
+
+def test_relevance_match_is_case_insensitive(monkeypatch):
+    import index
+    shouty = dict(_RELEVANT_YOUNGER_P2,
+                  title="OPEN_ORDERS_LATEST is not being written",
+                  body="no detail")
+    monkeypatch.setattr(index, "_cached_github_pat", lambda state: "pat")
+    monkeypatch.setattr(index, "_github_search_open_issues",
+                        lambda term, pat: [shouty])
+    res = index._resolve_owning_item(
+        "open_orders_latest", _OPEN_ORDERS_KEY, {"open_orders_latest"},
+        datetime(2026, 8, 26, tzinfo=timezone.utc),
+        index._new_lookup_state(),
+    )
+    assert res["owning_item"]["number"] == 8000
+
+
+def test_zero_namer_sorts_last_not_at_ninety_nine():
+    """The `... if n else 99` inversion, corrected.
+
+    DEFENSIVE, and honestly so: the sentinel only changed an outcome when a
+    competing item named 100+ registry artifacts, which no real item does.
+    The relevance gate above is what actually fixes the live defect. This is
+    here because `99` was a count-shaped magic number sitting in a
+    count-valued slot, and the next person to read it would reasonably
+    assume a zero-namer ranks between a 98-namer and a 100-namer — which is
+    exactly backwards from the intent stated in the docstring.
+    """
+    import index
+    broad = {"priority": "P1", "n_artifacts_named": 100,
+             "created_at": "2026-08-20T00:00:00Z", "number": 2}
+    names_none = {"priority": "P1", "n_artifacts_named": 0,
+                  "created_at": "2026-01-01T00:00:00Z", "number": 1}
+    assert sorted([names_none, broad], key=index._rank_key) == [
+        broad, names_none,
+    ]
+    # And the ordinary case is unchanged: narrower still beats broader.
+    narrow = dict(broad, n_artifacts_named=1, number=3)
+    assert sorted([broad, narrow], key=index._rank_key) == [narrow, broad]
+
+
+def test_dedated_key_strips_only_date_segments():
+    import index
+    assert index._dedated_key("predictor/2026-08-25/self_test.json") == (
+        "predictor/self_test.json")
+    assert index._dedated_key(_OPEN_ORDERS_KEY) == _OPEN_ORDERS_KEY
+    assert index._dedated_key("") == ""
 
 
 def test_pat_read_failure_degrades_the_lookup_and_never_raises(monkeypatch):


### PR DESCRIPTION
## What

Measured 2026-08-26T14:00:48Z — a CRITICAL freshness page attributed `open_orders_latest` to `alpha-engine-config#4500`:

```
artifact_id=open_orders_latest owner_repo=alpha-engine state=stale
escalated_from=warning escalation_basis=owning_item_age after_consecutive_miss_runs=1
owning_item=#4500 owning_item_priority=P0 owning_item_age_days=30.02 owning_item_sla_days=1
owning_item_title='Groom/alert-drain boxes run egress proxy v2.0.0 without auto-redaction'
owning_item_members_total=20
```

#4500's body matches neither `open_orders` nor `trades/` — verified live with `gh issue view 4500 --repo nousergon/alpha-engine-config --json body`. It cannot cause the staleness it was reported as owning.

## Root cause — two compounding halves

**1. `_search_terms` emitted the canonical key's bare first path segment** (`trades`, `predictor`, `director`). GitHub issue search is full-text, so one common word returns twenty-to-thirty open issues with nothing to do with the artifact. The two sibling rows in the same sweeps reported `owning_item_members_total` of 28 and 32.

**2. `_rank_key` scores no relevance at all.** Its specificity term was:

```python
item["n_artifacts_named"] if item["n_artifacts_named"] else 99
```

An item naming **zero** registry artifacts — maximally irrelevant — landed in the same bucket as every other zero-namer, so the sort collapsed to *oldest of the highest priority wins*. #4500 is `P0`, created `2026-07-27`, and was the oldest P0 in the candidate set.

## Why it is severity-amplifying, not cosmetic

`_alert_decision` replaces the miss-count ladder with the owning item's **age** the moment an item resolves:

```python
if severity == "warning" and owning_item and owning_item.get("created_at"):
    escalation_basis = "owning_item_age"
    escalated = owning_item["age_days"] >= owning_item["sla_days"]
```

A wrongly-attributed 30-day-old P0 makes `30.02 >= 1` trivially true, so a `severity: warning` row pages **CRITICAL on its first confirmed miss** with `WARNING_ESCALATION_RUNS = 3` bypassed. #4500 also carries `gate:dependency`, so its age only grows — the misattribution was a **permanent** critical-on-first-miss pin for that row.

## How

**A filter, not a rank term.** A relevance score that only reorders still crowns an irrelevant item whenever it is the only result — which is exactly the live case, where #4500 was the sole hit. `_is_relevant` requires the artifact_id (in one of its prose variants) or the de-dated S3 key to appear in the item's title or body. When nothing passes, `owning_item=None` and the miss-count ladder stays in force, which is the correct clock for a genuinely undiagnosed condition.

**The path prefix is demoted, not lost.** `_dedated_key` (`predictor/2026-08-25/self_test.json` → `predictor/self_test.json`) keeps it as a *relevance signal*, so an item that names the S3 path instead of the artifact_id still owns the row — the recall the prefix term was there to buy — without buying twenty irrelevant candidates alongside it.

**`n_filtered_irrelevant`** is recorded on every resolution, so a gate that silently rejects everything is visible as a number rather than as an absence (`principles.md` §2.7).

**The `else 99` → `_UNSPECIFIC_RANK` correction is defensive, and its test says so.** It only changed an outcome against a competing item naming 100+ artifacts, which no real item does. The relevance gate is what fixes the live defect; `99` is corrected because it is a count-shaped magic number in a count-valued slot that reads as ranking a zero-namer *between* a 98-namer and a 100-namer — backwards from the intent its own docstring states.

## Tests

7 new cases in `test_handler.py`:

| Case | Asserts |
|---|---|
| `test_irrelevant_old_p0_can_never_own_a_row` | the verbatim #4500 shape, as the ONLY result ⇒ unowned, `n_filtered_irrelevant >= 1` |
| `test_relevance_outranks_priority_and_age` | a 2-day-old P2 that names the artifact beats a month-old P0 that does not |
| `test_relevance_accepts_the_dedated_s3_key` | an item naming `predictor/self_test.json` still owns the row |
| `test_relevance_match_is_case_insensitive` | `OPEN_ORDERS_LATEST` matches |
| `test_search_terms_no_longer_emit_the_bare_path_prefix` | `trades` / `director` are no longer queries |
| `test_dedated_key_strips_only_date_segments` | date segments only |
| `test_zero_namer_sorts_last_not_at_ninety_nine` | the sentinel, plus narrower-still-beats-broader unchanged |

**4 fail against `origin/main`** — including `test_relevance_outranks_priority_and_age`, which reproduces the live misattribution by returning #4500 as the owner.

`test_search_terms_cover_the_human_prose_variant` was updated: it asserted `"director" in terms`, the prefix term this change deliberately removes. Its original purpose — the `director-retro-judge` prose variant from #6562 — is untouched and still asserted.

Full suite locally: **6578 passed, 17 skipped**.

## Scope note

This fixes *who* the monitor names as the owner. It does not change the §7.4a escalation rule itself — that a correctly-attributed old item still promotes a warning row to critical on its first miss is by design (I7326). One residual that rule surfaces is filed as `alpha-engine-config-I8691`: `backtest_pit_parity` is owned by `alpha-engine-config#7309`, a **deliberate, tracked** disable (`skip_parity`, 2026-08-13), so it pages critical daily for an accepted condition. That is a gate-label question, not a resolver one.

## Tracker

`alpha-engine-config-I8680` — cross-repo, so the closing keyword is inert here; the issue will be closed by hand once a live sweep shows the corrected attribution.

Prepared by: claude-opus-5 (1M context) via [Claude Code](https://claude.com/claude-code)
