### PR TITLE
fix(preflight-sweep): probe the trading day the launcher used, and let a ratified gap still be a clean run

### DIFF
--- a/infrastructure/preflight_sweep.py
+++ b/infrastructure/preflight_sweep.py
@@ -196,6 +196,16 @@ class SweepReport:
     stages_unsweepable_coverage_defect: int = 0
     stages_unsweepable_upstream_pending: int = 0
     stages_no_dry_path: int = 0
+    # The subset of `stages_no_dry_path` with NO written acknowledgement in
+    # preflight_sweep_manifest.json. The distinction decides whether the run
+    # can ever be clean: a RATIFIED no-dry-path stage is a reviewed, permanent
+    # boundary of the sweep's denominator, so gating `clean` on it made
+    # `outcome: ok` structurally unreachable and `last_clean.json` unwritable
+    # for the sweep's whole life (13 of 13 runs, 2026-08-14..2026-08-26). An
+    # UNACKNOWLEDGED one is a real gap and still keeps the run out of clean --
+    # it also raises its own blocking manifest_disagreement finding, so the
+    # protection is not carried by this counter alone.
+    stages_no_dry_path_unacknowledged: int = 0
     stages_not_attempted: int = 0
     coverage_findings: list[dict[str, Any]] = field(default_factory=list)
     # A stage unsweepable on EVERY run for the declared streak threshold is its
