### PR TITLE
feat(overseer): put a playbook's wake linkage on the AWS resources themselves (alpha-engine-config-I9045)

### DIFF
--- a/.github/workflows/deploy-alert-drain-dispatcher.yml
+++ b/.github/workflows/deploy-alert-drain-dispatcher.yml
@@ -27,6 +27,9 @@ on:
     branches: [main]
     paths:
       - 'infrastructure/lambdas/alert-drain-dispatcher/**'
+      - 'infrastructure/overseer/playbooks.yaml'
+      - 'infrastructure/overseer/trigger_descriptions.py'
+      - 'infrastructure/overseer/trigger_surface_drift.py'
       - '.github/workflows/deploy-alert-drain-dispatcher.yml'
   workflow_dispatch:
 
@@ -64,6 +67,25 @@ jobs:
       - name: Deploy alert-drain-dispatcher (code-only — no --bootstrap)
         working-directory: alpha-engine-data
         run: bash infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+
+      # alpha-engine-config-I9045. The linkage between a playbook and the AWS
+      # resources that wake it existed only as prose in playbooks.yaml. These
+      # two steps put it on the resources themselves and then assert it landed
+      # — the assertion is the half that matters: a description applied once by
+      # hand drifts the first time a wake leg is added, and is checked by
+      # nothing. Needs no new IAM: scheduler:{Create,Update}Schedule,
+      # events:PutRule and the matching reads are already on
+      # github-actions-lambda-deploy.
+      - name: Install the reconciler's one dependency
+        run: pip install --upgrade pyyaml
+
+      - name: Reconcile trigger descriptions from playbooks.yaml
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/alert-drain-dispatcher/deploy.sh --reconcile-triggers
+
+      - name: Assert the live trigger surface matches playbooks.yaml
+        working-directory: alpha-engine-data
+        run: python3 infrastructure/overseer/trigger_surface_drift.py --source-file infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
 
       - name: Report deployed version
         working-directory: alpha-engine-data

--- a/.github/workflows/deploy-freshness-monitor.yml
+++ b/.github/workflows/deploy-freshness-monitor.yml
@@ -24,6 +24,9 @@ on:
     branches: [main]
     paths:
       - 'infrastructure/lambdas/freshness-monitor/**'
+      - 'infrastructure/overseer/playbooks.yaml'
+      - 'infrastructure/overseer/trigger_descriptions.py'
+      - 'infrastructure/overseer/trigger_surface_drift.py'
       - '.github/workflows/deploy-freshness-monitor.yml'
   workflow_dispatch:
 
@@ -61,6 +64,25 @@ jobs:
       - name: Deploy freshness-monitor (code-only)
         working-directory: alpha-engine-data
         run: bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only
+
+      # alpha-engine-config-I9045. The linkage between a playbook and the AWS
+      # resources that wake it existed only as prose in playbooks.yaml. These
+      # two steps put it on the resources themselves and then assert it landed
+      # — the assertion is the half that matters: a description applied once by
+      # hand drifts the first time a wake leg is added, and is checked by
+      # nothing. Needs no new IAM: scheduler:{Create,Update}Schedule,
+      # events:PutRule and the matching reads are already on
+      # github-actions-lambda-deploy.
+      - name: Install the reconciler's one dependency
+        run: pip install --upgrade pyyaml
+
+      - name: Reconcile trigger descriptions from playbooks.yaml
+        working-directory: alpha-engine-data
+        run: bash infrastructure/lambdas/freshness-monitor/deploy.sh --reconcile-triggers
+
+      - name: Assert the live trigger surface matches playbooks.yaml
+        working-directory: alpha-engine-data
+        run: python3 infrastructure/overseer/trigger_surface_drift.py --source-file infrastructure/lambdas/freshness-monitor/deploy.sh
 
       - name: Report deployed version
         working-directory: alpha-engine-data

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -198,3 +198,24 @@ jobs:
       # daily sweep rather than on every push of a branch.
       - name: schedule-manifest.json drift (fleet-wide, vs live AWS)
         run: python3 infrastructure/scheduler/check-manifest-drift.py --live
+
+      # alpha-engine-config-I9045. Does the AWS trigger surface still say what
+      # playbooks.yaml says? Measured 2026-08-28: alert-drain's four schedules
+      # were DISABLED with `Description: null` while the playbook ran daily off
+      # an EventBridge RULE nothing on AWS connected to it. Both deploy
+      # workflows now stamp that linkage and assert it in the same job; this is
+      # the out-of-band half — a description edited in the console, a resource
+      # created by hand, a wake leg added to the registry with no deploy behind
+      # it.
+      #
+      # `if: github.event_name != 'push'` is not an exemption, it is a RACE
+      # removal. On a merge, deploy-{alert-drain-dispatcher,freshness-monitor}
+      # .yml run concurrently with this workflow, so a push-triggered run here
+      # would grade the surface before the reconcile that fixes it had a chance
+      # to run, and report drift that nothing did wrong. The merge path is
+      # covered strictly better inside those workflows, where the assertion is
+      # the step immediately after the write. Every OTHER step here is on the
+      # push trigger deliberately (see this file's header) and stays there.
+      - name: Playbook trigger surface drift (playbooks.yaml vs live AWS)
+        if: github.event_name != 'push'
+        run: python3 infrastructure/overseer/trigger_surface_drift.py

--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -20,9 +20,10 @@
 # is code-only (GHA auto-deploy path); --bootstrap is operator-only.
 #
 # Usage:
-#   bash .../alert-drain-dispatcher/deploy.sh             # update code only
-#   bash .../alert-drain-dispatcher/deploy.sh --bootstrap # operator-only: role + Lambda + schedules
-#   bash .../alert-drain-dispatcher/deploy.sh --apply-iam # re-apply iam-policy.json only (no bootstrap side effects, config#2825)
+#   bash .../alert-drain-dispatcher/deploy.sh                     # update code only
+#   bash .../alert-drain-dispatcher/deploy.sh --bootstrap         # operator-only: role + Lambda + schedules
+#   bash .../alert-drain-dispatcher/deploy.sh --reconcile-triggers # upsert the four schedules ONLY (the CI path; no packaging)
+#   bash .../alert-drain-dispatcher/deploy.sh --apply-iam         # re-apply iam-policy.json only (no bootstrap side effects, config#2825)
 #   bash .../alert-drain-dispatcher/deploy.sh --dry-run
 
 set -euo pipefail
@@ -35,6 +36,28 @@ POLICY_NAME="alpha-engine-alert-drain-dispatcher-policy"
 ROUTER_FUNCTION="alpha-engine-overseer-dispatcher"
 SCHED_ROLE_NAME="alpha-engine-overseer-scheduler-role"
 SCHED_POLICY_NAME="invoke-overseer-dispatcher"
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default. `scheduler update-schedule` is a FULL
+# REPLACE with no "leave the state alone" option, so every reconcile of a
+# paused schedule silently un-paused it until this was sourced here.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
+
+# The FOUR live drain schedules, in the shape trigger_surface_drift.py scans
+# for (alpha-engine-config-I9045). Until this array existed, deploy.sh's
+# bootstrap loop wrote only the 1000/2200 slots while 0400 and 1600 also
+# existed live — created out of band, codified nowhere, covered by no drift
+# check. Measured 2026-08-28, the cost of that: config#2902's zero-retry fix
+# (MaximumRetryAttempts 185 -> 0, so a transient router error cannot
+# re-dispatch a drain for a day) reached 1000/2200 and NEVER reached
+# 0400/1600, which still carried the AWS default of 185 attempts / 86400s.
+RECONCILE_DESCRIPTION_TRIGGERS=(
+  "scheduler:alpha-engine-alert-drain-0400utc"
+  "scheduler:alpha-engine-alert-drain-1000utc"
+  "scheduler:alpha-engine-alert-drain-1600utc"
+  "scheduler:alpha-engine-alert-drain-2200utc"
+)
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 ROUTER_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${ROUTER_FUNCTION}"
@@ -48,10 +71,12 @@ case "${DRY_RUN:-false}" in
 esac
 BOOTSTRAP=false
 APPLY_IAM=false
+RECONCILE_TRIGGERS=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --bootstrap) BOOTSTRAP=true ;;
+    --reconcile-triggers) RECONCILE_TRIGGERS=true ;;
     --apply-iam) APPLY_IAM=true ;;
     -h|--help) sed -n '2,/^$/p' "$0"; exit 0 ;;
   esac
