### PR TITLE
fix(weekly-sf): an in-band eval-judge ERROR must mark the run degraded (alpha-engine-config-I9058)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2127,7 +2127,7 @@
             },
             "EvalJudgePollChoice": {
               "Type": "Choice",
-              "Comment": "Branch on Submit's processing_status. EMPTY (no captures or all empty-input skipped client-side) \u2192 route directly to Process so the empty-batch case still emits a clean SF result + downstream metric inputs. OK \u2192 enter the Wait/Poll loop. Anything else (ERROR, missing fields) routes to EvalRollingMean as a fail-soft.",
+              "Comment": "Branch on Submit's processing_status. EMPTY (no captures, or all empty-input skipped client-side) -> route directly to Process so the empty-batch case still emits a clean SF result + downstream metric inputs. OK -> enter the Wait/Poll loop. Anything else (ERROR, missing fields) is fail-soft but NOT silent: it routes through MarkEvalJudgeDegraded, which threads $.research_degraded_local=true and then continues to EvalRollingMean exactly as before. alpha-engine-config-I9058: the Default used to jump straight to EvalRollingMean, so a submit Lambda that SUCCEEDED while returning status=ERROR in its payload bypassed the degraded marker every one of this chain's four Catches goes through. On 2026-08-22 EvalJudgeSubmitWeekly returned status=ERROR (Anthropic 400, credit balance too low), the chain skipped Poll and Process, decision_artifacts/_eval/latest.json was never rewritten, and nothing in the run recorded a degradation -- the only signal was the freshness row going stale five days later.",
               "Choices": [
                 {
                   "And": [
@@ -2157,7 +2157,7 @@
                   "Next": "EvalJudgePollWait"
                 }
               ],
-              "Default": "EvalRollingMean"
+              "Default": "MarkEvalJudgeDegraded"
             },
             "EvalJudgePollWait": {
               "Type": "Wait",
@@ -2205,7 +2205,7 @@
             },
             "EvalJudgePollDecision": {
               "Type": "Choice",
-              "Comment": "Branch on poll status. processing_status='ended' \u2192 run Process. exceeded_max_wait=true \u2192 fail-soft (batch results stay retrievable for 29 days; an operator can re-run the chain offline). Anything else \u2192 loop back to Wait. Includes the synthetic 'ended_empty' status (Submit short-circuited an empty plan) so the empty case still hits Process.",
+              "Comment": "Branch on poll status. processing_status='ended' -> run Process. exceeded_max_wait=true -> fail-soft, and a malformed payload (neither field present) likewise. Anything else -> loop back to Wait. Includes the synthetic 'ended_empty' status (Submit short-circuited an empty plan) so the empty case still hits Process. alpha-engine-config-I9058: both fail-soft exits now go through MarkEvalJudgeDegraded rather than straight to EvalRollingMean -- same continuation, but the run records that the judge produced nothing. A batch abandoned at the 6h cap and a batch that was never submitted are both degradations; only the Catch paths said so.",
               "Choices": [
                 {
                   "And": [
@@ -2239,7 +2239,7 @@
                       "BooleanEquals": true
                     }
                   ],
-                  "Next": "EvalRollingMean"
+                  "Next": "MarkEvalJudgeDegraded"
                 },
                 {
                   "And": [
@@ -2256,8 +2256,8 @@
                       }
                     }
                   ],
-                  "Comment": "config#2275: a poll payload carrying NEITHER processing_status NOR exceeded_max_wait is malformed \u2014 fail-soft to EvalRollingMean (eval is observability; mirrors this state's Catch posture) instead of States.Runtime, and instead of looping in Wait until the global ceiling.",
-                  "Next": "EvalRollingMean"
+                  "Comment": "config#2275: a poll payload carrying NEITHER processing_status NOR exceeded_max_wait is malformed \u2014 fail-soft via MarkEvalJudgeDegraded to EvalRollingMean (eval is observability; mirrors this state's Catch posture) instead of States.Runtime, and instead of looping in Wait until the global ceiling.",
+                  "Next": "MarkEvalJudgeDegraded"
                 }
               ],
               "Default": "EvalJudgePollWait"