@@ -408,6 +418,83 @@ def _finding(kind: str, detail: str, *, blocking: bool, stage: str | None = None
     return {"kind": kind, "stage": stage, "blocking": blocking, "finding": detail}
 
 
+# ── Probe-date normalization (closed vocabulary; add by PR) ──────────────────
+# The sweep binds `run_date` to its own UTC calendar date, exactly as the SF's
+# InitializeInput does. The LAUNCHERS do not use that value directly: every
+# crucible-backtester stage calls `spot_common_normalize_run_date`
+# (infrastructure/_spot_common.sh), which snaps RUN_DATE back to the NYSE
+# trading day before its stage preflight reads
+# `backtest/${RUN_DATE}/`. On any Saturday, Sunday or market holiday the stage
+# therefore probes a DIFFERENT prefix than the sweep does, and the manifest's
+# stated safety property — "a stage that fails while its upstream prefix IS
+# populated stays FAILED" — is void: the sweep would find the (always empty)
+# calendar-dated prefix and downgrade a REAL failure to upstream_pending, which
+# does not page. Measured on 2026-08-22 and 2026-08-23, where the stage read
+# the populated backtest/2026-08-21/ while the sweep's probe named an empty
+# backtest/2026-08-2{2,3}/.
+#
+# So the normalization is DECLARED per dependency and applied to the probe. It
+# is never guessed from the launcher, and it never falls back to the calendar
+# date when it cannot be computed — falling back is the bug.
+NORMALIZE_NONE = "none"
+NORMALIZE_NYSE_TRADING_DAY = "nyse_trading_day"
+DATE_NORMALIZATIONS = (NORMALIZE_NONE, NORMALIZE_NYSE_TRADING_DAY)
+
+
+class DateNormalizationUnavailable(Exception):
+    """The declared probe-date normalization could not be computed.
+
+    Raised rather than degraded to the calendar date: a probe naming a prefix
+    the stage never read is worse than no probe, because it silently reclassifies
+    real failures.
+    """
+
+
+def normalize_probe_date(run_date: str, mode: str) -> str:
+    """Resolve the date the STAGE will have used, from the sweep's binding.
+
+    ``none`` returns the binding unchanged. ``nyse_trading_day`` routes through
+    the same ``nousergon_lib.trading_calendar`` chokepoint
+    ``spot_common_normalize_run_date`` uses, so the sweep and the launcher can
+    never name different prefixes.
+    """
+    if mode == NORMALIZE_NONE:
+        return run_date
+    if mode != NORMALIZE_NYSE_TRADING_DAY:
+        raise DateNormalizationUnavailable(
+            f"unknown date_normalization {mode!r} — expected one of "
+            f"{', '.join(DATE_NORMALIZATIONS)}"
+        )
+    try:
+        from nousergon_lib import trading_calendar as tc  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+        raise DateNormalizationUnavailable(
+            f"nousergon_lib.trading_calendar is not importable ({type(exc).__name__}: "
+            f"{exc}), so the NYSE trading day the launcher normalizes to cannot be "
+            "computed"
+        ) from exc
+    try:
+        day = dt.date.fromisoformat(run_date[:10])
+        return (day if tc.is_trading_day(day) else tc.previous_trading_day(day)).isoformat()
+    except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+        raise DateNormalizationUnavailable(
+            f"normalizing {run_date!r} to the NYSE trading day raised "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _probe_bindings(bindings: dict[str, Any], mode: str) -> dict[str, Any]:
+    """``bindings`` with ``run_date`` moved to the date the stage actually used."""
+    if mode == NORMALIZE_NONE:
+        return bindings
+    run_date = bindings.get("run_date")
+    if not run_date:
+        raise DateNormalizationUnavailable(
+            "the sweep has no run_date binding to normalize"
+        )
+    return {**bindings, "run_date": normalize_probe_date(str(run_date), mode)}
+
+
 def upstream_content(
     prefix: str, ignore_subprefixes: list[str], lister
 ) -> tuple[bool, dict[str, Any]]:
@@ -455,10 +542,27 @@ def classify_upstream(
       declaration;
     * upstream prefix is empty     -> ``unsweepable`` / ``upstream_pending``,
       naming the producing stage and the prefix. Not a failure, does not page;
-    * the probe itself could not run -> ``unmeasured``. The sweep cannot tell a
-      real failure from an unmet upstream, and saying either would be a guess.
+    * the probe itself could not run, or the declared probe-date normalization
+      could not be computed -> ``unmeasured``. The sweep cannot tell a real
+      failure from an unmet upstream, and saying either would be a guess.
+
+    The prefix is rendered from the date the STAGE used, not the sweep's own
+    calendar date — see ``normalize_probe_date``.
     """
     template = declaration["prefix"]
+    mode = declaration.get("date_normalization") or NORMALIZE_NONE
+    try:
+        bindings = _probe_bindings(bindings, mode)
+    except DateNormalizationUnavailable as exc:
+        result.verdict = UNMEASURED
+        result.reason = (
+            f"preflight exited rc={result.returncode}, and the declared upstream prefix "
+            f"{template!r} could not be dated: {exc}. The launcher normalizes RUN_DATE to "
+            "the NYSE trading day before reading this prefix, so probing the sweep's raw "
+            "calendar date would name a prefix the stage never read and could silently "
+            "downgrade a real failure — neither verdict is claimed."
+        )
+        return result
     try:
         prefix = template.format(**bindings)
     except (KeyError, IndexError, ValueError) as exc:
@@ -802,6 +906,12 @@ def sweep(
         for entry in (manifest.get("no_dry_path_stages") or [])
         if isinstance(entry, dict) and entry.get("stage")
     }
+    report.stages_no_dry_path_unacknowledged = sum(
+        1
+        for st in stages
+        if st.classification == NO_DRY_PATH
+        and not (acknowledgements.get(st.name) or {}).get("reason")
+    )
 
     results: list[StageResult] = []
     for stage in stages:
@@ -1014,16 +1124,32 @@ def sweep(
 
     blocking_findings = [f for f in report.coverage_findings if _is_blocking(f)]
     # A run is CLEAN only if every stage the sweep is accountable for passed.
-    # An acknowledged no-dry-path stage and a stage awaiting its upstream are
-    # not failures — and they are not passes either, so they keep the run out
-    # of OK and out of last_clean.json. Rendering "measured 14 of 19" as green
-    # is exactly the failure this component exists to avoid.
+    # A stage awaiting its upstream is not a failure and not a pass, so it
+    # keeps the run out of OK and out of last_clean.json — rendering
+    # "measured 14 of 19" as green is exactly the failure this component
+    # exists to avoid.
+    #
+    # A RATIFIED no-dry-path stage is deliberately NOT in this predicate. It is
+    # a permanent, reviewed boundary of the denominator, not a same-day
+    # measurement gap: five of them are declared, none will ever gain a dry
+    # path (three were ruled that way in alpha-engine-config#7329), so gating
+    # `clean` on the raw count made `ok` unreachable on every possible day and
+    # `_preflight_sweep/last_clean.json` — the pointer this module's own
+    # docstring calls the artifact a detector reads as proof, and which
+    # registry.d/ae-preflight-sweep.yaml declares this component PRODUCES —
+    # was never written once in the sweep's life. A status with one reachable
+    # value grades nothing (principles.md §2.7 read the other way round:
+    # a permanent amber is as uninformative as a permanent green). The gap is
+    # still named on every surface: each such stage carries its own no_dry_path
+    # verdict row and its own coverage finding, and an UNACKNOWLEDGED one both
+    # raises a blocking manifest_disagreement finding and is counted in
+    # stages_no_dry_path_unacknowledged above, so it still cannot be clean.
     clean = (
         report.stages_failed == 0
         and report.stages_unsweepable == 0
         and report.stages_unmeasured == 0
         and report.stages_not_attempted == 0
-        and report.stages_no_dry_path == 0
+        and report.stages_no_dry_path_unacknowledged == 0
         and not blocking_findings
     )
     if clean and report.stages_passed > 0:

--- a/infrastructure/preflight_sweep_manifest.json
+++ b/infrastructure/preflight_sweep_manifest.json
@@ -29,7 +29,7 @@
     }
   ],
 
-  "_upstream_purpose": "DECLARED same-day upstream artifact dependencies. A stage listed here reads an artifact that a PRECEDING stage of the same execution produces, so its preflight cannot pass on a day the real pipeline has not already run — a --preflight-only run by definition does not produce its stage's output. Such a stage is UNSWEEPABLE that day (could not measure), never FAILED (found a defect). The classification is DECLARED HERE and nowhere else: it is never inferred from the launcher's stderr text, so rewording an error message cannot reclassify a real failure as unsweepable, and adding a dependency is a reviewed diff. The declaration only ARMS the reclassification — the sweep still probes the named prefix on the day, and a stage that fails while its upstream prefix IS populated stays FAILED.",
+  "_upstream_purpose": "DECLARED same-day upstream artifact dependencies. A stage listed here reads an artifact that a PRECEDING stage of the same execution produces, so its preflight cannot pass on a day the real pipeline has not already run — a --preflight-only run by definition does not produce its stage's output. Such a stage is UNSWEEPABLE that day (could not measure), never FAILED (found a defect). The classification is DECLARED HERE and nowhere else: it is never inferred from the launcher's stderr text, so rewording an error message cannot reclassify a real failure as unsweepable, and adding a dependency is a reviewed diff. Each declaration also states how its probe date is derived (see _date_normalization_reason) — the sweep probes the date the STAGE used, not its own calendar date. The declaration only ARMS the reclassification — the sweep still probes the named prefix on the day, and a stage that fails while its upstream prefix IS populated stays FAILED.",
 
   "unsweepable_streak_threshold_days": 8,
   "_unsweepable_streak_threshold_reason": "A stage that is unsweepable on EVERY run for this many consecutive days is its own finding (the sweep covers nothing there), emitted separately from coverage_findings so it never reads as coverage. 8 days is one full weekly-pipeline cycle plus one: the backtest chain is legitimately unsweepable on the ~6 non-Saturday days of any week, so a threshold of 7 or less would fire on the normal case, and a threshold of 8 fires only when a whole weekly cycle passed without the stage ever becoming measurable — which means either the weekly pipeline stopped running or the dependency declaration is wrong. Counted in RUNS internally, derived as threshold_days x (1440 / cadence_minutes) from preflight_sweep_cadence.json, so changing the sweep cadence does not silently change what this means.",
@@ -40,6 +40,7 @@
       "produced_by": "Backtester",
       "prefix": "backtest/{run_date}/",
       "ignore_subprefixes": [".phases/"],
+      "date_normalization": "nyse_trading_day",
       "reason": "spot_predictor_backtest.sh's stage preflight asserts spot_common_s3_prefix_nonempty \"backtest/${RUN_DATE}/\" — the Backtester stage's sweep output. Backtester's own --preflight-only run exits before producing it, so on any day the real weekly pipeline has not run, this stage's preconditions are unknowable rather than broken. Reported as FAILED on the sweep's first run (preflight-sweep-20260814T080010Z), which is alpha-engine-config#7323.",
       "acknowledged": "2026-08-14"
     },
@@ -48,10 +49,13 @@
       "produced_by": "PredictorBacktest",
       "prefix": "backtest/{run_date}/",
       "ignore_subprefixes": [".phases/"],
+      "date_normalization": "nyse_trading_day",
       "reason": "spot_portfolio_optimizer_backtest.sh asserts the same prefix, one link further down the Backtester -> PredictorBacktest -> PortfolioOptimizerBacktest chain. Same structural argument, same first-run false failure.",
       "acknowledged": "2026-08-14"
     }
   ],
+
+  "_date_normalization_reason": "NON-INFERABLE GOTCHA, measured 2026-08-26. The sweep binds run_date to its own UTC CALENDAR date, exactly as the SF's InitializeInput does — but no backtester stage reads that value directly: spot_predictor_backtest.sh and spot_portfolio_optimizer_backtest.sh both call spot_common_normalize_run_date (crucible-backtester infrastructure/_spot_common.sh), which snaps RUN_DATE back to the NYSE trading day BEFORE the stage preflight reads backtest/${RUN_DATE}/. On every Saturday, Sunday and market holiday the stage and the sweep therefore name DIFFERENT prefixes, and the safety property stated in _upstream_purpose — a stage that fails while its upstream prefix IS populated stays FAILED — is void: the sweep probes the always-empty calendar-dated prefix and downgrades a REAL failure to upstream_pending, which does not page. Observed on 2026-08-22 and 2026-08-23, where both stages PASSED against the populated backtest/2026-08-21/ while the sweep's own probe would have named an empty backtest/2026-08-22|23/. Declared here rather than inferred: the sweep applies this normalization to the probe date only, through the same nousergon_lib.trading_calendar chokepoint the launcher uses, and reports the stage UNMEASURED rather than falling back to the calendar date when that library is unavailable. Closed vocabulary: none | nyse_trading_day.",
 
   "_ignore_subprefixes_reason": "NON-INFERABLE GOTCHA. s3://alpha-engine-research/backtest/<date>/ EXISTS on a day nothing produced it, because the sweep's OWN phase markers (.phases/preflight.json, .phases/runtime_smoke.json) are written under it. A probe testing prefix EXISTENCE rather than prefix CONTENT would read as satisfied and measure nothing — it would silently re-classify every real upstream failure as a genuine stage failure and every genuine failure as real, i.e. it would do nothing at all while appearing to work. Keys under an ignored sub-prefix, and zero-byte keys, do not count as upstream content.",
 

--- a/infrastructure/preflight_sweep_stages.py
+++ b/infrastructure/preflight_sweep_stages.py
@@ -475,6 +475,14 @@ def map_binding_disagreement(required: set[str], manifest: dict) -> list[str]:
 
 _REQUIRED_UPSTREAM_FIELDS = ("stage", "produced_by", "prefix", "reason")
 
+#: How the probe date is resolved from the sweep's ``run_date`` binding. Closed
+#: vocabulary, mirrored in preflight_sweep.py. Every dependency must DECLARE
+#: one: a launcher that normalizes RUN_DATE (every crucible-backtester stage
+#: does, via spot_common_normalize_run_date) reads a different prefix than the
+#: sweep's raw calendar date names, and an undeclared default is exactly how a
+#: real weekend failure gets downgraded to "awaiting upstream".
+_DATE_NORMALIZATIONS = ("none", "nyse_trading_day")
+
 
 def upstream_dependencies(manifest: dict) -> dict[str, dict]:
     """The DECLARED same-day upstream artifact dependency of each stage.
@@ -552,6 +560,21 @@ def upstream_dependency_disagreement(stages: list[Stage], manifest: dict) -> lis
                 f"manifest declares an upstream dependency for stage {name!r}, but that "
                 f"stage is classified {NO_DRY_PATH!r} — it is never exercised at all, so "
                 "the declaration can never apply; drop it or give the stage a dry path"
+            )
+        normalization = entry.get("date_normalization")
+        if normalization is None:
+            findings.append(
+                f"upstream dependency for {name!r} declares no date_normalization — the "
+                "probe would use the sweep's raw calendar run_date while the launcher "
+                "normalizes RUN_DATE to the NYSE trading day, so on every non-trading day "
+                "a REAL failure would be downgraded to upstream_pending; declare one of "
+                f"{', '.join(_DATE_NORMALIZATIONS)}"
+            )
+        elif normalization not in _DATE_NORMALIZATIONS:
+            findings.append(
+                f"upstream dependency for {name!r} declares date_normalization="
+                f"{normalization!r}, which is not one of {', '.join(_DATE_NORMALIZATIONS)} "
+                "— the probe cannot be dated and the stage will report unmeasured"
             )
         producer = entry["produced_by"]
         if producer not in by_name:

--- a/tests/test_preflight_sweep.py
+++ b/tests/test_preflight_sweep.py
@@ -105,8 +105,17 @@ def _sweep_run_date() -> str:
     an empty upstream probe, which is exactly the state it asserts — so it
     passed for the wrong reason in that window and would have kept passing
     if the probe had stopped working entirely.
+
+    Second half, measured 2026-08-26: the probe is dated by the NYSE TRADING
+    DAY, not the calendar date, because that is what the launcher normalizes
+    RUN_DATE to before reading the prefix. A fixture keyed on the raw UTC date
+    would miss the probe on every Saturday, Sunday and market holiday — the
+    same passed-for-the-wrong-reason failure, one axis over.
     """
-    return dt.datetime.now(dt.timezone.utc).date().isoformat()
+    return ps.normalize_probe_date(
+        dt.datetime.now(dt.timezone.utc).date().isoformat(),
+        ps.NORMALIZE_NYSE_TRADING_DAY,
+    )
 
 
 def test_a_clean_preflight_is_a_pass(tmp_path):
@@ -903,3 +912,117 @@ def test_the_sweep_derives_run_date_from_utc_not_local_time():
         "sweep uses LOCAL today() for run_date — the fixtures, the SF's "
         "InitializeInput and the sweep must all agree on one clock"
     )
+
+
+# ── The probe is dated by the NYSE trading day the LAUNCHER uses ─────────────
+# Measured 2026-08-26. `spot_common_normalize_run_date` (crucible-backtester
+# infrastructure/_spot_common.sh) snaps RUN_DATE back to the previous trading
+# day before the stage preflight reads `backtest/${RUN_DATE}/`, so on every
+# non-trading day the sweep's raw calendar probe named a prefix the stage never
+# read — and an empty probe DOWNGRADES a real failure to upstream_pending,
+# which does not page.
+
+_WEEKEND_BINDINGS = {"run_date": "2026-08-23"}  # a Sunday
+_NORMALIZED_DECL = {**DECL, "date_normalization": "nyse_trading_day"}
+
+
+def test_the_probe_uses_the_trading_day_the_launcher_normalized_to():
+    seen: list[str] = []
+
+    def lister(prefix):
+        seen.append(prefix)
+        return []
+
+    ps.classify_upstream(_failed(), _NORMALIZED_DECL, _WEEKEND_BINDINGS, lister)
+    assert seen == ["backtest/2026-08-21/"], (
+        "the Sunday probe must name the Friday prefix the stage actually read"
+    )
+
+
+def test_a_real_weekend_failure_is_not_downgraded_when_the_traded_prefix_is_full():
+    """The regression this exists for: before the normalization, the probe named
+    the always-empty Sunday prefix and reclassified a REAL failure."""
+    listing = {"backtest/2026-08-21/": [
+        {"Key": "backtest/2026-08-21/results/backtest.parquet", "Size": 8123},
+    ]}
+    result = ps.classify_upstream(
+        _failed(), _NORMALIZED_DECL, _WEEKEND_BINDINGS,
+        lambda p: listing.get(p, []),
+    )
+    assert result.verdict == ps.FAILED
+    assert "IS populated" in result.reason
+
+
+def test_an_uncomputable_probe_date_is_unmeasured_never_the_calendar_date(monkeypatch):
+    """Falling back to the calendar date IS the defect, so it must never happen:
+    the sweep says it could not tell instead."""
+    def boom(_run_date, _mode):
+        raise ps.DateNormalizationUnavailable("no trading calendar on this box")
+
+    monkeypatch.setattr(ps, "normalize_probe_date", boom)
+    result = ps.classify_upstream(
+        _failed(), _NORMALIZED_DECL, _WEEKEND_BINDINGS, lambda _p: [])
+    assert result.verdict == ps.UNMEASURED
+    assert "no trading calendar on this box" in result.reason
+
+
+def test_every_declared_upstream_dependency_declares_its_probe_date_rule():
+    manifest = ps.load_manifest(MANIFEST_PATH)
+    decls = manifest["upstream_artifact_dependencies"]
+    assert decls
+    for entry in decls:
+        assert entry.get("date_normalization") in ("none", "nyse_trading_day"), entry
+
+
+# ── A ratified no-dry-path stage must not make `ok` unreachable ──────────────
+# 13 of 13 runs (2026-08-14..2026-08-26) were non-clean and
+# `_preflight_sweep/last_clean.json` was never written once, because `clean`
+# was gated on the raw no-dry-path count and five stages are permanently
+# ratified as having none. A status with one reachable value grades nothing.
+
+
+def test_a_run_whose_only_gap_is_ratified_no_dry_path_stages_is_ok(tmp_path):
+    root = _fake_checkout(tmp_path)
+    run_date = _sweep_run_date()
+    aws = FakeAws(listing={f"backtest/{run_date}/": [
+        {"Key": f"backtest/{run_date}/results/backtest.parquet", "Size": 8123},
+    ]})
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, str(root), "t", aws=aws,
+                      runner=_completed(0))
+    assert report.stages_failed == 0
+    assert report.stages_no_dry_path > 0, "the ratified gaps are still counted"
+    assert report.stages_no_dry_path_unacknowledged == 0
+    assert report.outcome == ps.OUTCOME_OK
+    ps.emit(report, aws, "arn:sns")
+    assert f"{ps.REPORT_PREFIX}/last_clean.json" in aws.objects
+
+
+def test_an_unacknowledged_no_dry_path_stage_still_keeps_the_run_out_of_ok(tmp_path):
+    root = _fake_checkout(tmp_path)
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    manifest["no_dry_path_stages"] = [
+        e for e in manifest["no_dry_path_stages"]
+        if e["stage"] != "SaturdayHealthCheck"
+    ]
+    stripped = tmp_path / "manifest.json"
+    stripped.write_text(json.dumps(manifest))
+    report = ps.sweep(SF_PATH, stripped, str(root), "t", runner=_completed(0))
+    assert report.stages_no_dry_path_unacknowledged == 1
+    assert report.outcome == ps.OUTCOME_FAILED
+
+
+def test_the_gaps_stay_named_on_every_surface_even_on_an_ok_run(tmp_path):
+    """Reachable OK must not be bought by hiding the coverage gap."""
+    root = _fake_checkout(tmp_path)
+    run_date = _sweep_run_date()
+    aws = FakeAws(listing={f"backtest/{run_date}/": [
+        {"Key": f"backtest/{run_date}/results/backtest.parquet", "Size": 8123},
+    ]})
+    report = ps.sweep(SF_PATH, MANIFEST_PATH, str(root), "t", aws=aws,
+                      runner=_completed(0))
+    assert report.outcome == ps.OUTCOME_OK
+    named = {f.get("stage") for f in report.coverage_findings
+             if f.get("kind") == ps.FINDING_NO_DRY_PATH}
+    rows = {r["stage"] for r in report.results
+            if r["verdict"] == ps.NO_DRY_PATH_VERDICT}
+    assert named == rows and len(rows) == report.stages_no_dry_path > 0

--- a/tests/test_preflight_sweep_stages.py
+++ b/tests/test_preflight_sweep_stages.py
@@ -346,7 +346,8 @@ def test_a_declaration_for_a_stage_the_definition_lost_is_a_finding(stages):
 def test_a_declaration_naming_a_producer_that_does_not_exist_is_a_finding(stages):
     bad = {"upstream_artifact_dependencies": [
         {"stage": "PredictorBacktest", "produced_by": "NoSuchStage",
-         "prefix": "backtest/{run_date}/", "reason": "r"}
+         "prefix": "backtest/{run_date}/", "reason": "r",
+         "date_normalization": "nyse_trading_day"}
     ]}
     findings = upstream_dependency_disagreement(stages, bad)
     assert findings and "not a stage in the definition" in findings[0]


### PR DESCRIPTION
## What this fixes

Two defects in `ae-preflight-sweep`, both found by reading the 13 reports it has written since 2026-08-14 against what the launchers actually do. Neither is visible from the code alone.

### 1. The probe named a prefix the stage never read — `alpha-engine-config-I8687`

`preflight_sweep.py` binds `run_date` to its own **UTC calendar date**, mirroring the SF's `InitializeInput`. But no backtester stage uses that value directly: `spot_predictor_backtest.sh` and `spot_portfolio_optimizer_backtest.sh` both call `spot_common_normalize_run_date` (`crucible-backtester/infrastructure/_spot_common.sh`), which snaps `RUN_DATE` to the **NYSE trading day** before the stage preflight reads `backtest/${RUN_DATE}/`.

On every Saturday, Sunday and market holiday the two disagree, and the safety property the manifest states — *"a stage that fails while its upstream prefix IS populated stays FAILED"* — is void. The calendar-dated prefix is always empty on those days, so a **real** failure gets downgraded to `unsweepable / upstream_pending`, which does not page.

Measured:

| Sweep run | Probe named | Stage read | Verdict |
|---|---|---|---|
| `20260822T080009Z` (Sat) | `backtest/2026-08-22/` — empty at 08:00Z | `backtest/2026-08-21/` — populated | `passed` |
| `20260823T080009Z` (Sun) | `backtest/2026-08-23/` — never created | `backtest/2026-08-21/` — populated | `passed` |

Latent only because both stages happened to pass.

**Fix.** The normalization is now declared per dependency (`"date_normalization": "none" | "nyse_trading_day"`), applied to the probe through the same `nousergon_lib.trading_calendar` chokepoint the launcher uses, and reports the stage `unmeasured` — never the calendar date — when it cannot be computed. A dependency declaring no rule, or an unknown one, raises a blocking finding, so a new dependency cannot silently inherit calendar dating.

### 2. `outcome: ok` was structurally unreachable — `alpha-engine-config-I8688`

`clean` was gated on `stages_no_dry_path == 0`, while **five** stages are permanently ratified as having no dry path (`alpha-engine-config#7329` ruled that giving two of them one would *reverse* the config#902 decision; `I7267` covers the other two). The count can never be zero.

- 13 of 13 runs (2026-08-14 → 2026-08-26) were `degraded` or `failed`.
- `s3://alpha-engine-research/_preflight_sweep/last_clean.json` returns **404** — never written once — although `registry.d/ae-preflight-sweep.yaml` declares it under `produces:` and this module's own docstring calls it *"the artifact a detector reads as proof"*.
- `20260822T080009Z` and `20260823T080009Z` had 16 passed / 0 failed / 0 unsweepable and were degraded *solely* by that count.

A status with one reachable value grades nothing — a permanent amber is as uninformative as a permanent green, on the one component whose job is to say whether the pipeline can start.

**Fix.** New `stages_no_dry_path_unacknowledged`; `clean` gates on that. A ratified stage is a reviewed, permanent boundary of the denominator. An unacknowledged one still blocks — and independently raises its own blocking `manifest_disagreement` finding, so the protection is not carried by one counter. Nothing is hidden: every ratified gap keeps its `no_dry_path` verdict row, its named coverage finding, its console row and its notification line, and a test asserts that on an `ok` run.

Effect on the observed history: 08-22 and 08-23 shaped runs become `ok` and advance `last_clean.json`; Mon–Wed runs stay `degraded`, because the backtest chain's upstream genuinely has not been produced — which is the honest statement.

## SOTA and delta

SOTA is a single chokepoint for a derived value and a status whose every value is reachable. Both are met here: the probe date routes through the same `trading_calendar` call the launcher uses rather than a second copy of the rule, and the outcome vocabulary regains `ok`. **No delta.**

## Testing

- `tests/test_preflight_sweep.py` — 7 new tests: the probe names the trading day; a real weekend failure is not downgraded when the traded prefix is populated; an uncomputable date is `unmeasured`, never the calendar date; every declared dependency states its rule; a ratified-only gap is `ok` and writes `last_clean.json`; an unacknowledged one is not; the gaps stay named on an `ok` run.
- `tests/test_preflight_sweep_stages.py` — the `date_normalization` validator.
- `_sweep_run_date` now normalizes: a fixture keyed on the raw UTC date missed the probe every weekend — the same passed-for-the-wrong-reason failure as `alpha-engine-config#7390`, one axis over.
- Full `nousergon-data` suite: **6585 passed, 17 skipped**, run locally before push.

## Out of scope, noted

The two suite failures seen on first run were **stale local packages, not repo defects** — `krepis` 0.59.24 against the `0.59.33` pin, and `nousergon-lib` 0.124.83 against the `v0.124.88` pin. Both cleared on installing the pinned versions. Recurrence of the known class; no repo change needed.

## Post-merge

None. No command to run after the merge — the sweep reads these files from its own checkout on the launcher box at 08:00 UTC.

Closes `alpha-engine-config-I8687`, `alpha-engine-config-I8688` (cross-repo: closing keywords are inert here, both are closed by hand after merge verification).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WGhr213PkkuibMMTFEmhs
