### PR TITLE
fix(deploy): the code-only path must not create IAM roles, and its tolerance wrapper must survive run()'s exit

### DIFF
--- a/infrastructure/lambdas/_shared/apply_iam_policy.sh
+++ b/infrastructure/lambdas/_shared/apply_iam_policy.sh
@@ -29,23 +29,96 @@
 # Expects the caller to already define `run()` (the $DRY_RUN-aware command
 # wrapper) and `$DRY_RUN`, exactly as every deploy.sh already does.
 #
-# Usage: apply_iam_policy <role_name> <policy_name> <policy_file> <trust_policy_json>
+# probe_role_presence <role_name> -> prints "present" | "absent" | "unknown"
+#
+# WHY THIS EXISTS (the four-permanently-red-deploys defect, 2026-08-28).
+#
+# The old existence check was:
+#
+#   if ! aws iam get-role --role-name "$r" ... >/dev/null 2>&1; then  # CREATE
+#
+# `2>&1` to /dev/null makes AccessDenied and NoSuchEntity the same observation,
+# and the `!` branch reads BOTH as "the role does not exist". The CI auto-deploy
+# identity `github-actions-lambda-deploy` holds `iam:GetRole` on exactly two
+# roles (alpha-engine-eventbridge-sfn-role, alpha-engine-step-functions-role)
+# and on NO lambda execution role — by design, per the single-writer rule. So
+# every code-only deploy that reached this helper probed a role it may not read,
+# was denied, concluded "absent", printed `Creating IAM role: <name>` and called
+# `aws iam create-role` — a grant it also does not hold and must not hold.
+#
+# A denied READ is not evidence of absence. Distinguishing the two is the whole
+# job here, and it is why the stderr is captured instead of discarded.
+probe_role_presence() {
+  local role_name="${1:?probe_role_presence: role name required}"
+  local err rc=0
+  err="$(aws iam get-role --role-name "${role_name}" \
+           --query 'Role.RoleName' --output text 2>&1 >/dev/null)" || rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    echo present
+    return 0
+  fi
+  # Only an explicit NoSuchEntity proves absence. Everything else — AccessDenied,
+  # an expired token, a throttle, a network failure — is `unknown`.
+  if printf '%s' "${err}" | grep -qiE 'NoSuchEntity|cannot be found|does not exist'; then
+    echo absent
+    return 0
+  fi
+  echo unknown
+  return 0
+}
+
+# Usage: apply_iam_policy <role_name> <policy_name> <policy_file> <trust_policy_json> [may_create_role]
+#
+# `may_create_role` (default "true") governs the ROLE-CREATION half only. The
+# policy apply below runs either way. See probe_role_presence and
+# apply_iam_policy_on_deploy for why the auto-apply path passes "false".
 apply_iam_policy() {
   local role_name="$1" policy_name="$2" policy_file="$3" trust_policy="$4"
+  local may_create_role="${5:-true}"
 
-  if ! aws iam get-role --role-name "${role_name}" --query 'Role.RoleName' --output text >/dev/null 2>&1; then
-    echo "  Creating IAM role: ${role_name}"
-    run aws iam create-role \
-      --role-name "${role_name}" \
-      --assume-role-policy-document "${trust_policy}" \
-      --query 'Role.RoleName' --output text
-    if ! $DRY_RUN; then
-      echo "  Waiting 10s for IAM role propagation..."
-      sleep 10
-    fi
-  else
-    echo "  IAM role exists: ${role_name}"
-  fi
+  local presence
+  presence="$(probe_role_presence "${role_name}")"
+  case "${presence}" in
+    present)
+      echo "  IAM role exists: ${role_name}"
+      ;;
+    absent)
+      if [ "${may_create_role}" != "true" ]; then
+        # alpha-engine-config-I9045 / the four-red-deploys defect. Creating a
+        # role is a BOOTSTRAP act, and the single-writer rule (infrastructure/
+        # iam/README.md) reserves it for an operator. The auto-apply-on-deploy
+        # path must never attempt it: it holds no iam:CreateRole by design, so
+        # the attempt can only ever fail, and failing here aborts a deploy
+        # whose CODE has already shipped.
+        echo "  IAM role ABSENT: ${role_name} — not creating it from this path." >&2
+        echo "  This is the code-only auto-apply path, which is deliberately not a" >&2
+        echo "  role creator (single-writer rule). Run this deploy.sh --bootstrap as" >&2
+        echo "  an operator to create it. Skipping the policy apply too: there is no" >&2
+        echo "  role to put it on." >&2
+        APPLY_IAM_POLICY_VERDICT="role-absent"
+        return 0
+      fi
+      echo "  Creating IAM role: ${role_name}"
+      run aws iam create-role \
+        --role-name "${role_name}" \
+        --assume-role-policy-document "${trust_policy}" \
+        --query 'Role.RoleName' --output text
+      if ! $DRY_RUN; then
+        echo "  Waiting 10s for IAM role propagation..."
+        sleep 10
+      fi
+      ;;
+    *)
+      # `unknown` — the probe was DENIED or failed for a reason that is not
+      # NoSuchEntity. It is NOT evidence of absence, and the old code treated
+      # it as exactly that (see probe_role_presence). Fall through to the
+      # policy apply, which is the call whose own success or AccessDenied is
+      # the real answer.
+      echo "  IAM role presence UNKNOWN for ${role_name} (the get-role probe was" >&2
+      echo "  denied or unreadable). Not creating anything on an unknown; the" >&2
+      echo "  policy apply below is the authoritative attempt." >&2
+      ;;
+  esac
 
   # Report whether this apply actually CHANGES anything
   # (alpha-engine-config-I7444).