--- a/tests/test_sf_choice_guards.py
+++ b/tests/test_sf_choice_guards.py
@@ -314,10 +314,16 @@ def _choice_target(definition: dict, choice_name: str, data) -> str:
          "LibPinGateDegradedFromProbe"),
         ("PipelineContractGate", {"pipeline_contract_result": {"Payload": {}}},
          "PipelineContractGateDegradedFromProbe"),
+        # alpha-engine-config-I9058: still fail-soft (eval is observability),
+        # but through MarkEvalJudgeDegraded — the same shape the LibPin and
+        # PipelineContract gates above already use. A degraded eval leg that
+        # routes straight to EvalRollingMean is indistinguishable from a clean
+        # one, which is how the 2026-08-22 weekly run skipped the judge and
+        # reported nothing.
         ("EvalJudgePollChoice", {"eval_judge_submit": {"Payload": {}}},
-         "EvalRollingMean"),  # eval is observability — fail-soft
+         "MarkEvalJudgeDegraded"),  # eval is observability — fail-soft, marked
         ("EvalJudgePollDecision", {"eval_judge_poll": {"Payload": {}}},
-         "EvalRollingMean"),  # malformed poll payload — fail-soft, no Wait loop
+         "MarkEvalJudgeDegraded"),  # malformed poll payload — no Wait loop
         # Healthy-path sanity: the guards must not change live semantics.
         ("WeeklyRunDayGateChoice",
          {"weekly_run_day_gate": {"Payload": {"is_weekly_run_day": False}}},

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -392,10 +392,32 @@ class TestEvalJudgePollChoice:
         )
         assert choice["Next"] == "EvalJudgePollWait"
 
-    def test_default_is_fail_soft_to_rolling_mean(self, states):
-        # Anything other than EMPTY/OK (ERROR, malformed) must NOT
-        # halt the pipeline.
-        assert states["EvalJudgePollChoice"]["Default"] == "EvalRollingMean"
+    def test_default_is_fail_soft_but_marks_degraded(self, states):
+        # Anything other than EMPTY/OK (ERROR, malformed) must NOT halt the
+        # pipeline — and must not be SILENT either.
+        #
+        # alpha-engine-config-I9058. This Default used to be EvalRollingMean.
+        # The four Catches on this chain (SubmitFirstSaturday, SubmitWeekly,
+        # Poll, Process) all route through MarkEvalJudgeDegraded, but a Catch
+        # only fires when the Lambda RAISED. A submit Lambda that SUCCEEDS
+        # while returning {"status": "ERROR"} in its payload is an in-band
+        # failure and lands here — so it bypassed the degraded marker entirely.
+        # Measured 2026-08-22 on ne-weekly-freshness-pipeline execution
+        # 1ed4d68f-...-c59654eb426d: EvalJudgeSubmitWeekly returned
+        # status=ERROR (Anthropic 400, credit balance too low), the run jumped
+        # Submit -> EvalRollingMean in 25s, decision_artifacts/_eval/latest.json
+        # was never rewritten, and NOTHING in the execution recorded a
+        # degradation. The condition first surfaced five days later as a
+        # freshness-monitor CRITICAL.
+        assert states["EvalJudgePollChoice"]["Default"] == "MarkEvalJudgeDegraded"
+        # Continuation is unchanged: the marker is a Pass that threads
+        # $.research_degraded_local and hands straight on to EvalRollingMean.
+        assert states["MarkEvalJudgeDegraded"]["Type"] == "Pass"
+        assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
+        assert (
+            states["MarkEvalJudgeDegraded"]["ResultPath"]
+            == "$.research_degraded_local"
+        )
 
 
 class TestEvalJudgePollLoop:
@@ -458,11 +480,63 @@ class TestEvalJudgePollLoop:
         )
         # Fail-soft — Anthropic retains batch results for 29 days, so
         # operator can re-run Process offline against the same batch_id.
