### PR TITLE
[P1/mid] fix(freshness-monitor): a declared-off producer renders, never pages; T1 outcome split (I8719, I8686)

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -360,13 +360,18 @@ def load_registry(s3_client: Any, bucket: str, key: str) -> list[ArtifactSpec]:
 def load_registry_with_recovery(
     s3_client: Any, bucket: str, key: str
 ) -> tuple[list[ArtifactSpec], dict[str, dict], dict[str, list[str]],
-           dict[str, bool], dict[str, str], dict[str, str]]:
+           dict[str, bool], dict[str, str], dict[str, str],
+           dict[str, Any]]:
     """Like :func:`load_registry`, but also returns the per-artifact
     ``recovery:`` spec map (config#1240), the
     ``critical_while_champion_arm`` map (config-I3086), the
     ``escalate_to_issue`` map (config#2055 Gap 2), the
-    ``remediation:`` declared-response-lane map (config-I3282), and the
-    ``producer_trigger`` map (config-I6570), all keyed by ``artifact_id``.
+    ``remediation:`` declared-response-lane map (config-I3282), the
+    ``producer_trigger`` map (config-I6570) — all keyed by ``artifact_id`` —
+    and the ``declared_off`` input (config-I8719): the well-formed
+    ``declared_off:`` blocks plus the publisher's ``declared_off_resolution``
+    block, which :func:`resolve_declared_off` turns into a suppression map
+    once ``now`` is known.
 
     ``ArtifactSpec`` is a frozen lib dataclass without a ``recovery``
     field (the monitor's dispatch concern is not the substrate's
@@ -438,8 +443,17 @@ def load_registry_with_recovery(
                     "row on fewer producers than it declares",
                     spec.artifact_id, producer_trigger,
                 )
+    # config-I8719 — the declared-off input. Both halves come from THIS file:
+    # the per-row declarations and the publisher's resolution of their clearing
+    # milestones, so a declaration can never be read against a resolution from
+    # a different publish.
+    declared_off_input = {
+        "rows": parse_declared_off(data),
+        "resolution": data.get("declared_off_resolution"),
+    }
     return (specs, recovery_by_id, critical_arms_by_id,
-            escalate_to_issue_by_id, remediation_by_id, producer_trigger_by_id)
+            escalate_to_issue_by_id, remediation_by_id, producer_trigger_by_id,
+            declared_off_input)
 
 
 # ── Dynamic severity (config-I3086) ─────────────────────────────────────────
@@ -844,6 +858,215 @@ def _save_producer_disabled_since(s3_client: Any, mapping: dict[str, str]) -> No
             "ages from today on the next pass instead of from first observation",
             type(exc).__name__, exc,
         )
+
+
+# ── Declared-off rows (alpha-engine-config-I8719) ───────────────────────────
+#
+# `producer_trigger` above answers "is this artifact's producing SCHEDULE
+# switched off?" by asking live AWS or the GitHub workflow inventory. There is
+# a class it structurally cannot see: a producer switched off INSIDE a pipeline
+# that is itself still enabled.
+#
+# `backtest_pit_parity` is that class. The weekly SF's `SaturdayTrigger` rule
+# is ENABLED and fires every week; what is off is the `PitParityCompare` stage,
+# bypassed by `"skip_parity": true` on the trigger Input (Brian ruling
+# 2026-08-13, re-affirmed 2026-08-26, gated on the `crucible_phase_3`
+# milestone). No AWS object's state answers "does PitParityCompare run?", so
+# there is nothing to probe — and on 2026-08-26T12:00:17Z the row was CRITICAL
+# with `escalation_basis=owning_item_age`, i.e. the escalation fired precisely
+# BECAUSE the deliberate disable was old. The ladder was anti-correlated with
+# the thing it should measure.
+#
+# So this state is DECLARED, in the registry row, never inferred
+# (`observability-policy.md` §8.3: DISABLED, DEPRECATED and RETIRED are the
+# three declared states, and a disposition that exists only as an inference has
+# to be re-derived by hand every time anyone asks).
+#
+# THE SAME THREE PROPERTIES as producer-trigger suppression, and they are why
+# this is a sibling of that mechanism rather than a new one:
+#
+#   1. It FAILS TOWARD PAGING. A malformed block, an absent resolution, an
+#      unknown milestone, a milestone already `reached`, or a resolution older
+#      than DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS all leave the row alerting
+#      exactly as today. Nothing about this path can be made to silence a row
+#      by breaking it.
+#   2. It is NEVER SILENT. A declared-off row still lands in
+#      check_results.json with its true state, `declared_off: true`,
+#      `console_state: "DISABLED"`, the ruling's date, its age in days, the
+#      owning item and the clearing milestone — so the console renders
+#      "declared off, N days" with the ruling attached, never green and never
+#      an omission. `principles.md` §2.7: no data is never green, and neither
+#      is deliberately-off.
+#   3. It EXPIRES BY ITS OWN PREDICATE, and by nothing else. There is
+#      deliberately NO day-count ceiling here, unlike
+#      PRODUCER_SUPPRESSION_MAX_DAYS. A pause nobody owns is a latch and going
+#      loud is the right end state; a declared-off row is the opposite case —
+#      it names its owning item and its clearing milestone up front, and a
+#      calendar expiry would page for a producer that is still deliberately
+#      off. It clears when MILESTONE_REGISTRY.yaml flips the named milestone to
+#      `reached`, which is the same predicate that clears the `gate:milestone`
+#      label on the owning item.
+#
+# WHERE THE MILESTONE COMES FROM. This Lambda holds no GitHub credential and
+# must not acquire one (same argument as GHA_WORKFLOW_STATE_KEY above). The
+# milestone is resolved at PUBLISH time by
+# `alpha-engine-config/scripts/resolve_declared_off.py` and appended to the
+# registry we already read as a top-level `declared_off_resolution` block. So
+# the declaration and its resolved predicate arrive together, in one file, over
+# the transport that already exists.
+#
+# THE STALENESS CEILING is on the RESOLUTION, not on the declaration.
+# `sync-artifact-registry.yml` republishes daily; if it stops — broken,
+# disabled, or switched off by GitHub for repo dormancy
+# (alpha-engine-config-I7370) — `resolved_at` ages past this ceiling inside
+# 36h and every declared-off row pages again. A resolution nothing refreshes is
+# a permanent blindfold, and that is the one failure this mechanism must not
+# introduce.
+DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS = int(
+    os.environ.get("DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS", "36")
+)
+#: Every key a `declared_off:` block must carry to be honoured. A block short
+#: of any of them is DROPPED (the row keeps paging) and logged — matching
+#: `producer_trigger`'s degrade-to-alerting posture, because a suppression
+#: field must never be able to take down a registry load.
+DECLARED_OFF_REQUIRED = ("since", "reason", "owning_item", "clears_when")
+
+
+def parse_declared_off(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Extract well-formed ``declared_off`` blocks from a parsed registry.
+
+    Returns ``{artifact_id: block}``. A malformed block is dropped with a
+    WARNING rather than raising: the field's whole job is to REMOVE a page, so
+    a typo must degrade to today's behaviour, not to a registry that fails to
+    load and takes every row's monitoring with it. The PR-time chokepoint is
+    ``alpha-engine-config/scripts/validate_artifact_registry.py``, which fails
+    loudly on exactly the shapes dropped here.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for entry in data.get("artifacts") or []:
+        if not isinstance(entry, dict):
+            continue
+        block = entry.get("declared_off")
+        if block is None:
+            continue
+        aid = str(entry.get("artifact_id"))
+        if not isinstance(block, dict):
+            logger.warning(
+                "registry row %s carries a declared_off that is not a mapping "
+                "(%s) — row keeps alerting", aid, type(block).__name__,
+            )
+            continue
+        missing = [k for k in DECLARED_OFF_REQUIRED if not block.get(k)]
+        milestone = (block.get("clears_when") or {}).get("milestone") \
+            if isinstance(block.get("clears_when"), dict) else None
+        if missing or not milestone:
+            logger.warning(
+                "registry row %s carries a malformed declared_off "
+                "(missing=%s, milestone=%r) — row keeps alerting. A "
+                "declared-off state without a clearing milestone could never "
+                "lapse, which is worse than the page it would have removed",
+                aid, missing, milestone,
+            )
+            continue
+        out[aid] = dict(block)
+    return out
+
+
+def resolve_declared_off(
+    declared_off_by_id: dict[str, dict[str, Any]],
+    resolution: Any,
+    now: datetime,
+) -> dict[str, dict[str, Any]]:
+    """Decide which declared-off rows are actually suppressed this sweep.
+
+    Returns ``{artifact_id: {...}}`` for EVERY row carrying a well-formed
+    block — including the ones that are NOT suppressed. That is deliberate:
+    the console has to render a declared-off row whose suppression has lapsed
+    differently from one that never declared anything, and dropping the
+    un-suppressed rows here would make those two indistinguishable downstream.
+
+    ``suppressed`` is True only when ALL of the following hold. Every other
+    combination leaves the row on the normal page path:
+
+      * the published registry carries a ``declared_off_resolution`` block;
+      * that block names this artifact;
+      * its ``milestone_status`` is ``pending`` (``reached`` means the ruling
+        has cleared and normal freshness resumes; ``unknown`` means the
+        publisher could not evaluate the predicate at all);
+      * its ``resolved_at`` parses and is within
+        :data:`DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS`.
+    """
+    if not declared_off_by_id:
+        return {}
+    res = resolution if isinstance(resolution, dict) else {}
+    rows = res.get("rows") if isinstance(res.get("rows"), dict) else {}
+    resolved_at_raw = res.get("resolved_at")
+    resolution_age_hours: float | None = None
+    if isinstance(resolved_at_raw, str):
+        try:
+            parsed = datetime.fromisoformat(resolved_at_raw)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            resolution_age_hours = (now - parsed).total_seconds() / 3600.0
+        except ValueError:
+            resolution_age_hours = None
+    resolution_fresh = (
+        resolution_age_hours is not None
+        and resolution_age_hours <= DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS
+    )
+    if declared_off_by_id and not resolution_fresh:
+        logger.warning(
+            "declared-off resolution is ABSENT or STALE (resolved_at=%r, "
+            "age_hours=%s, ceiling=%d) — %d declared-off row(s) keep alerting. "
+            "The publisher is alpha-engine-config's sync-artifact-registry.yml, "
+            "which runs daily; a resolution nothing refreshes is a permanent "
+            "blindfold, so this fails toward paging on purpose",
+            resolved_at_raw, resolution_age_hours,
+            DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS, len(declared_off_by_id),
+        )
+
+    out: dict[str, dict[str, Any]] = {}
+    for aid, block in declared_off_by_id.items():
+        milestone = str((block.get("clears_when") or {}).get("milestone") or "")
+        row = rows.get(aid) if isinstance(rows.get(aid), dict) else {}
+        status = str(row.get("milestone_status") or "unresolved")
+        since = str(block.get("since") or "")
+        try:
+            days = (now.date() - date.fromisoformat(since)).days
+        except ValueError:
+            days = 0
+        suppressed = bool(resolution_fresh and status == "pending")
+        if not suppressed:
+            logger.warning(
+                "declared-off NOT suppressed for %s: milestone=%s status=%s "
+                "resolution_fresh=%s — the row pages exactly as it would "
+                "without the block",
+                aid, milestone, status, resolution_fresh,
+            )
+        else:
+            logger.info(
+                "declared-off (config-I8719): %s — %s (since %s, %d days, "
+                "owning_item=%s, clears when milestone %s is reached); "
+                "console-only, no SNS/Telegram, and NOT eligible for "
+                "owning_item_age escalation",
+                aid, block.get("reason"), since, days,
+                block.get("owning_item"), milestone,
+            )
+        out[aid] = {
+            "suppressed": suppressed,
+            "since": since,
+            "days_declared_off": days,
+            "reason": block.get("reason"),
+            "owning_item": block.get("owning_item"),
+            "clears_when_milestone": milestone,
+            "milestone_status": status,
+            "resolution_age_hours": (
+                round(resolution_age_hours, 2)
+                if resolution_age_hours is not None else None
+            ),
+            "resolution_fresh": resolution_fresh,
+        }
+    return out
 
 
 def _declared_triggers(value: Any) -> tuple[str, ...]:
@@ -1371,6 +1594,7 @@ def _serialize_check_results(
     coerced_ids: set[str] | None = None,
     issue_filed_by_id: dict[str, str | None] | None = None,
     suppression_by_id: dict[str, dict[str, Any]] | None = None,
+    declared_off_by_id: dict[str, dict[str, Any]] | None = None,
     owning_by_id: dict[str, dict[str, Any]] | None = None,
     execution_loop: dict[str, Any] | None = None,
     coverage: dict[str, Any] | None = None,
@@ -1396,10 +1620,12 @@ def _serialize_check_results(
     coerced_ids = coerced_ids or set()
     issue_filed_by_id = issue_filed_by_id or {}
     suppression_by_id = suppression_by_id or {}
+    declared_off_by_id = declared_off_by_id or {}
     owning_by_id = owning_by_id or {}
     rows = []
     for spec, result in pairs:
         suppression = suppression_by_id.get(spec.artifact_id)
+        declared_off = declared_off_by_id.get(spec.artifact_id)
         # §7.4a: the RECORD carries the full owning-item block for every
         # row that had one resolved — including rows whose page was
         # console-only or suppressed. Suppression is a delivery decision,
@@ -1428,7 +1654,55 @@ def _serialize_check_results(
                     suppression["disabled_since"] if suppression else None
                 ),
                 "alert_suppressed": bool(
-                    suppression and suppression["suppressed"]
+                    (suppression and suppression["suppressed"])
+                    or (declared_off and declared_off["suppressed"])
+                ),
+                # config-I8719 — the DECLARED-off half. Deliberately its own
+                # set of fields rather than reusing `producer_disabled`: that
+                # one means "a live probe found the producing trigger
+                # DISABLED", and a declared-off row has no such probe. Two
+                # senses of one word made a check unclearable once already
+                # (config-I8105); these stay distinct.
+                #
+                # `console_state` resolves the row to a member of
+                # observability-policy.md §8.3's closed vocabulary, so the
+                # console renders a declared decision rather than inferring one
+                # from an absent artifact. Only a SUPPRESSED row is DISABLED —
+                # a declared-off row whose resolution went stale or whose
+                # milestone was reached is back under normal freshness, and
+                # saying DISABLED there would be a claim the monitor is no
+                # longer acting on.
+                "declared_off": declared_off is not None,
+                "declared_off_suppressed": bool(
+                    declared_off and declared_off["suppressed"]
+                ),
+                "declared_off_since": (
+                    declared_off["since"] if declared_off else None
+                ),
+                "days_declared_off": (
+                    declared_off["days_declared_off"] if declared_off else None
+                ),
+                "declared_off_reason": (
+                    declared_off["reason"] if declared_off else None
+                ),
+                "declared_off_owning_item": (
+                    declared_off["owning_item"] if declared_off else None
+                ),
+                "declared_off_clears_when_milestone": (
+                    declared_off["clears_when_milestone"]
+                    if declared_off else None
+                ),
+                "declared_off_milestone_status": (
+                    declared_off["milestone_status"] if declared_off else None
+                ),
+                "declared_off_resolution_age_hours": (
+                    declared_off["resolution_age_hours"]
+                    if declared_off else None
+                ),
+                "console_state": (
+                    "DISABLED"
+                    if (declared_off and declared_off["suppressed"])
+                    else None
                 ),
                 # config-I7622 — True: no instance has EVER existed under this
                 # key, so the row is a producer-birth gap and does not page.
@@ -2535,7 +2809,8 @@ def _alert_decision(spec: ArtifactSpec, result: CheckResult, now: datetime,
                     consecutive_miss_runs: int = 0,
                     producer_suppression: dict[str, Any] | None = None,
                     owning: dict[str, Any] | None = None,
-                    never_written: bool | None = None) -> dict[str, Any] | None:
+                    never_written: bool | None = None,
+                    declared_off: dict[str, Any] | None = None) -> dict[str, Any] | None:
     """Decide whether this probe result belongs on the operator page, and
     return the decision. Returns ``None`` when it does not.
 