@@ -161,8 +234,41 @@ apply_iam_policy_on_deploy() {
   local err_file rc=0 stderr_text
   err_file="$(mktemp)"
 
-  apply_iam_policy "${role_name}" "${policy_name}" "${policy_file}" "${trust_policy}" \
-    2>"${err_file}" || rc=$?
+  # THE SUBSHELL IS LOAD-BEARING (the four-permanently-red-deploys defect).
+  #
+  # `run()` in _shared/deploy_run.sh calls `exit`, not `return` — deliberate,
+  # and correct, per alpha-engine-config-I8033. But `exit` inside a function
+  # terminates the SHELL, and `|| rc=$?` guards a non-zero RETURN. There is no
+  # return to guard, so the moment run() started exiting (merged 2026-08-21),
+  # the classifier below became unreachable: a denied `aws iam create-role`
+  # killed the whole deploy at exit 254, the captured stderr in "${err_file}"
+  # was never replayed, and the CI log ended at `Creating IAM role: <name>`
+  # with no AWS error text at all. Four workflows went red on every run for a
+  # week and the log could not say why.
+  #
+  # This is the SAME class alpha-engine-config-I8125 fixed for `run ... || true`
+  # call sites with run_tolerating(). It fixed the call-site shape and missed
+  # this one — a FUNCTION-level tolerance wrapper. A subshell closes it
+  # generally: an `exit` inside `( ... )` sets the subshell's exit status, which
+  # `||` does catch, so run()'s fail-loud semantics are preserved everywhere and
+  # this one classifier still gets to run.
+  #
+  # Cost of the subshell: assignments inside it do not escape, so
+  # APPLY_IAM_POLICY_VERDICT is round-tripped on stdout's last line below
+  # rather than read from the variable.
+  local out_file
+  out_file="$(mktemp)"
+  (
+    apply_iam_policy "${role_name}" "${policy_name}" "${policy_file}" \
+      "${trust_policy}" "false"
+    printf 'APPLY_IAM_POLICY_VERDICT=%s\n' "${APPLY_IAM_POLICY_VERDICT:-unknown}"
+  ) >"${out_file}" 2>"${err_file}" || rc=$?
+
+  # Replay stdout minus the verdict marker, and lift the verdict out of the
+  # subshell.
+  APPLY_IAM_POLICY_VERDICT="$(sed -n 's/^APPLY_IAM_POLICY_VERDICT=//p' "${out_file}" | tail -1)"
+  grep -v '^APPLY_IAM_POLICY_VERDICT=' "${out_file}" || true
+  rm -f "${out_file}"
 
   stderr_text="$(cat "${err_file}" 2>/dev/null || true)"
   rm -f "${err_file}"
@@ -184,6 +290,15 @@ apply_iam_policy_on_deploy() {
     echo "WARN: role=${role_name} policy=${policy_name}. This is expected for the CI" >&2
     echo "WARN: auto-deploy OIDC role (single-writer rule). check-drift.py is the backstop;" >&2
     echo "WARN: an operator must run this deploy.sh --apply-iam to land the change." >&2
+    # Replay the AWS error VERBATIM even though this failure is tolerated. The
+    # header above has claimed since it was written that "captured stderr is
+    # replayed verbatim on both paths below" — it was not, on this path, and
+    # nothing noticed because the assertion lived only in a comment. A
+    # tolerated failure whose cause never prints is how a WRONG tolerance
+    # survives: `AccessDenied` matched on some OTHER operation than the one
+    # assumed reads exactly like the expected boundary.
+    printf 'WARN: --- captured stderr (tolerated) ---\n%s\nWARN: --- end stderr ---\n' \
+      "${stderr_text}" >&2
     return 0
   fi
 

--- a/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
+++ b/infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh
@@ -46,6 +46,16 @@ done
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+# These tests existed beside index.py and this deploy.sh never ran them, so
+# the post-merge gate was absent for this lambda entirely (the config#2295
+# shape: ci.yml's own glob runner keeps it green PRE-merge, which is exactly
+# what makes the missing POST-merge gate invisible). No extra deps: this
+# lambda's tests stub boto3 in sys.modules, and the helper's contract is that
+# such a caller must NOT get boto3 installed alongside the stub.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
+
 # Validate index.py syntax locally before shipping.
 python3 -c "
 import ast, sys

--- a/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
@@ -49,6 +49,16 @@ done
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+# These tests existed beside index.py and this deploy.sh never ran them, so
+# the post-merge gate was absent for this lambda entirely (the config#2295
+# shape: ci.yml's own glob runner keeps it green PRE-merge, which is exactly
+# what makes the missing POST-merge gate invisible). No extra deps: this
+# lambda's tests stub boto3 in sys.modules, and the helper's contract is that
+# such a caller must NOT get boto3 installed alongside the stub.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
+
 # ----- 0. Validate handler syntax -------------------------------------------
 
 python3 -c "

--- a/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-dispatcher/deploy.sh
@@ -84,8 +84,7 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
 PKG=$(mktemp -d)
-TEST_DEPS=$(mktemp -d)
-trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+trap "rm -rf '$PKG'" EXIT
 
 python3 -c "
 import ast
@@ -96,12 +95,17 @@ print('index.py syntax OK')
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing pytest into ${TEST_DEPS}..."
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
-  echo "Running handler unit tests..."
-  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
+# The shared gate (config#2381), not a hand-rolled copy. The copy this
+# replaced installed only `pytest`, ran ONLY test_handler.py, and put
+# nothing but the scratch dir on PYTHONPATH. Measured 2026-08-28,
+# preflight-sweep-dispatcher had failed 6 of 6 runs since the workflow
+# shipped on 2026-08-13 — `ModuleNotFoundError: No module named boto3`,
+# because its index.py imports boto3 at module scope and the hand-rolled
+# list did not. spot-interruption-recorder had already hit the identical
+# wall and patched its own copy in place rather than the shared helper,
+# which is what left the other three exposed.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 

--- a/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh
@@ -68,8 +68,7 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
 PKG=$(mktemp -d)
-TEST_DEPS=$(mktemp -d)
-trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+trap "rm -rf '$PKG'" EXIT
 
 python3 -c "
 import ast
@@ -80,12 +79,17 @@ print('index.py syntax OK')
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing pytest into ${TEST_DEPS}..."
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
-  echo "Running handler unit tests..."
-  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
+# The shared gate (config#2381), not a hand-rolled copy. The copy this
+# replaced installed only `pytest`, ran ONLY test_handler.py, and put
+# nothing but the scratch dir on PYTHONPATH. Measured 2026-08-28,
+# preflight-sweep-dispatcher had failed 6 of 6 runs since the workflow
+# shipped on 2026-08-13 — `ModuleNotFoundError: No module named boto3`,
+# because its index.py imports boto3 at module scope and the hand-rolled
+# list did not. spot-interruption-recorder had already hit the identical
+# wall and patched its own copy in place rather than the shared helper,
+# which is what left the other three exposed.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 

--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -90,6 +90,16 @@ done
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+# These tests existed beside index.py and this deploy.sh never ran them, so
+# the post-merge gate was absent for this lambda entirely (the config#2295
+# shape: ci.yml's own glob runner keeps it green PRE-merge, which is exactly
+# what makes the missing POST-merge gate invisible). No extra deps: this
+# lambda's tests stub boto3 in sys.modules, and the helper's contract is that
+# such a caller must NOT get boto3 installed alongside the stub.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
+
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
 
 PKG=$(mktemp -d)

--- a/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh
@@ -94,8 +94,7 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
 PKG=$(mktemp -d)
-TEST_DEPS=$(mktemp -d)
-trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+trap "rm -rf '$PKG'" EXIT
 
 python3 -c "
 import ast
@@ -106,12 +105,17 @@ print('index.py syntax OK')
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing pytest into ${TEST_DEPS}..."
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
-  echo "Running handler unit tests..."
-  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
+# The shared gate (config#2381), not a hand-rolled copy. The copy this
+# replaced installed only `pytest`, ran ONLY test_handler.py, and put
+# nothing but the scratch dir on PYTHONPATH. Measured 2026-08-28,
+# preflight-sweep-dispatcher had failed 6 of 6 runs since the workflow
+# shipped on 2026-08-13 — `ModuleNotFoundError: No module named boto3`,
+# because its index.py imports boto3 at module scope and the hand-rolled
+# list did not. spot-interruption-recorder had already hit the identical
+# wall and patched its own copy in place rather than the shared helper,
+# which is what left the other three exposed.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------
 

--- a/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
+++ b/infrastructure/lambdas/spot-interruption-recorder/deploy.sh
@@ -65,8 +65,7 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # ----- 0. Scratch dirs + validate handler syntax -----------------------------
 
 PKG=$(mktemp -d)
-TEST_DEPS=$(mktemp -d)
-trap "rm -rf '$PKG' '$TEST_DEPS'" EXIT
+trap "rm -rf '$PKG'" EXIT
 
 python3 -c "
 import ast
@@ -76,14 +75,17 @@ print('index.py syntax OK')
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
 
-if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
-  echo "Installing test deps into ${TEST_DEPS}..."
-  # boto3 (and its botocore dependency) are needed because the handler
-  # imports botocore.config.Config at module level (fa7979c sibling fix).
-  python3 -m pip install --quiet --target "${TEST_DEPS}" pytest boto3
-  echo "Running handler unit tests..."
-  PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
-fi
+# The shared gate (config#2381), not a hand-rolled copy. The copy this
+# replaced installed only `pytest`, ran ONLY test_handler.py, and put
+# nothing but the scratch dir on PYTHONPATH. Measured 2026-08-28,
+# preflight-sweep-dispatcher had failed 6 of 6 runs since the workflow
+# shipped on 2026-08-13 — `ModuleNotFoundError: No module named boto3`,
+# because its index.py imports boto3 at module scope and the hand-rolled
+# list did not. spot-interruption-recorder had already hit the identical
+# wall and patched its own copy in place rather than the shared helper,
+# which is what left the other three exposed.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}" boto3
 
 # ----- 1. Package ------------------------------------------------------------
 

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -61,6 +61,16 @@ done
 # shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
 source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+# These tests existed beside index.py and this deploy.sh never ran them, so
+# the post-merge gate was absent for this lambda entirely (the config#2295
+# shape: ci.yml's own glob runner keeps it green PRE-merge, which is exactly
+# what makes the missing POST-merge gate invisible). No extra deps: this
+# lambda's tests stub boto3 in sys.modules, and the helper's contract is that
+# such a caller must NOT get boto3 installed alongside the stub.
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
+
 PKG="$(mktemp -d)"
 trap 'rm -rf "${PKG}"' EXIT
 

--- a/tests/test_deploy_preflight_tests_use_the_shared_gate.py
+++ b/tests/test_deploy_preflight_tests_use_the_shared_gate.py
@@ -1,0 +1,171 @@
+"""No deploy.sh may hand-roll its preflight handler-test block.
+
+WHY (measured 2026-08-28). `_shared/run_handler_tests.sh` exists precisely so
+the "install this lambda's test deps, then run its tests" step cannot drift
+per-script (config#2381, after the config#2295 incident). Thirty-one deploy.sh
+scripts used it. FOUR still carried a hand-rolled copy, and every one of the
+four was a variant of:
+
+    if [[ -f "${SCRIPT_DIR}/test_handler.py" ]]; then
+      python3 -m pip install --quiet --target "${TEST_DEPS}" pytest
+      PYTHONPATH="${TEST_DEPS}" python3 -m pytest "${SCRIPT_DIR}/test_handler.py" -q
+    fi
+
+Three defects live in that shape, all of which the shared helper had already
+fixed for everyone else:
+
+  1. The dep list is hand-written, so it silently omits what index.py imports
+     at module scope. `deploy-preflight-sweep-dispatcher.yml` failed **6 of 6
+     runs since it shipped on 2026-08-13** — `ModuleNotFoundError: No module
+     named boto3` — and had therefore NEVER deployed successfully.
+     `spot-interruption-recorder` hit the identical wall earlier and patched
+     its own copy in place instead of the helper, which is exactly what left
+     the other three exposed: fixing one call site of a systemic defect is not
+     a fix.
+  2. Only `test_handler.py` runs. Sibling `test_*.py` files beside it are
+     silently never executed, so a test added next to the handler is dead on
+     arrival.
+  3. `PYTHONPATH` carries only the scratch dir, not `infrastructure/lambdas/`,
+     so a handler importing a shared sibling by bare name (flow_doctor_telegram,
+     eod_artifact_verification) passes locally and ModuleNotFounds on the
+     runner — alpha-engine-config-I7582, already absorbed by the helper.
+
+WHY A DERIVED SCOPE. A hardcoded list of today's scripts leaves the next one
+uncovered on the day it lands, which is how all four of these survived. The
+universe is every git-tracked `infrastructure/lambdas/*/deploy.sh`.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The two carve-outs the helper's own header declares: these run
+# `python3 test_handler.py` directly with zero deps and no pytest at all, and
+# that is preserved deliberately in ci.yml too. Named here so the exemption is
+# visible and finite rather than inferred from a passing test.
+_DECLARED_CARVE_OUTS = {
+    "changelog-incident-mirror",
+    "changelog-cloudwatch-mirror",
+}
+
+# Two lambdas are KNOWN-UNGATED and deliberately not fixed in the change that
+# introduced this test. Each is tracked, each has a named reason, and this set
+# must shrink — it is a debt register, not a permanent exemption. An entry
+# whose issue is closed and whose gate is still missing is itself a finding.
+#
+#   thinktank-spot-dispatcher       — its deploy.sh is a separate dialect: it
+#     sources none of the _shared helpers and hand-rolls its own IAM with the
+#     very `get-role >/dev/null 2>&1 || create-role` misclassification the
+#     shared applier was fixed for. Wiring only the test gate would leave the
+#     larger defect in place and imply it had been reviewed.
+#     Tracked: alpha-engine-config-I9075.
+#   weekly-freshness-spot-dispatcher — nousergon-data#1562 (draft) is editing
+#     this exact deploy.sh; a second concurrent edit to it would collide.
+#     Tracked: alpha-engine-config-I9076.
+_TRACKED_UNGATED = {
+    "thinktank-spot-dispatcher",
+    "weekly-freshness-spot-dispatcher",
+}
+
+# A hand-rolled gate is any direct `python3 -m pytest` invocation inside a
+# deploy.sh. The helper is the only sanctioned way to reach pytest from one.
+_BARE_PYTEST = re.compile(r"python3\s+-m\s+pytest")
+
+
+def _code_only(body: str) -> str:
+    """Shell source with `#` comments stripped.
+
+    NOT cosmetic. Eleven deploy.sh scripts carry the line
+
+        # ... so this gate can never re-drift into the naive no-install
+        # `python3 -m pytest` form (config#2295).
+
+    directly above their CORRECT `run_handler_tests` call. A scan that reads
+    that comment as an execution path reports eleven false offenders and puts
+    the pressure on deleting the rationale that explains the fix — the fleet
+    has already recorded this exact shape once (a scheduled-identity scan that
+    matched a role name inside a YAML comment and went red on main).
+
+    Deliberately naive about `#` inside quotes: a false NEGATIVE here costs a
+    missed offender that the sibling assertion below still catches, whereas a
+    false POSITIVE costs a red main and a deleted comment.
+    """
+    return "\n".join(line.split("#", 1)[0] for line in body.splitlines())
+
+
+def _deploy_scripts() -> list[Path]:
+    out = subprocess.run(  # noqa: S603
+        ["git", "ls-files", "infrastructure/lambdas/*/deploy.sh"],  # noqa: S607
+        cwd=_REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    paths = [_REPO_ROOT / line for line in out.stdout.split() if line]
+    assert paths, "no deploy.sh discovered — the glob or cwd is wrong"
+    return paths
+
+
+def test_every_deploy_script_reaches_pytest_through_the_shared_gate() -> None:
+    offenders: list[str] = []
+    for path in _deploy_scripts():
+        if path.parent.name in _DECLARED_CARVE_OUTS:
+            continue
+        body = _code_only(path.read_text())
+        if _BARE_PYTEST.search(body):
+            offenders.append(f"{path.parent.name}: invokes `python3 -m pytest` directly")
+    assert not offenders, (
+        "deploy.sh scripts hand-rolling their preflight handler tests instead of "
+        "sourcing _shared/run_handler_tests.sh:\n  " + "\n  ".join(offenders)
+        + "\n\nUse:\n"
+        '  source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"\n'
+        '  run_handler_tests "${SCRIPT_DIR}" [deps...]\n'
+        "\nA hand-rolled copy hand-writes its dep list (which is how "
+        "preflight-sweep-dispatcher failed 6 of 6 deploys on a missing boto3), "
+        "runs only test_handler.py, and omits infrastructure/lambdas/ from "
+        "PYTHONPATH."
+    )
+
+
+def test_a_lambda_with_handler_tests_actually_runs_them() -> None:
+    """The other half: sourcing the helper is not the same as calling it. A
+    deploy.sh with a test_handler.py beside it that never invokes the gate has
+    no preflight at all — the config#2295 shape, where the drift was invisible
+    pre-merge because ci.yml has its own correct runner."""
+    offenders: list[str] = []
+    for path in _deploy_scripts():
+        name = path.parent.name
+        if name in _DECLARED_CARVE_OUTS or name in _TRACKED_UNGATED:
+            continue
+        if not (path.parent / "test_handler.py").exists():
+            continue
+        if "run_handler_tests " not in _code_only(path.read_text()):
+            offenders.append(name)
+    assert not offenders, (
+        "these lambdas have a test_handler.py that their deploy.sh never runs, "
+        "so the post-merge preflight gate is absent for them:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_ungated_debt_register_does_not_grow_silently() -> None:
+    """`_TRACKED_UNGATED` is a debt register with two named, tracked entries.
+    It must shrink, never grow — and an entry that has since been GATED must be
+    removed from it, or the exemption outlives the debt and starts hiding a
+    regression on the same lambda."""
+    assert len(_TRACKED_UNGATED) <= 2, (
+        "the ungated-lambda exemption list grew. A new lambda shipping without "
+        "its preflight gate is the defect this file exists to stop; add the "
+        "gate rather than an exemption."
+    )
+    still_ungated = {
+        name for name in _TRACKED_UNGATED
+        if "run_handler_tests " not in _code_only(
+            (_REPO_ROOT / "infrastructure" / "lambdas" / name / "deploy.sh").read_text()
+        )
+    }
+    assert still_ungated == _TRACKED_UNGATED, (
+        "these are now gated and must be removed from _TRACKED_UNGATED: "
+        f"{sorted(_TRACKED_UNGATED - still_ungated)}"
+    )

--- a/tests/test_deploy_preflight_tests_use_the_shared_gate.py
+++ b/tests/test_deploy_preflight_tests_use_the_shared_gate.py
@@ -62,10 +62,10 @@ _DECLARED_CARVE_OUTS = {
 #     very `get-role >/dev/null 2>&1 || create-role` misclassification the
 #     shared applier was fixed for. Wiring only the test gate would leave the
 #     larger defect in place and imply it had been reviewed.
-#     Tracked: alpha-engine-config-I9075.
+#     Tracked: alpha-engine-config-I9114.
 #   weekly-freshness-spot-dispatcher — nousergon-data#1562 (draft) is editing
 #     this exact deploy.sh; a second concurrent edit to it would collide.
-#     Tracked: alpha-engine-config-I9076.
+#     Tracked: alpha-engine-config-I9115.
 _TRACKED_UNGATED = {
     "thinktank-spot-dispatcher",
     "weekly-freshness-spot-dispatcher",

--- a/tests/test_iam_auto_apply_code_only_path.py
+++ b/tests/test_iam_auto_apply_code_only_path.py
@@ -1,0 +1,357 @@
+"""The code-only deploy path must never attempt IAM role CREATION, and its
+tolerance wrapper must survive `run()`'s `exit`.
+
+THE DEFECT THIS PINS (measured 2026-08-28)
+------------------------------------------
+Four workflows in this repo failed 100% of their runs on `main` for a week —
+`deploy-alert-drain-dispatcher`, `deploy-overseer-dispatcher`,
+`deploy-alert-drain-liveness-probe`, `deploy-overseer-liveness-probe`. Every
+one shipped its Lambda CODE successfully and then died at exit 254 on a line
+reading `Creating IAM role: alpha-engine-alert-drain-dispatcher-role` — a role
+that has existed since 2026-07-22. The AWS error text appeared NOWHERE in the
+job log.
+
+Two independent defects, both closed here:
+
+1. `apply_iam_policy` probed the role with
+   `aws iam get-role ... >/dev/null 2>&1`, which makes AccessDenied and
+   NoSuchEntity the same observation. `github-actions-lambda-deploy` holds
+   `iam:GetRole` on exactly two roles and on no lambda execution role — by
+   design (infrastructure/iam/README.md, single-writer rule). So the probe was
+   DENIED, read as "absent", and the script went on to call `iam:CreateRole`,
+   a grant the CI identity does not and must not hold.
+
+2. `apply_iam_policy_on_deploy` wrapped that call in `... || rc=$?` to classify
+   an AccessDenied as the one tolerated failure. But `run()` in
+   `_shared/deploy_run.sh` calls `exit`, not `return` (alpha-engine-config-
+   I8033), and `exit` inside a function terminates the SHELL — `||` guards a
+   RETURN and there is nothing to guard. The classifier was unreachable from
+   the day run() started exiting (2026-08-21, the exact commit at which all
+   four workflows went red), and the captured stderr was never replayed, which
+   is why the log carried no AWS error at all.
+
+   This is the same class alpha-engine-config-I8125 fixed for `run ... || true`
+   call sites with `run_tolerating`. It fixed the call-site shape and missed
+   the function-level wrapper.
+
+WHY THESE TESTS EXECUTE THE SHELL
+---------------------------------
+"A loop proven only by reading it is a loop nobody has run." Every case below
+sources the real `_shared/apply_iam_policy.sh` and `_shared/deploy_run.sh` and
+runs them against a fake `aws` on PATH that reproduces the exact stderr AWS
+emits. Asserting on the file's TEXT would have passed against the broken
+version: the broken version also contained the word `AccessDenied`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SHARED = _REPO_ROOT / "infrastructure" / "lambdas" / "_shared"
+
+# The literal stderr `aws iam` emits for each condition. Reproduced verbatim so
+# a change in how the classifier greps is caught here rather than in CI.
+_DENIED = (
+    "An error occurred (AccessDenied) when calling the {op} operation: "
+    "User: arn:aws:sts::711398986525:assumed-role/github-actions-lambda-deploy/"
+    "GitHubActions is not authorized to perform: iam:{op} on resource: "
+    "arn:aws:iam::711398986525:role/{role}"
+)
+_NO_SUCH_ENTITY = (
+    "An error occurred (NoSuchEntity) when calling the GetRole operation: "
+    "The role with name {role} cannot be found."
+)
+
+ROLE = "alpha-engine-alert-drain-dispatcher-role"
+
+
+def _fake_aws(tmp_path: Path, *, behaviours: dict[str, tuple[int, str]]) -> Path:
+    """A fake `aws` binary. `behaviours` maps an "iam get-role"-style command
+    prefix to (exit_code, stderr_text). Every invocation is appended to
+    `calls.log`, which is what the "never attempted" assertions read."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "calls.log"
+    cases = "\n".join(
+        f'  "{prefix}") echo {stderr!r} >&2; exit {rc} ;;'
+        for prefix, (rc, stderr) in behaviours.items()
+    )
+    fake = bindir / "aws"
+    fake.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            echo "$*" >> {log}
+            case "$1 $2" in
+            {cases}
+              *) exit 0 ;;
+            esac
+            """
+        )
+    )
+    fake.chmod(0o755)
+    return bindir
+
+
+def _harness(tmp_path: Path, body: str, bindir: Path) -> subprocess.CompletedProcess:
+    policy = tmp_path / "iam-policy.json"
+    policy.write_text('{"Version":"2012-10-17","Statement":[]}')
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            set -uo pipefail
+            DRY_RUN=false
+            source "{_SHARED}/deploy_run.sh"
+            source "{_SHARED}/apply_iam_policy.sh"
+            POLICY_FILE="{policy}"
+            TRUST='{{"Version":"2012-10-17"}}'
+            {body}
+            """
+        )
+    )
+    # A minimal, explicit environment: the fake `aws` must win over any real
+    # one, and nothing from the developer's shell may leak into the harness.
+    shell_env = {"PATH": f"{bindir}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", str(script)],  # noqa: S607
+        capture_output=True,
+        text=True,
+        env=shell_env,
+        timeout=120,
+        check=False,
+    )
+
+
+def _calls(tmp_path: Path) -> str:
+    log = tmp_path / "calls.log"
+    return log.read_text() if log.exists() else ""
+
+
+@pytest.fixture
+def denied_everywhere(tmp_path: Path) -> Path:
+    """The live CI identity: no iam:GetRole, no iam:CreateRole, no
+    iam:PutRolePolicy on a lambda execution role."""
+    return _fake_aws(
+        tmp_path,
+        behaviours={
+            "iam get-role": (254, _DENIED.format(op="GetRole", role=ROLE)),
+            "iam create-role": (254, _DENIED.format(op="CreateRole", role=ROLE)),
+            "iam put-role-policy": (
+                254, _DENIED.format(op="PutRolePolicy", role=ROLE)),
+            "iam get-role-policy": (
+                254, _DENIED.format(op="GetRolePolicy", role=ROLE)),
+        },
+    )
+
+
+def test_the_code_only_path_survives_an_identity_with_no_iam_writes(
+    tmp_path: Path, denied_everywhere: Path
+) -> None:
+    """THE REGRESSION. Exit 254 here is a deploy that shipped code and then
+    reported failure — indistinguishable from a broken change."""
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; '
+        'echo "RC=$?"',
+        denied_everywhere,
+    )
+    assert "RC=0" in r.stdout, (
+        f"the code-only deploy path aborted.\nstdout:\n{r.stdout}\n"
+        f"stderr:\n{r.stderr}"
+    )
+    assert r.returncode == 0
+
+
+def test_a_denied_get_role_is_never_read_as_an_absent_role(
+    tmp_path: Path, denied_everywhere: Path
+) -> None:
+    """The half that made the log unreadable: `Creating IAM role: <name>` was
+    printed for a role that had existed for five weeks."""
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"',
+        denied_everywhere,
+    )
+    assert "Creating IAM role" not in (r.stdout + r.stderr)
+    assert "create-role" not in _calls(tmp_path), (
+        "the code-only path attempted iam:CreateRole — a grant the CI identity "
+        "does not and must not hold"
+    )
+
+
+def test_the_tolerated_access_denied_is_reported_not_swallowed(
+    tmp_path: Path, denied_everywhere: Path
+) -> None:
+    """Tolerated is not the same as silent: the operator must still be told the
+    policy did not land and what to run."""
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"',
+        denied_everywhere,
+    )
+    assert "IAM auto-apply skipped" in r.stderr
+    assert "--apply-iam" in r.stderr
+
+
+def test_the_aws_error_text_reaches_the_log(
+    tmp_path: Path, denied_everywhere: Path
+) -> None:
+    """The captured stderr was lost entirely when run()'s `exit` killed the
+    shell before the replay. A tolerated failure whose cause never printed is
+    how a wrong tolerance survives."""
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"',
+        denied_everywhere,
+    )
+    assert "is not authorized to perform" in r.stderr
+
+
+def test_a_role_that_is_genuinely_absent_is_not_created_from_the_deploy_path(
+    tmp_path: Path,
+) -> None:
+    """NoSuchEntity is the one observation that DOES prove absence — and the
+    answer is still not to create it here. Role creation is a bootstrap act
+    reserved to an operator by the single-writer rule."""
+    bindir = _fake_aws(
+        tmp_path,
+        behaviours={"iam get-role": (254, _NO_SUCH_ENTITY.format(role=ROLE))},
+    )
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; '
+        'echo "RC=$?"',
+        bindir,
+    )
+    assert "RC=0" in r.stdout, r.stdout + r.stderr
+    assert "create-role" not in _calls(tmp_path)
+    assert "IAM role ABSENT" in r.stderr
+
+
+def test_the_operator_bootstrap_path_still_creates_an_absent_role(
+    tmp_path: Path,
+) -> None:
+    """The fix must not disarm --bootstrap. `apply_iam_policy` called directly
+    (may_create_role defaults true) still creates on a proven NoSuchEntity."""
+    bindir = _fake_aws(
+        tmp_path,
+        behaviours={"iam get-role": (254, _NO_SUCH_ENTITY.format(role=ROLE))},
+    )
+    r = _harness(
+        tmp_path,
+        # sleep is stubbed away: the real function waits 10s for IAM propagation.
+        "sleep() { :; }\n"
+        f'apply_iam_policy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; echo "RC=$?"',
+        bindir,
+    )
+    assert "RC=0" in r.stdout, r.stdout + r.stderr
+    assert "create-role" in _calls(tmp_path), (
+        "the operator bootstrap path stopped creating roles — the fix "
+        "over-reached"
+    )
+
+
+def test_a_failure_that_is_not_a_permission_boundary_still_aborts_the_deploy(
+    tmp_path: Path,
+) -> None:
+    """The tolerance is exactly one cause. A broken applier — a throttle, a
+    malformed document, a missing binary — must still be fatal, or this becomes
+    the `|| true` that alpha-engine-config-I7338 removed."""
+    bindir = _fake_aws(
+        tmp_path,
+        behaviours={
+            "iam get-role": (0, ""),
+            "iam get-role-policy": (254, "boom"),
+            "iam put-role-policy": (
+                254,
+                "An error occurred (MalformedPolicyDocument) when calling the "
+                "PutRolePolicy operation: Syntax errors in policy.",
+            ),
+        },
+    )
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; '
+        'echo "RC=$?"',
+        bindir,
+    )
+    assert "RC=0" not in r.stdout, (
+        "a MalformedPolicyDocument was tolerated — the applier is broken and "
+        "the deploy reported success"
+    )
+    assert "IAM auto-apply FAILED" in r.stderr
+    assert "MalformedPolicyDocument" in r.stderr
+
+
+def test_an_identity_that_can_write_iam_still_applies_the_policy(
+    tmp_path: Path,
+) -> None:
+    """ne-admin / the operator path: nothing about the fix may stop a
+    privileged caller from actually landing the policy."""
+    bindir = _fake_aws(tmp_path, behaviours={"iam get-role": (0, "")})
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; '
+        'echo "RC=$?"',
+        bindir,
+    )
+    assert "RC=0" in r.stdout, r.stdout + r.stderr
+    assert "put-role-policy" in _calls(tmp_path)
+    assert "IAM role exists" in r.stdout
+
+
+def test_the_verdict_survives_the_subshell(tmp_path: Path) -> None:
+    """APPLY_IAM_POLICY_VERDICT is set inside the subshell the fix introduced.
+    A variable that silently stopped escaping would make every caller reading
+    it report `unknown` forever — the exact `absence of signal` class. The
+    internal round-trip marker must not leak into the deploy log either.
+
+    The absent-role case is used because its verdict (`role-absent`) is
+    distinctive: `unknown` is a legitimate value the comparison can produce on
+    its own, so asserting against it would pass on a broken round-trip."""
+    bindir = _fake_aws(
+        tmp_path,
+        behaviours={"iam get-role": (254, _NO_SUCH_ENTITY.format(role=ROLE))},
+    )
+    r = _harness(
+        tmp_path,
+        f'apply_iam_policy_on_deploy "{ROLE}" pol "$POLICY_FILE" "$TRUST"; '
+        'echo "VERDICT=${APPLY_IAM_POLICY_VERDICT}"',
+        bindir,
+    )
+    assert "VERDICT=role-absent" in r.stdout, r.stdout + r.stderr
+    assert "APPLY_IAM_POLICY_VERDICT=" not in r.stdout, (
+        "the internal round-trip marker leaked into the deploy log"
+    )
+
+
+def test_run_exiting_inside_a_tolerance_wrapper_is_catchable(
+    tmp_path: Path,
+) -> None:
+    """The generalised class, stated directly. `run()` calls `exit`; any future
+    tolerance wrapper that guards it with `||` alone is unreachable. This
+    asserts both halves — that run() still exits (I8033 has not regressed) and
+    that the subshell idiom the fix uses actually catches it — so the next
+    author has an executable statement of the rule, not a comment."""
+    bindir = _fake_aws(tmp_path, behaviours={"iam get-role": (254, "denied")})
+    unguarded = _harness(
+        tmp_path,
+        'rc=0; run aws iam get-role --role-name x || rc=$?; echo "RC=$rc"',
+        bindir,
+    )
+    assert "RC=" not in unguarded.stdout, (
+        "run() no longer exits — alpha-engine-config-I8033 has regressed, and "
+        "a failing deploy command may again be non-fatal"
+    )
+    guarded = _harness(
+        tmp_path,
+        'rc=0; ( run aws iam get-role --role-name x ) || rc=$?; echo "RC=$rc"',
+        bindir,
+    )
+    assert "RC=254" in guarded.stdout, guarded.stdout + guarded.stderr


### PR DESCRIPTION
## The four permanently-red deploys

`deploy-alert-drain-dispatcher`, `deploy-overseer-dispatcher`, `deploy-alert-drain-liveness-probe` and `deploy-overseer-liveness-probe` have failed **every run on `main` since 2026-08-21**. Each one shipped its Lambda code successfully and then died at exit 254 on:

```
  ✓ verified live CodeSha256 matches /tmp/…/function.zip
  preserving ALERT_DRAIN_DISPATCH_ENABLED=true (operator-owned)
  Creating IAM role: alpha-engine-alert-drain-dispatcher-role
##[error]Process completed with exit code 254.
```

That role has existed since 2026-07-22. **No AWS error text appears anywhere in any of the job logs** — which is itself the second defect.

### Root cause — two defects, both in `_shared/apply_iam_policy.sh`

**1. A denied READ was treated as proof of absence.** The role probe was:

```bash
if ! aws iam get-role --role-name "$r" --query 'Role.RoleName' --output text >/dev/null 2>&1; then  # CREATE
```

`2>&1` to `/dev/null` makes `AccessDenied` and `NoSuchEntity` the same observation, and the `!` branch reads both as "the role does not exist". Measured against the live policy, `github-actions-lambda-deploy` holds `iam:GetRole` on exactly two roles — `alpha-engine-eventbridge-sfn-role` and `alpha-engine-step-functions-role` — and on **no lambda execution role**, by design (single-writer rule, `nous-ergon-ops/infrastructure/iam/README.md`). So the probe was denied, misread as absent, and the script called `aws iam create-role`: a grant the CI identity does not hold and must not hold.

**2. The tolerance wrapper was unreachable.** `apply_iam_policy_on_deploy` guarded the call with `... || rc=$?` so an `AccessDenied` could be classified as its one tolerated failure. But `run()` in `_shared/deploy_run.sh` calls **`exit`, not `return`** (alpha-engine-config-I8033), and `exit` inside a function terminates the *shell*: `||` guards a non-zero RETURN and there was none to guard. The classifier had been dead since the day `run()` started exiting — **2026-08-21, the exact commit at which all four workflows went red** — and the captured stderr in `err_file` was never replayed, which is why the log ends at `Creating IAM role:` with no cause.

This is the same class alpha-engine-config-I8125 closed for `run … || true` call sites with `run_tolerating()`. It fixed the *call-site* shape and missed this one, a **function-level** tolerance wrapper.

### The fix, and the layer it lands at

Both in `infrastructure/lambdas/_shared/apply_iam_policy.sh` — the shared helper all four scripts source, not any one call site.

- **`probe_role_presence()`** returns `present` / `absent` / `unknown`, capturing stderr instead of discarding it. Only an explicit `NoSuchEntity` proves absence; `AccessDenied`, an expired token, a throttle and a network failure are all `unknown`, and **nothing is created on an unknown**.
- **`apply_iam_policy` takes `may_create_role`**, and `apply_iam_policy_on_deploy` passes `false`. The code-only auto-apply path is no longer a role creator at all: role creation is a bootstrap act, reserved to an operator. `--bootstrap` and `--apply-iam` are unchanged and still create.
- **A subshell** around the call, so `run()`'s `exit` becomes a catchable exit status. `run()` keeps its fail-loud semantics everywhere else — the fix does not weaken it.
- **The captured stderr is now replayed on the tolerated path too.** The function header had claimed since it was written that stderr is "replayed verbatim on both paths below". It was not, on that path, and nothing noticed because the claim lived only in a comment. A tolerated failure whose cause never prints is how a *wrong* tolerance survives.

**No IAM grant is widened.** Per `identity-access-policy.md` §4, authority is derived from measured need, and the measured need here is the opposite: the code-only path must stop reaching a call it should never have made. `check-drift.py` remains the backstop for a policy change that needs an operator's `--apply-iam`.

## Blast radius — the class, not the four that surfaced

Every deploy workflow in this repo was swept (`gh run list --workflow=<f>`, last 10 runs on `main`). Exactly four `deploy.sh` call `apply_iam_policy_on_deploy`, and they are exactly the four reported. The sweep also turned up a **fifth permanently-red workflow with an unrelated cause**:

| workflow | history (last 10 on `main`) | cause |
|---|---|---|
| `deploy-overseer-liveness-probe.yml` | **10F / 0S** | IAM applier (this PR) |
| `deploy-alert-drain-dispatcher.yml` | 9F / 1S, red since 08-21 | IAM applier (this PR) |
| `deploy-alert-drain-liveness-probe.yml` | 9F / 1S, red since 08-21 | IAM applier (this PR) |
| `deploy-overseer-dispatcher.yml` | 7F / 3S, red since 08-21 | IAM applier (this PR) |
| `deploy-preflight-sweep-dispatcher.yml` | **6F / 0S — never once succeeded**, since it shipped 2026-08-13 | hand-rolled preflight gate (this PR) |
| `deploy-sf-telegram-notifier.yml` | 9F / 1S, **latest green** | `ModuleNotFoundError: nousergon_lib`; fixed by someone else 2026-08-28T17:20 — not mine |
| the other 24 `deploy-*.yml` | 0F / 10S | — |

### The second class: hand-rolled preflight gates

`deploy-preflight-sweep-dispatcher` failed 6 of 6 runs with `ModuleNotFoundError: No module named 'boto3'`. `_shared/run_handler_tests.sh` exists precisely so this step cannot drift per-script (config#2381). 31 `deploy.sh` used it; **four still carried a hand-rolled copy**, which hand-writes its dep list, runs only `test_handler.py`, and omits `infrastructure/lambdas/` from `PYTHONPATH`. `spot-interruption-recorder` had already hit the identical wall and **patched its own copy in place instead of the helper** — which is exactly what left the other three exposed. Fixing one call site of a systemic defect is not a fix.

All four migrated. A further four lambdas had a `test_handler.py` their `deploy.sh` **never ran at all** — the post-merge gate was simply absent — and are now gated: `alpha-engine-alerts-forwarder`, `backstop-telegram-notifier`, `data-spot-dispatcher`, `ssm-reachability-probe`.

Two are deliberately **not** fixed here, tracked and recorded in the guard test's debt register rather than silently skipped:
- `thinktank-spot-dispatcher` — its `deploy.sh` is a separate dialect that sources none of the `_shared` helpers and hand-rolls the *same* `get-role >/dev/null 2>&1 || create-role` misclassification. Wiring only the test gate would leave the larger defect in place and imply it had been reviewed. → **alpha-engine-config-I9114**
- `weekly-freshness-spot-dispatcher` — nousergon-data#1562 (draft) is editing this exact file. → **alpha-engine-config-I9115**

## Tests — behaviour, executed, not file text

`tests/test_iam_auto_apply_code_only_path.py` sources the **real** `apply_iam_policy.sh` and `deploy_run.sh` and runs them against a fake `aws` on `PATH` reproducing AWS's exact stderr. Asserting on file text would have passed against the broken version: it also contained the word `AccessDenied`.

**7 of the 10 cases fail against `origin/main`'s helper**, including reproducing the live signature `Creating IAM role: alpha-engine-alert-drain-dispatcher-role` verbatim. Covered: the code-only path survives an identity with no IAM writes · a denied `get-role` is never read as absent · `create-role` is never invoked from the deploy path · the tolerated `AccessDenied` is reported, not swallowed · the AWS error text reaches the log · a genuinely absent role is still not created from the deploy path · **the operator bootstrap path still creates** · a `MalformedPolicyDocument` still aborts loudly · the verdict survives the subshell · and, stated directly for the next author, that `run()` still exits and that the subshell idiom catches it.

`tests/test_deploy_preflight_tests_use_the_shared_gate.py` is the derived guard, scoped from `git ls-files` so `deploy.sh` #45 is covered on the day it lands. Its matcher **strips shell comments first** — the naive version reported eleven false offenders by matching the phrase `python3 -m pytest` inside the *comment* that explains the correct fix, which is a shape this fleet has recorded before and whose pressure is to delete the rationale.

Every migrated preflight gate was **executed** locally: preflight-sweep 14 passed, spot-interruption-recorder 26, canary-replay-dispatcher 18, canary-replay-liveness-probe 14, plus the four newly-gated lambdas (12/19/6/9). "A loop proven only by reading it is a loop nobody has run."

## Suite

`pytest tests/ -q -p no:randomly` → **6674 passed, 17 skipped, 0 failed.**

Under the default random ordering one unrelated test, `test_pipeline_status_registry_source_check.py::test_every_substantive_state_has_registry_entry[Saturday]`, failed once. It **passes in isolation and passes under deterministic ordering**, and is unreachable from this diff, which touches only `deploy.sh` shell scripts and two new test files. Filed as **alpha-engine-config-I9116** rather than ignored.

`shellcheck --severity=error infrastructure/*.sh` (CI's exact invocation) → clean. Every file touched here is also clean under `shellcheck --severity=error`. Three *untouched* `deploy.sh` files lack a shebang (SC2148) and are outside CI's invocation — noted, not bundled: **alpha-engine-config-I9117**.

## Cross-repo

Paired with **alpha-engine-config-PR9113**, which makes a permanently-red deploy impossible to ignore next time. Independent; either order merges cleanly. Recommended: **this PR first** (turn the reds green), then 9083 (make future reds visible).

Referenced, not closed — a closing keyword never works across repositories: **alpha-engine-config-I9045**. Deliverable 1 of that issue landed only half-live because these jobs died before their `--reconcile-triggers` step; see the verification note below.

## Verification after merge

Nothing to run by hand. The merge itself re-runs `deploy-alert-drain-dispatcher.yml`, whose `--reconcile-triggers` step could never execute while the job died earlier in the script. Once it is green:

```
aws scheduler get-schedule --name alpha-engine-alert-drain-0400utc --query Description
```

should carry its `[wakes: …] [sibling-legs: …]` marker, as `alpha-engine-freshness-monitor-cron` already does. Measured before this PR: that query returns `None` for all four drain schedules (0400/1000/1600/2200), and `events describe-rule` on the freshness-monitor cron **does** carry its marker — the exact half-live split I9045 deliverable 1 is in.

This cannot be verified before merge: the reconcile runs only from `main` under the OIDC deploy identity, and this session's AWS access was deliberately read-only.

---

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
