### PR TITLE
fix(pipeline-watchdog): decode double-encoded _sf_completion marker (alpha-engine-config-I8217)

### DIFF
--- a/infrastructure/lambdas/pipeline-watchdog/index.py
+++ b/infrastructure/lambdas/pipeline-watchdog/index.py
@@ -176,6 +176,7 @@ from zoneinfo import ZoneInfo
 import boto3
 
 from nousergon_lib import alerts
+from nousergon_lib.pipeline_status.completion_marker import read_marker
 from nousergon_lib.trading_calendar import (
     is_trading_day,
     last_closed_trading_day,
@@ -1280,31 +1281,41 @@ def _completion_marker_status(
     failure modes here (S3 errors other than NoSuchKey, unparseable JSON,
     missing status field) all route to the caller's alert path plus a
     WARNING log, never to a silent pass.
+
+    alpha-engine-config-I8217: every object under ``_sf_completion/`` is
+    written by a Step Functions ``States.Format`` body, so the S3 object is
+    a JSON string LITERAL containing the JSON object — one ``json.loads``
+    yields a ``str``, not a ``dict``. This function used to do exactly that
+    single decode and then guard with ``isinstance(marker, dict)``, which
+    was therefore ALWAYS FALSE: every read fell through to "no usable status
+    field" (UNREADABLE) regardless of what the marker actually said, for
+    every pipeline, every date, since the guard was written. Delegates to
+    ``nousergon_lib.pipeline_status.completion_marker.read_marker``, the
+    fleet's canonical marker reader (alpha-engine-config-I8154/I8186),
+    which unwraps the double-encoding and classifies NoSuchKey as absence
+    rather than failure — closing this file's independent, broken
+    reimplementation of the same fix ``crucible-predictor/monitoring/
+    drift_detector.py::_load_json_maybe_wrapped`` already carried.
     """
     key = f"_sf_completion/{pipeline_name}/{target_date.isoformat()}.json"
     try:
-        resp = s3_client.get_object(Bucket=MARKER_BUCKET, Key=key)
-        marker = json.loads(resp["Body"].read())
-        status = marker.get("status") if isinstance(marker, dict) else None
-        if isinstance(status, str) and status:
-            return status
-        logger.warning(
-            "failed-day check: marker s3://%s/%s has no usable status field",
-            MARKER_BUCKET, key,
-        )
-        return "UNREADABLE"
+        marker = read_marker(s3_client, bucket=MARKER_BUCKET, key=key)
     except Exception as exc:  # classified below — never a silent pass
-        code = ""
-        response = getattr(exc, "response", None)
-        if isinstance(response, dict):
-            code = (response.get("Error") or {}).get("Code", "")
-        if code in ("NoSuchKey", "404"):
-            return "ABSENT"
         logger.warning(
             "failed-day check: marker s3://%s/%s unreadable (%s: %s)",
             MARKER_BUCKET, key, type(exc).__name__, exc,
         )
         return "UNREADABLE"
+    if marker is None:
+        return "ABSENT"
+    status = marker.get("status") if isinstance(marker, dict) else None
+    if isinstance(status, str) and status:
+        return status
+    logger.warning(
+        "failed-day check: marker s3://%s/%s has no usable status field",
+        MARKER_BUCKET, key,
+    )
+    return "UNREADABLE"
 
 
 def _last_due_weekly_day(now_utc: datetime) -> Optional[date]:

--- a/infrastructure/lambdas/pipeline-watchdog/test_handler.py
+++ b/infrastructure/lambdas/pipeline-watchdog/test_handler.py
@@ -9,6 +9,7 @@ dedup wiring, fail-loud) per the ``feedback_no_silent_fails`` discipline.
 
 from __future__ import annotations
 
+import importlib
 import json
 import sys
 import types
@@ -18,6 +19,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+# alpha-engine-config-I8217: import the REAL nousergon_lib.pipeline_status.
+# completion_marker before the blanket nousergon_lib stub below replaces the
+# top-level package — this is the fleet's canonical, tested double-decode
+# fix (I8154/I8186), and the whole point of the regression tests further
+# down is to exercise that real implementation, not a hand-rolled fake that
+# could silently diverge from it again. Once imported, it stays reachable
+# via sys.modules regardless of what the stub does to the parent package.
+importlib.import_module("nousergon_lib.pipeline_status.completion_marker")
 
 # Stub `nousergon_lib.trading_calendar` + `nousergon_lib.alerts` BEFORE
 # importing the handler so test envs without the lib installed still pass.
@@ -1309,12 +1319,21 @@ def _make_status_aware_sfn_client(rows_by_status: dict) -> MagicMock:
 
 
 def _make_s3_marker_client(*, marker: dict | None = None, error: Exception | None = None) -> MagicMock:
+    """alpha-engine-config-I8217: production ``_sf_completion/`` objects are
+    written by a Step Functions ``States.Format`` body, so the S3 object is
+    a JSON string LITERAL containing the JSON object (double-encoded) — NOT
+    a single ``json.dumps(marker)``. This fixture used to write the single-
+    encoded form, which is why every test built on it kept passing against
+    the (until this issue) permanently-broken ``_completion_marker_status``:
+    the fixture never exercised the double-decode the real object needs.
+    Encoding it the way the SF actually does turns every test below into a
+    real regression test for that bug, not a fixture-shaped pass."""
     s3 = MagicMock()
     if error is not None:
         s3.get_object.side_effect = error
     else:
         body = MagicMock()
-        body.read.return_value = _json.dumps(marker).encode()
+        body.read.return_value = _json.dumps(_json.dumps(marker)).encode()
         s3.get_object.return_value = {"Body": body}
     return s3
 
@@ -1396,6 +1415,32 @@ def test_failed_day_unreadable_marker_pages_unknown_is_not_pass():
     assert result.alert_emitted is True
     assert result.marker_status == "UNREADABLE"
     assert _alerts_mod.publish.call_args.kwargs["severity"] == "error"
+
+
+def test_completion_marker_status_decodes_real_double_encoded_object():
+    """alpha-engine-config-I8217 regression: this is the ACTUAL object body
+    read from s3://alpha-engine-research/_sf_completion/ne-weekly-freshness-pipeline/2026-08-22.json
+    (fetched read-only 2026-08-29), a real ``watch-rerun`` recovery marker
+    for the weekly cycle whose scheduled cron run FAILED at Director after
+    5h15m with APITimeoutError. Before the fix this always returned
+    UNREADABLE regardless of content; it must resolve the real ``status``."""
+    real_body = (
+        '"{\\"sf\\":\\"ne-weekly-freshness-pipeline\\",\\"execution_arn\\":'
+        '\\"arn:aws:states:us-east-1:711398986525:execution:'
+        'ne-weekly-freshness-pipeline:watch-rerun-2026-08-22-3\\",'
+        '\\"status\\":\\"SUCCEEDED\\",\\"started_at\\":'
+        '\\"2026-08-22T15:53:30.910Z\\",\\"completed_at\\":'
+        '\\"2026-08-22T16:08:02.407Z\\",\\"cycle_key\\":\\"2026-08-22\\",'
+        '\\"substrate_relaunches\\":0}"'
+    )
+    s3 = MagicMock()
+    body = MagicMock()
+    body.read.return_value = real_body.encode()
+    s3.get_object.return_value = {"Body": body}
+    status = index._completion_marker_status(
+        s3, "ne-weekly-freshness-pipeline", date(2026, 8, 22),
+    )
+    assert status == "SUCCEEDED"
 
 
 def test_failed_day_non_degraded_marker_status_still_pages():


### PR DESCRIPTION
## Summary

`_sf_completion/` objects are written by a Step Functions `States.Format` body — the S3 object is a JSON string LITERAL containing the JSON object. `_completion_marker_status` did one `json.loads` (yielding a `str`) and guarded with `isinstance(marker, dict)`, which was therefore ALWAYS FALSE: every read fell through to "no usable status field" (`UNREADABLE`) regardless of the marker's real content, for every pipeline, every date, since the guard was written.

Verified live 2026-08-29: fetched `s3://alpha-engine-research/_sf_completion/ne-weekly-freshness-pipeline/2026-08-22.json` read-only — it is exactly the double-encoded shape (`"{\"sf\":...}"`), and the old code would classify it `UNREADABLE` regardless of its actual `status: SUCCEEDED`.

**Practical impact of the bug:** not missed failure pages — `ABSENT` and `UNREADABLE` both already page — but a legitimate Option-A `DEGRADED` completion always double-paged as a hard FAILED (its status could never resolve to `"DEGRADED"`), and a genuine disagreement between the execution walk and a `SUCCEEDED` marker was silently never logged.

**Why this matters more than usual right now:** `alpha-engine-pipeline-watchdog-daily` (`cron(0 14 * * ? *)`) is the ONLY automatic detector left standing for `ne-weekly-freshness-pipeline` failures — every `alpha-engine-alert-drain-*` schedule and the Saturday-specific watch are DISABLED per the 2026-08-07 automation-pause ruling (`infrastructure/automation_pause.json`). This Lambda's failed-day check needs to classify tomorrow's (2026-08-29 09:00 UTC) run correctly.

## Fix

Delegates to `nousergon_lib.pipeline_status.completion_marker.read_marker` (already pinned via this Lambda's `requirements.txt` at v0.124.96) — the fleet's canonical marker reader (alpha-engine-config-I8154/I8186), which unwraps the double-encoding and classifies `NoSuchKey` as absence rather than failure.

## Class-wide sweep (alpha-engine-config-I8217's other deliverable)

Every `_sf_completion` reader in the fleet, fixed/unfixed:

| Reader | Status |
|---|---|
| `nousergon-data/infrastructure/lambdas/pipeline-watchdog/index.py::_completion_marker_status` | **Fixed here** — was always-broken |
| `crucible-predictor/monitoring/drift_detector.py::_load_json_maybe_wrapped` | Already correct (independent fix, alpha-engine-config-I8078 companion PR consolidates its verdict semantics but the decode was never broken) |
| `nousergon-data/infrastructure/lambdas/eod_artifact_verification.py` | Not affected — uses `head_object` (existence only), never decodes the body |
| `nousergon-data/scripts/weekly_sf_recovery_metric.py` | Not affected — lists the prefix for the latest key, never decodes a marker body |
| `nousergon-lib/src/nousergon_lib/pipeline_status/completion_marker.py` | The canonical, already-correct implementation (`decode_marker`) this PR now uses |

No second fork found needing consolidation into `nousergon-lib` — the library already carries the canonical fix (landed alpha-engine-config-I8154/I8186, PR #349); this PR migrates the one remaining broken reimplementation onto it.

## Test fixture defect (why this was never caught)

`_make_s3_marker_client` — the fixture every `_completion_marker_status`/`_check_failed_day` marker test uses — single-encoded its body (`json.dumps(marker)`), never matching production's double-encoded shape. That's why the existing suite passed against permanently-broken code: the tests never exercised the actual bug. Fixed to double-encode (turning every existing marker test into a real regression test), plus a new test pinned to the real live marker body fetched read-only 2026-08-29.

## Deploy

`.github/workflows/deploy-pipeline-watchdog.yml` auto-deploys this Lambda's code on merge to main (code-only `deploy.sh`, no infra changes) — **merging this PR ships the fix**, no post-merge step needed.

## Test plan

- [x] `infrastructure/lambdas/pipeline-watchdog/test_handler.py` — 88 passed
- [x] Full suite: `.venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration` — 6727 passed, 12 skipped, 0 failures

Companion: crucible-predictor-PR (alpha-engine-config-I8078, draft, `gate:weekly-sf`) — same session, consumer-side verdict-semantics fix on `monitoring/drift_detector.py`. No merge-order dependency; independent files, independent repos.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5ynuJyaxwpkNcQfmasoHt