### PR TITLE
refactor(install-guard): call the lifted parser from nousergon-lib, bump the 32 pins to v0.124.96 (alpha-engine-config-I9215)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -69,7 +69,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-liveness-probe/requirements.txt
@@ -1,4 +1,4 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler (this Lambda mirrors its reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.10.2

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-reclaim-sweep-handler/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for sf-watch reclaim-sweep handler.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.10.2

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -10,4 +10,4 @@
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
 # v0.124.88. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,7 +16,7 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # alpha-engine-config-I8155: this Lambda records its own coverage verdict via
 # krepis.stage_coverage. Pin the released contract that refuses a blank SF
 # execution run_date and uses no cycle-date fallback.

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.14.2
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ arcticdb>=6.23.0
 # JSON landing ahead of the registry entry. VERIFIED 2026-08-25 against the tag
 # itself (contents API at ref=v0.124.88), not against the merge: a green publish
 # that serves old metadata has happened on this fleet before.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.95
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.96
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_no_install_path_starts_a_scheduled_workload.py
+++ b/tests/test_no_install_path_starts_a_scheduled_workload.py
@@ -87,183 +87,49 @@ Two gaps this cannot see, named rather than left implicit:
     backstop for that is `crucible-dashboard`'s box-side
     `install_start_dependency_scan`, which reads merged systemd state on the box
     and is blind to no repo.
+
+WHERE THE PARSER LIVES
+----------------------
+`nousergon_lib.systemd_install_guard`, since 2026-08-28. This file was the
+SECOND of three copies cut the same day, and the second-adoption trigger had
+already fired when it was written; `alpha-engine-config-I9099` is the lift. The
+shell-noise and `reenable` fixes this copy carried are in the lifted version,
+along with one more of the same class none of the three had: a trailing
+`# comment` after a `systemctl` invocation had its words harvested as unit
+names.
+
+What stays HERE is what must not become a library allowlist: the paths, the
+presence assertions, this narrative, and the failure message that names this
+repo's fix.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
+from nousergon_lib.systemd_install_guard import (
+    load_units,
+    may_start,
+    scheduled_workloads,
+    start_closure,
+    started_units,
+    violations,
+)
 
 INFRA = Path(__file__).resolve().parents[1] / "infrastructure"
 SYSTEMD = INFRA / "systemd"
 
-# systemctl verbs that cause a unit to be ACTIVATED. `enable` alone and
-# `daemon-reload` do not, which is why they are absent.
-_START_RE = re.compile(
-    r"systemctl\s+(?P<flags>(?:--\S+\s+)*)"
-    r"(?P<verb>start|restart|enable|reenable|reload-or-restart|try-restart)\s+"
-    r"(?P<rest>[^\n;|&)]*)"
-)
-_DEP_KEYS = ("Requires", "Requisite", "BindsTo", "Wants")
-
-# `reenable` rewrites symlinks and does NOT activate; it is matched above only so
-# that a following `start` on the same unit is not the sole signal, and dropped
-# here.
-_INERT_VERBS = {"reenable"}
-
-
-def _sections(text: str) -> dict[str, list[str]]:
-    """Split a unit file into {section: [lines]}, ignoring comments."""
-    out: dict[str, list[str]] = {}
-    current = ""
-    for raw in text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith(("#", ";")):
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            current = line[1:-1]
-            out.setdefault(current, [])
-            continue
-        out.setdefault(current, []).append(line)
-    return out
-
-
-def _directive(lines: list[str], key: str) -> list[str]:
-    vals: list[str] = []
-    for line in lines:
-        k, _, v = line.partition("=")
-        if k.strip() == key:
-            vals.extend(v.split())
-    return vals
-
-
-def _load_units() -> dict[str, dict[str, list[str]]]:
-    """Every unit this repo installs, with its drop-ins merged in."""
-    units: dict[str, dict[str, list[str]]] = {}
-    for path in sorted(SYSTEMD.glob("*")):
-        if path.is_dir() or path.suffix not in (".service", ".timer"):
-            continue
-        units[path.name] = _sections(path.read_text())
-    for dropin_dir in sorted(SYSTEMD.glob("*.service.d")):
-        target = units.setdefault(dropin_dir.name[: -len(".d")], {})
-        for conf in sorted(dropin_dir.glob("*.conf")):
-            for section, lines in _sections(conf.read_text()).items():
-                target.setdefault(section, []).extend(lines)
-    return units
-
-
-UNITS = _load_units()
-
-
-def _triggered_service(timer: str, sections: dict[str, list[str]]) -> str:
-    explicit = _directive(sections.get("Timer", []), "Unit")
-    if explicit:
-        return explicit[-1]
-    return timer[: -len(".timer")] + ".service"
-
-
-def _scheduled_workloads() -> set[str]:
-    """Type=oneshot services that a timer in this repo exists to trigger."""
-    out = set()
-    for name, sections in UNITS.items():
-        if not name.endswith(".timer"):
-            continue
-        target = _triggered_service(name, sections)
-        target_sections = UNITS.get(target)
-        if target_sections is None:
-            continue
-        if "oneshot" in _directive(target_sections.get("Service", []), "Type"):
-            out.add(target)
-    return out
-
-
-# Shell noise that is not a unit name. `>/dev/null` and the `2>` left behind when
-# `_START_RE` stops at the `&` of `2>&1` both survive a naive split, and
-# `crucible-dashboard` PR792's copy of this parser reports them as units named
-# `>/dev/null.service` and `2>.service`. They can never match a real unit, so
-# they change no verdict — but a guard whose output contains obvious garbage is
-# a guard nobody trusts the day it fires for real.
-_NOT_A_UNIT_NAME = set("<>&(){}[]!\\`")
-
-
-def _normalise(token: str) -> str | None:
-    token = token.strip().strip("\"'")
-    if not token or token.startswith("-") or "$" in token or "*" in token:
-        return None
-    if _NOT_A_UNIT_NAME & set(token):
-        return None
-    if "." not in token.rsplit("/", 1)[-1]:
-        return token + ".service"
-    return token
-
-
-# A `systemctl` inside an `echo`/`printf`/`log` is operator guidance printed by
-# an installer ("Run now: sudo systemctl start x.service"), not something the
-# script does. Reading those as executions is how a guard cries wolf until it is
-# deleted — the same class as the 2026-08-27 scan that matched `ne-admin` inside
-# a YAML comment. Full-line comments are stripped in `_started_units`; only
-# FULL-line, because truncating at any `#` turns a false positive into a false
-# negative (`systemctl start x  # why` would stop being seen).
-_QUOTED_RE = re.compile(r"\b(echo|printf|log|say|cat)\b")
-
-
-def _started_units(script: Path) -> set[str]:
-    """Units the script activates, by source text."""
-    started: set[str] = set()
-    for line in script.read_text().splitlines():
-        if line.lstrip().startswith("#"):
-            continue
-        for match in _START_RE.finditer(line):
-            prefix = line[: match.start()]
-            if _QUOTED_RE.search(prefix):
-                continue
-            verb = match.group("verb")
-            if verb in _INERT_VERBS:
-                continue
-            flags = match.group("flags") or ""
-            rest = match.group("rest")
-            if verb == "enable" and "--now" not in flags and "--now" not in rest:
-                continue
-            for token in rest.split():
-                unit = _normalise(token)
-                if unit:
-                    started.add(unit)
-    return started
-
-
-def _start_closure(unit: str) -> set[str]:
-    """`unit` plus everything starting it pulls in, per this repo's units."""
-    seen: set[str] = set()
-    stack = [unit]
-    while stack:
-        current = stack.pop()
-        if current in seen:
-            continue
-        seen.add(current)
-        sections = UNITS.get(current)
-        if sections is None:
-            continue
-        for key in _DEP_KEYS:
-            for dep in _directive(sections.get("Unit", []), key):
-                if dep.endswith((".service", ".timer")) and dep not in seen:
-                    stack.append(dep)
-    return seen
+UNITS = load_units(SYSTEMD)
 
 
 def _install_paths() -> list[Path]:
     return sorted(INFRA.glob("install-*.sh"))
 
 
-def _may_start(unit: str) -> bool:
-    sections = UNITS.get(unit, {})
-    return "yes" in _directive(sections.get("Unit", []), "X-InstallMayStart")
-
-
 def test_the_repo_still_has_scheduled_workloads_to_protect():
     """Guard against the guard silently covering nothing."""
-    workloads = _scheduled_workloads()
+    workloads = scheduled_workloads(UNITS)
     assert "daily-news.service" in workloads, workloads
     assert "systemd-unit-drift-check.service" in workloads, workloads
     assert len(workloads) >= 3, workloads
@@ -274,8 +140,8 @@ def test_install_paths_are_parsed_at_all():
     paths = _install_paths()
     assert len(paths) >= 2, paths
     installer = INFRA / "install-daily-news.sh"
-    assert "daily-news.timer" in _started_units(installer)
-    assert "systemd-unit-drift-check.timer" in _started_units(installer)
+    assert "daily-news.timer" in started_units(installer)
+    assert "systemd-unit-drift-check.timer" in started_units(installer)
 
 
 def test_a_commented_out_systemctl_is_not_read_as_an_execution():
@@ -285,7 +151,7 @@ def test_a_commented_out_systemctl_is_not_read_as_an_execution():
     and `systemctl enable --now` without ever ..." in a full-line comment. A
     scanner that reads it as an execution path reports a unit named `without`.
     """
-    started = _started_units(INFRA / "install-metron-intraday.sh")
+    started = started_units(INFRA / "install-metron-intraday.sh")
     assert "without.service" not in started, started
     assert started == {
         "metron-intraday.timer",
@@ -295,13 +161,7 @@ def test_a_commented_out_systemctl_is_not_read_as_an_execution():
 
 @pytest.mark.parametrize("script", _install_paths(), ids=lambda p: p.name)
 def test_no_install_path_starts_a_scheduled_workload(script: Path):
-    workloads = _scheduled_workloads()
-    offenders: dict[str, set[str]] = {}
-    for unit in _started_units(script):
-        pulled = _start_closure(unit) & workloads
-        pulled = {u for u in pulled if not _may_start(u)}
-        if pulled:
-            offenders[unit] = pulled
+    offenders = violations(script, UNITS)
     assert not offenders, (
         f"{script.name} activates a scheduled workload off-schedule: "
         + "; ".join(
@@ -325,11 +185,11 @@ def test_every_install_may_start_declaration_is_still_exercised():
     than by allowlisting the start. The assertion exists so the FIRST
     declaration is held to the same bar `crucible-dashboard`'s three are.
     """
-    declared = {u for u in UNITS if _may_start(u)}
+    declared = {u for u in UNITS if may_start(u, UNITS)}
     started: set[str] = set()
     for script in _install_paths():
-        for unit in _started_units(script):
-            started |= _start_closure(unit)
+        for unit in started_units(script):
+            started |= start_closure(unit, UNITS)
     unused = declared - started
     assert not unused, (
         f"X-InstallMayStart=yes declared on {sorted(unused)} but no install path "

--- a/tests/test_pipeline_status_registry_source_check.py
+++ b/tests/test_pipeline_status_registry_source_check.py
@@ -61,7 +61,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # no hedge, "the Saturday SF has 1 substantive Task state NOT in the registry …
 # add each state to the registry in nousergon-lib". Measured 2026-08-28: the
 # venv held v0.124.88 (137 registry entries, no `NormalizeRunDates`) while
-# requirements.txt pinned v0.124.95 (138, with it). CI installs the pin and
+# requirements.txt pinned v0.124.96 (138, with it). CI installs the pin and
 # passes; the reader on the laptop is sent to nousergon-lib to add an entry that
 # already exists there.
 #
@@ -272,9 +272,9 @@ def test_pin_parser_reads_the_pin_and_not_the_comments_above_it() -> None:
         "# the floor. Superseded by nousergon-lib @ git+https://x/y@v0.124.78.\n"
         "some-other-pkg==1.2.3\n"
         "nousergon-lib[arcticdb,rag] @ git+https://github.com/nousergon/"
-        "nousergon-lib@v0.124.95\n"
+        "nousergon-lib@v0.124.96\n"
     )
-    assert _pinned_lib_version(text) == "v0.124.95"
+    assert _pinned_lib_version(text) == "v0.124.96"
 
 
 def test_pin_parser_reads_the_real_requirements_file() -> None:
@@ -291,16 +291,16 @@ def test_pin_parser_reads_the_real_requirements_file() -> None:
 
 def test_a_stale_install_is_named_first_in_the_failure_message() -> None:
     """THE case that made this a defect. On 2026-08-28 a laptop venv held
-    v0.124.88 against a v0.124.95 pin, and the message sent the reader to
+    v0.124.88 against a v0.124.96 pin, and the message sent the reader to
     nousergon-lib to add a `NormalizeRunDates` entry that already existed
     there."""
-    note = _provenance_note("v0.124.88", "v0.124.95")
+    note = _provenance_note("v0.124.88", "v0.124.96")
     assert note, "a version mismatch produced no qualifier at all"
     assert note.startswith("READ THIS FIRST"), (
         "the qualifier must LEAD. Appended below a 10-line accusation about the "
         "SF definition, it is not read."
     )
-    assert "v0.124.88" in note and "v0.124.95" in note, (
+    assert "v0.124.88" in note and "v0.124.96" in note, (
         f"the qualifier names neither version, so it cannot be acted on:\n{note}"
     )
     assert "pip install -r requirements.txt" in note, (
@@ -312,15 +312,15 @@ def test_matched_versions_produce_no_qualifier() -> None:
     """It is a qualifier, not a suppressor. With the clocks in lockstep the
     failure must read exactly as it did before — an accusation against the SF
     definition, which is then correct."""
-    assert _provenance_note("v0.124.95", "v0.124.95") == ""
+    assert _provenance_note("v0.124.96", "v0.124.96") == ""
 
 
 def test_unreadable_provenance_produces_no_qualifier() -> None:
     """An unreadable pin or a missing distribution must not invent a mismatch.
     Absence of evidence is not a version skew — the same conflation that made
     a denied `iam:GetRole` read as an absent role."""
-    assert _provenance_note(None, "v0.124.95") == ""
-    assert _provenance_note("v0.124.95", None) == ""
+    assert _provenance_note(None, "v0.124.96") == ""
+    assert _provenance_note("v0.124.96", None) == ""
 
 
 def test_real_drift_still_fails_loudly_when_versions_match(monkeypatch) -> None:


### PR DESCRIPTION
## What

`tests/test_no_install_path_starts_a_scheduled_workload.py` stops defining the
install-start-dependency parser and imports it from
`nousergon_lib.systemd_install_guard`, and the `nousergon-lib` pin moves
`v0.124.95 -> v0.124.96` across **all 32 surfaces in lockstep** — the tag
`nousergon-lib-PR368`'s merge published.

171 lines of parser removed, 31 added. What stays here is what must not become
a library allowlist: the path constants, this repo's presence assertions, the
`WHY` narrative, and the failure message that names this repo's fix.

## Why

`shared-code-policy`'s second-adoption trigger fired at the second copy; by the
end of 2026-08-28 there were three, all cut that day
(`crucible-dashboard-PR792`, `nousergon-data-PR1566`, `nous-ergon-ops-PR919`
for `alpha-engine-config-I9000`). The lift is `alpha-engine-config-I9099`;
this is its stage 2, `alpha-engine-config-I9215`.

This copy was the SECOND of the three. It already carried the shell-noise fix
(`>/dev/null.service` / `2>.service`) and the `reenable` drop that the
`crucible-dashboard` original lacked; both are in the lifted module, along with
one further fix of the same class the module's own tests found — a trailing
`# seed the cache` after a `systemctl` invocation had its WORDS harvested as
unit names, which none of the three copies caught.

The full-line-only comment rule is preserved in both directions:
`# systemctl enable --now ...` in prose is not an execution, and truncating at
any `#` would turn `systemctl start x.service  # why` from a false positive into
a false **negative**.

## The pin: 32 surfaces, because a partial bump is the drift class

`tests/test_lib_pin_lockstep.py` re-greps every one of them and fails a
single-file bump by design — the Dockerfile strips the lib out of
`requirements.txt` before `pip install` and installs it from its own hardcoded
line, so a requirements-only bump reaches no Lambda image (three production
incidents in that docstring). Moved here:

- `requirements.txt`, `Dockerfile`, `requirements-daily-news.txt`,
  `.github/workflows/deploy-infrastructure.yml`
- 28 × `infrastructure/lambdas/*/requirements.txt`

**Deliberately untouched:** `.github/workflows/pause-reconcile.yml`, which sits
outside the lockstep guard at `v0.124.82` and is being edited by
`nousergon-data-PR1572` — moving it here would collide for no gain.

Verified against the **tag itself**, not the merge: commit
`8f79c284592f695ceb4aca18ab8b73c2f9cb89da` is `v0.124.96`. A green publish that
serves old metadata has happened on this fleet before.

## Out of scope, deliberately

- The `X-InstallMayStart=yes` escape hatch's **value** stays in each service's
  own `[Unit]` with the reason beside it, never an allowlist in the library.
- `crucible-dashboard`'s live `install_start_dependency_scan` in
  `infrastructure/box_health.sh` — the merged-live-systemd reader, which is the
  half no source-text parser can reach.

## Verification

- **Seeded regression reproduced.** Restoring `Requires=daily-news.service` to
  `infrastructure/systemd/daily-news.timer` reddens the guard on the lifted
  parser, naming the exact edge:
  `install-daily-news.sh activates a scheduled workload off-schedule:`
  `` `systemctl start daily-news.timer` pulls in ['daily-news.service'] ``
  (1 failed, 5 passed). Reverted: 6 passed.
- **Full suite, with the pinned lib actually installed** — not a `PYTHONPATH`
  shim: `pytest tests/ -q` → **6680 passed, 17 skipped**.
- `shellcheck --severity=error infrastructure/*.sh` → clean.
- **`alpha-engine-config-I9070` is resolved by this bump, measured.**
  `tests/test_pipeline_status_registry_source_check.py` failed locally only
  because this laptop had `nousergon_lib` 0.124.88 installed against a much
  newer pin. Installing `v0.124.96` for this run turned it green (7 passed), so
  the local-vs-CI divergence that issue tracks was a stale local install and
  nothing in this repo.

## Cross-repo

Three consumer PRs, one per repo. They may land in **any order among
themselves**, but all after `nousergon-lib-PR368`, which is **already merged**
(2026-08-29T00:33:58Z) — nothing here is gated.

- `crucible-dashboard-PR801`
- `nousergon-data-PR1573` (this one)
- `nous-ergon-ops-PR925`

Tracked as `alpha-engine-config-I9215` (stage 2) under
`alpha-engine-config-I9099`. A closing keyword cannot reach another repo's
tracker, so neither issue auto-closes on this merge; both are closed by hand
once all three land.

No post-merge step. This PR is deployable by the merge button alone.

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