@@ -2565,6 +2840,35 @@ def _alert_decision(spec: ArtifactSpec, result: CheckResult, now: datetime,
     how many 15min probes have already fired in this window.
     """
     if result.state not in _ALERTING_STATES:
+        return None
+
+    # config-I8719 — the producer is off BY A RECORDED RULING that no live
+    # probe can observe (a bypassed stage inside a still-enabled pipeline).
+    #
+    # Placed FIRST, above every other gate including the config-I3086 warning
+    # ladder and the §7.4a `owning_item_age` basis, and that position is the
+    # whole fix: `owning_item_age` promotes a warning row once its owning item
+    # is old enough, and a declared-off row's owning item is old PRECISELY
+    # BECAUSE the producer is deliberately off. The escalation got louder the
+    # longer the declared state held — anti-correlated with the thing it exists
+    # to measure. Returning here means an `owning_item_age` promotion is
+    # structurally unreachable for a declared-off row, rather than suppressed
+    # after the fact somewhere further down.
+    #
+    # This removes a PAGE, never a fact: the row still reaches
+    # check_results.json with its true state, `declared_off: true`,
+    # `console_state: "DISABLED"` and its age in days (see
+    # `_serialize_check_results`).
+    if declared_off and declared_off.get("suppressed"):
+        logger.info(
+            "declared-off (config-I8719): %s state=%s — %s (declared off %s, "
+            "%d days; owning_item=%s; clears when milestone %s is reached); "
+            "console-only, no SNS/Telegram, no escalation",
+            spec.artifact_id, result.state, declared_off.get("reason"),
+            declared_off.get("since"), declared_off.get("days_declared_off"),
+            declared_off.get("owning_item"),
+            declared_off.get("clears_when_milestone"),
+        )
         return None
 
     # config-I6570 — the producing trigger is live-confirmed DISABLED, so this
@@ -2707,7 +3011,8 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
                  consecutive_miss_runs: int = 0,
                  producer_suppression: dict[str, Any] | None = None,
                  owning: dict[str, Any] | None = None,
-                 never_written: bool | None = None) -> bool:
+                 never_written: bool | None = None,
+                 declared_off: dict[str, Any] | None = None) -> bool:
     """Whether this row belongs on the sweep's page.
 
     Retained as the boolean face of :func:`_alert_decision` — it is the gate
@@ -2722,6 +3027,7 @@ def _maybe_alert(spec: ArtifactSpec, result: CheckResult, now: datetime,
         producer_suppression=producer_suppression,
         owning=owning,
         never_written=never_written,
+        declared_off=declared_off,
     ) is not None
 
 
@@ -3437,7 +3743,7 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
     )
 
     (specs, recovery_by_id, critical_arms_by_id, _escalate_to_issue_by_id,
-     remediation_by_id, producer_trigger_by_id) = (
+     remediation_by_id, producer_trigger_by_id, declared_off_input) = (
         load_registry_with_recovery(s3_client, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     specs, _coerced = apply_dynamic_severity(s3_client, specs, critical_arms_by_id)
@@ -3458,12 +3764,25 @@ def _handle_intraday(s3_client: Any, now: datetime, started_at: float) -> dict:
     suppression_by_id = apply_producer_suppression(
         s3_client, intraday_triggers, now
     )
+    # config-I8719 — restricted to the intraday rows for the same reason the
+    # trigger suppression is: this path runs every 30min and must not do work
+    # for rows it will not probe. No AWS call either way — the declaration and
+    # its resolution both came from the registry object already read.
+    declared_off_by_id = {
+        aid: v for aid, v in resolve_declared_off(
+            declared_off_input.get("rows") or {},
+            declared_off_input.get("resolution"),
+            now,
+        ).items()
+        if aid in INTRADAY_ARTIFACT_IDS
+    }
 
     (pairs, alerted, dispatched, per_spec_exceptions, _miss_counts,
      _telemetry) = _run_probe_pass(
         s3_client, intraday_specs, recovery_by_id, now,
         remediation_by_id=remediation_by_id,
         suppression_by_id=suppression_by_id,
+        declared_off_by_id=declared_off_by_id,
     )
 
     duration_seconds = round(time.time() - started_at, 2)
@@ -3495,6 +3814,7 @@ def _run_probe_pass(
     prev_miss_counts: dict[str, int] | None = None,
     remediation_by_id: dict[str, str] | None = None,
     suppression_by_id: dict[str, dict[str, Any]] | None = None,
+    declared_off_by_id: dict[str, dict[str, Any]] | None = None,
     prev_issue_filed: dict[str, str] | None = None,
 ) -> tuple[
     list[tuple[ArtifactSpec, CheckResult]], int, int, int, dict[str, int],
@@ -3622,8 +3942,16 @@ def _run_probe_pass(
         # its true state; what it loses is an owning-item block on a page it was
         # never going to appear on.
         _suppressed = (suppression_by_id or {}).get(spec.artifact_id)
+        # config-I8719 — a declared-off row is the third shape that cannot
+        # page, and it is exactly `_alert_decision`'s first early return, so
+        # skipping the lookup for it cannot change any verdict. Including it
+        # here is not an optimisation: on 2026-08-19 the 24-query cap was spent
+        # on rows that could not page and the ONE row that DID page carried
+        # `lookup_budget_exhausted` onto Brian's Telegram.
+        _declared_off = (declared_off_by_id or {}).get(spec.artifact_id)
         _cannot_page = (
             (_suppressed and _suppressed.get("suppressed"))
+            or (_declared_off and _declared_off.get("suppressed"))
             or never_written_by_id.get(spec.artifact_id) is True
             or suppress_page
         )
@@ -3658,6 +3986,7 @@ def _run_probe_pass(
                     spec.artifact_id),
                 owning=owning,
                 never_written=never_written,
+                declared_off=(declared_off_by_id or {}).get(spec.artifact_id),
             )
         paged = decision is not None
         if paged:
@@ -3766,7 +4095,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     # Load registry. If THIS fails, we want the Lambda to error out
     # so the CW alarm fires — a broken registry must not be silent.
     (specs, recovery_by_id, critical_arms_by_id, escalate_to_issue_by_id,
-     remediation_by_id, producer_trigger_by_id) = (
+     remediation_by_id, producer_trigger_by_id, declared_off_input) = (
         load_registry_with_recovery(s3, REGISTRY_BUCKET, REGISTRY_KEY)
     )
     logger.info(
@@ -3784,6 +4113,28 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     prev_miss_counts = _load_prev_miss_counts(s3)
     # config-I6570: which producers are deliberately switched off right now.
     suppression_by_id = apply_producer_suppression(s3, producer_trigger_by_id, now)
+    # config-I8719 — the declared-off half. No AWS call: both the declarations
+    # and the publisher's resolution of their clearing milestones came from the
+    # registry object already read above.
+    declared_off_by_id = resolve_declared_off(
+        declared_off_input.get("rows") or {},
+        declared_off_input.get("resolution"),
+        now,
+    )
+    # Emit zero rather than nothing. A sweep with no declared-off rows says so,
+    # and a sweep whose declared-off rows are NOT suppressed says that too —
+    # otherwise "the mechanism found nothing" and "the mechanism did not run"
+    # are the same silence (observability-policy.md §3.1).
+    logger.info(
+        "declared-off rows: %d declared, %d suppressed this sweep (%s)",
+        len(declared_off_by_id),
+        len([v for v in declared_off_by_id.values() if v["suppressed"]]),
+        ", ".join(
+            f"{a}={'suppressed' if v['suppressed'] else 'PAGING'}"
+            f"/milestone={v['clears_when_milestone']}:{v['milestone_status']}"
+            for a, v in sorted(declared_off_by_id.items())
+        ) or "none",
+    )
     if suppression_by_id:
         logger.info(
             "producer-trigger suppression active for %d artifact(s): %s",
@@ -3815,6 +4166,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         s3, specs, recovery_by_id, now, prev_miss_counts,
         remediation_by_id=remediation_by_id,
         suppression_by_id=suppression_by_id,
+        declared_off_by_id=declared_off_by_id,
         prev_issue_filed=prev_issue_filed,
     )
     owning_by_id = pass_telemetry["owning_by_id"]
@@ -3868,6 +4220,7 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         pairs, now, miss_counts=miss_counts, coerced_ids=coerced_ids,
         issue_filed_by_id=issue_filed_by_id,
         suppression_by_id=suppression_by_id,
+        declared_off_by_id=declared_off_by_id,
         owning_by_id=owning_by_id,
         execution_loop=execution_loop,
         coverage=coverage,

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -1812,7 +1812,7 @@ def test_load_registry_with_recovery_parses_block(monkeypatch, fake_s3):
     artifact_id; artifacts without a block are absent from the map."""
     fake_s3._registry_body = _RECOVERY_REGISTRY
     import index
-    specs, recovery, critical_arms, _esc, _rem, _pt = index.load_registry_with_recovery(
+    specs, recovery, critical_arms, _esc, _rem, _pt, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert len(specs) == 2
     assert set(recovery) == {"closes_recoverable"}
@@ -1867,7 +1867,7 @@ def _keyed_get_object(fake_s3, extra: dict[str, bytes]) -> None:
 def test_load_registry_parses_critical_while_champion_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    _specs, _recovery, critical_arms, _esc, _rem, _pt = index.load_registry_with_recovery(
+    _specs, _recovery, critical_arms, _esc, _rem, _pt, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert critical_arms == {"champion_feed": ["scanner_predictor_direct"]}
 
@@ -1875,7 +1875,7 @@ def test_load_registry_parses_critical_while_champion_arm(fake_s3):
 def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt, _do = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY:
             b'{"schema_version": 1, "champion": "scanner_predictor_direct"}',
@@ -1891,7 +1891,7 @@ def test_dynamic_severity_coerces_when_champion_arm_matches(fake_s3):
 def test_dynamic_severity_not_coerced_for_other_arm(fake_s3):
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt, _do = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {
         index.CHAMPION_POINTER_KEY: b'{"schema_version": 1, "champion": "think_tank"}',
     })
@@ -1906,7 +1906,7 @@ def test_dynamic_severity_pointer_read_failure_fails_toward_critical(fake_s3):
     fail toward paging, never toward silence."""
     fake_s3._registry_body = _CHAMPION_ARM_REGISTRY
     import index
-    specs, _r, arms, _esc, _rem, _pt = index.load_registry_with_recovery(fake_s3, "b", "k")
+    specs, _r, arms, _esc, _rem, _pt, _do = index.load_registry_with_recovery(fake_s3, "b", "k")
     _keyed_get_object(fake_s3, {index.CHAMPION_POINTER_KEY: None})
     coerced_specs, coerced_ids = index.apply_dynamic_severity(
         fake_s3, specs, arms)
@@ -2054,7 +2054,7 @@ artifacts:
     created_at: 2025-01-01
 """
     import index
-    _specs, _recovery, _arms, escalate, _rem, _pt = index.load_registry_with_recovery(
+    _specs, _recovery, _arms, escalate, _rem, _pt, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k")
     assert escalate == {"config_scoring_weights": True}
 
@@ -2397,7 +2397,7 @@ def test_load_registry_parses_remediation_map(monkeypatch, fake_s3):
     undeclared rows are simply absent."""
     import index
     fake_s3._registry_body = _DRAIN_REGISTRY
-    _s, _r, _a, _e, remediation, _pt = index.load_registry_with_recovery(
+    _s, _r, _a, _e, remediation, _pt, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k"
     )
     assert remediation == {
@@ -2595,7 +2595,7 @@ def test_loader_parses_producer_trigger_and_drops_malformed(fake_s3):
     today's alerting behaviour instead of taking the registry down."""
     import index
     fake_s3._registry_body = _PRODUCER_REGISTRY
-    specs, _r, _a, _e, _rem, producer = index.load_registry_with_recovery(
+    specs, _r, _a, _e, _rem, producer, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k"
     )
     assert {s.artifact_id for s in specs} == {
@@ -3875,7 +3875,7 @@ def test_partially_malformed_trigger_list_is_dropped_whole(fake_s3, caplog):
         b"      - scheduler:good\n"
         b"      - not-a-trigger\n"
     )
-    _s, _r, _a, _e, _rem, producer = index.load_registry_with_recovery(
+    _s, _r, _a, _e, _rem, producer, _do = index.load_registry_with_recovery(
         fake_s3, "b", "k"
     )
     assert producer == {}
@@ -4623,3 +4623,338 @@ def test_an_unsuppressed_paging_row_still_gets_its_lookup(
     spent = _lookup_calls(index, monkeypatch)
     index.handler({}, None)
     assert "probe_missing" in spent
+
+
+# ── Declared-off rows (alpha-engine-config-I8719) ───────────────────────────
+#
+# `backtest_pit_parity` CRITICAL-escalated every sweep for a stage that is off
+# by ruling, with `escalation_basis=owning_item_age` — the escalation fired
+# BECAUSE the deliberate disable was old. These pin the fix and, more
+# importantly, pin that the mechanism fails toward PAGING in every direction.
+
+_DO_BLOCK = {
+    "since": "2026-05-13",
+    "reason": "PitParityCompare is bypassed on every automatic weekly-SF "
+              "launch path by skip_parity. Brian ruling 2026-05-13.",
+    "owning_item": "alpha-engine-config-I7309",
+    "clears_when": {"milestone": "crucible_phase_3"},
+}
+
+
+def _resolution(index, now, *, status="pending", age_hours=1.0, artifact="champion_feed"):
+    resolved = (now - timedelta(hours=age_hours)).isoformat()
+    return {
+        "resolved_at": resolved,
+        "row_count": 1,
+        "rows": {artifact: {
+            "milestone": "crucible_phase_3",
+            "milestone_status": status,
+            "suppresses": status == "pending",
+        }},
+    }
+
+
+def _fresh_index(monkeypatch):
+    monkeypatch.setenv("FRESHNESS_MONITOR_ENABLED", "true")
+    import importlib
+    import index
+    importlib.reload(index)
+    return index
+
+
+# ── parse_declared_off ──────────────────────────────────────────────────────
+
+
+def test_parse_declared_off_keeps_a_well_formed_block(monkeypatch):
+    index = _fresh_index(monkeypatch)
+    out = index.parse_declared_off(
+        {"artifacts": [{"artifact_id": "a", "declared_off": dict(_DO_BLOCK)}]}
+    )
+    assert out["a"]["owning_item"] == "alpha-engine-config-I7309"
+
+
+@pytest.mark.parametrize("mutate", [
+    lambda b: b.pop("since"),
+    lambda b: b.pop("reason"),
+    lambda b: b.pop("owning_item"),
+    lambda b: b.pop("clears_when"),
+    lambda b: b.__setitem__("clears_when", {"date": "2026-09-30"}),
+    lambda b: b.__setitem__("clears_when", "crucible_phase_3"),
+])
+def test_a_malformed_declared_off_block_is_dropped_and_the_row_keeps_paging(
+        monkeypatch, mutate):
+    """Degrades to today's alerting, never to a registry that fails to load —
+    a suppression field must not be able to take every row's monitoring down
+    with it. The loud half is the PR-time validator in alpha-engine-config."""
+    index = _fresh_index(monkeypatch)
+    block = dict(_DO_BLOCK)
+    mutate(block)
+    out = index.parse_declared_off(
+        {"artifacts": [{"artifact_id": "a", "declared_off": block}]}
+    )
+    assert out == {}
+
+
+def test_a_non_mapping_declared_off_is_dropped(monkeypatch):
+    index = _fresh_index(monkeypatch)
+    assert index.parse_declared_off(
+        {"artifacts": [{"artifact_id": "a", "declared_off": "off"}]}
+    ) == {}
+
+
+# ── resolve_declared_off ────────────────────────────────────────────────────
+
+
+def test_a_pending_milestone_with_a_fresh_resolution_suppresses(
+        monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now),
+        fixed_now,
+    )
+    assert out["champion_feed"]["suppressed"] is True
+    assert out["champion_feed"]["days_declared_off"] == 17
+    assert out["champion_feed"]["clears_when_milestone"] == "crucible_phase_3"
+
+
+def test_a_reached_milestone_does_not_suppress(monkeypatch, fixed_now):
+    """The designed clearing path: normal freshness resumes the moment the
+    milestone flips, with no second manual step and no separate expiry."""
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, status="reached"),
+        fixed_now,
+    )
+    assert out["champion_feed"]["suppressed"] is False
+    assert out["champion_feed"]["milestone_status"] == "reached"
+
+
+def test_an_absent_resolution_does_not_suppress(monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)}, None, fixed_now)
+    assert out["champion_feed"]["suppressed"] is False
+
+
+def test_a_resolution_for_a_different_artifact_does_not_suppress_this_one(
+        monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, artifact="some_other_row"),
+        fixed_now,
+    )
+    assert out["champion_feed"]["suppressed"] is False
+
+
+def test_a_stale_resolution_does_not_suppress(monkeypatch, fixed_now):
+    """The one failure this must not introduce is a resolution nothing
+    refreshes becoming a permanent blindfold. Past the ceiling, the row pages
+    and the page reads as 'this has been off for N days', which is the
+    decision the operator actually owes."""
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now,
+                    age_hours=index.DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS + 1),
+        fixed_now,
+    )
+    assert out["champion_feed"]["suppressed"] is False
+    assert out["champion_feed"]["resolution_fresh"] is False
+
+
+def test_a_resolution_exactly_at_the_ceiling_still_suppresses(
+        monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now,
+                    age_hours=index.DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS),
+        fixed_now,
+    )
+    assert out["champion_feed"]["suppressed"] is True
+
+
+def test_an_unparseable_resolved_at_does_not_suppress(monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    res = _resolution(index, fixed_now)
+    res["resolved_at"] = "not-a-timestamp"
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)}, res, fixed_now)
+    assert out["champion_feed"]["suppressed"] is False
+
+
+def test_an_unsuppressed_declared_off_row_is_still_returned(
+        monkeypatch, fixed_now):
+    """Dropping it would make 'declared off, suppression lapsed' and 'never
+    declared anything' indistinguishable to every consumer downstream."""
+    index = _fresh_index(monkeypatch)
+    out = index.resolve_declared_off(
+        {"champion_feed": dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, status="reached"),
+        fixed_now,
+    )
+    assert "champion_feed" in out
+
+
+def test_no_declared_off_rows_resolves_to_an_empty_map(monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    assert index.resolve_declared_off({}, None, fixed_now) == {}
+
+
+# ── the escalation half: owning_item_age must not promote a declared-off row ─
+
+
+def test_owning_item_age_does_not_promote_a_declared_off_row(
+        monkeypatch, fixed_now):
+    """The defect in one test. `owning_item_age` escalates a warning row once
+    its owning item is old enough — and a declared-off row's owning item is
+    old PRECISELY BECAUSE the producer is deliberately off. Same inputs as
+    `test_owning_item_age_drives_escalation_not_the_miss_count`, which pages
+    CRITICAL; the only difference is the declaration."""
+    index = _fresh_index(monkeypatch)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    spec, result = _warning_spec_and_missing_result(index)
+
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, artifact=spec.artifact_id),
+        fixed_now,
+    )[spec.artifact_id]
+
+    assert _page(index, spec, result, fixed_now, consecutive_miss_runs=3,
+                 owning=_owning(age_days=90.0, sla_days=3),
+                 declared_off=declared) is False
+    publish_mock.assert_not_called()
+
+
+def test_the_same_row_pages_when_its_declaration_is_not_suppressing(
+        monkeypatch, fixed_now):
+    """The control. Nothing about the escalation path was weakened — a row
+    whose declared-off state has lapsed escalates exactly as before."""
+    index = _fresh_index(monkeypatch)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    spec, result = _warning_spec_and_missing_result(index)
+
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, status="reached", artifact=spec.artifact_id),
+        fixed_now,
+    )[spec.artifact_id]
+
+    assert _page(index, spec, result, fixed_now, consecutive_miss_runs=3,
+                 owning=_owning(age_days=90.0, sla_days=3),
+                 declared_off=declared) is True
+    assert publish_mock.call_args.kwargs["severity"] == "critical"
+
+
+def test_the_miss_count_ladder_also_cannot_escalate_a_declared_off_row(
+        monkeypatch, fixed_now):
+    index = _fresh_index(monkeypatch)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    monkeypatch.setattr(index, "notify_via_flow_doctor", mock.Mock(return_value=True))
+    spec, result = _warning_spec_and_missing_result(index)
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, artifact=spec.artifact_id),
+        fixed_now,
+    )[spec.artifact_id]
+    assert _page(index, spec, result, fixed_now, consecutive_miss_runs=99,
+                 declared_off=declared) is False
+    publish_mock.assert_not_called()
+
+
+def test_a_probe_failure_on_a_declared_off_row_still_does_not_page(
+        monkeypatch, fixed_now):
+    """Deliberate. A probe failure means the MONITOR is broken, but a
+    declared-off row is one whose artifact is not expected to exist, so a
+    failed probe over it carries no information about the producer. It still
+    reaches check_results.json with state=probe_failed."""
+    from nousergon_lib.artifact_freshness import CheckResult
+    index = _fresh_index(monkeypatch)
+    publish_mock = mock.Mock(return_value=mock.Mock(dedup_skipped=False))
+    monkeypatch.setattr(index, "publish", publish_mock)
+    spec, _ = _warning_spec_and_missing_result(index)
+    result = CheckResult(state="probe_failed", reason="denied",
+                         canonical_key=spec.s3_key_template,
+                         sla_violated_by_minutes=0)
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, artifact=spec.artifact_id),
+        fixed_now,
+    )[spec.artifact_id]
+    assert _page(index, spec, result, fixed_now, declared_off=declared) is False
+
+
+# ── the console half: never silent ──────────────────────────────────────────
+
+
+def test_a_declared_off_row_renders_with_its_true_state_and_its_age(
+        monkeypatch, fixed_now):
+    """Removes a PAGE, never a FACT. observability-policy.md §8.3: DISABLED is
+    declared, and a declared state renders with its reason, its owner and its
+    age — never green and never an omission."""
+    index = _fresh_index(monkeypatch)
+    spec, result = _warning_spec_and_missing_result(index)
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, artifact=spec.artifact_id),
+        fixed_now,
+    )
+    payload = index._serialize_check_results(
+        [(spec, result)], fixed_now, declared_off_by_id=declared)
+    row = payload["results"][0]
+    assert row["state"] == "missing"          # true state, unchanged
+    assert row["declared_off"] is True
+    assert row["declared_off_suppressed"] is True
+    assert row["console_state"] == "DISABLED"
+    assert row["days_declared_off"] == 17
+    assert row["declared_off_owning_item"] == "alpha-engine-config-I7309"
+    assert row["declared_off_clears_when_milestone"] == "crucible_phase_3"
+    assert row["declared_off_milestone_status"] == "pending"
+    assert row["alert_suppressed"] is True
+    # Distinct from producer-trigger suppression: no live probe found a
+    # disabled trigger, and conflating the two senses is how a check became
+    # unclearable once already.
+    assert row["producer_disabled"] is False
+    assert row["producer_trigger"] is None
+
+
+def test_a_lapsed_declared_off_row_is_not_rendered_DISABLED(
+        monkeypatch, fixed_now):
+    """`console_state` is a claim the monitor is currently acting on. A row
+    that is paging must not simultaneously render as deliberately off."""
+    index = _fresh_index(monkeypatch)
+    spec, result = _warning_spec_and_missing_result(index)
+    declared = index.resolve_declared_off(
+        {spec.artifact_id: dict(_DO_BLOCK)},
+        _resolution(index, fixed_now, status="reached", artifact=spec.artifact_id),
+        fixed_now,
+    )
+    row = index._serialize_check_results(
+        [(spec, result)], fixed_now, declared_off_by_id=declared)["results"][0]
+    assert row["declared_off"] is True          # the declaration still shows
+    assert row["declared_off_suppressed"] is False
+    assert row["console_state"] is None
+    assert row["alert_suppressed"] is False
+
+
+def test_a_row_with_no_declaration_carries_the_fields_as_false_and_none(
+        monkeypatch, fixed_now):
+    """Emit zero rather than nothing — an absent field and a false one are
+    not the same claim to a console."""
+    index = _fresh_index(monkeypatch)
+    spec, result = _warning_spec_and_missing_result(index)
+    row = index._serialize_check_results(
+        [(spec, result)], fixed_now)["results"][0]
+    assert row["declared_off"] is False
+    assert row["declared_off_suppressed"] is False
+    assert row["days_declared_off"] is None
+    assert row["console_state"] is None

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -138,6 +138,10 @@
       "items": {
         "type": "object",
         "required": ["name", "description", "authorized_by", "added", "match", "remediation_steps", "success_predicate", "rollback", "max_consecutive_failures"],
+        "dependentRequired": {
+          "reauthorized_at": ["reauthorized_by"],
+          "reauthorized_by": ["reauthorized_at"]
+        },
         "additionalProperties": false,
         "properties": {
           "name": {
@@ -227,7 +231,17 @@
             "minimum": 1,
             "maximum": 10,
             "default": 2,
-            "description": "Number of consecutive predicate failures before automatic demotion to T2 + finding filed (overseer-policy.md §6)."
+            "description": "Number of consecutive FAILED outcomes before automatic demotion to T2 + finding filed (overseer-policy.md §6). config-I8686 (Brian ruling 2026-08-26): a run resolves to exactly one of verified / declined / failed, and ONLY `failed` — the automation could not EVALUATE its predicate (crash, timeout, unreadable input, malformed payload) — increments this counter. `declined` (the predicate was evaluated and is not satisfied) is the automation giving the CORRECT answer and is silent on the counter in both directions. Collapsing the two demotes an automation precisely when the fleet is broken, which is when its coverage is worth most."
+          },
+          "reauthorized_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "config-I8686 — the date this automation was re-authorized after a demotion. The drain voids any demotion recorded in the carryover ledger with `demoted_at` earlier than this date, resetting the counter. Re-authorization is therefore a reviewed, merged registry diff rather than a hand-edit of ledger state in S3, which is what §6's 'a reviewed issue authorizing it' actually requires. Requires `reauthorized_by`."
+          },
+          "reauthorized_by": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+-I[0-9]+$",
+            "description": "config-I8686 — the reviewed issue carrying the re-authorization ruling. Required whenever `reauthorized_at` is set."
           },
           "triggers": { "$ref": "#/$defs/triggers" }
         }

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1359,11 +1359,38 @@ alert_classes:
 # deterministic remediation with a machine-checkable success predicate, a
 # rollback path, and a reviewed issue authorizing it (listed in authorized_by).
 #
