### PR TITLE
docs(ci): fix stale test reference in sf-arn-drift-check.yml gate comment (alpha-engine-config-I9073)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -263,10 +263,14 @@ jobs:
       # deliberate `if: github.event_name != 'push'` race removal, and a step
       # excluded by its own `if:` has produced no verdict to fail on.
       #
-      # tests/test_sf_arn_drift_check_gate.py asserts that EVERY step running a
-      # checker here is both tolerated and named in this gate — a step added
-      # later without an id would otherwise be un-gated and its failure would
-      # silently pass the job, which is a worse defect than the one this fixes.
+      # tests/test_scheduled_workflow_reachability.py asserts that EVERY step
+      # running a checker here is both tolerated and named in this gate — a
+      # step added later without an id would otherwise be un-gated and its
+      # failure would silently pass the job, which is a worse defect than the
+      # one this fixes. (Corrected 2026-08-29, alpha-engine-config-I9073: this
+      # comment named a test file, test_sf_arn_drift_check_gate.py, that was
+      # never committed — the real guard landed under a different name in
+      # alpha-engine-config-I9121/nousergon-data-PR1572.)
       - name: Drift-check gate (fail the job on any failed check above)
         if: always()
         env:


### PR DESCRIPTION
## Summary

alpha-engine-config-I9073 was filed against a run where `sf-arn-drift-check.yml`'s "Scheduled-automation pause still holds (live)" step failed and skipped the six SF-drift checks behind it (no `if: always()`, plain sequential fail-fast).

**That defect is already fixed on `main`** by alpha-engine-config-I9121 / nousergon-data-PR1572 (merged 2026-08-28T18:45:59-07:00, ~35 min before this sweep started): every check step now has an `id` + `continue-on-error: true`, and a terminal `Drift-check gate` step (`if: always()`) grades all of them and fails the job iff any check failed. `tests/test_scheduled_workflow_reachability.py::test_every_drift_check_runs_and_is_graded` pins the shape so a future check step can't land un-gated.

This PR fixes the one thing PR1572 left inaccurate: the gate step's own comment names a test file, `tests/test_sf_arn_drift_check_gate.py`, that was never committed. The real guard is `tests/test_scheduled_workflow_reachability.py`. Corrected the reference.

## What was verified live (2026-08-29, ahead of the 09:00 UTC weekly run)

All six previously-blinded SF-drift checks, run by hand against live AWS (comparing against `origin/main` — the laptop's shared checkout was several commits stale and briefly showed false drift against its own stale files, not against what's deployed):

- EventBridge SF-ARN drift: clean (5 rules)
- SF LoggingConfiguration drift: clean (4 state machines)
- SF lambda:invoke Lambda-existence: clean (all referenced functions exist)
- SF definition drift (codified vs live vs S3-staged): clean for all 4 state machines
- EventBridge Scheduler rule drift (14 rules): clean
- schedule-manifest.json drift (8 entries, vs live): clean

Also re-ran the previously-blinded `automation_pause.py --check` and `overseer/arming.py --check` against current `main` content (which already includes I9121's alarm-classification fixes): both clean, exit 0.

**No drift threatens the 2026-08-29 09:00 UTC `ne-weekly-freshness-pipeline` run.**

## Class sweep

Searched nousergon-data (all workflows — no other instance), crucible-research, alpha-engine-config, and nous-ergon-ops workflows for the same shape (multiple independent live/codified-vs-live comparisons sharing one job's fail-fast, no `continue-on-error`/gate). Most flagged candidates turned out to be legitimate sequential build-then-check pipelines (deploy workflows, validate→publish→assert). One genuine instance found and filed, not fixed here (out of this repo): alpha-engine-config-I9229 (`artifact-cadence-coupling.yml`, three independent registry-drift checks).

## Test plan

- [x] `pytest tests/test_scheduled_workflow_reachability.py tests/test_automation_pause.py tests/test_automation_pause_breaching_split.py tests/test_overseer_arming.py tests/test_drift_checks_are_not_pr_gated.py -q` — 157 passed, 1 skipped
- [x] Full suite: `pytest tests/ -q --ignore=tests/integration` — 6727 passed, 12 skipped
- [x] Live AWS verification of all six previously-blinded checks (above)

Closes-when for alpha-engine-config-I9073 is already met by PR1572 (merged to main ahead of this PR); this PR just corrects the residual doc inaccuracy PR1572 left behind. Comment posted on I9073 with the live verification; not closed here (opened by another session/Brian, not this one).

Claude-Session: https://claude.ai/code/session_01W5ynuJyaxwpkNcQfmasoHt

---
Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)