### PR TITLE
fix(weekly-sf): derive DataPhase1's ceiling from measurement — it runs at 93% of it (alpha-engine-config-I9201)

### DIFF
--- a/infrastructure/sf_budgets.py
+++ b/infrastructure/sf_budgets.py
@@ -117,9 +117,18 @@ STAGE_BUDGETS: dict[str, StageBudget] = {
         max_budget_seconds=10_800,
         pipeline_segment="sequential",
     ),
+    # alpha-engine-config-I7176 / -I9201 (2026-08-28): 5_400 -> 6_600. Measured
+    # DataPhase1 wall clock on the four most recent real scheduled runs —
+    # 2026-08-01 2388s, 08-08 2418s, 08-15 4926s, 08-22 5018s. The step between
+    # 08-08 and 08-15 is the retirement of the daily exercise cadence
+    # (4159239d, Brian ruling 2026-08-13), whose Friday pass had been writing
+    # the .phases/ markers Saturday auto-skipped on; 4926/5018s is the true
+    # cold cost, not growth. 6_600 = 5018 x 1.31, well inside max_budget_seconds.
+    # Mirrored in infrastructure/spot_data_phase1.sh (MAX_RUNTIME_SECONDS) and
+    # step_function.json (executionTimeout / TimeoutSeconds / poll cap 240).
     "DataPhase1": StageBudget(
         name="DataPhase1",
-        current_timeout_seconds=5_400,
+        current_timeout_seconds=6_600,
         per_ticker_cost_seconds=2.2,  # estimated (same dispatch pattern)
         fixed_overhead_seconds=3_300,
         max_budget_seconds=10_800,

--- a/infrastructure/spot_data_phase1.sh
+++ b/infrastructure/spot_data_phase1.sh
@@ -25,7 +25,30 @@ source "$SCRIPT_DIR/_spot_common.sh"
 _SPOT_NAME="${_SPOT_NAME:-data-phase1}"
 _SSM_SLUG="${_SSM_SLUG:-spot-data-phase1}"
 _PROCESS_NAME="${_PROCESS_NAME:-data-phase1}"
-MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-5400}"
+# alpha-engine-config-I7176 / -I9201 (2026-08-28): 5400 -> 6600, DERIVED from
+# the two most recent cold runs rather than estimated. Measured span from the
+# DataPhase1 StateEntered event to the last CheckDataPhase1Status entry, one
+# dispatch attempt each, no reissues:
+#
+#   2026-08-01  2388s (44%)   2026-08-15  4926s (91%)
+#   2026-08-08  2418s (45%)   2026-08-22  5018s (93%)
+#
+# The step is NOT growth. Until 2026-08-13 a daily "exercise cadence" ran the
+# whole weekly pipeline every weekday; its Friday pass wrote the same
+# data/{date}/.phases/*.json markers PhaseRegistry auto-skips on, so Saturday
+# skipped 7 of 10 phases (`PHASE_SKIP ... reason=auto_skip_marker_ok` in
+# _ssm_logs/data-weekly/2026-08-08/). Retiring that cadence (4159239d, Brian
+# ruling 2026-08-13) removed the incidental pre-warm, and 4926/5018s is
+# DataPhase1's true cold cost — `fundamentals` (~1020s), `universe_classification`
+# (~508s) and `short_interest` (~505s) are sequential per-ticker API loops over
+# 903 tickers and account for ~1900s of it.
+#
+# 6600 = 5018 x 1.31, inside the 10800s max_budget_seconds already declared in
+# infrastructure/sf_budgets.py. This buys margin against a known, stable cost;
+# it is NOT a threshold widened until a stale value passes. The real fix is to
+# batch those three loops against their providers' rate limits —
+# alpha-engine-config-I9201 — and this ceiling comes back down when it lands.
+MAX_RUNTIME_SECONDS="${MAX_RUNTIME_SECONDS:-6600}"
 
 # ── Parse flags ──────────────────────────────────────────────────────────────
 MODE="run"

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -896,12 +896,12 @@
         "Parameters": {
           "commands.$": "States.Array('set -eo pipefail','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main','sudo -u ec2-user flock -w 150 /home/ec2-user/.ae-git-sync.lock git -C /home/ec2-user/alpha-engine-config pull --ff-only origin main','cd /home/ec2-user/alpha-engine-data','export HOME=/home/ec2-user',States.Format('export EXECUTION_RUN_DATE=\\'{}\\'',$.run_date),States.Format('/home/ec2-user/alpha-engine-dashboard/.venv/bin/python -m krepis.ssm_log_capture run --correlation-id {} --slug data-weekly --log /var/log/data-weekly.log -- bash infrastructure/spot_data_phase1.sh{}',$$.Execution.Name,$.preflight_args))",
           "executionTimeout": [
-            "5400"
+            "6600"
           ]
         },
-        "TimeoutSeconds": 5400
+        "TimeoutSeconds": 6600
       },