-# Demotion is automatic: ≥max_consecutive_failures consecutive predicate
-# failures → entry disabled (state=demoted) + finding filed. Consecutive-
-# failure count resets on any successful execution. Runtime state is tracked
-# in the drain carryover ledger (DRAIN_STATE_KEY t1_runtime block), NOT here
-# — this file is the static registry; the drain agent reads both.
+# Demotion is automatic: ≥max_consecutive_failures consecutive FAILED outcomes
+# → entry disabled (state=demoted) + finding filed. Consecutive-failure count
+# resets on any successful execution. Runtime state is tracked in the drain
+# carryover ledger (DRAIN_STATE_KEY t1_runtime block), NOT here — this file is
+# the static registry; the drain agent reads both.
+#
+# THREE OUTCOMES, ONE COUNTER (alpha-engine-config-I8686, Brian ruling
+# 2026-08-26). A run resolves to exactly one of:
+#
+#   verified  predicate evaluated and SATISFIED — condition auto-resolved
+#   declined  predicate evaluated and NOT satisfied — the automation gave the
+#             CORRECT answer to the question it was asked
+#   failed    the automation could not EVALUATE its predicate — crash, timeout,
+#             unreadable input, malformed payload, a step it could not complete
+#
+# Only `failed` increments max_consecutive_failures. The distinction is
+# EVALUABILITY, not the answer. `declined` and `failed` used to be collapsed,
+# and on 2026-08-26 `freshness-critical-auto-verify` was demoted after two runs
+# in which it worked perfectly: `trades/open_orders/latest.json` read
+# 2026-08-25T20:00:04Z at both the 12:01 and 14:30 runs because the executor
+# daemon was down (alpha-engine-config-I8682). The automation checked freshness,
+# found the artifact genuinely stale, and declined. Counting that as a failure
+# demotes the automation precisely when the fleet is broken — the moment its
+# coverage is worth most — and keeps it demoted through the outage that
+# triggered it. §6's ladder is right; what fed it was wrong.
+#
+# RE-AUTHORIZATION IS A REGISTRY EDIT. An entry may carry `reauthorized_at`
+# (with `reauthorized_by`); the drain voids any ledger demotion whose
+# `demoted_at` precedes that date and resets the counter. That makes §6's
+# "a reviewed issue authorizing it" the actual mechanism — a merged diff —
+# rather than an operator hand-editing JSON in S3 where nothing records who
+# did it or why.
 #
 # Schema: playbooks.schema.json §t1_automations (additive-only evolution —
 # new OPTIONAL fields are fine; renames/removals require a schema_version bump).