-        assert max_wait_choice["Next"] == "EvalRollingMean"
+        # alpha-engine-config-I9058: fail-soft, via the degraded marker. A
+        # batch abandoned at the 6h cap produced no eval artifact; that is a
+        # degradation whether or not any Lambda raised.
+        assert max_wait_choice["Next"] == "MarkEvalJudgeDegraded"
 
     def test_poll_decision_default_loops_back_to_wait(self, states):
         # Continue polling until ended OR max_wait exceeded.
         assert states["EvalJudgePollDecision"]["Default"] == "EvalJudgePollWait"
+
+    def test_poll_decision_malformed_payload_marks_degraded(self, states):
+        """config#2275's malformed-payload branch is a fail-soft exit too.
+
+        alpha-engine-config-I9058 — same class as the max_wait branch: a poll
+        payload carrying neither ``processing_status`` nor
+        ``exceeded_max_wait`` means the chain gave up without producing an
+        eval artifact, so it must leave through the degraded marker rather
+        than land on EvalRollingMean looking like a clean run.
+        """
+        malformed = next(
+            c for c in states["EvalJudgePollDecision"]["Choices"]
+            if all("Not" in leaf for leaf in c.get("And", []))
+        )
+        assert malformed["Next"] == "MarkEvalJudgeDegraded"
+
+    def test_no_eval_judge_failure_path_reaches_rolling_mean_unmarked(
+        self, states
+    ):
+        """The invariant, stated once over the whole chain.
+
+        alpha-engine-config-I9058. Every way the eval-judge chain can end
+        WITHOUT writing ``decision_artifacts/_eval/latest.json`` must pass
+        through ``MarkEvalJudgeDegraded``. Only the success paths
+        (``OK`` -> poll loop, ``ended``/``ended_empty`` -> Process) and the
+        marker itself may name ``EvalRollingMean`` as a Next.
+
+        Written as a whole-chain sweep rather than three separate branch
+        assertions because the defect it pins is additive: the failure mode is
+        someone adding a FOURTH fail-soft exit later and wiring it straight to
+        EvalRollingMean, which no per-branch test would catch.
+        """
+        offenders = []
+        for name in ("EvalJudgePollChoice", "EvalJudgePollDecision"):
+            state = states[name]
+            targets = [
+                (name, "Default", state.get("Default"))
+            ] + [
+                (name, f"Choices[{i}]", c.get("Next"))
+                for i, c in enumerate(state.get("Choices", []))
+            ]
+            offenders += [t for t in targets if t[2] == "EvalRollingMean"]
+        assert offenders == [], (
+            "eval-judge Choice exits reach EvalRollingMean without passing "
+            f"through MarkEvalJudgeDegraded: {offenders}"
+        )
+        # And the marker is still the only door to EvalRollingMean from this
+        # chain — i.e. the fix routes, it does not orphan.
+        assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
 
 
 class TestEvalJudgeProcessContract:


### PR DESCRIPTION
## What this changes

Three Choice exits in the weekly SF's eval-judge chain now route through `MarkEvalJudgeDegraded` instead of jumping straight to `EvalRollingMean`:

