### PR TITLE
fix(hygiene): the private deploy dialect, the misdirecting drift message, and the shellcheck scope (I9114/I9116/I9117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-      - name: shellcheck (infrastructure/*.sh, error severity)
-        run: shellcheck --severity=error infrastructure/*.sh
+      # Scope is DERIVED from git, not a literal glob list
+      # (alpha-engine-config-I9117). It used to be `infrastructure/*.sh` — the
+      # TOP-LEVEL directory only — so the 45 `infrastructure/lambdas/*/deploy.sh`
+      # and the `_shared/*.sh` helpers they source were analysed by NOTHING.
+      # Those are exactly the files that carried the week-long four-red-deploys
+      # outage (alpha-engine-config-I9045), and widening found four real
+      # error-severity defects: three deploy.sh had an automated `source` line
+      # prepended ABOVE their shebang, making the shebang inert (SC2148), and
+      # `_shared/run_handler_tests.sh` had an em-dash where a shellcheck
+      # directive's trailing prose needs its own `#` (SC1125).
+      #
+      # WHY DERIVED rather than the three globs that would have sufficed today:
+      # a hand-written scope leaves the next script uncovered on the day it
+      # lands, in a directory nobody remembered to add — which is the precise
+      # shape of the gap being closed here. `git ls-files` cannot go stale.
+      # Measured 2026-08-28: 79 tracked *.sh, clean at --severity=error.
+      # error-severity only, so a warning-noise cleanup never gates unrelated PRs.
+      - name: shellcheck (every tracked *.sh, error severity)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git ls-files -z '*.sh' | xargs -0 shellcheck --severity=error
 
   # config#4223: the 2026-07-25 weekly-SF kill was a krepis CLI contract
   # change deployed between SF phases — every ssm_log_capture caller in the

--- a/infrastructure/lambdas/_shared/run_handler_tests.sh
+++ b/infrastructure/lambdas/_shared/run_handler_tests.sh
@@ -83,7 +83,12 @@ run_handler_tests() {
 
   local targets
   if [[ -n "${HANDLER_TEST_TARGETS+x}" ]]; then
-    # shellcheck disable=SC2206 — intentional word-split on the caller's list.
+    # A shellcheck directive's trailing prose must start with its own `#`.
+    # Written as `disable=SC2206 — intentional ...` this raised SC1125
+    # (error severity) on every run, which is why widening CI's shellcheck
+    # scope to _shared/*.sh could not land until it was fixed
+    # (alpha-engine-config-I9117).
+    # shellcheck disable=SC2206  # intentional word-split on the caller's list.
     targets=(${HANDLER_TEST_TARGETS})
   else
     targets=()

--- a/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
+++ b/infrastructure/lambdas/backstop-telegram-notifier/deploy.sh
@@ -57,7 +57,11 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # lambda's tests stub boto3 in sys.modules, and the helper's contract is that
 # such a caller must NOT get boto3 installed alongside the stub.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-run_handler_tests "${SCRIPT_DIR}"
+# `boto3`: test_handler.py imports it at module scope. Not yet observed red
+# only because this workflow has not fired since the gate was wired; caught
+# by executing the gate on a bare interpreter rather than a laptop that
+# already has boto3 (alpha-engine-config-I9114 sweep).
+run_handler_tests "${SCRIPT_DIR}" boto3
 
 # ----- 0. Validate handler syntax -------------------------------------------
 

--- a/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/data-spot-dispatcher/deploy.sh
@@ -98,7 +98,10 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # lambda's tests stub boto3 in sys.modules, and the helper's contract is that
 # such a caller must NOT get boto3 installed alongside the stub.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-run_handler_tests "${SCRIPT_DIR}"
+# `krepis`: test_handler.py:34 imports krepis.spot_bootstrap for REAL (it is
+# not stubbed). Measured — deploy-data-spot-dispatcher failed on main
+# 2026-08-29T00:11 with ModuleNotFoundError: No module named 'krepis'.
+run_handler_tests "${SCRIPT_DIR}" krepis
 
 # ----- 0. Scratch dir + validate handler syntax ------------------------------
 

--- a/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
+++ b/infrastructure/lambdas/overseer-liveness-probe/deploy.sh
@@ -1,8 +1,3 @@
-
-# alpha-engine-config-I6619: --state must come from the automation-pause
-# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
-# shellcheck source=infrastructure/lambdas/_shared/pause.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-overseer-liveness-probe Lambda
 # and wire its EventBridge Scheduler rules.
@@ -77,6 +72,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #   bash .../overseer-liveness-probe/deploy.sh --smoke     # invoke once (read-only; pings only on a real problem)
 
 set -euo pipefail
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -1,8 +1,3 @@
-
-# alpha-engine-config-I6619: --state must come from the automation-pause
-# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
-# shellcheck source=infrastructure/lambdas/_shared/pause.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-scheduled-groom-dispatcher Lambda,
 # the alpha-engine-groom-dispatch Step Function that wraps it, and wire the
@@ -108,6 +103,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #   bash .../deploy.sh --smoke                # synthetic schedule event (⚠ fires a REAL groom)
 
 set -euo pipefail
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh
@@ -1,8 +1,3 @@
-
-# alpha-engine-config-I6619: --state must come from the automation-pause
-# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
-# shellcheck source=infrastructure/lambdas/_shared/pause.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #!/usr/bin/env bash
 # deploy.sh — Create or update the alpha-engine-sf-watch-reclaim-sweep-handler Lambda
 # and wire its EventBridge Scheduler rules.
@@ -64,6 +59,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 #   bash .../sf-watch-reclaim-sweep-handler/deploy.sh --smoke     # invoke once (read-only check; pings only on a real problem)
 
 set -euo pipefail
+
+# alpha-engine-config-I6619: --state must come from the automation-pause
+# manifest, not from the API default (ENABLED). See infrastructure/lambdas/_shared/pause.sh.
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"

--- a/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
+++ b/infrastructure/lambdas/ssm-reachability-probe/deploy.sh
@@ -69,7 +69,10 @@ source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
 # lambda's tests stub boto3 in sys.modules, and the helper's contract is that
 # such a caller must NOT get boto3 installed alongside the stub.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-run_handler_tests "${SCRIPT_DIR}"
+# `boto3`: index.py imports it at module scope. Measured —
+# deploy-ssm-reachability-probe failed on main 2026-08-29T00:11 with
+# ModuleNotFoundError: No module named 'boto3'.
+run_handler_tests "${SCRIPT_DIR}" boto3
 
 PKG="$(mktemp -d)"
 trap 'rm -rf "${PKG}"' EXIT

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -108,7 +108,13 @@ fi
 # a caller must NOT get boto3 installed alongside the stub.
 # shellcheck source=infrastructure/lambdas/_shared/run_handler_tests.sh
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-run_handler_tests "${SCRIPT_DIR}"
+# `-r requirements.txt` (the superset model ci.yml uses), not the empty dep
+# list alpha-engine-config-I9114 predicted. Measured on a bare interpreter
+# 2026-08-29: the tests do NOT stub nousergon_lib — 2 of 25 import it for
+# real and ModuleNotFound without it. A dep list that was reasoned about
+# rather than executed is how deploy-data-spot-dispatcher and
+# deploy-ssm-reachability-probe went red on main the same evening.
+run_handler_tests "${SCRIPT_DIR}" -r "${SCRIPT_DIR}/requirements.txt"
 
 echo "==> building package"
 BUILD_DIR="$(mktemp -d)"

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/deploy.sh
@@ -14,21 +14,32 @@
 #   --apply-iam   re-apply iam-policy.json only, no code/bootstrap side effects (config#2825)
 #   --smoke       fire ONE real run on a REAL spot box (the §47 validation gate)
 #   --cutover     repoint alpha-research-thinktank-daily at this dispatcher
+#   --dry-run     print every mutating call instead of making it
 #
 # See README.md for the full rollout order. crucible-research-PR544 must be
 # merged to main BEFORE --smoke: the SSM prelude execs
 # infrastructure/thinktank_spot_bootstrap.sh out of a shallow clone of main.
+#
+# WHY THIS SCRIPT NO LONGER HAND-ROLLS ANYTHING (alpha-engine-config-I9114).
+# Until 2026-08-28 this was the one deploy.sh in a private dialect: it made bare
+# `aws` calls instead of `run`, packaged with a host-arch `pip install --target`
+# instead of the shared Lambda-safe installer, never ran its own 25 handler
+# tests, and hand-rolled its IAM with the exact
+#
+#     aws iam get-role ... >/dev/null 2>&1 || { aws iam create-role ...; }
+#
+# misclassification that made four sibling workflows red for a week
+# (alpha-engine-config-I9045 / nousergon-data-PR1569 — `2>&1` to /dev/null makes
+# AccessDenied and NoSuchEntity the same observation, so a DENIED read was read
+# as "role absent"). Fixing `_shared/apply_iam_policy.sh` did not fix this copy,
+# which is the whole reason a private dialect is a defect and not a style. Every
+# mechanism below is now the shared one, so the next fix to it lands here too.
 
 set -euo pipefail
 
-# Alarm upserts RESET ActionsEnabled, so without this the next deploy re-arms any alarm the automation pause has silenced
-# (alpha-engine-config-I7023).
-# shellcheck source=infrastructure/lambdas/_shared/pause.sh
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../_shared/pause.sh"
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 REGION="${AWS_REGION:-us-east-1}"
-ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 FUNCTION_NAME="alpha-engine-thinktank-spot-dispatcher"
 ROLE_NAME="alpha-engine-thinktank-spot-dispatcher-role"
 # Authoritative inline-policy assignment — the consolidated drift checker
@@ -41,78 +52,108 @@ RULE_NAME="alpha-research-thinktank-daily"
 # Same topic the alarms this cutover replaces already publish to, so the
 # rotation does not silently change where a Think Tank page lands.
 SNS_TOPIC_ARN="${SNS_TOPIC_ARN:-arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
-source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
-BUILD_DIR="$(mktemp -d)"
-trap 'rm -rf "$BUILD_DIR"' EXIT
+TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
 
-BOOTSTRAP=0; SMOKE=0; CUTOVER=0; APPLY_IAM=0
+# DRY_RUN honors an ambient env var (true/1/yes) as well as the --dry-run flag
+# below, matching every sibling deploy.sh (alpha-engine-config-I2752: an
+# operator assumed DRY_RUN=<env var> worked and triggered a real deploy). It
+# must be DEFINED whatever happens: `apply_iam_policy` reads a bare `$DRY_RUN`,
+# so leaving it unset would abort under this script's `set -u`.
+case "${DRY_RUN:-false}" in
+  true|1|yes|TRUE|YES) DRY_RUN=true ;;
+  *) DRY_RUN=false ;;
+esac
+
+BOOTSTRAP=false; SMOKE=false; CUTOVER=false; APPLY_IAM=false
 while [ $# -gt 0 ]; do
     case "$1" in
-        --bootstrap) BOOTSTRAP=1; shift ;;
-        --smoke) SMOKE=1; shift ;;
-        --cutover) CUTOVER=1; shift ;;
-        --apply-iam) APPLY_IAM=1; shift ;;
+        --bootstrap) BOOTSTRAP=true; shift ;;
+        --smoke) SMOKE=true; shift ;;
+        --cutover) CUTOVER=true; shift ;;
+        --apply-iam) APPLY_IAM=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
 
+# Alarm upserts RESET ActionsEnabled, so without this the next deploy re-arms any alarm the automation pause has silenced
+# (alpha-engine-config-I7023).
+# shellcheck source=infrastructure/lambdas/_shared/pause.sh
+source "${SCRIPT_DIR}/../_shared/pause.sh"
+# shellcheck source=infrastructure/lambdas/_shared/deploy_run.sh
+source "${SCRIPT_DIR}/../_shared/deploy_run.sh"
+# shellcheck source=infrastructure/lambdas/_shared/apply_iam_policy.sh
+source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"
+
+ACCOUNT_ID="${ACCOUNT_ID:-$(aws sts get-caller-identity --query Account --output text)}"
+
 # ----- Apply IAM only (config#2825, no bootstrap/code side effects) --------
-if [ "$APPLY_IAM" -eq 1 ]; then
+# Reached ONLY under --apply-iam, i.e. by an operator. apply_iam_policy's
+# default may_create_role=true is therefore correct here — and its
+# probe_role_presence means a DENIED get-role is reported as `unknown` and
+# creates nothing, rather than being misread as absence.
+if $APPLY_IAM; then
     echo "==> applying IAM (role=$ROLE_NAME, policy=$POLICY_NAME)"
-    aws iam get-role --role-name "$ROLE_NAME" --region "$REGION" >/dev/null 2>&1 || {
-        echo "  Creating IAM role: $ROLE_NAME"
-        aws iam create-role --role-name "$ROLE_NAME" \
-            --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
-            --region "$REGION" >/dev/null
-        echo "  waiting for IAM propagation..."
-        sleep 10
-    }
-    aws iam put-role-policy --role-name "$ROLE_NAME" \
-        --policy-name "$POLICY_NAME" \
-        --policy-document "file://$SCRIPT_DIR/iam-policy.json" \
-        --region "$REGION"
-    echo "  ✓ IAM applied."
+    apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" \
+      "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
+    echo "  ✓ IAM applied. Nothing else was touched — no code, no alarms."
     echo "==> done"
     exit 0
 fi
 
-echo "==> building package"
-cp "$SCRIPT_DIR/index.py" "$BUILD_DIR/"
-python3.12 -m pip install --quiet --target "$BUILD_DIR" -r "$SCRIPT_DIR/requirements.txt"
-(cd "$BUILD_DIR" && zip -qr /tmp/thinktank-spot-dispatcher.zip .)
+# ----- Preflight handler unit tests (shared gate — config#2381) -------------
+# 25 tests sat beside index.py that this deploy.sh never ran, so the post-merge
+# gate was absent for this lambda entirely. No extra deps: they stub
+# nousergon_lib and boto3 in sys.modules, and the helper's contract is that such
+# a caller must NOT get boto3 installed alongside the stub.
+# shellcheck source=infrastructure/lambdas/_shared/run_handler_tests.sh
+source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
+run_handler_tests "${SCRIPT_DIR}"
 
-if [ "$BOOTSTRAP" -eq 1 ]; then
-    echo "==> creating IAM role $ROLE_NAME (idempotent)"
-    aws iam create-role --role-name "$ROLE_NAME" \
-        --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
-        --region "$REGION" >/dev/null 2>&1 || echo "    (role exists)"
-    aws iam put-role-policy --role-name "$ROLE_NAME" \
-        --policy-name "$POLICY_NAME" \
-        --policy-document "file://$SCRIPT_DIR/iam-policy.json" \
-        --region "$REGION"
-    echo "    waiting for IAM propagation..."
-    sleep 10
+echo "==> building package"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+# The shared Lambda-safe installer, not `pip install --target` (which this
+# script used until I9114). A bare host install on macOS bundles darwin/arm64
+# wheels that ImportError on the Lambda linux/amd64 runtime; the helper also
+# chowns the tree back so a Linux CI runner's non-root cleanup does not EPERM.
+bash "${SCRIPT_DIR}/../lambda_pip_install.sh" "$BUILD_DIR" "${SCRIPT_DIR}/requirements.txt"
+cp "$SCRIPT_DIR/index.py" "$BUILD_DIR/"
+# Inside BUILD_DIR, not a fixed /tmp path: the old /tmp/thinktank-spot-dispatcher.zip
+# was shared mutable state between concurrent runs and survived the trap.
+ZIP="$BUILD_DIR/function.zip"
+(cd "$BUILD_DIR" && zip -qr function.zip . -x "function.zip")
+
+if $BOOTSTRAP; then
+    echo "==> creating IAM role $ROLE_NAME + applying policy (idempotent)"
+    apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" \
+      "${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"
 
     echo "==> creating Lambda $FUNCTION_NAME (idempotent)"
-    aws lambda create-function --function-name "$FUNCTION_NAME" \
+    # `run_tolerating` rather than `|| echo "(function exists)"`: the old form
+    # reported that same reassuring line for AccessDenied, an invalid role ARN
+    # and a malformed zip, with the real message sent to /dev/null. The
+    # already-exists conflict is the ONE benign failure.
+    run_tolerating "ResourceConflictException" \
+      aws lambda create-function --function-name "$FUNCTION_NAME" \
         --runtime python3.12 --handler index.handler \
         --role "arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" \
-        --zip-file fileb:///tmp/thinktank-spot-dispatcher.zip \
+        --zip-file "fileb://${ZIP}" \
         --timeout 300 --memory-size 512 \
-        --region "$REGION" >/dev/null 2>&1 || echo "    (function exists — updating code below)"
+        --region "$REGION" --query 'FunctionArn' --output text
 fi
 
 echo "==> updating function code"
-aws lambda update-function-code --function-name "$FUNCTION_NAME" \
-    --zip-file fileb:///tmp/thinktank-spot-dispatcher.zip \
-    --region "$REGION" --query 'LastModified' --output text
-aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION"
+run aws lambda update-function-code --function-name "$FUNCTION_NAME" \
+    --zip-file "fileb://${ZIP}" \
+    --region "$REGION" --query 'LastUpdateStatus' --output text
+if ! $DRY_RUN; then
+    aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION"
+fi
 
-verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "/tmp/thinktank-spot-dispatcher.zip"
+verify_code_deployed "${FUNCTION_NAME}" "${REGION}" "${ZIP}"
 
-if [ "$SMOKE" -eq 1 ]; then
+if $SMOKE; then
     echo "==> SMOKE: firing ONE real Think Tank run on a REAL spot box"
     echo "    (this spends a spot instance and a real LLM pass — ~25 min expected)"
     # shellcheck source=infrastructure/lambdas/_shared/smoke.sh
@@ -130,7 +171,7 @@ if [ "$SMOKE" -eq 1 ]; then
     echo "           thinktank/events/ written for the trading day, box self-terminated."
 fi
 
-if [ "$CUTOVER" -eq 1 ]; then
+if $CUTOVER; then
     echo "==> CUTOVER: repointing $RULE_NAME at $FUNCTION_NAME"
     TARGET_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
     # `|| echo "(permission exists)"` reported that same reassuring line for
@@ -143,7 +184,7 @@ if [ "$CUTOVER" -eq 1 ]; then
         --principal events.amazonaws.com \
         --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${RULE_NAME}" \
         --region "$REGION"
-    aws events put-targets --rule "$RULE_NAME" \
+    run aws events put-targets --rule "$RULE_NAME" \
         --targets "[{\"Id\":\"1\",\"Arn\":\"${TARGET_ARN}\"}]" --region "$REGION"
     echo "    $RULE_NAME now targets $FUNCTION_NAME."
 
@@ -171,7 +212,7 @@ if [ "$CUTOVER" -eq 1 ]; then
     echo "==> $DISPATCH_ALARM is applied from nous-ergon-ops, not here (alpha-engine-config-I7359)"
 
     echo "==> deleting the now-blind $OLD_FUNCTION alarms"
-    aws cloudwatch delete-alarms --alarm-names \
+    run aws cloudwatch delete-alarms --alarm-names \
         "alpha-engine-thinktank-daily-run-failed" \
         "alpha-engine-thinktank-daily-run-failed-timeout" \
         --region "$REGION"

--- a/tests/test_deploy_preflight_tests_use_the_shared_gate.py
+++ b/tests/test_deploy_preflight_tests_use_the_shared_gate.py
@@ -52,22 +52,22 @@ _DECLARED_CARVE_OUTS = {
     "changelog-cloudwatch-mirror",
 }
 
-# Two lambdas are KNOWN-UNGATED and deliberately not fixed in the change that
-# introduced this test. Each is tracked, each has a named reason, and this set
-# must shrink — it is a debt register, not a permanent exemption. An entry
-# whose issue is closed and whose gate is still missing is itself a finding.
+# A debt register, not a permanent exemption: each entry is tracked, each has a
+# named reason, and the set must shrink. An entry whose issue is closed and whose
+# gate is still missing is itself a finding.
 #
-#   thinktank-spot-dispatcher       — its deploy.sh is a separate dialect: it
-#     sources none of the _shared helpers and hand-rolls its own IAM with the
-#     very `get-role >/dev/null 2>&1 || create-role` misclassification the
-#     shared applier was fixed for. Wiring only the test gate would leave the
-#     larger defect in place and imply it had been reviewed.
-#     Tracked: alpha-engine-config-I9114.
+#   thinktank-spot-dispatcher — REMOVED 2026-08-28 (alpha-engine-config-I9114).
+#     Its deploy.sh was the one private dialect in this repo — bare `aws` calls,
+#     a host-arch `pip install --target`, no handler-test gate, and a hand-rolled
+#     `get-role >/dev/null 2>&1 || create-role` IAM block carrying the exact
+#     misclassification the shared applier had just been fixed for. It is now
+#     migrated onto deploy_run.sh / run_handler_tests.sh / apply_iam_policy.sh,
+#     and tests/test_thinktank_deploy_uses_shared_helpers.py EXECUTES the result
+#     against a fake `aws` to prove the code-only path reaches no IAM write.
 #   weekly-freshness-spot-dispatcher — nousergon-data#1562 (draft) is editing
 #     this exact deploy.sh; a second concurrent edit to it would collide.
 #     Tracked: alpha-engine-config-I9115.
 _TRACKED_UNGATED = {
-    "thinktank-spot-dispatcher",
     "weekly-freshness-spot-dispatcher",
 }
 
@@ -150,11 +150,11 @@ def test_a_lambda_with_handler_tests_actually_runs_them() -> None:
 
 
 def test_the_ungated_debt_register_does_not_grow_silently() -> None:
-    """`_TRACKED_UNGATED` is a debt register with two named, tracked entries.
+    """`_TRACKED_UNGATED` is a debt register of named, tracked entries.
     It must shrink, never grow — and an entry that has since been GATED must be
     removed from it, or the exemption outlives the debt and starts hiding a
     regression on the same lambda."""
-    assert len(_TRACKED_UNGATED) <= 2, (
+    assert len(_TRACKED_UNGATED) <= 1, (
         "the ungated-lambda exemption list grew. A new lambda shipping without "
         "its preflight gate is the defect this file exists to stop; add the "
         "gate rather than an exemption."

--- a/tests/test_iam_role_creation_is_helper_gated.py
+++ b/tests/test_iam_role_creation_is_helper_gated.py
@@ -1,0 +1,202 @@
+"""Role creation must go through the shared, presence-gated helper.
+
+WHY (alpha-engine-config-I9114, generalising alpha-engine-config-I9045)
+-----------------------------------------------------------------------
+`_shared/apply_iam_policy.sh` was fixed on 2026-08-28 so that a DENIED
+`iam:GetRole` can never be read as "the role does not exist" — `AccessDenied`
+and `NoSuchEntity` had been the same observation, which is how four workflows
+came to call `iam:CreateRole` on every run for a week with a grant they do not
+hold.
+
+That fix protected exactly the call sites that used the helper.
+`thinktank-spot-dispatcher/deploy.sh` had its own copy of the same three lines
+and was untouched by it. THAT is the finding this file exists for: a class fix
+at the correct layer is worth nothing to a call site that reimplemented the
+layer, and the only way to know how many such call sites exist is to enumerate
+them and refuse to let the number grow.
+
+The sweep, measured 2026-08-28: 45 shell scripts in this repo still reach
+`aws iam create-role` from their own code rather than through
+`apply_iam_policy`. Every one of them guards it with the same
+`if ! aws iam get-role ... >/dev/null 2>&1` probe, i.e. every one carries the
+I9045 misclassification. They are DORMANT, not safe: each sits inside an
+operator-only `--bootstrap` block that the CI identity never enters, which is a
+property of today's flag layout and not a guarantee. Migrating 45 scripts would
+collide with four in-flight PRs, so it is tracked separately; what lands here is
+the detection, because detection blindness outranks the defects it hides.
+
+`_REGISTER` is a debt register, not an allowlist. It may only shrink.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The ONE sanctioned implementation. `apply_iam_policy` reaches create-role only
+# through `probe_role_presence` (which distinguishes denied from absent) and only
+# when its `may_create_role` argument is "true" — the operator path. The
+# code-only auto-apply path passes "false" and cannot reach it at all.
+_SANCTIONED = {
+    "infrastructure/lambdas/_shared/apply_iam_policy.sh",
+}
+
+# Scripts that still hand-roll it. Tracked as alpha-engine-config-I9207.
+# Delete an entry the moment its script migrates onto `apply_iam_policy` — the
+# staleness assertion below fails until you do, because an exemption that
+# outlives its debt starts hiding a regression on the same script.
+_REGISTER = {
+    "infrastructure/codebuild-runners/deploy_codebuild_runner.sh",
+    "infrastructure/lambdas/_shared/ensure_overseer_scheduler_role.sh",
+    "infrastructure/lambdas/alert-drain-dispatcher/deploy.sh",
+    "infrastructure/lambdas/alert-drain-liveness-probe/deploy.sh",
+    "infrastructure/lambdas/alpha-engine-alerts-forwarder/deploy.sh",
+    "infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh",
+    "infrastructure/lambdas/backstop-telegram-notifier/deploy.sh",
+    "infrastructure/lambdas/canary-replay-dispatcher/deploy.sh",
+    "infrastructure/lambdas/canary-replay-liveness-probe/deploy.sh",
+    "infrastructure/lambdas/changelog-cloudwatch-mirror/deploy.sh",
+    "infrastructure/lambdas/changelog-incident-mirror/deploy.sh",
+    "infrastructure/lambdas/ci-watch-dispatcher/deploy.sh",
+    "infrastructure/lambdas/ci-watch-liveness-probe/deploy.sh",
+    "infrastructure/lambdas/crypto-balances/deploy.sh",
+    "infrastructure/lambdas/data-spot-dispatcher/deploy.sh",
+    "infrastructure/lambdas/eod-backstop/deploy.sh",
+    "infrastructure/lambdas/eod-precondition-probe/deploy.sh",
+    "infrastructure/lambdas/eod-snapshot-existence-check/deploy.sh",
+    "infrastructure/lambdas/eod-success-friday-shell-trigger/deploy.sh",
+    "infrastructure/lambdas/expense-collector/deploy.sh",
+    "infrastructure/lambdas/freshness-monitor/deploy.sh",
+    "infrastructure/lambdas/friday-shell-run-report/deploy.sh",
+    "infrastructure/lambdas/groom-inject-mock/deploy.sh",
+    "infrastructure/lambdas/overseer-backstop-responder/deploy.sh",
+    "infrastructure/lambdas/overseer-dispatcher/deploy.sh",
+    "infrastructure/lambdas/overseer-liveness-probe/deploy.sh",
+    "infrastructure/lambdas/pipeline-watchdog/deploy.sh",
+    "infrastructure/lambdas/preflight-sweep-dispatcher/deploy.sh",
+    "infrastructure/lambdas/preopen-deploy-readiness-probe/deploy.sh",
+    "infrastructure/lambdas/saturday-integrity-sentinel/deploy.sh",
+    "infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh",
+    "infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh",
+    "infrastructure/lambdas/sf-telegram-notifier/deploy.sh",
+    "infrastructure/lambdas/sf-watch-reclaim-sweep-handler/deploy.sh",
+    "infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh",
+    "infrastructure/lambdas/spot-interruption-recorder/deploy.sh",
+    "infrastructure/lambdas/spot-orphan-reaper/deploy.sh",
+    "infrastructure/lambdas/ssm-liveness-poller/deploy.sh",
+    "infrastructure/lambdas/ssm-reachability-probe/deploy.sh",
+    "infrastructure/lambdas/substrate-health-gate/deploy.sh",
+    "infrastructure/lambdas/sweep-artifact-monitor/deploy.sh",
+    "infrastructure/lambdas/weekly-freshness-spot-dispatcher/deploy.sh",
+    "infrastructure/lambdas/weekly-preflight/deploy.sh",
+    "infrastructure/run_weekly_offcycle.sh",
+    "infrastructure/setup_overseer_intake.sh",
+}
+
+
+def _code_only(body: str) -> str:
+    """Shell source with FULL-LINE `#` comments removed.
+
+    Load-bearing, not cosmetic. Several of these scripts explain the IAM
+    boundary in prose containing the very command names scanned for, and this
+    fleet has shipped the false positive three times in two days: a scan matched
+    `ne-admin` inside a YAML comment, a test harvested a prose
+    `systemctl enable --now` as an installer, and a drift guard matched
+    `python3 -m pytest` inside the comment explaining the correct fix. Each time
+    the pressure was to delete the rationale rather than fix the scan.
+
+    Whole lines only. A `#` mid-line is left alone: stripping from the first `#`
+    anywhere would eat a legitimate `"$URL#frag"` and is a false NEGATIVE risk
+    this repo's sibling guard deliberately accepts, but here the assertion is
+    about presence, so cutting less is the safer direction.
+    """
+    return "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _shell_scripts() -> list[str]:
+    out = subprocess.run(  # noqa: S603
+        ["git", "ls-files", "*.sh"],  # noqa: S607
+        cwd=_REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    paths = [line for line in out.stdout.split() if line]
+    assert paths, "no shell scripts discovered — the glob or cwd is wrong"
+    return paths
+
+
+def _hand_rolled_creators() -> set[str]:
+    """Every tracked shell script reaching `aws iam create-role` in CODE."""
+    return {
+        rel
+        for rel in _shell_scripts()
+        if "aws iam create-role" in _code_only((_REPO_ROOT / rel).read_text())
+    } - _SANCTIONED
+
+
+def test_no_new_script_hand_rolls_iam_role_creation() -> None:
+    """The ratchet. A NEW script reaching `aws iam create-role` on its own is
+    the defect this file exists to stop — it arrives carrying the I9045 probe
+    because it is copied from a neighbour that has it."""
+    new = sorted(_hand_rolled_creators() - _REGISTER)
+    assert not new, (
+        "these scripts reach `aws iam create-role` without going through "
+        "_shared/apply_iam_policy.sh:\n  " + "\n  ".join(new)
+        + "\n\nUse:\n"
+        '  source "${SCRIPT_DIR}/../_shared/apply_iam_policy.sh"\n'
+        '  apply_iam_policy "${ROLE_NAME}" "${POLICY_NAME}" '
+        '"${SCRIPT_DIR}/iam-policy.json" "${TRUST_POLICY}"\n'
+        "\nA hand-rolled `if ! aws iam get-role ... >/dev/null 2>&1` probe makes "
+        "AccessDenied and NoSuchEntity the same observation, so a DENIED read is "
+        "acted on as proof of absence. That is alpha-engine-config-I9045: four "
+        "workflows red on every run for a week. `apply_iam_policy` reaches "
+        "create-role only via probe_role_presence, which classifies a denial as "
+        "`unknown` and creates nothing.\n"
+        "Adding a name to _REGISTER instead is not the fix — the register may "
+        "only shrink."
+    )
+
+
+def test_the_register_does_not_outlive_its_debt() -> None:
+    """A register entry whose script has since migrated must be deleted. Left in
+    place it is a standing exemption for a script that no longer needs one, and
+    it would silently absorb a regression that re-introduced the hand-rolled
+    probe there."""
+    stale = sorted(_REGISTER - _hand_rolled_creators())
+    assert not stale, (
+        "these scripts no longer hand-roll `aws iam create-role`, so their "
+        "entries in _REGISTER are stale. Delete each line "
+        f"(tests/{Path(__file__).name}):\n  " + "\n  ".join(stale)
+    )
+
+
+def test_the_register_only_shrinks() -> None:
+    """A hard ceiling, so growth cannot be laundered through an edit to the set
+    literal in the same commit that adds an offender. Measured 2026-08-28: 45,
+    down from 46 — thinktank-spot-dispatcher migrated in
+    alpha-engine-config-I9114. Lower this number when you remove entries; never
+    raise it."""
+    assert len(_REGISTER) <= 45, (
+        "the hand-rolled-IAM debt register grew. Migrate the script onto "
+        "_shared/apply_iam_policy.sh instead (alpha-engine-config-I9207)."
+    )
+
+
+def test_the_shared_helper_is_the_only_sanctioned_creator() -> None:
+    """The sanctioned set is not a second register. It names one file, and that
+    file must actually still be the presence-gated implementation — otherwise
+    this whole guard is asserting against a helper that has itself regressed."""
+    assert _SANCTIONED == {"infrastructure/lambdas/_shared/apply_iam_policy.sh"}
+    helper = _code_only(
+        (_REPO_ROOT / "infrastructure/lambdas/_shared/apply_iam_policy.sh").read_text()
+    )
+    assert "probe_role_presence" in helper, (
+        "apply_iam_policy.sh no longer defines the presence probe, so nothing "
+        "distinguishes a denied read from an absent role (alpha-engine-config-I9045)."
+    )
+    assert "may_create_role" in helper, (
+        "apply_iam_policy.sh no longer gates role creation, so the code-only "
+        "auto-apply path can reach iam:CreateRole again."
+    )

--- a/tests/test_pipeline_status_registry_source_check.py
+++ b/tests/test_pipeline_status_registry_source_check.py
@@ -37,7 +37,9 @@ files (Saturday/Weekday/EOD) ARE asserted on hard, per this issue's scope.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -49,6 +51,75 @@ from nousergon_lib.pipeline_status.registry import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# ── Installed-versus-pinned provenance (alpha-engine-config-I9116) ───────────
+#
+# This test reads the SF JSONs from the working tree and the registry from the
+# INSTALLED `nousergon_lib`. Those are two different clocks. When the installed
+# lib is behind `requirements.txt`, the invariant fails for a reason that has
+# nothing to do with the SF definition — and the message below used to say, with
+# no hedge, "the Saturday SF has 1 substantive Task state NOT in the registry …
+# add each state to the registry in nousergon-lib". Measured 2026-08-28: the
+# venv held v0.124.88 (137 registry entries, no `NormalizeRunDates`) while
+# requirements.txt pinned v0.124.95 (138, with it). CI installs the pin and
+# passes; the reader on the laptop is sent to nousergon-lib to add an entry that
+# already exists there.
+#
+# A test whose failure text sends the reader to the wrong place is a defect in
+# its own right, so the provenance is now part of the verdict. It is a
+# QUALIFIER, never a suppressor: a version mismatch still fails, it just fails
+# saying which of the two things to go fix. The environment half is tracked
+# separately as alpha-engine-config-I9070; nothing here tries to repair it.
+_PIN_RE = re.compile(r"nousergon-lib(?:\[[^\]]*\])?\s*@\s*\S+@(v[0-9][^\s#]*)")
+
+
+def _pinned_lib_version(requirements: str) -> str | None:
+    """The `nousergon-lib@vX.Y.Z` tag from requirements.txt text.
+
+    FULL-LINE comments are stripped first, and that is load-bearing, not
+    tidiness: this repo's requirements.txt carries at least four comment lines
+    naming superseded tags (`v0.124.53`, `v0.124.78`, …) directly above the real
+    pin, explaining why each was bumped. A matcher that reads those would report
+    a mismatch against a version nobody installed — the same shape as the
+    scheduled-identity scan that matched a role name inside a YAML comment and
+    went red on main. Only whole comment lines are removed: a `#` mid-line is
+    left alone, because a pin may legitimately carry a trailing note.
+    """
+    code = "\n".join(
+        line for line in requirements.splitlines() if not line.lstrip().startswith("#")
+    )
+    match = _PIN_RE.search(code)
+    return match.group(1) if match else None
+
+
+def _installed_lib_version() -> str | None:
+    try:
+        return "v" + importlib.metadata.version("nousergon-lib")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover - env-only
+        return None
+
+
+def _provenance_note(installed: str | None, pinned: str | None) -> str:
+    """The paragraph prepended to a drift failure when the two clocks disagree.
+
+    Empty string when they agree or when either is unreadable — in which case
+    the failure is the SF-definition drift the assertion was written for.
+    """
+    if installed is None or pinned is None or installed == pinned:
+        return ""
+    return (
+        f"READ THIS FIRST — your installed nousergon-lib does NOT match the pin.\n"
+        f"  installed: {installed}\n"
+        f"  pinned in requirements.txt: {pinned}\n"
+        f"This check reads the SF JSONs from the working tree but the registry "
+        f"from the INSTALLED lib, so a stale install produces exactly the "
+        f"failure below WITHOUT any drift existing. Reinstall the pin first and "
+        f"re-run:\n"
+        f"    python3 -m pip install -r requirements.txt\n"
+        f"Only if it still fails afterwards is the SF-definition drift described "
+        f"below real. (alpha-engine-config-I9116; the environment drift itself is "
+        f"tracked as alpha-engine-config-I9070.)\n\n"
+    )
 
 _SF_JSON_FILES = [
     ("Saturday", REPO_ROOT / "infrastructure" / "step_function.json"),
@@ -106,7 +177,9 @@ def test_every_substantive_state_has_registry_entry(label, json_path):
     substantive -= set(WAIT_GROUPING.keys())
     missing = substantive - set(STATE_TO_ARCHIVE_PAGE.keys())
 
-    assert not missing, (
+    assert not missing, _provenance_note(
+        _installed_lib_version(), _pinned_lib_version((REPO_ROOT / "requirements.txt").read_text())
+    ) + (
         f"{label} SF ({json_path.relative_to(REPO_ROOT)}) has {len(missing)} "
         f"substantive Task state(s) NOT in "
         f"nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE: "
@@ -148,7 +221,9 @@ def test_wait_companions_in_json_are_in_wait_grouping(label, json_path):
     wait_states = _collect_wait_states(sf.get("States", {}), set())
     missing = wait_states - set(WAIT_GROUPING.keys())
 
-    assert not missing, (
+    assert not missing, _provenance_note(
+        _installed_lib_version(), _pinned_lib_version((REPO_ROOT / "requirements.txt").read_text())
+    ) + (
         f"{label} SF has {len(missing)} ``WaitFor*`` state(s) NOT in "
         f"nousergon_lib.pipeline_status.registry.WAIT_GROUPING: "
         f"{sorted(missing)}. Each must map to its parent Task state name; "
@@ -179,3 +254,166 @@ def test_groom_sf_registry_coverage_visibility():
             f"(dashboard test never covered groom either). See this test "
             f"file's module docstring."
         )
+
+
+# ── The provenance qualifier's own tests (alpha-engine-config-I9116) ─────────
+#
+# Both halves, or the change is worse than what it replaced: the corrected
+# message must appear under a stale-lib condition, AND a genuine drift with the
+# versions in lockstep must still fail loudly and still name the states.
+
+
+def test_pin_parser_reads_the_pin_and_not_the_comments_above_it() -> None:
+    """The comment trap. requirements.txt names superseded tags in prose
+    directly above the live pin; a matcher that harvested those would report a
+    mismatch against a version nobody installed."""
+    text = (
+        "# nousergon-lib-PR311 adds all five and MUST merge first; v0.124.53 was\n"
+        "# the floor. Superseded by nousergon-lib @ git+https://x/y@v0.124.78.\n"
+        "some-other-pkg==1.2.3\n"
+        "nousergon-lib[arcticdb,rag] @ git+https://github.com/nousergon/"
+        "nousergon-lib@v0.124.95\n"
+    )
+    assert _pinned_lib_version(text) == "v0.124.95"
+
+
+def test_pin_parser_reads_the_real_requirements_file() -> None:
+    """A parser proven only on a fixture is a parser nobody ran on the real
+    input. The live file must yield a pin, or the qualifier silently degrades to
+    'unreadable' and never fires."""
+    pinned = _pinned_lib_version((REPO_ROOT / "requirements.txt").read_text())
+    assert pinned is not None and pinned.startswith("v"), (
+        "requirements.txt no longer yields a nousergon-lib pin this parser can "
+        "read. Fix _PIN_RE — a silently unparseable pin turns the provenance "
+        "qualifier off without failing anything."
+    )
+
+
+def test_a_stale_install_is_named_first_in_the_failure_message() -> None:
+    """THE case that made this a defect. On 2026-08-28 a laptop venv held
+    v0.124.88 against a v0.124.95 pin, and the message sent the reader to
+    nousergon-lib to add a `NormalizeRunDates` entry that already existed
+    there."""
+    note = _provenance_note("v0.124.88", "v0.124.95")
+    assert note, "a version mismatch produced no qualifier at all"
+    assert note.startswith("READ THIS FIRST"), (
+        "the qualifier must LEAD. Appended below a 10-line accusation about the "
+        "SF definition, it is not read."
+    )
+    assert "v0.124.88" in note and "v0.124.95" in note, (
+        f"the qualifier names neither version, so it cannot be acted on:\n{note}"
+    )
+    assert "pip install -r requirements.txt" in note, (
+        f"the qualifier does not say what to actually do:\n{note}"
+    )
+
+
+def test_matched_versions_produce_no_qualifier() -> None:
+    """It is a qualifier, not a suppressor. With the clocks in lockstep the
+    failure must read exactly as it did before — an accusation against the SF
+    definition, which is then correct."""
+    assert _provenance_note("v0.124.95", "v0.124.95") == ""
+
+
+def test_unreadable_provenance_produces_no_qualifier() -> None:
+    """An unreadable pin or a missing distribution must not invent a mismatch.
+    Absence of evidence is not a version skew — the same conflation that made
+    a denied `iam:GetRole` read as an absent role."""
+    assert _provenance_note(None, "v0.124.95") == ""
+    assert _provenance_note("v0.124.95", None) == ""
+
+
+def test_real_drift_still_fails_loudly_when_versions_match(monkeypatch) -> None:
+    """The other half. Inject a substantive Task state that no registry entry
+    covers, with installed == pinned, and assert the check still fails AND still
+    names the offending state. Without this, the change could have turned a real
+    invariant into a version-mismatch reporter."""
+    real_pin = _pinned_lib_version((REPO_ROOT / "requirements.txt").read_text())
+    monkeypatch.setattr(
+        "tests.test_pipeline_status_registry_source_check._installed_lib_version",
+        lambda: real_pin,
+        raising=False,
+    )
+    resource = next(iter(SUBSTANTIVE_RESOURCES))
+    invented = "AStateNoRegistryEverHeardOf"
+    assert invented not in STATE_TO_ARCHIVE_PAGE
+    states = {invented: {"Type": "Task", "Resource": resource}}
+    found = _walk_substantive_task_states(states, set())
+    assert found == {invented}, (
+        "the walker no longer recognises a plain substantive Task state, so the "
+        "invariant would pass vacuously on real drift"
+    )
+    missing = found - set(STATE_TO_ARCHIVE_PAGE.keys()) - set(WAIT_GROUPING.keys())
+    note = _provenance_note(real_pin, real_pin)
+    message = note + f"has {len(missing)} substantive Task state(s): {sorted(missing)}"
+    assert note == "", "versions match, so no qualifier should precede the drift text"
+    assert invented in message, (
+        "a genuine drift failure no longer names the offending state"
+    )
+
+
+def test_the_real_assertion_renders_the_qualifier_under_a_stale_install(
+    monkeypatch,
+) -> None:
+    """End-to-end, through the REAL assertion — not the helper in isolation.
+
+    Reproduces the measured 2026-08-28 condition: the working tree's Saturday SF
+    is unchanged and correct, but the installed lib is behind the pin and its
+    registry is missing a state the SF has. The rendered AssertionError must LEAD
+    with the version skew, because that is where the reader has to go.
+    """
+    label, json_path = _SF_JSON_FILES[0]
+    substantive = _all_substantive_states(json_path) - set(WAIT_GROUPING.keys())
+    assert substantive, "the Saturday SF walked to zero substantive states"
+    dropped = sorted(substantive)[0]
+
+    stale_registry = {k: v for k, v in STATE_TO_ARCHIVE_PAGE.items() if k != dropped}
+    monkeypatch.setattr(
+        "tests.test_pipeline_status_registry_source_check.STATE_TO_ARCHIVE_PAGE",
+        stale_registry,
+    )
+    monkeypatch.setattr(
+        "tests.test_pipeline_status_registry_source_check._installed_lib_version",
+        lambda: "v0.124.88",
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        test_every_substantive_state_has_registry_entry(label, json_path)
+
+    rendered = str(excinfo.value)
+    assert rendered.startswith("READ THIS FIRST"), (
+        "under a stale install the failure still opens by accusing the SF "
+        f"definition:\n{rendered}"
+    )
+    assert "v0.124.88" in rendered, rendered
+    assert dropped in rendered, (
+        "the qualifier swallowed the underlying finding — it must ADD context, "
+        f"never replace it:\n{rendered}"
+    )
+
+
+def test_the_real_assertion_accuses_the_sf_when_versions_match(monkeypatch) -> None:
+    """And the inverse: with the clocks in lockstep, a genuine gap must produce
+    the original, correct accusation with no hedge in front of it."""
+    label, json_path = _SF_JSON_FILES[0]
+    substantive = _all_substantive_states(json_path) - set(WAIT_GROUPING.keys())
+    dropped = sorted(substantive)[0]
+
+    monkeypatch.setattr(
+        "tests.test_pipeline_status_registry_source_check.STATE_TO_ARCHIVE_PAGE",
+        {k: v for k, v in STATE_TO_ARCHIVE_PAGE.items() if k != dropped},
+    )
+    pinned = _pinned_lib_version((REPO_ROOT / "requirements.txt").read_text())
+    monkeypatch.setattr(
+        "tests.test_pipeline_status_registry_source_check._installed_lib_version",
+        lambda: pinned,
+    )
+
+    with pytest.raises(AssertionError) as excinfo:
+        test_every_substantive_state_has_registry_entry(label, json_path)
+
+    rendered = str(excinfo.value)
+    assert "READ THIS FIRST" not in rendered, (
+        f"a version qualifier appeared with the versions in lockstep:\n{rendered}"
+    )
+    assert dropped in rendered and "STATE_TO_ARCHIVE_PAGE" in rendered, rendered

--- a/tests/test_thinktank_deploy_uses_shared_helpers.py
+++ b/tests/test_thinktank_deploy_uses_shared_helpers.py
@@ -1,0 +1,274 @@
+"""thinktank-spot-dispatcher/deploy.sh, EXECUTED — not read.
+
+WHY THIS FILE EXISTS (alpha-engine-config-I9114)
+------------------------------------------------
+Four workflows in this repo failed 100% of their runs on `main` for a week
+because `_shared/apply_iam_policy.sh` probed a role with
+
+    aws iam get-role ... >/dev/null 2>&1
+
+which makes AccessDenied and NoSuchEntity the SAME observation: a denied read
+was read as "the role is absent", so the script called `iam:CreateRole`, a grant
+the CI identity does not and must not hold. nousergon-data-PR1569 fixed that in
+the shared helper.
+
+It did not fix `thinktank-spot-dispatcher/deploy.sh`, because that script did
+not use the shared helper. It carried its own copy of the same three lines. That
+is the whole cost of a private dialect: a class fix at the correct layer sails
+straight past the one call site that reimplemented the layer. It had not gone
+red only because its IAM lived behind `--apply-iam` / `--bootstrap`, which the
+CI path does not pass — a property of the current flag layout, not a guarantee.
+
+WHY THESE TESTS RUN THE SHELL
+-----------------------------
+"A loop proven only by reading it is a loop nobody has run." Asserting on the
+file's TEXT would pass against the broken version too: the broken version also
+contained the strings `create-role` and `get-role`. Every case below executes
+the REAL deploy.sh against a fake `aws`/`python3`/`docker`/`zip` on PATH and
+asserts on what was actually invoked.
+
+The cases are deliberately a matched set. Proving role creation is unreachable
+is only half an answer — a script that had simply deleted its IAM handling would
+pass that alone. `test_bootstrap_still_creates_a_genuinely_absent_role` is the
+other half: on an explicit NoSuchEntity the operator path must still create it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEPLOY = (
+    _REPO_ROOT / "infrastructure" / "lambdas" / "thinktank-spot-dispatcher" / "deploy.sh"
+)
+
+ROLE = "alpha-engine-thinktank-spot-dispatcher-role"
+
+# The literal stderr `aws iam` emits for each condition, reproduced verbatim so
+# a change in how probe_role_presence greps is caught here and not in CI.
+_DENIED = (
+    "An error occurred (AccessDenied) when calling the GetRole operation: "
+    "User: arn:aws:sts::711398986525:assumed-role/github-actions-lambda-deploy/"
+    "GitHubActions is not authorized to perform: iam:GetRole on resource: "
+    f"arn:aws:iam::711398986525:role/{ROLE}"
+)
+_NO_SUCH_ENTITY = (
+    "An error occurred (NoSuchEntity) when calling the GetRole operation: "
+    f"The role with name {ROLE} cannot be found."
+)
+
+# Whatever the fake python3 prints as the artifact digest, the fake
+# `aws lambda get-function` must echo back, or verify_code_deployed correctly
+# refuses.
+_SHA = "FAKECODESHA256="
+
+
+def _fake_bin(tmp_path: Path, *, get_role: tuple[int, str]) -> Path:
+    """A PATH shim standing in for every external binary deploy.sh reaches.
+
+    `get_role` is (exit_code, stderr) for `aws iam get-role` — the one call
+    whose classification this whole file is about.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    aws_log = tmp_path / "aws-calls.log"
+    py_log = tmp_path / "python3-calls.log"
+
+    rc, err = get_role
+    (bindir / "aws").write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            echo "$*" >> {aws_log}
+            case "$1 $2" in
+              "sts get-caller-identity") echo 711398986525 ;;
+              "iam get-role") echo {err!r} >&2; exit {rc} ;;
+              "iam get-role-policy") exit 1 ;;
+              "lambda get-function") echo "{_SHA}" ;;
+            esac
+            exit 0
+            """
+        )
+    )
+    # `-c` is verify_code_deployed computing the artifact digest; `-m pytest` is
+    # the shared handler-test gate; `-m pip` is that gate provisioning its deps.
+    (bindir / "python3").write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            echo "$*" >> {py_log}
+            for a in "$@"; do
+              if [ "$a" = "-c" ]; then echo "{_SHA}"; exit 0; fi
+            done
+            exit 0
+            """
+        )
+    )
+    (bindir / "docker").write_text(
+        f'#!/usr/bin/env bash\necho "docker $*" >> {aws_log}\nexit 0\n'
+    )
+    # zip's target is the first argument ending in .zip; create it so
+    # verify_code_deployed finds a readable artifact.
+    (bindir / "zip").write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            for a in "$@"; do
+              case "$a" in *.zip) : > "$a"; exit 0 ;; esac
+            done
+            exit 0
+            """
+        )
+    )
+    for name in ("aws", "python3", "docker", "zip"):
+        (bindir / name).chmod(0o755)
+    return bindir
+
+
+def _deploy(tmp_path: Path, *flags: str, get_role: tuple[int, str]):
+    bindir = _fake_bin(tmp_path, get_role=get_role)
+    # A minimal, explicit environment: the fakes must win over any real binary,
+    # and nothing from the developer's shell may leak into the run.
+    shell_env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "AWS_REGION": "us-east-1",
+    }
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", str(_DEPLOY), *flags],
+        capture_output=True,
+        text=True,
+        env=shell_env,
+        timeout=300,
+        check=False,
+    )
+
+
+def _aws_calls(tmp_path: Path) -> str:
+    log = tmp_path / "aws-calls.log"
+    return log.read_text() if log.exists() else ""
+
+
+def _python_calls(tmp_path: Path) -> str:
+    log = tmp_path / "python3-calls.log"
+    return log.read_text() if log.exists() else ""
+
+
+def test_deploy_script_exists_and_is_valid_bash() -> None:
+    assert _DEPLOY.exists(), f"thinktank deploy.sh not found at {_DEPLOY}"
+    syntax = subprocess.run(  # noqa: S603
+        ["/bin/bash", "-n", str(_DEPLOY)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+def test_code_only_path_makes_no_iam_call_at_all(tmp_path: Path) -> None:
+    """THE load-bearing case. The flagless run is what
+    `.github/workflows/deploy-thinktank-spot-dispatcher.yml` executes as
+    `github-actions-lambda-deploy`, an identity holding neither `iam:GetRole`
+    nor `iam:CreateRole` on any lambda execution role. It must not merely avoid
+    CREATING a role — it must not touch IAM at all, so no probe of any kind can
+    be misclassified into an attempt.
+    """
+    proc = _deploy(tmp_path, get_role=(255, _DENIED))
+    calls = _aws_calls(tmp_path)
+    assert proc.returncode == 0, (
+        f"code-only deploy failed:\n{proc.stdout}\n{proc.stderr}"
+    )
+    iam_calls = [line for line in calls.splitlines() if line.startswith("iam ")]
+    assert not iam_calls, (
+        "the code-only deploy path reached IAM. It must not: the CI identity "
+        "holds no iam:GetRole/iam:CreateRole/iam:PutRolePolicy on a lambda "
+        "execution role by design (single-writer rule), and a DENIED probe is "
+        "what got misread as 'role absent' in alpha-engine-config-I9045.\n"
+        f"calls: {iam_calls}"
+    )
+    assert "lambda update-function-code" in calls, (
+        f"the code-only path did not ship any code:\n{calls}"
+    )
+    assert "lambda get-function" in calls, (
+        "verify_code_deployed did not read back the live CodeSha256 — the "
+        "upload's own exit code is not trusted (alpha-engine-config-I8033)."
+    )
+
+
+def test_code_only_path_runs_the_shared_handler_test_gate(tmp_path: Path) -> None:
+    """25 handler tests sat beside index.py that this deploy.sh never ran. The
+    gate must be the SHARED one, so it cannot re-drift into the no-install form
+    that made saturday-sf-watch-dispatcher's deploy red (config#2295)."""
+    _deploy(tmp_path, get_role=(255, _DENIED))
+    py = _python_calls(tmp_path)
+    assert "-m pytest" in py, f"no pytest invocation reached:\n{py}"
+    assert "thinktank-spot-dispatcher/test_handler.py" in py, (
+        f"the lambda's own test_handler.py was never run:\n{py}"
+    )
+    assert "-m pip install" in py, (
+        "the gate ran pytest without provisioning it — the exact config#2295 "
+        f"no-install shape:\n{py}"
+    )
+
+
+def test_a_denied_probe_is_never_read_as_an_absent_role(tmp_path: Path) -> None:
+    """The operator `--bootstrap` path under a DENIED `iam:GetRole`. This is the
+    literal alpha-engine-config-I9045 condition. `probe_role_presence` must
+    classify it `unknown` — not `absent` — so nothing is created, and the
+    `put-role-policy` attempt (whose own success or AccessDenied is the real
+    answer) is what speaks."""
+    proc = _deploy(tmp_path, "--bootstrap", get_role=(255, _DENIED))
+    calls = _aws_calls(tmp_path)
+    assert "iam get-role " in calls, f"the role was never probed at all:\n{calls}"
+    assert "iam create-role" not in calls, (
+        "a DENIED iam:GetRole was treated as evidence the role does not exist, "
+        "and role creation was attempted. AccessDenied is not absence — that "
+        "conflation is alpha-engine-config-I9045, which made four workflows red "
+        f"for a week.\ncalls:\n{calls}\nstderr:\n{proc.stderr}"
+    )
+    assert "UNKNOWN" in proc.stderr, (
+        "the unknown-presence verdict was not reported. A probe that cannot "
+        "answer must SAY it cannot answer; that message is the whole remedy "
+        f"for the silent misclassification.\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_bootstrap_still_creates_a_genuinely_absent_role(tmp_path: Path) -> None:
+    """The other half. On an explicit NoSuchEntity — the only observation that
+    actually proves absence — the operator bootstrap path must still create the
+    role. Without this case, deleting the IAM handling outright would pass every
+    other test in this file."""
+    proc = _deploy(tmp_path, "--bootstrap", get_role=(255, _NO_SUCH_ENTITY))
+    calls = _aws_calls(tmp_path)
+    assert "iam create-role" in calls, (
+        "an explicit NoSuchEntity did not lead to role creation on the operator "
+        f"bootstrap path.\ncalls:\n{calls}\nstdout:\n{proc.stdout}\n{proc.stderr}"
+    )
+    assert "iam put-role-policy" in calls, (
+        f"the inline policy was never applied after creating the role:\n{calls}"
+    )
+
+
+@pytest.mark.parametrize(
+    "helper",
+    ["deploy_run.sh", "run_handler_tests.sh", "apply_iam_policy.sh"],
+)
+def test_no_private_dialect_remains(helper: str) -> None:
+    """A cheap companion to the executed cases above: the script must SOURCE
+    each shared helper rather than reimplement it. Text-level on purpose — this
+    one asserts the absence of a second implementation, which no execution can
+    observe. Comments are stripped first: a scan that reads a rationale comment
+    as code is a shape this fleet has already shipped twice."""
+    body = "\n".join(
+        line.split("#", 1)[0] for line in _DEPLOY.read_text().splitlines()
+    )
+    assert f"_shared/{helper}" in body, (
+        f"thinktank-spot-dispatcher/deploy.sh no longer sources _shared/{helper}. "
+        "Every mechanism here is the shared one so that the next fix to it lands "
+        "here too — which is exactly what did NOT happen for the IAM probe "
+        "(alpha-engine-config-I9114)."
+    )


### PR DESCRIPTION
Three repo-hygiene defects surfaced by today's deploy-workflow arc (`alpha-engine-config-I9045` / #1569), plus two live reds on `main` found while verifying the first of them. One PR because they are one thing: everything that made a week-long outage invisible or unfixable-in-one-place.

Branched from #1569's head; **#1569 merged as `ab1a5f06` while this was in flight**, so this is rebased onto `main` and carries only its own four commits. No merge order left to observe.

Tracked as `alpha-engine-config-I9114`, `-I9116`, `-I9117` (no `Closes` — a closing keyword is silently inert across repositories). New follow-ups filed: `alpha-engine-config-I9207`, `-I9208`.

---

## I9114 — thinktank-spot-dispatcher was the one deploy.sh in a private dialect

**Root cause.** It reimplemented the shared mechanisms instead of sourcing them, so #1569's fix to `_shared/apply_iam_policy.sh` did not reach it. Its copy was the exact I9045 defect: `aws iam get-role ... >/dev/null 2>&1 || { aws iam create-role ...; }` makes `AccessDenied` and `NoSuchEntity` the same observation, so a *denied* read is acted on as proof of absence. It had not gone red only because that block sits behind `--apply-iam` / `--bootstrap`, which the CI path does not pass — a property of today's flag layout, not a guarantee.

**Layer.** The shared helpers, not this copy. It now sources `deploy_run.sh` (`run` / `run_tolerating` / `verify_code_deployed`), `run_handler_tests.sh` (25 handler tests no deploy had ever executed) and `apply_iam_policy.sh`, and packages through `lambda_pip_install.sh` instead of a host-arch `pip install --target`. The zip moves out of a fixed `/tmp` path into the trapped scratch dir. `thinktank-spot-dispatcher` leaves `_TRACKED_UNGATED`; the ceiling ratchets 2 → 1.

**Evidence.** `tests/test_thinktank_deploy_uses_shared_helpers.py` *executes* the real `deploy.sh` against a fake `aws`/`python3`/`docker`/`zip` on PATH. Asserting on file text would have passed against the broken version, which also contained `create-role`. **Six of its eight cases fail against the pre-change script.** The cases are a matched pair on purpose — the code-only path must reach *no* IAM call at all, **and** an explicit `NoSuchEntity` must still create the role on the operator path, or deleting the IAM handling outright would pass.

**Sweep.** Thinktank was the only *private dialect*. But 45 further tracked `.sh` still reach `aws iam create-role` from their own code, every one behind the same `get-role >/dev/null 2>&1` probe — dormant inside operator-only `--bootstrap` blocks, not safe. Plus `infrastructure/deploy_step_function.sh:110`, which uses the probe as a precondition and on a denied read prints `role does not exist` with a remediation that is wrong for a permissions failure.

Migrating 45 scripts would collide with the in-flight PRs, so what lands here is the **detection**: `tests/test_iam_role_creation_is_helper_gated.py` enumerates offenders from `git ls-files`, holds them in a shrink-only register with a hard ceiling, and fails on a 46th or on a stale entry. Remediation tracked as `alpha-engine-config-I9207`. Detection blindness outranks the defects it hides.

## I9116 — one defect, not two: the message accused the wrong thing

**The issue's order-dependence claim did not reproduce.** The target test passed in isolation, in the full suite under `-p no:randomly`, and in every random-ordered full-suite run across distinct seeds. `pytest-randomly` is a local venv extra and is not in `requirements.txt`, so **CI never randomises at all**. No polluter was found and none is claimed.

**What actually happened.** The venv held `nousergon-lib` v0.124.88 (137 registry entries, no `NormalizeRunDates`) while `requirements.txt` pinned v0.124.95 (138, with it). The check reads the SF JSONs from the working tree and the registry from the *installed* lib — two clocks — and its message asserted with no hedge that the reader should go to nousergon-lib and add an entry that already existed there. That is deterministic, and it is the defect: a test whose failure text sends the reader to the wrong place.

**Fix.** The verdict carries its provenance. On a version mismatch the failure **leads** with the skew, both versions and the reinstall command, then the original finding verbatim — a qualifier, never a suppressor. With the versions in lockstep the message is unchanged. The pin parser strips **full-line** comments first: `requirements.txt` names four superseded tags in prose directly above the live pin.

**Evidence.** Both halves, through the *real* assertion rather than the helper — `test_the_real_assertion_renders_the_qualifier_under_a_stale_install` and `test_the_real_assertion_accuses_the_sf_when_versions_match`, plus the comment-trap case and the unreadable-provenance case. The environment drift itself stays tracked as `alpha-engine-config-I9070`; nothing here tries to repair it.

## I9117 — the shellcheck scope, and the four defects it was blind to

**Findings: 4 → 0.**

- `overseer-liveness-probe`, `scheduled-groom-dispatcher`, `sf-watch-reclaim-sweep-handler` each had an automated I6619 `source ../_shared/pause.sh` block prepended **above** their shebang, leaving a blank line 1 and the shebang inert at line 6 (SC2148). Not fixed by adding a second shebang — the block moves below `set -euo pipefail`, where every correct sibling has it, which also stops it running before errexit is armed.
- `_shared/run_handler_tests.sh` wrote `# shellcheck disable=SC2206 — reason`; a directive's trailing prose needs its own `#`, so the em-dash raised SC1125 on every run. **Correcting the record:** measured here, the disable itself still applied — SC2206 was *not* exposed. The permanent error-severity finding was, and that is what made the widening unlandable.

**Scope is derived, not the three literal globs the issue named.** `git ls-files -z '*.sh' | xargs -0 shellcheck --severity=error`. Those three globs leave `infrastructure/lambdas/lambda_pip_install.sh` and `infrastructure/codebuild-runners/deploy_codebuild_runner.sh` uncovered today, and the next script uncovered on the day it lands in a directory nobody remembered to add — the precise shape of the gap being closed. Measured: 79 tracked `*.sh`, clean at `--severity=error`.

## Also here — two live reds on `main`, found while verifying I9114

#1569 wired the shared handler-test gate into eight `deploy.sh`, six with an empty dep list. Within 40 minutes of its merge, two workflows were failing on `main`:

- `deploy-data-spot-dispatcher` — `ModuleNotFoundError: No module named 'krepis'` (`test_handler.py:34` imports `krepis.spot_bootstrap` for real)
- `deploy-ssm-reachability-probe` — `ModuleNotFoundError: No module named 'boto3'`

Two more were latent: `backstop-telegram-notifier` (its workflow simply had not fired) and **`thinktank-spot-dispatcher`, which this branch had just gated** on I9114's stated measurement that "its tests pass with no extra deps — they stub `nousergon_lib`". They do not: 2 of 25 import it for real. Caught before shipping, by the same sweep.

Each fix is one word. Each is verified by *executing* `run_handler_tests` on a bare `python3 -m venv` interpreter — `backstop-telegram-notifier boto3` 19 passed · `data-spot-dispatcher krepis` 6 passed · `ssm-reachability-probe boto3` 9 passed · `thinktank-spot-dispatcher -r requirements.txt` 25 passed. Each was reproduced as failing first.

**That is the finding.** `run_handler_tests` installs into a scratch `--target` dir but does not isolate the ambient interpreter, so all four pass on an operator laptop that already has `boto3`, `krepis` and `nousergon_lib`. That is how all four dep lists came to be "verified".

The class — nothing executes a `deploy.sh`'s own dep list before the merge, because `ci.yml`'s glob step passes `-r requirements.txt` (a superset) — is filed as `alpha-engine-config-I9208` with the design. It needs a `--tests-only` flag on ~44 `deploy.sh` so CI runs the real script; an extractor that parses the argument tail was built and discarded here (eight `deploy.sh` compute their deps from shell variables, so any parser is a second implementation of the dialect the helper exists to remove, and its first run produced 39 false failures).

---

## Verification

- Full suite locally, `-p no:randomly`, incl. `tests/integration`: **6703 passed, 17 skipped, 0 failed**.
- Random-ordered full-suite runs on distinct seeds: green; no `test_pipeline_status_registry_source_check` failure in any of them.
- `git ls-files -z '*.sh' | xargs -0 shellcheck --severity=error` (the new CI step, verbatim): exit 0 over 79 files.
- New tests replayed against the pre-change tree to confirm they fail: **6 of 8** in `test_thinktank_deploy_uses_shared_helpers.py`.
- Each corrected deploy dep list executed through `run_handler_tests` on a bare `venv` interpreter, each reproduced as failing first.

No post-merge step. Nothing here mutates a live resource; no AWS call was made outside read-only inspection.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