@@ -1383,6 +1410,10 @@ t1_automations:
       compare last-modified to the alert's SLA floor. If fresher, the producer
       ran between alert and drain — the incident is T0-resolved with zero
       diagnosis. This is the T2 agent's own first step, made deterministic.
+      A row carrying `declared_off:` in ARTIFACT_REGISTRY.yaml
+      (alpha-engine-config-I8719) emits no freshness CRITICAL at all and so
+      never enters this population — the exclusion is enforced at the
+      freshness monitor, not here, so there is one contract and not two.
     authorized_by: alpha-engine-config-I4483
     added: "2026-07-28"
     match:
@@ -1402,13 +1433,24 @@ t1_automations:
     remediation_steps:
       - "Read the artifact's `s3_key_template` from `alpha-engine-config/private-docs/ARTIFACT_REGISTRY.yaml` (trust the registry template, not the alert's spelling — some surfaces render `_` as `-`)."
       - "Run `aws s3 ls <artifact_key>` to get the last-modified timestamp."
-      - "Compare to the alert's SLA floor (the staleness threshold). If last-modified ≥ SLA floor, the incident is T0-resolved: record it with disposition `t1-resolved` and note the observed freshness timestamp. If still stale, the T1 automation declines — fall through to T2 diagnosis."
+      - "Compare to the alert's SLA floor (the staleness threshold). If last-modified >= SLA floor, the outcome is `verified`: record the incident with disposition `t1-resolved` and the observed freshness timestamp, and RESET consecutive_failures."
+      - "If still stale, the outcome is `declined` — NOT `failed`. The predicate was evaluated and answered correctly. Do not increment consecutive_failures (config-I8686)."
+      - "On `declined`, DECLARE the incident rather than only returning 'not fresh': record the artifact_id, its s3_key_template, the measured last-modified, the SLA floor it missed, the declared producer from ARTIFACT_REGISTRY.yaml (`produced_by`, or `producer_trigger` where the row carries one), and the owning item where the row or the alert names one. Walk the producer, not the artifact. Then fall through to T2."
+      - "The outcome is `failed` ONLY when the predicate could not be EVALUATED: the registry is unreadable, `aws s3 ls` errors rather than returning empty, the alert carries no resolvable SLA floor, or a step could not be completed at all. Increment consecutive_failures on this and on nothing else."
     success_predicate:
-      description: "Artifact last-modified timestamp is ≥ the alert's SLA floor"
-      check: "aws s3 ls <artifact_key> returns a timestamp ≥ SLA floor"
+      description: "Artifact last-modified timestamp is >= the alert's SLA floor. Evaluating this and getting `no` is a `declined` outcome, not a failure; only being unable to evaluate it at all is `failed` (config-I8686)."
+      check: "aws s3 ls <artifact_key> returns a timestamp >= SLA floor"
     rollback:
       description: "Read-only verification — no state to roll back. If the predicate check was wrong (artifact actually stale), the incident falls through to T2 and is properly diagnosed."
     max_consecutive_failures: 2
+    # config-I8686 — Brian ruled Option A (fix, then re-authorize) on
+    # 2026-08-26. The fix is the outcome split above plus the decline-declares
+    # step; this date is the re-authorization, and it lands in the SAME merge as
+    # the fix it is conditional on. The drain voids the 2026-08-26 demotion
+    # (whose two recorded "failures" were both correct declines) and re-enters
+    # the automation at consecutive_failures: 0 rather than at 2/2.
+    reauthorized_at: "2026-08-26"
+    reauthorized_by: alpha-engine-config-I8686
 
   # Second seed — groom lifecycle ONLINE notices ride the bus at info severity
   # with a dedup_key that is deterministic (mode + filter + model). They are