| state | exit | was | now |
|---|---|---|---|
| `EvalJudgePollChoice` | `Default` (submit status ERROR / missing) | `EvalRollingMean` | `MarkEvalJudgeDegraded` |
| `EvalJudgePollDecision` | `exceeded_max_wait = true` | `EvalRollingMean` | `MarkEvalJudgeDegraded` |
| `EvalJudgePollDecision` | malformed payload (config#2275) | `EvalRollingMean` | `MarkEvalJudgeDegraded` |

`MarkEvalJudgeDegraded` is a `Pass` whose `Next` is `EvalRollingMean`, so **the continuation is unchanged**. It threads `$.research_degraded_local = true`, which folds up through `BranchAComplete` -> `AggregateBranchOutcomes` -> `CheckGateDegradedNotify` -> `NotifyCompleteMultipleDegraded`. Eval stays fail-soft; it stops being silent.

## Why

`EvalJudgeSubmitFirstSaturday`, `EvalJudgeSubmitWeekly`, `EvalJudgePoll` and `EvalJudgeProcess` each carry a `Catch` routing through `MarkEvalJudgeDegraded` (`alpha-engine-config#6722`). A `Catch` only fires when the Lambda **raised**. A submit Lambda that **succeeds** while returning `{"status": "ERROR"}` in its payload is an in-band failure — it reaches `EvalJudgePollChoice`, whose `Default` bypassed the marker entirely.

Measured on `ne-weekly-freshness-pipeline` execution `1ed4d68f-574b-7496-6196-cf052d7178ba_ab3ec94b-b6ea-10fe-bb4b-63c393d65199` (2026-08-22), state history read live with `AWS_PROFILE=ne-admin`:

```
05:06:05  EvalJudgeSubmitWeekly  -> Payload.status = "ERROR"
                                    (Anthropic 400 — credit balance too low)
05:06:30  EvalJudgePollChoice    -> Default
05:06:30  EvalRollingMean
```

`EvalJudgePoll` and `EvalJudgeProcess` were never entered, `persist_eval_artifact` never ran, and `s3://alpha-engine-research/decision_artifacts/_eval/latest.json` has not been rewritten since `2026-08-13T16:59:42Z` (verified `head-object`). Nothing in the execution recorded a degradation. The condition first became visible **five days later**, as a freshness-monitor CRITICAL on `eval_artifact_latest` — one of four artifacts currently causing a daily `freshness-critical` alert-drain dispatch.

The same argument covers the `exceeded_max_wait` and malformed-payload exits: a batch abandoned at the 6h cap produced no eval artifact, which is a degradation whether or not any Lambda raised.

This is the shape the sibling gates already use — `LibPinDriftGate` and `PipelineContractGate` route their malformed-payload arms to `*GateDegradedFromProbe` rather than to the happy continuation.

**The cause of the ERROR itself (Anthropic credit exhaustion) is `alpha-engine-config-I9049` and is NOT addressed here.** This PR fixes the second, independent defect the same execution exposed: the run did not say it had degraded.

## Tests

- `tests/test_sf_eval_judge_wiring.py` — `test_default_is_fail_soft_but_marks_degraded`, `test_poll_decision_max_wait_routes_to_rolling_mean` (updated), `test_poll_decision_malformed_payload_marks_degraded` (new), and `test_no_eval_judge_failure_path_reaches_rolling_mean_unmarked` (new) — the last is a whole-chain sweep, written that way because the failure mode this pins is additive: a FOURTH fail-soft exit added later and wired straight to `EvalRollingMean` would pass every per-branch assertion.
- `tests/test_sf_choice_guards.py` — the two partial-payload drills updated to the new explicit route.

Full suite locally: `6629 passed, 17 skipped, 1 failed`. The single failure is `test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday]`, and it is a **stale local environment, not a repo failure**: it wants `NormalizeRunDates` in `nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE`; `requirements.txt` pins `nousergon-lib@v0.124.94`, that tag carries the entry (verified `git grep NormalizeRunDates v0.124.94`), and the laptop had `0.124.88` installed. CI installs the pin.

## Deployment

`deploy-infrastructure.yml` restamps the state machine on every push to `main` (no path filter), so **the merge button alone deploys this**. No post-merge step.

## Merge order / timing

- Standalone — depends on nothing.
- `alpha-engine-config-I9049` asks that no weekly-SF-behaviour change merge before **2026-08-29 09:00 UTC**, so that the Saturday run is not perturbed while the credit-exhaustion cause is still open. This PR is in scope for that hold.
- Companion (different repo, no shared files, no merge-order dependency): `alpha-engine-config-PR9063` declares the two I6984-paused freshness rows off.

Filed as `alpha-engine-config-I9058`.

Rehearsal-path: tests/test_sf_eval_judge_wiring.py

The change is a pure routing edit to `infrastructure/step_function.json` with no new Task, Lambda, IAM grant or payload field. Its entire observable effect is which state name follows three Choice exits, which is exactly what the definition-file tests assert — `test_no_eval_judge_failure_path_reaches_rolling_mean_unmarked` walks both Choice states and fails on any exit reaching `EvalRollingMean` without the marker, and `tests/test_sf_choice_guards.py` re-drives both partial-payload cases through the real definition. A live rehearsal would exercise no code path these do not.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9ta9bhET4fj4mDvAKcoTd
