### PR TITLE
deps: bump nousergon-lib pin to v0.124.91 across the repo (alpha-engine-config-I8737, I8694)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -10,4 +10,4 @@
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
 # v0.124.88. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,7 +16,7 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # alpha-engine-config-I8155: this Lambda records its own coverage verdict via
 # krepis.stage_coverage. Pin the released contract that refuses a blank SF
 # execution run_date and uses no cycle-date fallback.

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ arcticdb>=6.23.0
 # JSON landing ahead of the registry entry. VERIFIED 2026-08-25 against the tag
 # itself (contents API at ref=v0.124.88), not against the merge: a green publish
 # that serves old metadata has happened on this fleet before.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.90
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.91
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,


### PR DESCRIPTION
## What this does

Bumps `nousergon-lib` from `v0.124.90` to `v0.124.91` at all 31 pin sites in this repo.

`v0.124.91` is the auto-bump tag on `nousergon-lib#357`, which changes `_freshness_floor` to scale as `ceil(interval_minutes / 1440)` trading days instead of hardcoding a 1-trading-day lookback for every producer with `interval_minutes >= 1440`. The daily case is byte-identical; only producers slower than daily change behaviour.

## Why it is repo-wide rather than one Lambda

`alpha-engine-config-I8737` asks only for the `freshness-monitor` Lambda's pin. That is not a legal change on its own — `tests/test_lib_pin_lockstep.py::test_lambda_pins_match_or_are_explicitly_exempted` fails any per-Lambda pin that diverges from the root pin unless it is added to `_LAMBDA_PIN_EXEMPTIONS` with a written contract reason:

```
AssertionError: freshness-monitor: pin 'v0.124.91' must match root pin 'v0.124.90',
or be added to _LAMBDA_PIN_EXEMPTIONS with a contract reason
```

There is no contract reason here — nothing about `freshness-monitor` needs to diverge, the whole repo simply wants the fix. Adding an exemption to dodge the lockstep guard would be the wrong half of the choice. So: root `requirements.txt`, `requirements-daily-news.txt`, `.github/workflows/deploy-infrastructure.yml`, and 28 Lambda `requirements.txt` files, all together.

## What this fixes downstream

`alpha-engine-config-I8694` — `predictor_self_test` is a WEEKLY producer (`interval_minutes: 10080`) given a 2-trading-day floor, so it reads stale by construction from Monday every week. It is the live instance of the class; a registry sweep found it is the only `cadence`/`interval_minutes` disagreement in the registry today.

## Verification

Full local suite before push: **6599 passed, 17 skipped**. That includes the four suites that exist specifically to reject this class of divergence — `test_lib_pin_lockstep.py`, `test_ensure_lib_pin_rename_agnostic.py`, `test_sf_lib_pin_drift_wiring.py`, `test_sf_lib_pin_self_heal_wiring.py` (25 passed, 1 skipped as a group).

## Deployment

No post-merge step. Each Lambda's existing deploy workflow installs from its own `requirements.txt` on merge.

Refs `alpha-engine-config-I8737`, `alpha-engine-config-I8694`, `nousergon-lib#357`.


Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