--- a/tests/test_overseer_playbook_registry.py
+++ b/tests/test_overseer_playbook_registry.py
@@ -528,3 +528,63 @@ def test_every_registry_bundling_lambda_redeploys_on_registry_change():
     assert checked >= 2, (
         f"expected >=2 registry-bundling lambdas (router + liveness probe), found {checked}"
     )
+
+
+# ── T1 outcome split + re-authorization (alpha-engine-config-I8686) ──────────
+
+
+def _t1(name):
+    return next(e for e in REGISTRY["t1_automations"] if e["name"] == name)
+
+
+def test_the_auto_verify_entry_distinguishes_declined_from_failed():
+    """Brian ruling 2026-08-26: a correct DECLINE is an outcome, not a
+    predicate failure. The steps are the executable spec for a
+    non-deterministic runner, so the distinction has to be IN them."""
+    steps = " ".join(_t1("freshness-critical-auto-verify")["remediation_steps"])
+    assert "`declined` — NOT `failed`" in steps
+    assert "Do not increment consecutive_failures" in steps
+    assert "could not be EVALUATED" in steps
+
+
+def test_a_decline_declares_the_incident():
+    """The half that turns a decline into work. Without it the T1 lane earns
+    its keep only on the resolved path, and the full-agent cost the demotion
+    notice names is never removed."""
+    steps = " ".join(_t1("freshness-critical-auto-verify")["remediation_steps"])
+    assert "DECLARE the incident" in steps
+    for fact in ("artifact_id", "last-modified", "SLA floor",
+                 "produced_by", "owning item"):
+        assert fact in steps, fact
+
+
+def test_the_auto_verify_entry_is_reauthorized_by_the_ruling_issue():
+    """Re-authorization is a merged registry diff, never a hand-edit of the
+    carryover ledger in S3 — that is what makes overseer-policy.md §6's
+    'a reviewed issue authorizing it' an actual mechanism."""
+    entry = _t1("freshness-critical-auto-verify")
+    assert entry["reauthorized_at"] == "2026-08-26"
+    assert entry["reauthorized_by"] == "alpha-engine-config-I8686"
+
+
+def test_reauthorized_at_and_reauthorized_by_are_required_together():
+    """A date with no authorizing issue would re-arm an automation with no
+    record of who decided to."""
+    dep = SCHEMA["properties"]["t1_automations"]["items"]["dependentRequired"]
+    assert dep["reauthorized_at"] == ["reauthorized_by"]
+    assert dep["reauthorized_by"] == ["reauthorized_at"]
+
+
+def test_max_consecutive_failures_is_documented_as_failed_only():
+    desc = (SCHEMA["properties"]["t1_automations"]["items"]
+            ["properties"]["max_consecutive_failures"]["description"])
+    assert "ONLY `failed`" in desc
+    assert "declined" in desc
+
+
+def test_the_auto_verify_entry_excludes_declared_off_rows():
+    """The coupling with alpha-engine-config-I8719, stated where the
+    population is defined — one contract, enforced at the producer."""
+    desc = _t1("freshness-critical-auto-verify")["description"]
+    assert "declared_off" in desc
+    assert "alpha-engine-config-I8719" in desc