@@ -59,6 +84,69 @@ done
 
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
+
+# ----- Reconcile the drain schedules (shared by --bootstrap and the CI path) --
+#
+# alpha-engine-config-I9045. Every field below is written on EVERY run, because
+# `scheduler update-schedule` is a full replace: whatever this function does not
+# say, AWS resets. Three of those fields exist for a reason worth stating:
+#
+#   --state        from the pause manifest (I6619). Omitting it defaults to
+#                  ENABLED, which would silently lift Brian's 2026-08-07 pause
+#                  on the next merge that touched this Lambda.
+#   RetryPolicy    zero-retry (config#2902). AWS defaults to 185 attempts over
+#                  24h, which would re-dispatch a drain all day on a transient
+#                  router error.
+#   --description  prose + the machine-readable marker derived from
+#                  playbooks.yaml. This is the deliverable: the marker names the
+#                  event-time freshness leg that also wakes alert-drain, so
+#                  `aws scheduler get-schedule` alone answers "what runs this",
+#                  instead of a DISABLED state implying nothing does.
+reconcile_drain_schedules() {
+  local key surface sched_name slot hh input input_escaped desc verb
+  for key in "${RECONCILE_DESCRIPTION_TRIGGERS[@]}"; do
+    surface="${key%%:*}"
+    sched_name="${key#*:}"
+    slot="${sched_name#alpha-engine-alert-drain-}"
+    slot="${slot%utc}"
+    hh="${slot:0:2}"
+    input="{\"playbook\":\"alert-drain\",\"payload\":{\"trigger\":\"scheduled-${slot}utc\"}}"
+    # Input must be a JSON-ESCAPED string inside the target JSON.
+    input_escaped=$(printf '%s' "$input" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
+    # Fails the whole run if playbooks.yaml does not declare this schedule —
+    # a schedule created with no declaration behind it is the other half of
+    # the same defect, and it must not be creatable by this script.
+    desc=$(python3 "${SCRIPT_DIR}/../../overseer/trigger_descriptions.py" \
+      --trigger "${surface}:${sched_name}" \
+      --prose "Overseer alert-drain ${slot} UTC daily via the overseer-dispatcher router (alpha-engine-config-I2824)")
+    if aws scheduler get-schedule --name "${sched_name}" --region "${REGION}" >/dev/null 2>&1; then
+      verb=update-schedule
+    else
+      verb=create-schedule
+    fi
+    echo "  ${verb} ${sched_name} (state=$(pause_state "${sched_name}"))"
+    run aws scheduler "${verb}" \
+      --name "${sched_name}" \
+      --state "$(pause_state "${sched_name}")" \
+      --schedule-expression "cron(0 ${hh} * * ? *)" \
+      --flexible-time-window '{"Mode":"OFF"}' \
+      --description "${desc}" \
+      --target "{\"Arn\":\"${ROUTER_ARN}\",\"RoleArn\":\"arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}\",\"Input\":${input_escaped},\"RetryPolicy\":{\"MaximumRetryAttempts\":0,\"MaximumEventAgeInSeconds\":60}}" \
+      --region "${REGION}" > /dev/null
+  done
+}
+
+# ----- Schedules-only run (the CI path) --------------------------------------
+# Placed BEFORE packaging and EXITING, for the reason nous-ergon-ops-I520 made
+# expensive: "only" has to mean the whole run. Nothing below this point is
+# needed to write a description, and a schedules-only mode that fell through
+# into a code deploy would be a second deploy path nobody asked for.
+if $RECONCILE_TRIGGERS; then
+  echo "Reconciling alert-drain schedules (descriptions + state + retry policy)..."
+  reconcile_drain_schedules
+  echo "  ✓ schedules reconciled. Nothing else was touched — no code, no env, no IAM."
+  exit 0
+fi
 
 # ----- 0. Validate handler syntax + preflight unit tests ---------------------
 PKG=$(mktemp -d)
@@ -142,35 +230,11 @@ if $BOOTSTRAP; then
     --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"${ROUTER_ARN}\"}]}"
   if ! $DRY_RUN; then sleep 10; fi
 
-  # --- Twice-daily drain schedules -> ROUTER (playbook alert-drain) ----------
-  # 10:00 UTC (pre-market, after overnight alert accrual) + 22:00 UTC
-  # (post-close, after the daily pipelines) — both outside US market hours
-  # (13:30-20:00 UTC standard AND daylight time).
-  for slot in 1000 2200; do
-    HH="${slot:0:2}"
-    SCHED_NAME="alpha-engine-alert-drain-${slot}utc"
-    INPUT="{\"playbook\":\"alert-drain\",\"payload\":{\"trigger\":\"scheduled-${slot}utc\"}}"
-    if aws scheduler get-schedule --name "${SCHED_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-      echo "  Schedule exists: ${SCHED_NAME} (updating)"
-      VERB=update-schedule
-    else
-      VERB=create-schedule
-    fi
-    # Input must be a JSON-ESCAPED string inside the target JSON.
-    INPUT_ESCAPED=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
-    # config#2902: zero-retry on the router-targeting schedule — AWS Scheduler
-    # defaults to MaximumRetryAttempts=185, which would re-dispatch this
-    # payload for up to a day on any transient router error. The router's
-    # clean-JSON-never-raise contract + watch-plane Errors alarm are the
-    # intended failure surface, not scheduler-level retry.
-    run aws scheduler "${VERB}" \
-      --name "${SCHED_NAME}" \
-      --schedule-expression "cron(0 ${HH} * * ? *)" \
-      --flexible-time-window '{"Mode":"OFF"}' \
-      --description "Overseer alert-drain ${slot} UTC daily via the overseer-dispatcher router (alpha-engine-config-I2824)" \
-      --target "{\"Arn\":\"${ROUTER_ARN}\",\"RoleArn\":\"arn:aws:iam::${ACCOUNT_ID}:role/${SCHED_ROLE_NAME}\",\"Input\":${INPUT_ESCAPED},\"RetryPolicy\":{\"MaximumRetryAttempts\":0,\"MaximumEventAgeInSeconds\":60}}" \
-      --region "${REGION}" > /dev/null || echo "  WARN: ${VERB} ${SCHED_NAME} failed"
-  done
+  # --- The daily drain schedules -> ROUTER (playbook alert-drain) -----------
+  # One function, shared with --reconcile-triggers, so bootstrap and the CI
+  # path can never write different schedules (they did: this block used to
+  # loop over `1000 2200` while 0400 and 1600 existed live).
+  reconcile_drain_schedules
 fi
 
 # ----- 3. Update code (always) -----------------------------------------------

--- a/infrastructure/lambdas/freshness-monitor/deploy.sh
+++ b/infrastructure/lambdas/freshness-monitor/deploy.sh
@@ -30,6 +30,7 @@
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh             # update code + registry (operator; needs ae-config clone)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --code-only # update code ONLY (CI path; no registry, no ae-config clone)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --bootstrap # first-time create + wire EventBridge
+#   bash infrastructure/lambdas/freshness-monitor/deploy.sh --reconcile-triggers # upsert the three cron rules ONLY (the CI path; no packaging)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --apply-iam # re-apply iam-policy.json and EXIT — no code, no env, no registry (config#2825, config-I6661)
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --dry-run   # show actions, do not apply
 #   bash infrastructure/lambdas/freshness-monitor/deploy.sh --smoke     # invoke once after deploy
@@ -49,6 +50,35 @@ POLICY_NAME="alpha-engine-freshness-monitor-policy"
 RULE_NAME="alpha-engine-freshness-monitor-cron"
 HISTORICAL_RULE_NAME="alpha-engine-freshness-monitor-historical-cron"
 INTRADAY_RULE_NAME="alpha-engine-freshness-monitor-intraday-cron"
+
+# alpha-engine-config-I9045. These three rules wake the freshness monitor, and
+# the daily one ALSO wakes the Overseer alert-drain playbook: on a freshness
+# CRITICAL with no declared operator/recovery lane the handler invokes
+# alpha-engine-overseer-dispatcher directly with {"playbook":"alert-drain"}
+# (config-I3282, gated by FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED, verified
+# live true 2026-08-28). Measured the same day: that leg was running the drain
+# EVERY DAY while all four of alert-drain's own Scheduler schedules sat
+# DISABLED — and no tag, description or field on any AWS resource said so.
+# Listing the rules here opts them into the reconcile below and into
+# infrastructure/overseer/trigger_surface_drift.py's grading. Each cron and
+# state is written on every run: `events put-rule` is an upsert that DEFAULTS
+# TO ENABLED when --state is omitted (I6619) and drops the description when
+# --description is omitted.
+RECONCILE_DESCRIPTION_TRIGGERS=(
+  "events:alpha-engine-freshness-monitor-cron"
+  "events:alpha-engine-freshness-monitor-historical-cron"
+  "events:alpha-engine-freshness-monitor-intraday-cron"
+)
+RECONCILE_CRONS=(
+  "cron(0 12 * * ? *)"
+  "cron(0 4 * * ? *)"
+  "cron(0/30 14-21 ? * MON-FRI *)"
+)
+RECONCILE_PROSE=(
+  "Daily 12:00 UTC probe of the artifact freshness registry"
+  "Daily 04:00 UTC historical-cycle probe (mode=historical)"
+  "30-min weekday 14-21 UTC intraday probe (mode=intraday)"
+)
 REGION="${AWS_REGION:-us-east-1}"
 ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 
@@ -74,10 +104,12 @@ BOOTSTRAP=false
 APPLY_IAM=false
 SMOKE=false
 CODE_ONLY=false
+RECONCILE_TRIGGERS=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --bootstrap) BOOTSTRAP=true ;;
+    --reconcile-triggers) RECONCILE_TRIGGERS=true ;;
     --apply-iam) APPLY_IAM=true ;;
     --smoke) SMOKE=true ;;
     --code-only) CODE_ONLY=true ;;
@@ -87,6 +119,40 @@ done
 
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
+
+# ----- Reconcile the three cron rules' state + description ------------------
+# The description is prose + a marker derived from playbooks.yaml, so the
+# alert-drain dispatch leg is legible from `aws events describe-rule` alone.
+# Targets are NOT touched: `put-rule` with --schedule-expression leaves them in
+# place, and re-declaring them here would be a second copy of the bootstrap's
+# mode= Input JSON to keep in sync.
+reconcile_freshness_rules() {
+  local i key rule_name desc
+  for i in "${!RECONCILE_DESCRIPTION_TRIGGERS[@]}"; do
+    key="${RECONCILE_DESCRIPTION_TRIGGERS[$i]}"
+    rule_name="${key#*:}"
+    desc=$(python3 "${SCRIPT_DIR}/../../overseer/trigger_descriptions.py" \
+      --trigger "${key}" --prose "${RECONCILE_PROSE[$i]}")
+    echo "  put-rule ${rule_name} (state=$(pause_state "${rule_name}"))"
+    run aws events put-rule \
+      --name "${rule_name}" --state "$(pause_state "${rule_name}")" \
+      --schedule-expression "${RECONCILE_CRONS[$i]}" \
+      --description "${desc}" \
+      --region "${REGION}" \
+      --query 'RuleArn' --output text
+  done
+}
+
+# ----- Reconcile-triggers only, then EXIT ------------------------------------
+# Placed FIRST, alongside --apply-iam and for the same nous-ergon-ops-I520
+# reason: nothing below installs, tests or zips anything this mode needs, and a
+# mode that fell through would become a second, undeclared deploy path.
+if $RECONCILE_TRIGGERS; then
+  echo "Reconciling freshness-monitor EventBridge rules (state + description)..."
+  reconcile_freshness_rules
+  echo "  ✓ rules reconciled. Nothing else was touched — no code, no env, no registry."
+  exit 0
+fi
 
 # ----- Apply IAM only, then EXIT (config#2825, config-I6661) ---------------
 # Placed FIRST, before packaging, deliberately. "only" has to mean the whole
@@ -244,13 +310,12 @@ if $BOOTSTRAP; then
   # The genuinely-intraday artifacts (open_orders_latest,
   # freshness_monitor_heartbeat) are NOT blinded by this — they're also
   # covered by the separate 30-min mini-rule below.
-  echo "  Creating EventBridge cron: ${RULE_NAME}"
-  run aws events put-rule \
-    --name "${RULE_NAME}" --state "$(pause_state "${RULE_NAME}")" \
-    --schedule-expression "cron(0 12 * * ? *)" \
-    --description "Daily 12:00 UTC probe of the artifact freshness registry" \
-    --region "${REGION}" \
-    --query 'RuleArn' --output text
+  # All three rules are created by the SAME function the CI reconcile calls
+  # (alpha-engine-config-I9045). Bootstrap used to write its own put-rule per
+  # rule, with its own description literal — two writers of one field is how
+  # the marker would have gone missing on the next bootstrap.
+  echo "  Creating/updating the three EventBridge crons"
+  reconcile_freshness_rules
 
   FN_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
   run aws events put-targets \