-      "TimeoutSeconds": 5460,
+      "TimeoutSeconds": 6660,
       "Retry": [
         {
           "ErrorEquals": [
@@ -1011,7 +1011,7 @@
             },
             {
               "Variable": "$.data_phase1_polls",
-              "NumericLessThan": 216
+              "NumericLessThan": 240
             }
           ],
           "Next": "DataPhase1Wait"


### PR DESCRIPTION
## What

Raises `DataPhase1`'s ceiling 5400s → 6600s and its poll cap 216 → 240, in the four places that carry the number. `alpha-engine-config-I9201`.

## Why — measured, not estimated

`DataPhase1` wall clock on the four most recent real scheduled weekly runs, from the `DataPhase1` `StateEntered` event to the last `CheckDataPhase1Status` entry (one dispatch attempt each, zero reissues):

| scheduled run | wall | % of the 5400s ceiling |
|---|---|---|
| 2026-08-01 | 2388s | 44% |
| 2026-08-08 | 2418s | 45% |
| 2026-08-15 | 4926s | **91%** |
| 2026-08-22 | 5018s | **93%** |

The step between 08-08 and 08-15 is **not growth**. Until 2026-08-13 a daily exercise cadence ran the whole weekly pipeline every weekday; its Friday pass wrote the same `data/{trading_day}/.phases/*.json` markers `PhaseRegistry` auto-skips on, so Saturday skipped 7 of 10 phases. Direct evidence: `s3://alpha-engine-research/data/2026-08-07/.phases/*` `LastModified` Friday 08-07 13:05–14:53 UTC, and `_ssm_logs/data-weekly/2026-08-08/…` logging `PHASE_SKIP name=<X> reason=auto_skip_marker_ok` for exactly those 7 phases — versus `data/2026-08-14/.phases/*` written during the 08-15 run itself, with all 10 phases reaching `PHASE_END`. `4159239d` retired that cadence (Brian's 2026-08-13 ruling) and removed the incidental pre-warm with it. ~5000s is DataPhase1's true cold cost. Universe was 903/903 in both the fast and slow weeks.

A breach is not a soft failure: `DataPhase1RetryGate` → `DataPhase1Reissue` → one full re-run (~83 min) → `ExtractDataPhase1Error` → `FailExecution`. A deterministic overrun costs ~2.7h and still fails the run.

## Why this is not a widened threshold

`sf-pipeline-policy` and the fleet SOTA rule forbid widening a bound until a stale value passes. This is the other case: the value being cleared is **measured, stable across two runs, and its cause is identified**. 6600 = 5018 × 1.31, inside the `max_budget_seconds=10_800` that `infrastructure/sf_budgets.py` already declares for this stage — the headroom was pre-authorised, not invented here.

The real fix — batching `fundamentals` (~1020s), `universe_classification` (~508s) and `short_interest` (~505s), three sequential per-ticker API loops over 903 tickers that account for ~1900s of the ~5000s — is filed as `alpha-engine-config-I9201` with the provider rate-limit constraints and the producer-repo fail-loud requirement written into it. **That issue's closes-when brings this number back down.** This PR is the stopgap it names.

## Changes

| file | change |
|---|---|
| `infrastructure/sf_budgets.py` | `STAGE_BUDGETS["DataPhase1"].current_timeout_seconds` 5_400 → 6_600, with the derivation |
| `infrastructure/spot_data_phase1.sh` | `MAX_RUNTIME_SECONDS` default 5400 → 6600, with the derivation |
| `infrastructure/step_function.json` | `DataPhase1`: `executionTimeout` "5400"→"6600", `Parameters.TimeoutSeconds` 5400→6600, state `TimeoutSeconds` 5460→6660 (the +60 convention held); `CheckDataPhase1Status` poll cap `NumericLessThan` 216 → 240 so 240×30s = 7200s stays above the new ceiling |

`MAX_RUNTIME_SECONDS` is both the SSM command budget and the argument arming the spot box's hard-timeout timer via `krepis.spot_bootstrap --max-runtime-seconds` (`alpha-engine-config-I7372`) — both move together here, which is why the launcher and the definition are in one diff.

The number now appears in four places. That is the defect `alpha-engine-config-I7010` already names for `PredictorTraining` (have the SF export the budget, the launcher read it); `I9201` carries closing it for this stage rather than leaving it implied.

## Out of scope, named rather than silently left

`ReplayConcordance`, `EvalJudgeProcess`, `Director` and `EvalRollingMean` timeouts are untouched — `EvalRollingMean` is being changed by a concurrent session (`alpha-engine-config-I9102`), and the other three are correct under `_SERVICE_MAX_GUARD_BAND`. The diff is confined to `DataPhase1`'s own states so it rebases cleanly onto `nousergon-data-PR1567`, which also edits `infrastructure/step_function.json` (different states).

## Tests

`PYTHONPATH=. .venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration` → **6645 passed, 12 skipped** on this branch. `tests/test_sf_budgets.py`'s `TestSsmExecutionTimeoutPins::test_data_phase1` pins `sf_budgets.py` against the live JSON and passes on the new pair. No test pinned DataPhase1's poll cap (the `216` assertion in `test_sf_research_predictor_parallel_wiring.py` is DataPhase2's and is unchanged).

## Deploy

Merging deploys the definition through this repo's existing SF deploy path — no post-merge command.

Closes #— *(cross-repo: tracked as `alpha-engine-config-I9201`, closed by hand; a closing keyword is inert across repositories)*

Related: `alpha-engine-config-I7176` (weekly-SF readiness register), `alpha-engine-config-I7010`, `alpha-engine-config-I7372`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)


Rehearsal-path: tests/test_sf_budgets.py

The change is three numbers and a poll cap; `tests/test_sf_budgets.py::TestSsmExecutionTimeoutPins::test_data_phase1` pins `sf_budgets.py`'s declared `current_timeout_seconds` against the live `step_function.json` value, so the two cannot drift apart, and `sf-definition-validate` proves the definition still compiles. An off-cycle shell rehearsal cannot exercise this change by construction — a shell run short-circuits the DataPhase1 workload, which is precisely the gap this ceiling covers.