### PR DESCRIPTION
The code half of one contract. Config half: `alpha-engine-config-PR8726`.

## I8719 — `owning_item_age` promoted a row BECAUSE the disable was old

Measured at sweep `2026-08-26T12:00:17Z`: `backtest_pit_parity` CRITICAL, `escalation_basis=owning_item_age`, `after_consecutive_miss_runs=3`, on a row whose declared `severity` is `warning`. §7.4a's basis escalates a warning row once its owning item is old enough — and a declared-off row's owning item is old **precisely because** the producer is deliberately off. The ladder was anti-correlated with the thing it exists to measure.

`producer_trigger` (config-I6570) structurally cannot see this class: the weekly SF's `SaturdayTrigger` rule is **ENABLED** and fires every week; what is off is the `PitParityCompare` stage, bypassed by `"skip_parity": true` on the trigger Input (`infrastructure/cloudformation/alpha-engine-orchestration.yaml`, Brian ruling 2026-08-13, re-affirmed 2026-08-26). No AWS object's state answers "does that stage run?", so the state is **declared** in the registry row — `observability-policy.md` §8.3: `DISABLED` is declared, never inferred.

### Where the fix sits, and why there

`_alert_decision` returns on a suppressed declared-off row **first**, above the config-I3086 miss ladder and above the §7.4a owning-item basis. That position is the fix: an `owning_item_age` promotion becomes structurally unreachable for a declared-off row, rather than suppressed after the fact somewhere further down where the next edit to the ladder could reintroduce it. `test_owning_item_age_does_not_promote_a_declared_off_row` is `test_owning_item_age_drives_escalation_not_the_miss_count` with the declaration added and nothing else changed.