@@ -273,14 +338,6 @@ if $BOOTSTRAP; then
   # cycles of each artifact and writes _freshness_monitor/history.json
   # (page 26 reads this for per-row history expanders + gap counts).
   # Lookback defaults: 12 saturday + 30 weekday/eod cycles.
-  echo "  Creating EventBridge historical cron: ${HISTORICAL_RULE_NAME}"
-  run aws events put-rule \
-    --name "${HISTORICAL_RULE_NAME}" --state "$(pause_state "${HISTORICAL_RULE_NAME}")" \
-    --schedule-expression "cron(0 4 * * ? *)" \
-    --description "Daily 04:00 UTC historical-cycle probe (mode=historical)" \
-    --region "${REGION}" \
-    --query 'RuleArn' --output text
-
   # JSON Input (`{"mode":"historical"}`) doesn't fit the put-targets
   # shorthand form (Id=,Arn=,Input= chokes on the embedded quotes +
   # comma). Write a temp JSON file + pass via file:// to dodge the
@@ -318,14 +375,6 @@ EOF
   # genuinely-intraday artifacts (open_orders_latest,
   # freshness_monitor_heartbeat) without touching the shared
   # check_results/heartbeat/cycle_verdict surfaces the daily sweep owns.
-  echo "  Creating EventBridge intraday cron: ${INTRADAY_RULE_NAME}"
-  run aws events put-rule \
-    --name "${INTRADAY_RULE_NAME}" --state "$(pause_state "${INTRADAY_RULE_NAME}")" \
-    --schedule-expression "cron(0/30 14-21 ? * MON-FRI *)" \
-    --description "30-min weekday 14-21 UTC intraday probe (mode=intraday)" \
-    --region "${REGION}" \
-    --query 'RuleArn' --output text
-
   # Same file:// dodge as the historical target above (embedded-quote JSON
   # doesn't survive the put-targets shorthand form).
   INTRADAY_TARGET_JSON=$(mktemp)

--- a/infrastructure/overseer/arming.py
+++ b/infrastructure/overseer/arming.py
@@ -140,6 +140,49 @@ def _classify_trigger(trig: dict, paused: set[str], kept: set[str], live_state) 
     out = {"surface": surface, "name": trig.get("name") or trig.get("ref")}
 
     if surface not in JOINABLE_SURFACES:
+        # alpha-engine-config-I9045. A leg with no AWS resource of its own may
+        # still declare `depends_on`: the resources whose live state IS its
+        # arming. Resolving it is not a nicety — measured 2026-08-28,
+        # alert-drain's event-time leg was the ONLY thing running the drain
+        # (daily, all week) while its four schedules sat DISABLED, and this
+        # branch reported the one live leg as `unjoinable`. A blank standing
+        # where the answer was derivable is what §8.3 forbids.
+        deps = trig.get("depends_on") or []
+        if deps:
+            resolved = [
+                _classify_trigger(dict(d), paused, kept, live_state) for d in deps
+            ]
+            out["declared"] = trig.get("declared_by") or "derived-from-dependencies"
+            out["depends_on"] = resolved
+            dep_verdicts = [r["verdict"] for r in resolved]
+            out["live"] = ",".join(str(r.get("live", "-")) for r in resolved)
+            if "armed" in dep_verdicts:
+                # ANY armed dependency wakes this leg. Not `all` — the leg fires
+                # whenever any one of the rules it rides fires, and reading it
+                # as dark because a sibling is off is the false-negative that
+                # would hide a running playbook all over again.
+                out["verdict"] = "armed-via-dependency"
+            elif "trigger-absent" in dep_verdicts:
+                out["verdict"] = "trigger-absent"
+                out["detail"] = (
+                    f"event-time leg '{out['name']}' depends on a trigger that does not "
+                    "exist live, so this wake path is broken: "
+                    + "; ".join(
+                        r.get("detail", "") for r in resolved
+                        if r["verdict"] == "trigger-absent"
+                    )
+                )
+            elif all(v == "paused-declared" for v in dep_verdicts):
+                out["verdict"] = "paused-declared"
+            else:
+                out["verdict"] = "undeclared-dark"
+                out["detail"] = (
+                    f"event-time leg '{out['name']}' is dark: every trigger it depends on "
+                    "is DISABLED and at least one of them is in neither the paused nor "
+                    "the kept block of automation_pause.json."
+                )
+            return out
+
         out["verdict"] = "unjoinable"
         out["declared"] = trig.get("declared_by") or "out-of-band"
         out["detail"] = trig.get("reason") or (
@@ -186,7 +229,13 @@ def _unit_verdict(triggers: list[dict]) -> str:
     and `undeclared-dark` outranks everything because an undeclared dark
     trigger is the one condition that makes every other reading unsafe.
     """
-    v = [t["verdict"] for t in triggers]
+    # `armed-via-dependency` is an ARMED reading, not a weaker one: the leg has
+    # a live enabled AWS resource behind it, reached one hop away
+    # (alpha-engine-config-I9045). Folding it here is what makes a playbook
+    # running solely off its event-time leg read `partially-armed` rather than
+    # `paused-declared` — the false reading measured on 2026-08-12.
+    v = ["armed" if t["verdict"] == "armed-via-dependency" else t["verdict"]
+         for t in triggers]
     if not v:
         return "undeclared-no-triggers"
     if "undeclared-dark" in v:

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -311,6 +311,26 @@
           "declared_by": {
             "type": "string",
             "description": "Optional: the ruling or issue that decided this leg's state."
+          },
+          "depends_on": {
+            "type": "array",
+            "minItems": 1,
+            "description": "alpha-engine-config-I9045 — for a leg with no AWS trigger resource of its own (`surface: event-time`), the AWS resources whose live state IS this leg's arming. Measured 2026-08-28: alert-drain's four Scheduler schedules were all DISABLED and it ran every day off its event-time leg, which arming.py could only report `unjoinable` because `reason` said so in prose. With this, the leg resolves to `armed-via-dependency` or `dark-via-dependency`, and trigger_descriptions.py can stamp `[wakes: <playbook>]` onto the dispatching rule so the linkage is legible from `aws events list-rules` alone.",
+            "items": {
+              "type": "object",
+              "required": ["surface", "name"],
+              "additionalProperties": false,
+              "properties": {
+                "surface": {
+                  "enum": ["events", "scheduler"],
+                  "description": "Only probeable surfaces may be depended on. A dependency whose own state cannot be read would move the blank rather than remove it."
+                },
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9.-]{0,127}$"
+                }
+              }
+            }
           }
         }
       }

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -62,6 +62,17 @@ playbooks:
       - {surface: events, name: alpha-engine-saturday-sf-watch-failed}
       - {surface: events, name: alpha-engine-sf-watch-spot-interruption}
       - {surface: events, name: alpha-engine-sf-watch-instance-terminated}
+      # Found by trigger_surface_drift.py on its first live run
+      # (alpha-engine-config-I9045). This schedule dispatches
+      # {"playbook": "sf-watch", "payload": {"is_drill": "true", ...}} through
+      # the router — a real wake path for THIS playbook — and it was declared
+      # only under canary-replay, whose triggers list it because the drill is
+      # canary-replay's instrument. Both are true and both belong here: the
+      # ci-watch drill twin is already declared on both sides, which is what
+      # made the asymmetry visible. Being drill-only does not exempt it —
+      # `drill_isolation` governs how a drill run is graded, not whether the
+      # thing that starts it is a trigger.
+      - {surface: scheduler, name: alpha-engine-sf-watch-canary-drill-weekly}
     executor_function: alpha-engine-sf-watch-spot-dispatcher
     executor_lambda_dir: sf-watch-spot-dispatcher
     # Executor verdict `reason` values that are by-design declines — the
@@ -229,6 +240,21 @@ playbooks:
           invoke the router directly (config-I3282). Its arming is the arming of
           alpha-engine-freshness-monitor-{cron,historical-cron,intraday-cron},
           all three of which the pause manifest declares KEPT.
+        # alpha-engine-config-I9045. The sentence above was true, joinable by a
+        # human, and readable by nothing. Measured 2026-08-28: all four
+        # schedules above were live DISABLED and alert-drain ran EVERY DAY that
+        # week off this leg — and `arming.py` could only report the leg
+        # `unjoinable`, because "its arming is the arming of X" lived in prose.
+        # `depends_on` is that sentence in a form the code can follow: these are
+        # the AWS resources whose live state IS this leg's arming, so the leg
+        # resolves to armed/dark instead of a blank, and
+        # `trigger_descriptions.py` can stamp the linkage onto both ends of it
+        # (the rules gain `[wakes: alert-drain]`, the schedules gain a
+        # `[sibling-legs: ...]` naming the rule that is doing the work).
+        depends_on:
+          - {surface: events, name: alpha-engine-freshness-monitor-cron}
+          - {surface: events, name: alpha-engine-freshness-monitor-historical-cron}
+          - {surface: events, name: alpha-engine-freshness-monitor-intraday-cron}
     executor_function: alpha-engine-alert-drain-dispatcher
     executor_lambda_dir: alert-drain-dispatcher
     benign_reasons: [concurrent_skip, disabled]

--- a/infrastructure/overseer/trigger_descriptions.py
+++ b/infrastructure/overseer/trigger_descriptions.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""trigger_descriptions.py — the AWS-surface half of a playbook's wake declaration.
+
+**The defect this closes (alpha-engine-config-I9045).** Measured 2026-08-28:
+``aws scheduler list-schedules`` showed all four
+``alpha-engine-alert-drain-{0400,1000,1600,2200}utc`` schedules ``DISABLED``, and
+the drain had nonetheless run every day that week (``drain_ledger`` objects for
+08-24 through 08-28, each with an EC2 spot run log). The real wake leg is an
+EventBridge **Rule**, ``alpha-engine-freshness-monitor-cron``, whose Lambda
+invokes the Overseer router directly with ``{"playbook":"alert-drain"}`` on a
+freshness CRITICAL (``alpha-engine-config-I3282``). That linkage was written
+down — in ``playbooks.yaml``'s ``wake:`` prose, in one YAML file, in one private
+repo. **Nothing on the AWS resources said it.** An operator, a cost audit, a
+conformance sweep or an incident responder reading the AWS surface alone reached
+the wrong answer in whichever direction they happened to be looking.
+
+``principles.md`` §7: a component is not healthy because a list says DISABLED.
+Here the inverse bit — the list said DISABLED and the thing was running.
+
+**What this module does.** It derives, from ``playbooks.yaml`` alone, a compact
+machine-readable marker for each live AWS trigger resource, which the owning
+``deploy.sh`` appends to that resource's ``Description`` on every reconcile. One
+derivation, two consumers:
+
+  * ``infrastructure/lambdas/*/deploy.sh --reconcile-triggers`` WRITES it.
+  * ``infrastructure/overseer/trigger_surface_drift.py`` ASSERTS it.
+
+Because both call this function, a hand-edited description or a stale deploy is
+drift rather than a second opinion, and there is no second copy of the grammar
+to keep in sync.
+
+**The grammar**, stable and greppable::
+
+    [wakes: alert-drain] [sibling-legs: events:alpha-engine-freshness-monitor-cron,...]
+
+  ``wakes``         — every playbook this AWS resource can start, whether it
+                      targets the router itself (a ``scheduler``/``events``
+                      trigger declared on the playbook) or starts a Lambda that
+                      dispatches the router in-process (an ``event-time``
+                      trigger's ``depends_on``). The two are indistinguishable
+                      to whoever is asking "what runs alert-drain".
+  ``sibling-legs``  — every OTHER live AWS resource that can start any of those
+                      same playbooks. This is the field that answers I9045: read
+                      off a DISABLED alert-drain schedule, it names the enabled
+                      freshness rule that is doing the work.
+
+**Prose is NOT part of the marker.** Each ``deploy.sh`` keeps its own
+human-readable sentence and this module appends the marker to it. The drift
+check compares the MARKER only, so an operator improving the prose is not
+graded as drift, while the machine-readable half cannot be edited away.
+
+Usage:
+  ./trigger_descriptions.py --trigger scheduler:alpha-engine-alert-drain-0400utc \\
+      --prose "Overseer alert-drain 0400 UTC daily via the overseer-dispatcher router"
+  ./trigger_descriptions.py --trigger events:alpha-engine-freshness-monitor-cron --marker-only
+  ./trigger_descriptions.py --list           # every resource playbooks.yaml implies
+  ./trigger_descriptions.py --list --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent.resolve()
+REGISTRY_PATH = HERE / "playbooks.yaml"
+
+#: Surfaces that name a real, probeable AWS trigger resource. Same vocabulary as
+#: ``arming.py``'s ``JOINABLE_SURFACES`` and ``automation_pause.py``'s manifest
+#: blocks — ``events`` (EventBridge Rule) and ``scheduler`` (EventBridge
+#: Scheduler schedule) are DIFFERENT APIs, not aliases.
+AWS_SURFACES = ("events", "scheduler")
+
+#: AWS caps both ``events:PutRule --description`` and
+#: ``scheduler:{Create,Update}Schedule --description`` at 512 characters, and
+#: both TRUNCATE rather than reject on some paths. A truncated marker is a
+#: marker that parses to the wrong answer, so the generator refuses instead.
+MAX_DESCRIPTION_CHARS = 512
+
+
+class DescriptionTooLong(ValueError):
+    """The prose + marker would exceed what AWS will store intact."""
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def declared_units(registry: dict) -> list[tuple[str, list[dict]]]:
+    """``(unit name, triggers)`` for every playbook and T1 automation.
+
+    Mirrors ``arming.py::declared_units`` in what it walks — both halves of
+    ``playbooks.yaml`` declare triggers and both owe an AWS-surface marker.
+    """
+    units: list[tuple[str, list[dict]]] = []
+    for name, spec in sorted((registry.get("playbooks") or {}).items()):
+        units.append((name, list((spec or {}).get("triggers") or [])))
+    for entry in registry.get("t1_automations") or []:
+        units.append((entry.get("name"), list(entry.get("triggers") or [])))
+    return units
+
+
+def _key(surface: str, name: str) -> str:
+    return f"{surface}:{name}"
+
+
+def resource_index(registry: dict) -> dict[str, dict]:
+    """``{"scheduler:name": {"wakes": {playbook, ...}, "kinds": {...}}}``.
+
+    An AWS resource earns an entry two ways, and the distinction is recorded but
+    deliberately does NOT change ``wakes``:
+
+      ``direct``    — the playbook declares it as its own ``events``/``scheduler``
+                      trigger. The resource targets the Overseer router.
+      ``event-time``— the playbook declares an ``event-time`` leg whose
+                      ``depends_on`` names it. The resource starts some other
+                      Lambda, which then invokes the router in-process. This is
+                      the alert-drain / freshness-monitor shape, and it is
+                      precisely the leg that was invisible.
+    """
+    index: dict[str, dict] = {}
+
+    def _add(surface: str, name: str, unit: str, kind: str) -> None:
+        if surface not in AWS_SURFACES or not name or not unit:
+            return
+        entry = index.setdefault(_key(surface, name), {"wakes": set(), "kinds": set()})
+        entry["wakes"].add(unit)
+        entry["kinds"].add(kind)
+
+    for unit, triggers in declared_units(registry):
+        for trig in triggers:
+            surface = trig.get("surface")
+            if surface in AWS_SURFACES:
+                _add(surface, trig.get("name"), unit, "direct")
+            elif surface == "event-time":
+                for dep in trig.get("depends_on") or []:
+                    _add(dep.get("surface"), dep.get("name"), unit, "event-time")
+    return index
+
+
+def sibling_legs(index: dict[str, dict], key: str) -> list[str]:
+    """Other AWS resources that can start any playbook ``key`` starts."""
+    wakes = index[key]["wakes"]
+    return sorted(k for k, v in index.items() if k != key and v["wakes"] & wakes)
+
+
+def marker_for(registry: dict, surface: str, name: str) -> str:
+    """The machine-readable suffix for one AWS trigger resource.
+
+    Raises ``KeyError`` when ``playbooks.yaml`` does not imply this resource at
+    all. That is not defensiveness: a deploy.sh asking for a marker it cannot
+    get is a resource being created with no declaration behind it, which is the
+    undeclared-trigger half of the same defect.
+    """
+    index = resource_index(registry)
+    key = _key(surface, name)
+    if key not in index:
+        raise KeyError(
+            f"{key} is not declared in playbooks.yaml — no playbook lists it as a "
+            "trigger and no event-time leg names it in depends_on. Declare it "
+            "before creating it, or this resource is a wake path nothing records."
+        )
+    parts = [f"[wakes: {','.join(sorted(index[key]['wakes']))}]"]
+    siblings = sibling_legs(index, key)
+    if siblings:
+        parts.append(f"[sibling-legs: {','.join(siblings)}]")
+    return " ".join(parts)
+
+
+def description_for(registry: dict, surface: str, name: str, prose: str) -> str:
+    """``prose`` + the marker, refusing anything AWS would silently truncate."""
+    marker = marker_for(registry, surface, name)
+    prose = (prose or "").strip()
+    full = f"{prose} {marker}".strip() if prose else marker
+    if len(full) > MAX_DESCRIPTION_CHARS:
+        raise DescriptionTooLong(
+            f"{_key(surface, name)}: description is {len(full)} chars, over AWS's "
+            f"{MAX_DESCRIPTION_CHARS}-char ceiling (marker alone is {len(marker)}). "
+            "Shorten the prose — the marker is not optional and must not be cut."
+        )
+    return full
+
+
+def _split_trigger(spec: str) -> tuple[str, str]:
+    surface, _, name = spec.partition(":")
+    if surface not in AWS_SURFACES or not name:
+        raise SystemExit(
+            f"--trigger must be '<{'|'.join(AWS_SURFACES)}>:<resource-name>', got {spec!r}"
+        )
+    return surface, name
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--playbooks", type=Path, default=REGISTRY_PATH)
+    p.add_argument("--trigger", help="<surface>:<name> of one AWS trigger resource")
+    p.add_argument("--prose", default="", help="the human-readable half")
+    p.add_argument("--marker-only", action="store_true")
+    p.add_argument("--list", action="store_true", help="every resource + marker")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    registry = load_registry(args.playbooks)
+
+    if args.list:
+        index = resource_index(registry)
+        rows = [
+            {
+                "resource": key,
+                "wakes": sorted(index[key]["wakes"]),
+                "kinds": sorted(index[key]["kinds"]),
+                "marker": marker_for(registry, *key.split(":", 1)),
+            }
+            for key in sorted(index)
+        ]
+        print(json.dumps(rows, indent=2) if args.json
+              else "\n".join(f"{r['resource']}\n    {r['marker']}" for r in rows))
+        return 0
+
+    if not args.trigger:
+        p.error("one of --trigger or --list is required")
+
+    surface, name = _split_trigger(args.trigger)
+    try:
+        out = (marker_for(registry, surface, name) if args.marker_only
+               else description_for(registry, surface, name, args.prose))
+    except (KeyError, DescriptionTooLong) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/overseer/trigger_surface_drift.py
+++ b/infrastructure/overseer/trigger_surface_drift.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""trigger_surface_drift.py — does the AWS trigger surface say what playbooks.yaml says?
+
+**alpha-engine-config-I9045.** ``playbooks.yaml`` declares, per playbook, every
+leg that can wake it. Live AWS carried none of that. Measured 2026-08-28: all
+four ``alpha-engine-alert-drain-*utc`` Scheduler schedules were ``DISABLED``, the
+drain ran daily anyway off ``alpha-engine-freshness-monitor-cron``'s event-time
+leg, every one of the four schedules had ``Description: null``, and the rule
+doing the work said only *"Daily 12:00 UTC probe of the artifact freshness
+registry"*. Anyone reading the AWS surface alone — an operator, an incident
+responder, a cost audit, a conformance sweep — got the wrong answer, and the
+correction existed only as a YAML comment in a private repo.
+
+``infrastructure/lambdas/*/deploy.sh --reconcile-triggers`` now stamps a marker
+derived from ``playbooks.yaml`` onto each resource it owns. **This is the check
+that the stamp is still there and still true.** Without it the tags are a
+one-time hand-wave that drifts the first time a leg is added, renamed or
+retimed — the same class of defect as the one being fixed.
+
+Findings (any of them exits 1):
+
+  ``marker-missing``      A resource a ``deploy.sh`` declares it reconciles has
+                          no ``[wakes: ...]`` marker live. Either the deploy has
+                          not run since the marker landed, or something
+                          overwrote the description.
+  ``marker-drift``        A marker is present and DISAGREES with what
+                          ``playbooks.yaml`` now implies — a wake leg was added
+                          or removed and the surface still claims the old set.
+  ``trigger-absent``      A reconciled resource does not exist live at all.
+  ``undeclared-trigger``  A live EventBridge Scheduler schedule targets the
+                          Overseer router with a ``playbook`` in its Input, and
+                          ``playbooks.yaml`` does not list it under that
+                          playbook's ``triggers:``. This one needs no coverage
+                          gate and it is the reverse-direction catch: it is what
+                          finds a wake path that exists on AWS and nowhere else.
+                          It fired on the real thing — ``deploy.sh`` codified
+                          only the ``1000``/``2200`` slots while ``0400`` and
+                          ``1600`` existed live, so config#2902's zero-retry fix
+                          reached two of four and nothing noticed for a year.
+
+Reported but NOT red:
+
+  ``marker-pending``      A resource ``playbooks.yaml`` implies that no
+                          ``deploy.sh`` has opted into reconciling yet. Counted
+                          and named on every run so the remaining coverage is a
+                          number on a surface rather than an unstated backlog
+                          (``alpha-engine-config-I9068``). It becomes graded the
+                          moment its owning deploy script adds it to
+                          ``RECONCILE_DESCRIPTION_TRIGGERS`` — coverage is
+                          discovered by scanning the deploy scripts, so there is
+                          no allowlist here that could be widened to hide one.
+
+**Exit codes** follow the fleet convention (``check_port_registry_drift.py``):
+
+  ``0``  every graded resource agrees with the declaration
+  ``1``  drift — at least one finding above
+  ``2``  **could not measure** — no AWS credentials, no ``aws`` CLI, or an
+         AccessDenied. Distinct from ``0`` on purpose: a check that cannot see
+         its subject has NOT passed, and reporting "no drift" because it lost
+         its own access is how a detector grades itself green. ``--allow-unmeasured``
+         downgrades this to 0 for a PR-context run where credentials are not
+         expected; it never downgrades a real finding.
+
+Usage:
+  ./infrastructure/overseer/trigger_surface_drift.py            # everything
+  ./infrastructure/overseer/trigger_surface_drift.py --json
+  ./infrastructure/overseer/trigger_surface_drift.py --allow-unmeasured
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent.resolve()
+REPO_ROOT = HERE.parent.parent
+LAMBDAS_DIR = REPO_ROOT / "infrastructure" / "lambdas"
+
+sys.path.insert(0, str(HERE))
+import trigger_descriptions as td  # noqa: E402  (path must be set first)
+
+#: The Lambda every router-targeting Scheduler schedule points at. A schedule
+#: whose target is this function and whose Input names a playbook IS a wake leg,
+#: whatever the repo does or does not say about it.
+ROUTER_FUNCTION = "alpha-engine-overseer-dispatcher"
+
+#: The bash array a ``deploy.sh`` declares to opt its resources into grading.
+#: Discovery by scan rather than by registry, mirroring
+#: ``infrastructure/scheduler/check-schedule-drift.py`` and
+#: ``infrastructure/eventbridge/check-drift.py``: a deploy script that starts
+#: reconciling a resource is covered here the moment it lands, with nothing to
+#: remember to update.
+_COVERAGE_ARRAY_RE = re.compile(
+    r"^\s*RECONCILE_DESCRIPTION_TRIGGERS=\(\n(.*?)\n\s*\)", re.DOTALL | re.MULTILINE
+)
+_ENTRY_RE = re.compile(r'^\s*"([^"]+)"\s*$', re.MULTILINE)
+
+#: The marker's leading token. Present => the resource has been stamped.
+_MARKER_RE = re.compile(r"\[wakes:[^\]]*\](?:\s*\[sibling-legs:[^\]]*\])?")
+
+
+class CouldNotMeasure(RuntimeError):
+    """The live comparison could not be performed at all."""
+
+
+# ── discovery ────────────────────────────────────────────────────────────────
+
+def discover_reconciled_triggers(lambdas_dir: Path = LAMBDAS_DIR) -> dict[str, str]:
+    """``{"scheduler:name": "infrastructure/lambdas/x/deploy.sh"}``."""
+    covered: dict[str, str] = {}
+    for deploy in sorted(lambdas_dir.glob("*/deploy.sh")):
+        match = _COVERAGE_ARRAY_RE.search(deploy.read_text(encoding="utf-8"))
+        if not match:
+            continue
+        rel = str(deploy.relative_to(REPO_ROOT))
+        for entry in _ENTRY_RE.findall(match.group(1)):
+            covered[entry] = rel
+    return covered
+
+
+# ── live reads ───────────────────────────────────────────────────────────────
+
+def _aws(args: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(
+            ["aws"] + args, capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError as exc:  # no aws CLI on this machine
+        raise CouldNotMeasure("the `aws` CLI is not installed") from exc
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _raise_if_unmeasurable(err: str, what: str) -> None:
+    """Separate 'cannot see' from 'saw, and it is wrong'.
+
+    A credential or permission failure is NOT absence and must never be graded
+    as one. The same posture ``check-schedule-drift.py`` takes, and the reason
+    this module has a third exit code at all.
+    """
+    for token in (
+        "AccessDenied", "UnauthorizedOperation", "ExpiredToken",
+        "InvalidClientTokenId", "Unable to locate credentials",
+        "You must specify a region", "SignatureDoesNotMatch",
+        "NoCredentialProviders", "could not be found",
+    ):
+        if token in err:
+            raise CouldNotMeasure(f"{what}: {err}")
+
+
+def live_description(surface: str, name: str) -> str | None:
+    """The live ``Description``, ``""`` when unset, or ``None`` when absent."""
+    if surface == "scheduler":
+        rc, out, err = _aws([
+            "scheduler", "get-schedule", "--name", name,
+            "--query", "Description", "--output", "text",
+        ])
+        not_found = "ResourceNotFoundException"
+    else:
+        rc, out, err = _aws([
+            "events", "describe-rule", "--name", name,
+            "--query", "Description", "--output", "text",
+        ])
+        not_found = "ResourceNotFoundException"
+    if rc != 0:
+        _raise_if_unmeasurable(err, f"reading {surface}:{name}")
+        if not_found in err:
+            return None
+        raise CouldNotMeasure(f"reading {surface}:{name}: {err}")
+    # `--output text` renders a null Description as the literal "None".
+    return "" if out in ("", "None") else out
+
+
+def live_router_schedules() -> list[dict]:
+    """Every live Scheduler schedule that targets the Overseer router.
+
+    ``list-schedules`` does not return Target details, so each candidate needs a
+    ``get-schedule``. Scoped by the ``alpha-engine-`` name prefix, which is the
+    fleet's naming rule and what ``check-schedule-drift.py`` also scopes on.
+    """
+    rc, out, err = _aws([
+        "scheduler", "list-schedules", "--name-prefix", "alpha-engine-",
+        "--query", "Schedules[].Name", "--output", "text",
+    ])
+    if rc != 0:
+        _raise_if_unmeasurable(err, "listing schedules")
+        raise CouldNotMeasure(f"listing schedules: {err}")
+    found: list[dict] = []
+    for name in (out.split() if out else []):
+        rc, blob, err = _aws([
+            "scheduler", "get-schedule", "--name", name,
+            "--query", "{Arn:Target.Arn,Input:Target.Input}", "--output", "json",
+        ])
+        if rc != 0:
+            _raise_if_unmeasurable(err, f"reading scheduler:{name}")
+            continue
+        try:
+            target = json.loads(blob)
+        except json.JSONDecodeError:
+            continue
+        if ROUTER_FUNCTION not in (target.get("Arn") or ""):
+            continue
+        try:
+            playbook = (json.loads(target.get("Input") or "{}") or {}).get("playbook")
+        except json.JSONDecodeError:
+            playbook = None
+        if playbook:
+            found.append({"name": name, "playbook": playbook})
+    return found
+
+
+# ── the check ────────────────────────────────────────────────────────────────
+
+def extract_marker(description: str | None) -> str | None:
+    if not description:
+        return None
+    match = _MARKER_RE.search(description)
+    return match.group(0) if match else None
+
+
+def check(
+    registry: dict | None = None,
+    covered: dict[str, str] | None = None,
+    describe=live_description,
+    list_router_schedules=live_router_schedules,
+    source_file: str | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """``(findings, pending)``. Every collaborator is injected so the whole
+    verdict surface is testable without AWS — including, deliberately, the
+    failure paths, because a check nobody has watched fail is not a check."""
+    reg = registry if registry is not None else td.load_registry()
+    cov = covered if covered is not None else discover_reconciled_triggers()
+    index = td.resource_index(reg)
+
+    # `--source-file` scopes the run to one deploy script's own resources, and
+    # exists to remove a RACE rather than to narrow coverage. Each deploy
+    # workflow asserts immediately after its own reconcile; unscoped, the
+    # alert-drain job would also grade the freshness rules, which a CONCURRENT
+    # job is reconciling in the same merge — a red caused by scheduling, not by
+    # drift. The daily out-of-band run is unscoped and covers everything,
+    # including the reverse sweep this mode skips (a live wake path nobody
+    # declared belongs to no single deploy script).
+    if source_file:
+        cov = {k: v for k, v in cov.items() if v == source_file}
+        if not cov:
+            raise CouldNotMeasure(
+                f"no deploy script at {source_file!r} declares "
+                "RECONCILE_DESCRIPTION_TRIGGERS — nothing to grade, which is not a pass"
+            )
+        index = {k: v for k, v in index.items() if k in cov}
+
+    findings: list[dict] = []
+    pending: list[dict] = []
+
+    for key in sorted(index):
+        if key not in cov:
+            pending.append({
+                "resource": key,
+                "kind": "marker-pending",
+                "detail": (
+                    f"{key} is implied by playbooks.yaml but no deploy.sh lists it in "
+                    "RECONCILE_DESCRIPTION_TRIGGERS, so its AWS description is not "
+                    "reconciled and cannot be graded (alpha-engine-config-I9068)."
+                ),
+            })
+            continue
+
+        surface, name = key.split(":", 1)
+        expected = td.marker_for(reg, surface, name)
+        description = describe(surface, name)
+
+        if description is None:
+            findings.append({
+                "resource": key, "kind": "trigger-absent", "source_file": cov[key],
+                "detail": (
+                    f"{key} is reconciled by {cov[key]} and declared in playbooks.yaml, "
+                    "but does not exist live. Nothing can wake it."
+                ),
+            })
+            continue
+
+        actual = extract_marker(description)
+        if actual is None:
+            findings.append({
+                "resource": key, "kind": "marker-missing", "source_file": cov[key],
+                "expected": expected,
+                "detail": (
+                    f"{key} carries no [wakes: ...] marker live. Its wake linkage is "
+                    "invisible to anyone reading AWS alone — the exact I9045 condition. "
+                    f"Run `bash {cov[key]} --reconcile-triggers`, or let the merge that "
+                    "changed it deploy."
+                ),
+            })
+        elif actual != expected:
+            findings.append({
+                "resource": key, "kind": "marker-drift", "source_file": cov[key],
+                "expected": expected, "actual": actual,
+                "detail": (
+                    f"{key}'s live marker no longer matches playbooks.yaml. The wake "
+                    "declaration changed and the AWS surface still asserts the old one."
+                ),
+            })
+
+    # Reverse direction — a live wake path the registry has never heard of.
+    # Skipped under --source-file: an undeclared trigger belongs to no deploy
+    # script, so a scoped run cannot own the finding and would report it on
+    # whichever job happened to be scoped.
+    if source_file:
+        return findings, pending
+
+    declared_scheduler = {
+        key.split(":", 1)[1]: entry for key, entry in index.items()
+        if key.startswith("scheduler:")
+    }
+    for live in list_router_schedules():
+        entry = declared_scheduler.get(live["name"])
+        if entry is None:
+            findings.append({
+                "resource": f"scheduler:{live['name']}",
+                "kind": "undeclared-trigger",
+                "detail": (
+                    f"scheduler:{live['name']} dispatches playbook "
+                    f"'{live['playbook']}' through {ROUTER_FUNCTION}, and no playbook in "
+                    "playbooks.yaml declares it. It is a wake path that exists on AWS "
+                    "and nowhere else."
+                ),
+            })
+        elif live["playbook"] not in entry["wakes"]:
+            findings.append({
+                "resource": f"scheduler:{live['name']}",
+                "kind": "undeclared-trigger",
+                "detail": (
+                    f"scheduler:{live['name']} dispatches playbook '{live['playbook']}' "
+                    f"live, but playbooks.yaml declares it only for "
+                    f"{sorted(entry['wakes'])}."
+                ),
+            })
+
+    return findings, pending
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--json", action="store_true")
+    p.add_argument(
+        "--source-file",
+        help="grade only the resources this deploy.sh reconciles, e.g. "
+             "infrastructure/lambdas/alert-drain-dispatcher/deploy.sh",
+    )
+    p.add_argument(
+        "--allow-unmeasured", action="store_true",
+        help="exit 0 instead of 2 when the live comparison cannot be performed",
+    )
+    args = p.parse_args(argv)
+
+    try:
+        findings, pending = check(source_file=args.source_file)
+    except CouldNotMeasure as exc:
+        payload = {"status": "could_not_measure", "detail": str(exc)}
+        print(json.dumps(payload, indent=2) if args.json
+              else f"COULD NOT MEASURE: {exc}", file=sys.stderr)
+        return 0 if args.allow_unmeasured else 2
+
+    if args.json:
+        print(json.dumps({
+            "status": "drift" if findings else "ok",
+            "findings": findings,
+            "pending": pending,
+        }, indent=2))
+    else:
+        for row in pending:
+            print(f"  · [{row['kind']}] {row['resource']}")
+        if findings:
+            print(f"\n{len(findings)} finding(s):")
+            for row in findings:
+                print(f"  ✗ [{row['kind']}] {row['resource']}")
+                print(f"      {row['detail']}")
+                if "expected" in row:
+                    print(f"      expected: {row['expected']}")
+                if "actual" in row:
+                    print(f"      actual:   {row['actual']}")
+        else:
+            print(
+                f"\n  ✓ every reconciled trigger's AWS description matches "
+                f"playbooks.yaml ({len(pending)} not yet reconciled)"
+            )
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/overseer/trigger_surface_drift.py
+++ b/infrastructure/overseer/trigger_surface_drift.py
@@ -44,7 +44,7 @@ Reported but NOT red:
                           ``deploy.sh`` has opted into reconciling yet. Counted
                           and named on every run so the remaining coverage is a
                           number on a surface rather than an unstated backlog
-                          (``alpha-engine-config-I9068``). It becomes graded the
+                          (``alpha-engine-config-I9072``). It becomes graded the
                           moment its owning deploy script adds it to
                           ``RECONCILE_DESCRIPTION_TRIGGERS`` — coverage is
                           discovered by scanning the deploy scripts, so there is
@@ -263,7 +263,7 @@ def check(
                 "detail": (
                     f"{key} is implied by playbooks.yaml but no deploy.sh lists it in "
                     "RECONCILE_DESCRIPTION_TRIGGERS, so its AWS description is not "
-                    "reconciled and cannot be graded (alpha-engine-config-I9068)."
+                    "reconciled and cannot be graded (alpha-engine-config-I9072)."
                 ),
             })
             continue

--- a/tests/test_overseer_arming.py
+++ b/tests/test_overseer_arming.py
@@ -272,3 +272,100 @@ def test_ci_runs_the_arming_report():
     """A checker nothing runs is a comment. Pin the wiring."""
     wf = (ROOT / ".github" / "workflows" / "sf-arn-drift-check.yml").read_text(encoding="utf-8")
     assert "infrastructure/overseer/arming.py" in wf
+
+
+# ── the event-time leg: a blank where the answer was derivable (I9045) ───────
+
+def _event_time_registry():
+    """alert-drain's real shape: four paused schedules plus an event-time leg
+    riding an EventBridge rule that is deliberately KEPT enabled."""
+    return {"playbooks": {"alert-drain": {"triggers": [
+        {"surface": "scheduler", "name": "drain-sched"},
+        {"surface": "event-time",
+         "ref": "freshness CRITICAL -> router",
+         "reason": "the freshness Lambda invokes the router in-process",
+         "depends_on": [{"surface": "events", "name": "freshness-rule"}]},
+    ]}}}
+
+
+def _paused_drain_manifest(manifest):
+    m = dict(manifest)
+    m["paused"] = {"events_rules": {}, "scheduler_schedules": {"drain-sched": "ruled off"}}
+    m["not_paused"] = {"freshness-rule": "kept — detection only"}
+    m["pending"] = {}
+    return m
+
+
+def test_an_event_time_leg_resolves_through_its_dependencies(arming, manifest):
+    """The measured 2026-08-28 condition, and the reading that was wrong.
+
+    Every schedule DISABLED, the drain running daily, and this leg reported
+    `unjoinable` — so the playbook rolled up to `paused-declared`, i.e. "off by
+    ruling", about a thing that ran every day of that week. With `depends_on`
+    the leg resolves off the live rule and the playbook reads `partially-armed`.
+    """
+    rec = arming.build_record(
+        _event_time_registry(), _paused_drain_manifest(manifest),
+        _states({("scheduler", "drain-sched"): "DISABLED",
+                 ("events", "freshness-rule"): "ENABLED"}))
+    legs = rec["units"][0]["triggers"]
+    assert legs[1]["verdict"] == "armed-via-dependency"
+    assert rec["units"][0]["arming"] == "partially-armed"
+
+
+def test_an_event_time_leg_whose_every_dependency_is_paused_reads_paused(arming, manifest):
+    """The other direction. A declared pause is not a finding — reporting a
+    deliberate operator disable as a defect is §8.3's collapse the other way."""
+    m = _paused_drain_manifest(manifest)
+    m["paused"]["events_rules"] = {"freshness-rule": "ruled off"}
+    m["not_paused"] = {}
+    rec = arming.build_record(
+        _event_time_registry(), m,
+        _states({("scheduler", "drain-sched"): "DISABLED",
+                 ("events", "freshness-rule"): "DISABLED"}))
+    assert rec["units"][0]["triggers"][1]["verdict"] == "paused-declared"
+    assert rec["units"][0]["arming"] == "paused-declared"
+    assert arming.findings(rec) == []
+
+
+def test_an_event_time_leg_dark_with_nobody_s_decision_is_a_finding(arming, manifest):
+    """`undeclared-dark` must survive the extra hop. A leg going dark because
+    the rule it rides was disabled out of band is exactly as invisible as the
+    direct case, and now exactly as loud."""
+    m = _paused_drain_manifest(manifest)
+    m["not_paused"] = {}
+    rec = arming.build_record(
+        _event_time_registry(), m,
+        _states({("scheduler", "drain-sched"): "DISABLED",
+                 ("events", "freshness-rule"): "DISABLED"}))
+    assert rec["units"][0]["arming"] == "undeclared-dark"
+    assert [f["kind"] for f in arming.findings(rec)] == ["undeclared-dark"]
+
+
+def test_an_event_time_leg_whose_dependency_vanished_is_a_finding(arming, manifest):
+    rec = arming.build_record(
+        _event_time_registry(), _paused_drain_manifest(manifest),
+        _states({("scheduler", "drain-sched"): "DISABLED"}))
+    assert rec["units"][0]["arming"] == "trigger-absent"
+
+
+def test_a_leg_with_no_dependencies_is_still_unjoinable(arming, manifest):
+    """`depends_on` is optional and additive. A github-actions leg has no AWS
+    state to read and must stay NAMED-with-a-reason, never assumed armed."""
+    reg = {"playbooks": {"p": {"triggers": [
+        {"surface": "github-actions", "ref": "owner/repo/.github/workflows/x.yml",
+         "reason": "GitHub Actions carries no AWS trigger state to read"}]}}}
+    rec = arming.build_record(reg, _paused_drain_manifest(manifest), _states({}))
+    assert rec["units"][0]["triggers"][0]["verdict"] == "unjoinable"
+
+
+def test_the_live_registry_declares_the_freshness_rules_as_the_drain_s_event_time_leg(
+    registry,
+):
+    """Pins the real declaration, not a fixture: the linkage the AWS surface was
+    missing must exist in the registry the reconcile derives descriptions from."""
+    triggers = registry["playbooks"]["alert-drain"]["triggers"]
+    event_time = [t for t in triggers if t["surface"] == "event-time"]
+    assert len(event_time) == 1
+    deps = {d["name"] for d in event_time[0]["depends_on"]}
+    assert "alpha-engine-freshness-monitor-cron" in deps

--- a/tests/test_trigger_surface_drift.py
+++ b/tests/test_trigger_surface_drift.py
@@ -1,0 +1,344 @@
+"""Contract tests for the playbook -> AWS-surface linkage (alpha-engine-config-I9045).
+
+**The condition under test, measured live 2026-08-28.** All four
+``alpha-engine-alert-drain-*utc`` EventBridge Scheduler schedules were
+``DISABLED`` with ``Description: null``; the ``alert-drain`` playbook ran every
+single day that week off ``alpha-engine-freshness-monitor-cron``'s event-time
+leg; and nothing on any AWS resource connected the two. The AWS surface gave the
+wrong answer in both directions and the correction lived only in a YAML comment.
+
+``overseer-policy.md`` invariant 13 — *a guard is not a guard until it has been
+observed failing* — is what shapes this file. Every finding kind the checker can
+emit has a test that SEEDS the disagreement and asserts the checker goes red on
+it, and ``could_not_measure`` has its own tests proving it is distinguishable
+from a pass rather than collapsing into one. Two prior fleet defects are the
+reason that is spelled out: a gate that never executed a single job in 100 runs
+(``alpha-engine-config-I8729``), and a test that asserted an alert's message
+STRING and therefore could not catch a wrong tier. These assert BEHAVIOUR — the
+verdict and the exit code — never the text of a description.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERSEER = ROOT / "infrastructure" / "overseer"
+REGISTRY_PATH = OVERSEER / "playbooks.yaml"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def td():
+    return _load("trigger_descriptions", OVERSEER / "trigger_descriptions.py")
+
+
+@pytest.fixture(scope="module")
+def drift(td):
+    return _load("trigger_surface_drift", OVERSEER / "trigger_surface_drift.py")
+
+
+@pytest.fixture(scope="module")
+def registry():
+    return yaml.safe_load(REGISTRY_PATH.read_text(encoding="utf-8"))
+
+
+#: The registry shape the real defect had: a playbook woken by four schedules
+#: AND by an event-time leg that rides a separate EventBridge rule.
+def _drain_registry():
+    return {
+        "playbooks": {
+            "alert-drain": {
+                "triggers": [
+                    {"surface": "scheduler", "name": "sched-a"},
+                    {
+                        "surface": "event-time",
+                        "ref": "freshness CRITICAL -> router",
+                        "reason": "the Lambda invokes the router in-process",
+                        "depends_on": [{"surface": "events", "name": "rule-a"}],
+                    },
+                ]
+            }
+        }
+    }
+
+
+def _describe(mapping):
+    """A ``live_description`` stub. Unnamed resources are ABSENT, never blank."""
+    return lambda surface, name: mapping.get(f"{surface}:{name}")
+
+
+def _no_router_schedules():
+    return lambda: []
+
+
+# ── the derivation ───────────────────────────────────────────────────────────
+
+def test_the_event_time_leg_puts_the_playbook_on_the_rule_that_dispatches_it(td):
+    """The whole finding in one assertion.
+
+    ``alpha-engine-freshness-monitor-cron`` is an EventBridge RULE whose name,
+    schedule and old description say only "freshness". It is also the thing that
+    actually ran alert-drain every day. The marker is what makes
+    ``aws events describe-rule`` answer that.
+    """
+    marker = td.marker_for(_drain_registry(), "events", "rule-a")
+    assert "[wakes: alert-drain]" in marker
+
+
+def test_a_disabled_schedule_names_the_leg_doing_the_work(td):
+    """Read off a DISABLED schedule, ``sibling-legs`` is the answer to
+    "then what is running this?" — the question the AWS surface could not
+    answer on 2026-08-28."""
+    marker = td.marker_for(_drain_registry(), "scheduler", "sched-a")
+    assert "[wakes: alert-drain]" in marker
+    assert "events:rule-a" in marker
+
+
+def test_an_undeclared_resource_cannot_be_stamped(td):
+    """A deploy.sh asking for a marker it cannot get is creating a wake path
+    nothing records. It must fail the deploy, not emit a blank."""
+    with pytest.raises(KeyError):
+        td.marker_for(_drain_registry(), "scheduler", "never-declared")
+
+
+def test_a_description_aws_would_truncate_is_refused(td):
+    """AWS caps both description fields at 512 and truncates on some paths. A
+    truncated marker parses to the WRONG answer, which is worse than none."""
+    with pytest.raises(td.DescriptionTooLong):
+        td.description_for(_drain_registry(), "events", "rule-a", "x" * 600)
+
+
+def test_every_real_resource_fits_under_the_aws_ceiling(td, registry):
+    """The live registry, not a fixture — the ceiling is only useful if the
+    actual descriptions clear it."""
+    for key in td.resource_index(registry):
+        surface, name = key.split(":", 1)
+        assert len(td.marker_for(registry, surface, name)) <= td.MAX_DESCRIPTION_CHARS
+
+
+# ── seeded failures: the checker must be observed going red ──────────────────
+
+def test_a_missing_marker_is_a_finding(drift):
+    """The 2026-08-28 state itself: the resource exists, the description is
+    empty, and nothing on AWS says what it wakes."""
+    findings, _ = drift.check(
+        registry=_drain_registry(),
+        covered={"events:rule-a": "infrastructure/lambdas/x/deploy.sh"},
+        describe=_describe({"events:rule-a": ""}),
+        list_router_schedules=_no_router_schedules(),
+    )
+    assert [f["kind"] for f in findings] == ["marker-missing"]
+
+
+def test_a_stale_marker_is_a_finding_not_a_pass(drift, td):
+    """The drift case the whole check exists for: a marker is PRESENT, so a
+    check that only asked "is it stamped" would go green, while the set of legs
+    it names is no longer the set playbooks.yaml declares."""
+    stale = "[wakes: alert-drain] [sibling-legs: scheduler:some-retired-slot]"
+    findings, _ = drift.check(
+        registry=_drain_registry(),
+        covered={"events:rule-a": "infrastructure/lambdas/x/deploy.sh"},
+        describe=_describe({"events:rule-a": f"prose here {stale}"}),
+        list_router_schedules=_no_router_schedules(),
+    )
+    assert [f["kind"] for f in findings] == ["marker-drift"]
+    assert findings[0]["actual"] == stale
+
+
+def test_a_correct_marker_passes(drift, td):
+    """The negative control. Without it, every test above passes on a checker
+    that returns a finding unconditionally."""
+    reg = _drain_registry()
+    good = td.description_for(reg, "events", "rule-a", "Daily freshness probe")
+    findings, _ = drift.check(
+        registry=reg,
+        covered={"events:rule-a": "infrastructure/lambdas/x/deploy.sh"},
+        describe=_describe({"events:rule-a": good}),
+        list_router_schedules=_no_router_schedules(),
+    )
+    assert findings == []
+
+
+def test_a_reconciled_resource_that_vanished_is_a_finding(drift):
+    findings, _ = drift.check(
+        registry=_drain_registry(),
+        covered={"events:rule-a": "infrastructure/lambdas/x/deploy.sh"},
+        describe=_describe({}),
+        list_router_schedules=_no_router_schedules(),
+    )
+    assert [f["kind"] for f in findings] == ["trigger-absent"]
+
+
+def test_a_live_wake_path_nobody_declared_is_a_finding(drift):
+    """The reverse direction, and it caught a REAL one on its first live run:
+    ``alpha-engine-sf-watch-canary-drill-weekly`` dispatched playbook
+    ``sf-watch`` while playbooks.yaml declared it only under ``canary-replay``.
+    Nothing else in the fleet compares live Target Input against the registry."""
+    findings, _ = drift.check(
+        registry=_drain_registry(),
+        covered={},
+        describe=_describe({}),
+        list_router_schedules=lambda: [
+            {"name": "sched-nobody-declared", "playbook": "alert-drain"}
+        ],
+    )
+    assert [f["kind"] for f in findings] == ["undeclared-trigger"]
+
+
+def test_a_declared_schedule_dispatching_a_different_playbook_is_a_finding(drift):
+    findings, _ = drift.check(
+        registry=_drain_registry(),
+        covered={},
+        describe=_describe({}),
+        list_router_schedules=lambda: [
+            {"name": "sched-a", "playbook": "some-other-playbook"}
+        ],
+    )
+    assert [f["kind"] for f in findings] == ["undeclared-trigger"]
+
+
+def test_an_unreconciled_resource_is_pending_not_a_finding(drift):
+    """Coverage is discovered by scanning the deploy scripts, so a resource no
+    script reconciles is NAMED and counted rather than graded — and there is no
+    allowlist here that could be widened to hide one."""
+    findings, pending = drift.check(
+        registry=_drain_registry(),
+        covered={},
+        describe=_describe({}),
+        list_router_schedules=_no_router_schedules(),
+    )
+    assert findings == []
+    assert {p["resource"] for p in pending} == {"scheduler:sched-a", "events:rule-a"}
+
+
+# ── could-not-measure is its own state, never a pass ─────────────────────────
+
+@pytest.mark.parametrize("stderr", [
+    "An error occurred (AccessDeniedException) ... is not authorized",
+    "Unable to locate credentials. You can configure credentials by ...",
+    "The security token included in the request is expired (ExpiredToken)",
+])
+def test_losing_our_own_access_is_not_a_pass(drift, stderr):
+    """A detector that grades itself green by losing its access is the failure
+    mode the third exit code exists for."""
+    with pytest.raises(drift.CouldNotMeasure):
+        drift._raise_if_unmeasurable(stderr, "reading events:x")
+
+
+def test_a_genuine_not_found_is_absence_not_unmeasurable(drift):
+    """The opposite direction: ``ResourceNotFoundException`` IS an answer, and
+    collapsing it into could-not-measure would hide a vanished trigger."""
+    drift._raise_if_unmeasurable(
+        "An error occurred (ResourceNotFoundException) when calling DescribeRule",
+        "reading events:x",
+    )
+
+
+def test_could_not_measure_exits_2_and_drift_exits_1(drift, monkeypatch):
+    """The two states a caller acts on differently, proven at the exit code —
+    the surface CI actually reads."""
+    def boom(**kwargs):
+        raise drift.CouldNotMeasure("no credentials")
+    monkeypatch.setattr(drift, "check", boom)
+    assert drift.main([]) == 2
+    assert drift.main(["--allow-unmeasured"]) == 0
+
+    monkeypatch.setattr(
+        drift, "check",
+        lambda **kw: ([{"kind": "marker-missing", "resource": "events:x",
+                        "detail": "d"}], []),
+    )
+    assert drift.main([]) == 1
+    # --allow-unmeasured must never downgrade a REAL finding.
+    assert drift.main(["--allow-unmeasured"]) == 1
+
+    monkeypatch.setattr(drift, "check", lambda **kw: ([], []))
+    assert drift.main([]) == 0
+
+
+def test_a_scoped_run_with_nothing_to_grade_is_unmeasurable_not_green(drift):
+    """`--source-file` pointing at a script that reconciles nothing must not
+    report "no drift" — an assertion covering zero resources has not passed."""
+    with pytest.raises(drift.CouldNotMeasure):
+        drift.check(
+            registry=_drain_registry(),
+            covered={"events:rule-a": "infrastructure/lambdas/x/deploy.sh"},
+            describe=_describe({}),
+            list_router_schedules=_no_router_schedules(),
+            source_file="infrastructure/lambdas/typo/deploy.sh",
+        )
+
+
+# ── coverage discovery is real, not a constant someone must remember ─────────
+
+def test_the_two_reconciling_deploy_scripts_are_discovered(drift):
+    """The array in each deploy.sh is the single source both the deploy and this
+    check read. If the scan regex ever stops matching, coverage silently drops
+    to zero and every graded resource becomes `marker-pending` — green. This is
+    the test that makes that loud."""
+    covered = drift.discover_reconciled_triggers()
+    assert covered["scheduler:alpha-engine-alert-drain-0400utc"] == (
+        "infrastructure/lambdas/alert-drain-dispatcher/deploy.sh")
+    assert covered["events:alpha-engine-freshness-monitor-cron"] == (
+        "infrastructure/lambdas/freshness-monitor/deploy.sh")
+    assert len(covered) == 7
+
+
+def test_every_reconciled_resource_is_declared_in_playbooks_yaml(drift, td, registry):
+    """A deploy script that reconciles a resource playbooks.yaml does not
+    declare would crash mid-deploy on the marker lookup. Catch it here."""
+    index = td.resource_index(registry)
+    for key in drift.discover_reconciled_triggers():
+        assert key in index, f"{key} is reconciled by a deploy.sh but undeclared"
+
+
+def test_all_four_drain_slots_are_codified(drift):
+    """Measured 2026-08-28: deploy.sh codified only the 1000/2200 slots while
+    0400 and 1600 existed live, so config#2902's zero-retry fix reached two of
+    four (the other two still carried 185 attempts / 86400s) and no check in the
+    repo could see it. The array is the fix; this pins it."""
+    covered = drift.discover_reconciled_triggers()
+    for slot in ("0400", "1000", "1600", "2200"):
+        assert f"scheduler:alpha-engine-alert-drain-{slot}utc" in covered
+
+
+# ── the deploy scripts actually expose the mode CI invokes ───────────────────
+
+@pytest.mark.parametrize("lambda_dir", ["alert-drain-dispatcher", "freshness-monitor"])
+def test_reconcile_triggers_is_a_real_mode_that_exits_without_deploying(lambda_dir):
+    """Behaviour, not grep. ``--reconcile-triggers --dry-run`` must run to
+    completion and print no code-deploy step — the nous-ergon-ops-I520 defect
+    was a mode that applied its own effect and then FELL THROUGH into the full
+    deploy because its block had no `exit`."""
+    script = ROOT / "infrastructure" / "lambdas" / lambda_dir / "deploy.sh"
+    env = dict(os.environ)
+    # No credentials and no profile: the mode must complete on the strength of
+    # the repo alone. The only live call it makes is a read-only existence
+    # probe, wrapped in an `if`, so an AccessDenied or a missing `aws` binary
+    # selects create-schedule rather than aborting.
+    env.pop("AWS_PROFILE", None)
+    env["AWS_REGION"] = "us-east-1"
+    env["AWS_EC2_METADATA_DISABLED"] = "true"
+    proc = subprocess.run(
+        ["bash", str(script), "--reconcile-triggers", "--dry-run"],
+        capture_output=True, text=True, check=False, cwd=ROOT, env=env,
+    )
+    combined = proc.stdout + proc.stderr
+    assert "Nothing else was touched" in combined, combined[-2000:]
+    for forbidden in ("update-function-code", "Packaged ", "lambda_pip_install"):
+        assert forbidden not in combined, f"{forbidden} ran under --reconcile-triggers"


### PR DESCRIPTION
## The finding

Measured 2026-08-28. `aws scheduler list-schedules` showed all four `alpha-engine-alert-drain-{0400,1000,1600,2200}utc` schedules **DISABLED**, every one with `Description: null`. The `alert-drain` playbook nonetheless ran **every day** that week — `drain_ledger` objects for 08-24, 08-25, 08-26 (x2), 08-27, 08-28, each with an EC2 spot run log.

The real leg is an EventBridge **Rule**, `alpha-engine-freshness-monitor-cron` (`cron(0 12 * * ? *)`, ENABLED), whose Lambda invokes `alpha-engine-overseer-dispatcher` in-process with `{"playbook":"alert-drain"}` on a freshness CRITICAL (config-I3282; `FRESHNESS_MONITOR_DRAIN_DISPATCH_ENABLED=true` verified live).

That linkage was written down — `playbooks.yaml`'s `wake:` prose, plus a comment anticipating this exact confusion. **But only there.** No tag, description or machine-checkable field on any AWS resource pointed from the rule to the dispatch, and nothing on the four disabled schedules said what was doing the work. Anyone reading the AWS surface alone — operator, incident responder, cost audit, conformance sweep — got the wrong answer, in whichever direction they were looking. `principles.md` §7: a component is not healthy because a list says DISABLED; here the inverse bit.

## What lands

**1. The linkage is machine-readable, emitted from the IaC.**

`infrastructure/overseer/trigger_descriptions.py` derives, from `playbooks.yaml` alone, a marker per AWS trigger resource:

```
[wakes: alert-drain] [sibling-legs: events:alpha-engine-freshness-monitor-cron,...]
```

- `wakes` — every playbook this resource can start, whether it targets the router itself or starts a Lambda that dispatches the router in-process. Indistinguishable to whoever is asking "what runs alert-drain".
- `sibling-legs` — every other AWS resource that can start those same playbooks. Read off a DISABLED drain schedule, this is the answer to *"then what is running this?"*

`deploy.sh --reconcile-triggers` writes it (`scheduler update-schedule` / `events put-rule`), wired into `deploy-alert-drain-dispatcher.yml` and `deploy-freshness-monitor.yml`. **Deployable by the merge button alone** — no operator step, no new IAM (`scheduler:{Create,Update}Schedule`, `events:PutRule` and the matching reads are already on `github-actions-lambda-deploy`). Both workflows' path filters now include `playbooks.yaml`, so a declaration change reconciles too.

`--bootstrap` calls the *same* function rather than keeping its own description literals: two writers of one field is how the marker would have gone missing on the next bootstrap.

Prose stays in each `deploy.sh`; the marker is appended. The check compares the **marker only**, so improving the prose is not graded as drift while the machine-readable half cannot be edited away. The generator refuses any description over AWS's 512-char ceiling — a truncated marker parses to the wrong answer.

**2. A drift check that fails when the declaration and live AWS disagree.**

`infrastructure/overseer/trigger_surface_drift.py`. Findings: `marker-missing`, `marker-drift`, `trigger-absent`, `undeclared-trigger` (a live schedule dispatching a playbook the registry never declared — the reverse direction). Reported-not-red: `marker-pending`, for a resource no `deploy.sh` reconciles yet.

Exit codes follow `check_port_registry_drift.py`: **0** pass / **1** drift / **2** could-not-measure. A check that lost its own AWS access has not passed. `--allow-unmeasured` downgrades 2 to 0; it never downgrades a finding.

Coverage is **discovered by scanning** each `deploy.sh` for a `RECONCILE_DESCRIPTION_TRIGGERS` array — the same shape as `check-schedule-drift.py`'s `SCHED_NAMES` discovery. There is no allowlist here that could be widened to hide a resource; a script that starts reconciling one is graded the moment it lands.

Wired in three places: each deploy workflow asserts immediately after its own reconcile (`--source-file`, scoped to that script's resources — which removes a real race, since the two deploy jobs run concurrently on a merge), and `sf-arn-drift-check.yml` runs it unscoped on the daily out-of-band sweep with `if: github.event_name != 'push'` for the same reason.

**3. `arming.py` resolves the event-time leg.** `playbooks.yaml` gains `depends_on` on the `event-time` trigger, naming the three freshness rules whose live state *is* that leg's arming — the same sentence its `reason` already carried in prose, in a form code can follow. Verdicts `armed-via-dependency` / `paused-declared` / `undeclared-dark` / `trigger-absent` replace a flat `unjoinable`. Under the old code alert-drain rolled up to `paused-declared` — *"off by ruling"* — about a playbook that ran every day of that week.

## Two real defects the new machinery found on its first live run

- **`deploy.sh` codified only the 1000/2200 slots** while `0400` and `1600` existed live, created out of band and covered by no drift check. Cost, measured: config#2902's zero-retry fix (`MaximumRetryAttempts` 185 → 0, so a transient router error cannot re-dispatch a drain for a day) reached 1000/2200 and **never reached 0400/1600**, which still carry AWS's default 185 attempts / 86400s. All four are now codified; the reconcile writes `RetryPolicy` and `--state` (from the pause manifest, I6619 — `update-schedule` is a full replace and defaults to ENABLED) on every run.
- **`alpha-engine-sf-watch-canary-drill-weekly`** dispatches `{"playbook": "sf-watch", "payload": {"is_drill": "true", ...}}` live, and `playbooks.yaml` declared it only under `canary-replay`. Its ci-watch twin was already declared on both sides, which is what made the asymmetry visible. Now declared on both.

## Evidence the check works

`overseer-policy.md` invariant 13 — a guard is not a guard until it has been observed failing.

- **Live, unscoped, before any reconcile:** exit **1**, 7 `marker-missing` findings (4 schedules + 3 rules) plus the `undeclared-trigger` above, 13 `marker-pending`. After declaring the drill schedule under `sf-watch`, the `undeclared-trigger` cleared and the 7 remain — they clear when this merge deploys.
- **Every finding kind has a seeded-disagreement test** asserting the checker goes red, plus a negative control asserting a correct marker passes (without it, every test would pass on a checker that returns a finding unconditionally).
- **`could_not_measure` is proven distinguishable from a pass** at the exit code: AccessDenied / missing credentials / expired token → 2; a genuine `ResourceNotFoundException` is absence, not unmeasurability; `--allow-unmeasured` proven not to downgrade a real finding; a `--source-file` grading zero resources raises rather than reporting green.
- **`--reconcile-triggers` is exercised as a subprocess**, asserting it completes and that `update-function-code` / packaging never run — behaviour, not grep. The nous-ergon-ops-I520 defect was a mode that applied its effect and then fell through into the full deploy because its block had no `exit`.

## Tests

`pytest tests/ -q`: **6656 passed, 17 skipped, 1 failed**. The failure is `test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday]`, pre-existing on `main` and **local-environment only**: this laptop has `nousergon-lib` 0.124.88 installed while `requirements.txt` pins `v0.124.94`. Verified by installing the pinned version into a scratch `--target` — `NormalizeRunDates` is present in `STATE_TO_ARCHIVE_PAGE` at v0.124.94, so CI, which installs the pin, is unaffected.

`shellcheck --severity=error infrastructure/*.sh` (CI's invocation) clean; both modified `deploy.sh` files also clean. Every workflow re-parsed with a duplicate-key-rejecting loader, not `yaml.safe_load` — alpha-engine-config-I8729 is the reason.

## What this does NOT do

Deliverable 3 of I9045 — deleting or re-enabling the four disabled schedules — is **not** taken here. They are `Pause-owner:` entries of `alpha-engine-config-I6984`, whose restore plan requires them to exist; deleting them exceeds what the 2026-08-07 pause authorised. Filed decision-shaped instead: **alpha-engine-config-I9071** (`triage:session`). Deliverables 1 and 2 do not depend on it. Their *symptom* is nonetheless removed: the schedules stop being silent dead config, because each now names the live event-time leg that supersedes it.

Follow-up for the 13 `marker-pending` resources (sf-watch, groom, canary-replay, ci-watch): **alpha-engine-config-I9072**.

Refs: `alpha-engine-config-I9045` · parent `alpha-engine-config-I9044` · `alpha-engine-config-I6984` · config-I3282 · config#2902 · I6619 · I7056

No cross-repo dependency — this is the only PR in the set, merge order N/A.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
