### PR TITLE
ci(deploy-weekly-coverage-sweep): report what deploy.sh produces — the first run went red after a successful deploy (alpha-engine-config-I8809)

### DIFF
--- a/.github/workflows/deploy-weekly-coverage-sweep.yml
+++ b/.github/workflows/deploy-weekly-coverage-sweep.yml
@@ -14,7 +14,12 @@ name: Deploy weekly-coverage-sweep
 #
 # Separation of concerns, same as the preflight sibling: this deploys the
 # function CODE (deploy.sh default path = update-function-code +
-# publish-version + `live` alias). First-time creation is
+# verify_code_deployed; it publishes NO version and NO alias — the Step
+# Functions definition invokes the function unqualified, so $LATEST is what
+# runs). This workflow's first run (2026-08-28, alpha-engine-config-I8809)
+# went red on a report step that asked for a `live` alias the script never
+# creates, AFTER the code had deployed and verified — a red that read as
+# "not deployed" for a function that was. First-time creation is
 # `deploy.sh --bootstrap --apply-iam`, which needs IAM role creation
 # (nous-ergon-ops owns IAM) — the function is already live, so that bootstrap
 # is not on this path.
@@ -70,12 +75,14 @@ jobs:
 
       - name: Report deployed version
         working-directory: alpha-engine-data
+        # Report what deploy.sh actually produces — a new $LATEST — as the two
+        # facts a reader can compare against the merge time and the packaged
+        # zip, rather than an alias this path does not publish.
         run: |
           echo "Deployed commit: ${{ github.sha }}"
-          aws lambda get-alias \
+          aws lambda get-function-configuration \
             --function-name alpha-engine-weekly-coverage-sweep \
-            --name live \
-            --query 'FunctionVersion' \
+            --query '[LastModified, CodeSha256]' \
             --output text
 
       - name: Append to system-wide deploy changelog


### PR DESCRIPTION
## What
`.github/workflows/deploy-weekly-coverage-sweep.yml`: the 'Report deployed version' step reads the function's `LastModified`/`CodeSha256` instead of a `live` alias; the header no longer claims `deploy.sh` publishes a version + alias (it does update-function-code + verify only).

## Why
First run of this workflow (2026-08-28T02:09Z, after `nousergon-data-PR1556`) deployed and verified the code (`LastModified 02:10:29Z`) and then failed on `get-alias live` — an alias this path never creates. The SF invokes the function unqualified, so $LATEST is what runs; a red that reads as 'not deployed' for a function that was is the class `I8747` names. `alpha-engine-config-I8809`.

## Test plan
YAML parses; `pytest tests/ -k 'workflow or deploy or wiring'` green locally. Merging re-triggers this workflow on its own path — expected result: green with the LastModified line printed.

Rehearsal-exempt: structural

Prepared by: Claude Fable 5 via [Claude Code](https://claude.com/claude-code)