### The same three properties as producer-trigger suppression

This is a sibling of the I6570 mechanism, not a new one, and it keeps all three:

1. **Fails toward paging.** A malformed block, an absent / stale / unparseable resolution, an unknown milestone, or a milestone already `reached` all leave the row alerting exactly as today. Nothing on this path can silence a row by breaking.
2. **Never silent.** The row keeps its true state and gains `declared_off`, `declared_off_suppressed`, `console_state: "DISABLED"`, `days_declared_off`, the reason, the owning item, the clearing milestone and its status in `check_results.json`. Deliberately its **own** fields rather than reusing `producer_disabled`, which means "a live probe found the trigger DISABLED" — two senses of one word made a check unclearable once already (I8105).
3. **Expires by its own predicate, and nothing else.** There is deliberately **no** day-count ceiling here, unlike `PRODUCER_SUPPRESSION_MAX_DAYS`. A pause nobody owns is a latch and going loud is right; a declared-off row is the opposite case — it names its owner and its clearing milestone up front, and a calendar expiry would page for a producer that is still deliberately off.

The ceiling that **does** exist is on the **resolution**: `DECLARED_OFF_RESOLUTION_MAX_AGE_HOURS` (36h, env-overridable). `alpha-engine-config`'s `sync-artifact-registry.yml` republishes daily; if it stops, the resolution ages past the ceiling and every declared-off row pages again. A resolution nothing refreshes is the permanent blindfold this must not introduce.

Also added to the owning-item lookup budget gate: a declared-off row is the third shape that cannot page, so it must not spend one of the 24 GitHub queries. On 2026-08-19 that cap was spent on rows that could not page and the one row that DID page carried `lookup_budget_exhausted` onto Brian's Telegram.

## I8686 — a correct decline is not a predicate failure

Brian ruled Option A on 2026-08-26. `playbooks.yaml` and `playbooks.schema.json` now state the three outcomes: only `failed` — the automation could not **evaluate** its predicate — increments `max_consecutive_failures`. `declined` (evaluated, correctly not satisfied) is silent on the counter in both directions. The 2026-08-26 demotion was fed by two correct declines over a genuinely stale `trades/open_orders/latest.json` while the executor daemon was down (`I8682`, separate and out of scope).

The auto-verify entry's `remediation_steps` now carry the split explicitly, plus the decline-declares step: producer, artifact, measured staleness, owning item. And `reauthorized_at: "2026-08-26"` / `reauthorized_by: alpha-engine-config-I8686`, schema-enforced as a pair — so re-authorization is a reviewed merged diff and the drain voids the ledger demotion, rather than an operator hand-editing JSON in S3 where nothing records who did it or why. **That re-authorization lands in the same merge as the fix it is conditional on**, which is the only way one merge can satisfy "re-authorize only after (1) and (2) are merged".

The entry's `description` also states that a `declared_off` row never enters this population — the exclusion is enforced at the **producer** (this Lambda), not at the drain, so there is one contract and not two.

## Test plan — run before opening

- `infrastructure/lambdas/freshness-monitor/test_handler.py`: **203 passed** (24 new) — every malformed block shape dropped, every direction of the resolution failing toward paging, the ceiling boundary (exactly-at vs one hour past), `owning_item_age` refusing to promote, the miss-count ladder refusing too, the control that an un-suppressed row still escalates CRITICAL, and the console row's true state + age + `DISABLED`.
- `tests/test_overseer_playbook_registry.py`: **48 passed** (6 new).
- `tests/` full: **6598 passed, 17 skipped**. No pre-existing failures surfaced.

## Related

- `alpha-engine-config-PR8726` — the `declared_off` block on `backtest_pit_parity`, its PR-time validator, the publish-time resolver, the daily sync, the drain charter and the console emission.
- `nous-ergon-ops-PR890` — observability rows.
- **Merge order: `alpha-engine-config-PR8726`, then this, then C.** Either order of the first two is safe: 8726 alone publishes a field the deployed Lambda strips as unknown (row keeps paging); this alone reads a field nobody sets (no-op).
- `crucible-dashboard-PR779` — not extended, deliberately: that reads the four alert-drain schedules' **live** AWS `State` from `box_health.sh`. This is the case where no live state exists to read, in a Python Lambda. Same ruling, two surfaces, no shared code.

## Post-merge

`infrastructure/lambdas/freshness-monitor/deploy.sh` ships this Lambda. Nothing to run by hand and no state migration: a deployed Lambda reading a registry without a `declared_off_resolution` block simply suppresses nothing, which is the pre-change behaviour.

**A closing keyword is silently inert across repositories.** `I8719` and `I8686` live in `alpha-engine-config`, so this PR cannot close them and does not try — `alpha-engine-config-PR8726` carries the `Closes` lines, and the main session closes by hand if the keyword does not fire.

Deploy-mechanism: `infrastructure/lambdas/freshness-monitor/deploy.sh`

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
