### PR TITLE
Close the third state for metron-deploy-drift; detect pageable classes with no disposition (alpha-engine-config-I8991)

### DIFF
--- a/infrastructure/overseer/alert_class_response_gap.py
+++ b/infrastructure/overseer/alert_class_response_gap.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Overseer invariant-4 detector: a class in ``alert_classes:`` (playbooks.yaml)
+that can terminate in a page and carries neither ``operator_reason`` nor
+``migration_issue`` (alpha-engine-config-I8991, overseer-policy.md invariant
+4 — "closed loop or tracked gap ... there is no third state").
+
+This is a DIFFERENT axis from the existing schema-level requirement in
+``playbooks.schema.json`` (``intake: none`` rows must carry one of the two
+fields). That rule only covers drain-blind classes — ones the Overseer never
+sees at all. Most classes ARE seen (``intake: bus``/``cw-alarm``) and are
+routed to the alert-drain's T0-T3 tiers (``response: drain-queue``) or
+declared operator-only (``response: operator``); either can still terminate
+in an unactioned page, because ``severity`` is the push switch
+(``api/services/alerting.py``: error/critical push the phone, everything
+else is silent-in-channel) and neither ``response`` value guarantees a
+disposition beyond "a human sees it."
+
+A class is PAGEABLE here when:
+  - its ``severities`` set intersects {error, critical, dynamic} (dynamic
+    classes choose their severity at emit time and MAY reach error/critical,
+    so they are treated as pageable rather than assumed safe), AND
+  - its ``response`` is ``drain-queue`` or ``operator`` — NOT
+    ``playbook:<name>``, which is already routed to an automated T2 agent
+    and so is not in the third state this detector is for.
+
+``GRANDFATHERED_CLASSES`` covers the 43 pre-existing rows found by the
+alpha-engine-config-I8991 sweep — enforcing this immediately, unconditionally
+would redden the fleet's CI on a backlog nobody has triaged yet. Each
+grandfathered class needs a per-row ruling (page-only vs. tracked migration),
+tracked as `alpha-engine-config-I8996`. A NEWLY ADDED pageable class with
+neither field is NOT grandfathered and fails this check immediately — that is
+what stops the gap silently reopening every time a class is added.
+
+Usage:
+  python infrastructure/overseer/alert_class_response_gap.py \\
+    --playbooks infrastructure/overseer/playbooks.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# The 43 rows found pageable-with-no-field by the alpha-engine-config-I8991
+# sweep (2026-08-27), tracked for per-class disposition in
+# alpha-engine-config-I8996. Remove an entry here in the SAME PR that gives
+# its row an operator_reason or migration_issue — leaving it here after the
+# row is fixed is caught by test_grandfather_list_has_no_stale_entries.
+GRANDFATHERED_CLASSES: frozenset[str] = frozenset({
+    "alpha_engine_preopen_deploy_readiness_probe",
+    "backtester_champion_promotion",
+    "backtester_cost_anomaly",
+    "backtester_live_key_reconciliation",
+    "backtester_stance_drift",
+    "boot_pull",
+    "box_health",
+    "canary_replay_liveness",
+    "check_systemd_unit_drift",
+    "data_constituents_drift",
+    "data_phase_marker_sweep",
+    "data_sf_definition_drift",
+    "data_stage_output_sweep",
+    "deploy_notification_backtester_concordance",
+    "deploy_notification_backtester_counterfactual",
+    "deploy_notification_backtester_health",
+    "deploy_notification_changelog",
+    "deploy_notification_data_plane",
+    "deploy_notification_predictor",
+    "deploy_notification_research",
+    "deploy_on_merge",
+    "eod_snapshot_existence_check",
+    "executor_turnover_tripwire",
+    "executor_zero_entries_alarm",
+    "groom_lifecycle_bus_events",
+    "llm_egress_proxy_sli",
+    "llm_router_reload_health",
+    "metron_deploy",
+    "metron_reconciliation",
+    "overseer_dispatch_escalation",
+    "pipeline_watchdog_stuck_sf",
+    "predictor_inference",
+    "predictor_model_zoo",
+    "predictor_predictions_write",
+    "reboot_if_needed",
+    "research_archive_writer_quarantine",
+    "research_cut_promotion_alerts",
+    "research_daemon_down",
+    "research_eval_rolling_mean_producer_failure",
+    "research_signals_envelope_rejected",
+    "research_weekly_ledger_alerts",
+    "router_canary",
+    "weekly_sf_recovery_metric",
+})
+
+_PAGEABLE_SEVERITIES = frozenset({"error", "critical", "dynamic"})
+_PAGEABLE_RESPONSES = frozenset({"drain-queue", "operator"})
+
+
+def is_pageable(alert_class: dict) -> bool:
+    """True when this row's severities/response combination can reach a
+    human page with no automated disposition guaranteed."""
+    severities = set(alert_class.get("severities", []))
+    response = alert_class.get("response", "")
+    return bool(severities & _PAGEABLE_SEVERITIES) and response in _PAGEABLE_RESPONSES
+
+
+def has_disposition_field(alert_class: dict) -> bool:
+    return "operator_reason" in alert_class or "migration_issue" in alert_class
+
+
+def find_new_gaps(alert_classes: list[dict]) -> list[str]:
+    """Classes that are pageable, lack both fields, and are NOT grandfathered
+    — i.e. a class added or edited since the I8991 sweep without a
+    disposition. Non-empty means invariant 4 has regressed."""
+    return sorted(
+        c["class"]
+        for c in alert_classes
+        if is_pageable(c)
+        and not has_disposition_field(c)
+        and c["class"] not in GRANDFATHERED_CLASSES
+    )
+
+
+def find_stale_grandfather_entries(alert_classes: list[dict]) -> list[str]:
+    """Grandfathered class names that either no longer exist in the registry
+    or now carry a disposition field — both mean the grandfather list is
+    stale and must be trimmed in the same PR that fixed the row."""
+    by_name = {c["class"]: c for c in alert_classes}
+    stale = []
+    for name in sorted(GRANDFATHERED_CLASSES):
+        cls = by_name.get(name)
+        if cls is None or has_disposition_field(cls):
+            stale.append(name)
+    return stale
+
+
+def _load_alert_classes(playbooks_path: Path) -> list[dict]:
+    data = yaml.safe_load(playbooks_path.read_text())
+    return data.get("alert_classes", [])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect alert_classes rows in the third state overseer-policy.md "
+        "invariant 4 forbids: pageable, with neither operator_reason nor migration_issue."
+    )
+    parser.add_argument(
+        "--playbooks",
+        type=Path,
+        default=Path(__file__).resolve().parent / "playbooks.yaml",
+        help="Path to playbooks.yaml (default: sibling file).",
+    )
+    args = parser.parse_args(argv)
+
+    alert_classes = _load_alert_classes(args.playbooks)
+
+    new_gaps = find_new_gaps(alert_classes)
+    stale = find_stale_grandfather_entries(alert_classes)
+
+    ok = True
+    if new_gaps:
+        ok = False
+        print(
+            "overseer-policy.md invariant 4 violated — pageable alert_classes row(s) "
+            "with neither operator_reason nor migration_issue (alpha-engine-config-I8991):",
+            file=sys.stderr,
+        )
+        for name in new_gaps:
+            print(f"  - {name}", file=sys.stderr)
+    if stale:
+        ok = False
+        print(
+            "GRANDFATHERED_CLASSES has stale entries (row fixed or removed but still "
+            "listed) — trim these from alert_class_response_gap.py:",
+            file=sys.stderr,
+        )
+        for name in stale:
+            print(f"  - {name}", file=sys.stderr)
+
+    if ok:
+        print(f"alert_class_response_gap: OK ({len(alert_classes)} classes checked)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1099,6 +1099,35 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: metron_deploy_drift
+    # alpha-engine-config-I8991: metron-deploy-drift.timer (hourly,
+    # metron/api/services/deploy_drift.py::report) correctly detected the box
+    # running code behind origin/main and paged, then nothing acted — the box
+    # stayed undeployed for five hours (2026-08-27) until a human intervened.
+    # This is overseer-policy.md invariant 4's third state (terminates in a
+    # page, carries neither operator_reason nor migration_issue), closed here
+    # by recording the migration_issue. NOT promoted to T1 (see
+    # t1_automations note below): only 2 occurrences with this root cause
+    # (2026-08-02→03, 2026-08-27) are known and §6 requires ≥3 before a
+    # deterministic remediation may be added — this row records the tracked
+    # path to autonomy, not the automation itself.
+    #
+    # KNOWN GAP, flagged rather than silently worked around: metron's
+    # api/services/alerting.py::send_alert hardcodes source="metron" for
+    # every metron in-app alert, so this row's `source` is IDENTICAL to
+    # metron_reconciliation's above — the two classes are indistinguishable
+    # by the wire source the cross-repo drift scanner matches on. This row
+    # exists so the class is nameable in this registry and carries its own
+    # migration_issue per the closes-when in alpha-engine-config-I8991; it
+    # does not fix the underlying source-collision, which needs a metron-side
+    # change (a distinct source string per metron alert type, e.g.
+    # "metron/deploy-drift") that is out of scope for this PR and is not a
+    # mechanical call — filed as alpha-engine-config-I8995 for a ruling.
+    source: "metron"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+    migration_issue: alpha-engine-config-I8991
 
   # ── groom (alpha-engine-config emitter) ──
   - class: groom_lifecycle_bus_events

--- a/tests/test_alert_class_response_gap.py
+++ b/tests/test_alert_class_response_gap.py
@@ -1,0 +1,200 @@
+"""Tests for ``infrastructure/overseer/alert_class_response_gap.py`` — the
+overseer-policy.md invariant 4 detector added by alpha-engine-config-I8991
+("closed loop or tracked gap ... there is no third state").
+
+Pins:
+  1. The REAL registry has no un-grandfathered gap (find_new_gaps == []).
+  2. The grandfather list has no stale entries (every listed class still
+     exists and still lacks both fields).
+  3. ``metron_deploy_drift`` specifically carries
+     ``migration_issue: alpha-engine-config-I8991``.
+  4. The detector actually detects: a synthetic pageable class with neither
+     field, not in the grandfather list, IS flagged — the "demonstrated
+     failing" requirement for a self-detecting check. Without this test, a
+     regression in ``is_pageable``/``find_new_gaps`` (e.g. a typo'd severity
+     set) could silently stop catching real gaps and nothing would notice.
+  5. A grandfathered class that gains a disposition field but is left in the
+     grandfather list is caught as stale (proves the anti-drift half works,
+     not just the detection half).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "infrastructure" / "overseer"))
+import alert_class_response_gap as g  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLAYBOOKS_PATH = REPO_ROOT / "infrastructure" / "overseer" / "playbooks.yaml"
+REAL_ALERT_CLASSES = yaml.safe_load(PLAYBOOKS_PATH.read_text())["alert_classes"]
+
+
+# ── real registry ──
+
+
+def test_real_registry_has_no_new_gaps():
+    """Every pageable class either has a disposition field or is a tracked,
+    named grandfather entry (alpha-engine-config-I8996). A non-empty result
+    means a class was added or edited without a ruling."""
+    assert g.find_new_gaps(REAL_ALERT_CLASSES) == []
+
+
+def test_real_registry_grandfather_list_has_no_stale_entries():
+    """Every grandfathered class name still exists in the registry and still
+    lacks both fields. A class fixed in place (field added) but left on the
+    list, or a renamed/removed class still named, is stale bookkeeping that
+    hides real progress and must be trimmed in the fixing PR."""
+    assert g.find_stale_grandfather_entries(REAL_ALERT_CLASSES) == []
+
+
+def test_metron_deploy_drift_carries_migration_issue():
+    by_name = {c["class"]: c for c in REAL_ALERT_CLASSES}
+    assert "metron_deploy_drift" in by_name
+    row = by_name["metron_deploy_drift"]
+    assert row.get("migration_issue") == "alpha-engine-config-I8991"
+    assert "operator_reason" not in row  # exactly one of the two fields
+
+
+def test_all_43_swept_classes_are_grandfathered_and_only_those():
+    """Pins the exact I8991 sweep set so a future edit to GRANDFATHERED_CLASSES
+    is a visible diff against a known baseline, not silent growth or shrink."""
+    swept = {
+        "alpha_engine_preopen_deploy_readiness_probe", "backtester_champion_promotion",
+        "backtester_cost_anomaly", "backtester_live_key_reconciliation",
+        "backtester_stance_drift", "boot_pull", "box_health", "canary_replay_liveness",
+        "check_systemd_unit_drift", "data_constituents_drift", "data_phase_marker_sweep",
+        "data_sf_definition_drift", "data_stage_output_sweep",
+        "deploy_notification_backtester_concordance",
+        "deploy_notification_backtester_counterfactual",
+        "deploy_notification_backtester_health", "deploy_notification_changelog",
+        "deploy_notification_data_plane", "deploy_notification_predictor",
+        "deploy_notification_research", "deploy_on_merge", "eod_snapshot_existence_check",
+        "executor_turnover_tripwire", "executor_zero_entries_alarm",
+        "groom_lifecycle_bus_events", "llm_egress_proxy_sli", "llm_router_reload_health",
+        "metron_deploy", "metron_reconciliation", "overseer_dispatch_escalation",
+        "pipeline_watchdog_stuck_sf", "predictor_inference", "predictor_model_zoo",
+        "predictor_predictions_write", "reboot_if_needed",
+        "research_archive_writer_quarantine", "research_cut_promotion_alerts",
+        "research_daemon_down", "research_eval_rolling_mean_producer_failure",
+        "research_signals_envelope_rejected", "research_weekly_ledger_alerts",
+        "router_canary", "weekly_sf_recovery_metric",
+    }
+    assert g.GRANDFATHERED_CLASSES == swept
+    assert len(swept) == 43
+
+
+# ── synthetic: proves the detector actually detects ──
+
+_UNGRANDFATHERED_GAP_CLASS = {
+    "class": "synthetic_new_pageable_class_no_disposition",
+    "source": "synthetic-test-source",
+    "severities": ["error"],
+    "intake": "bus",
+    "response": "drain-queue",
+}
+
+
+def test_detects_a_new_pageable_class_with_no_disposition_field():
+    """A class shaped exactly like the real gaps found by the I8991 sweep —
+    pageable severity, drain-queue response, no operator_reason/migration_issue
+    — and NOT on the grandfather list, is flagged. This demonstrates the check
+    failing when a class's field is missing/removed, per I8991's task 4."""
+    assert _UNGRANDFATHERED_GAP_CLASS["class"] not in g.GRANDFATHERED_CLASSES
+    gaps = g.find_new_gaps([_UNGRANDFATHERED_GAP_CLASS])
+    assert gaps == ["synthetic_new_pageable_class_no_disposition"]
+
+
+def test_removing_the_disposition_field_from_metron_deploy_drift_is_detected():
+    """Directly demonstrates the 'field removed' scenario I8991 task 4 names:
+    take the real metron_deploy_drift row, strip migration_issue, and confirm
+    the detector flags it (it is not grandfathered, so nothing else hides
+    the regression)."""
+    by_name = {c["class"]: c for c in REAL_ALERT_CLASSES}
+    row = dict(by_name["metron_deploy_drift"])
+    assert "metron_deploy_drift" not in g.GRANDFATHERED_CLASSES
+    row.pop("migration_issue", None)
+    row.pop("operator_reason", None)
+    assert g.find_new_gaps([row]) == ["metron_deploy_drift"]
+
+
+def test_adding_a_disposition_field_removes_the_gap():
+    fixed = dict(_UNGRANDFATHERED_GAP_CLASS)
+    fixed["operator_reason"] = "Declared human-only for this synthetic test row."
+    assert g.find_new_gaps([fixed]) == []
+
+
+def test_response_playbook_is_not_pageable_in_this_sense():
+    """A class already routed to an automated T2 agent (response:playbook:*)
+    is not in the third state — it has a closed loop, just not via the
+    operator_reason/migration_issue mechanism."""
+    routed = {
+        "class": "already_routed_class",
+        "source": "x", "severities": ["error"], "intake": "bus",
+        "response": "playbook:alert-drain",
+    }
+    assert g.find_new_gaps([routed]) == []
+
+
+def test_warning_only_severity_is_not_pageable():
+    """A class whose severities never reach error/critical/dynamic never
+    pushes per alerting.py's severity-is-the-push-switch contract, so it is
+    not in the third state even with no disposition field."""
+    warn_only = {
+        "class": "warning_only_class",
+        "source": "x", "severities": ["warning"], "intake": "bus",
+        "response": "drain-queue",
+    }
+    assert g.find_new_gaps([warn_only]) == []
+
+
+def test_stale_grandfather_entry_detected_when_field_added_but_not_trimmed():
+    """Proves the anti-drift half: a grandfathered class that gains a
+    disposition field but is left on the list is caught, so a fixing PR
+    that forgets to trim the list does not silently understate progress."""
+    fixed_but_still_listed = {
+        "class": "backtester_stance_drift",  # a real grandfathered class
+        "source": "x", "severities": ["error"], "intake": "bus",
+        "response": "drain-queue",
+        "operator_reason": "Now declared page-only.",
+    }
+    stale = g.find_stale_grandfather_entries([fixed_but_still_listed])
+    assert "backtester_stance_drift" in stale
+
+
+def test_main_exits_nonzero_when_registry_has_a_gap(tmp_path):
+    playbooks = tmp_path / "playbooks.yaml"
+    playbooks.write_text(yaml.dump({
+        "schema_version": 1,
+        "playbooks": {},
+        "alert_classes": [_UNGRANDFATHERED_GAP_CLASS],
+    }))
+    rc = g.main(["--playbooks", str(playbooks)])
+    assert rc == 1
+
+
+def test_main_exits_zero_when_registry_is_clean(tmp_path):
+    """A registry containing every grandfathered class UNCHANGED (still no
+    field — nothing here claims they're fixed) plus one new class that DOES
+    carry a disposition field exits 0: no new gap, and nothing stale because
+    every grandfathered row is present and still matches its listing."""
+    playbooks = tmp_path / "playbooks.yaml"
+    clean = dict(_UNGRANDFATHERED_GAP_CLASS)
+    clean["migration_issue"] = "alpha-engine-config-I1"
+    grandfathered_rows = [
+        {
+            "class": name, "source": "x", "severities": ["error"],
+            "intake": "bus", "response": "drain-queue",
+        }
+        for name in g.GRANDFATHERED_CLASSES
+    ]
+    playbooks.write_text(yaml.dump({
+        "schema_version": 1,
+        "playbooks": {},
+        "alert_classes": grandfathered_rows + [clean],
+    }))
+    rc = g.main(["--playbooks", str(playbooks)])
+    assert rc == 0


### PR DESCRIPTION
## What & why

`alpha-engine-config-I8991`: `metron-deploy-drift.timer` detected the box running code behind `origin/main` and paged — then nothing acted; the box stayed on old code for five hours (2026-08-27) until a human intervened. `nous-ergon-ops/policies/overseer-policy.md` invariant 4: "Closed loop or tracked gap. Detect-and-notify is not a completed automation. Any class that terminates in a page carries either an `operator_reason` (declared human-only, permanently) or a `migration_issue` (tracked path to autonomy). There is no third state." This class was in the third state.

## Task 1 — does an Overseer class registry exist?

**Yes.** `infrastructure/overseer/playbooks.yaml`'s `alert_classes:` section (schema: `infrastructure/overseer/playbooks.schema.json`), enforced cross-repo by `alert_class_registry_drift.py`/`alert_class_pr_guard.py`. It already has `operator_reason`/`migration_issue` fields, but the existing schema requirement (`if intake == none, require one of the two`) only covers the **intake axis** (is the class drain-blind at all) — not the **response axis** invariant 4 names (does the class terminate in an unactioned page). A class with `intake: bus` and `response: drain-queue`/`operator` can still page with neither field declared, and nothing checked that until this PR.

## What changed

1. Added the `metron_deploy_drift` row: `migration_issue: alpha-engine-config-I8991`. The T1 remediation is SPECIFIED in the issue body (trigger, action, success predicate, budget, rollback, demotion rule) but **not enabled** — only 2 occurrences of this root cause are known (2026-08-02→03, 2026-08-27) and §6 requires ≥3 before promotion; no `t1_automations` entry was added.
2. **Known gap flagged, not silently worked around:** this row's `source: "metron"` is identical to the pre-existing `metron_reconciliation` row's, because `metron/api/services/alerting.py::send_alert` hardcodes one `source` literal for every metron alert. The cross-repo drift scanner matches by source coverage only (no uniqueness check), so the two classes are indistinguishable to it. Fixing this needs a metron-side source-naming change and is a judgment call, not mechanical — filed **alpha-engine-config-I8995**.
3. Added `infrastructure/overseer/alert_class_response_gap.py` + `tests/test_alert_class_response_gap.py`: the self-detecting check task 4 asked for. `find_new_gaps()` flags any `alert_classes` row that is pageable (severities intersect `{error, critical, dynamic}`, response in `{drain-queue, operator}`) and carries neither field, EXCEPT rows on a named `GRANDFATHERED_CLASSES` list. **Demonstrated failing**: `test_removing_the_disposition_field_from_metron_deploy_drift_is_detected` strips the new row's `migration_issue` and asserts detection; `test_detects_a_new_pageable_class_with_no_disposition_field` does the same for a synthetic new class. `test_grandfather_list_has_no_stale_entries` closes the other side (a class fixed but left on the grandfather list is also caught). Wired into CI automatically via `pytest tests/`.

## Task 3 — sweep result

**43 pre-existing rows are in the same third state** (pageable, neither field, found by `alert_class_response_gap.py` before grandfathering). These are a **genuine judgment call per class** (page-only vs. tracked migration — the same disposition `alpha-engine-config-I7740`'s 2026-08-21 ruling made for two other metron rows) and were not bulk-fixed here without that context. All 43 are named, grandfathered, and tracked as **alpha-engine-config-I8996** so the check does not instantly redden CI on unrelated PRs, and so the backlog is a register rather than silently reopening.

Negative space: no OTHER Overseer class registry exists in the fleet (checked `nous-ergon-ops` — no registry/policy file there needed editing; `overseer-policy.md` itself was read, not edited, per the never-autonomous "changing this policy" rule). No `t1_automations` entry was added (would require ≥3 occurrences, only 2 exist).

## Verification

- `playbooks.yaml` validates against `playbooks.schema.json` (`jsonschema.validate`, local).
- `pytest tests/ -q` in a clean venv against the pinned `requirements.txt` (fixed a **local** stale global `nousergon-lib` install unrelated to this change — the pinned `v0.124.94` installs clean and the full suite is **6628 passed, 17 skipped, 0 failed**, including the 12 new tests).
- `shellcheck --severity=error infrastructure/*.sh` clean (no `.sh` touched by this PR).

## Related

- `alpha-engine-config-I8991` (this issue)
- `alpha-engine-config-I8995` (metron source-string collision, filed from this PR, needs a ruling)
- `alpha-engine-config-I8996` (43-class grandfathered backlog, filed from this PR, needs per-class rulings)
- Sibling session in the same arc owns `alpha-engine-config/scripts/check_scheduled_workflow_health.py` (I8992) — untouched here.

No merge order dependency: this PR stands alone.

---

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)
