### PR TITLE
fix(sf-drift): a stale checkout must not page production, and every page names its repo side

### DIFF
--- a/infrastructure/step-functions/check-definition-drift.py
+++ b/infrastructure/step-functions/check-definition-drift.py
@@ -54,6 +54,22 @@ is passed. The import is lazy and best-effort: a missing/broken
 `nousergon_lib` degrades to a logged warning, never to a false "clean"
 exit — the non-zero exit code is always the authoritative signal.
 
+**Paging discipline (alpha-engine-config-I9036).** ``REPO_ROOT`` is derived
+from ``__file__``, so an out-of-band invocation inside a stale checkout
+compares THAT checkout's bytes against live and pages production with
+findings that are entirely local delta — measured 2026-08-29, six ERROR
+findings from a worktree 49 commits behind ``origin/main``, zero real drift.
+Two rules follow, and both are load-bearing:
+
+  * Every page carries the provenance of the "repo" side — ``REPO_ROOT``,
+    ``HEAD``, and the commits-behind count — and leads with the
+    ``stale_checkout_note`` when there is one. A drift page whose repo side
+    is unidentified is unactionable by construction.
+  * ``main()`` REFUSES to page from a checkout whose definition files differ
+    from the remote's DEFAULT branch. The findings still print and the exit
+    code is still 1 — only the page is withheld. Both legitimate callers
+    (deploy-infrastructure.yml, sf-arn-drift-check.yml) run on ``main``.
+
 Usage:
   ./infrastructure/step-functions/check-definition-drift.py               # every codified SF, alerts on drift
   ./infrastructure/step-functions/check-definition-drift.py --name NAME   # one (by SF name)
@@ -74,6 +90,7 @@ real AWS access in CI).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -93,6 +110,10 @@ DEFAULT_ACCOUNT_ID = "711398986525"
 # deploy-infrastructure.sh ($BUCKET) and the CFN DefinitionS3Location keys.
 S3_BUCKET = "alpha-engine-research"
 S3_PREFIX = "infrastructure/"
+
+# Last-resort ref for the staleness comparison when git cannot name the
+# remote's default branch. Never the tracked branch: see default_upstream().
+DEFAULT_UPSTREAM = "origin/main"
 
 # repo definition file -> live state machine name. Mirrors the ARN mapping in
 # deploy-infrastructure.sh step 3. A renamed/removed file or SF fails loud
@@ -220,7 +241,69 @@ def _git(*args: str) -> str | None:
     return result.stdout.strip() if result.returncode == 0 else None
 
 
-def stale_definition_files(entries) -> list[str]:
+def default_upstream() -> str:
+    """The remote's DEFAULT branch (e.g. ``origin/main``), never the branch
+    this checkout happens to track.
+
+    ``stale_definition_files`` originally resolved ``@{upstream}``, which on a
+    feature branch resolves to that feature branch's own remote ref — so a
+    checkout tens of commits behind ``main`` compares clean against itself and
+    the guard reports nothing. That is the exact configuration that produced a
+    false production page on 2026-08-29 from a worktree 49 commits behind
+    ``origin/main``. When this script is deciding whether it may PAGE, the only
+    meaningful reference is the branch the deployment is built from.
+
+    Falls back to ``DEFAULT_UPSTREAM`` when git cannot answer (a CI checkout
+    does not always carry ``refs/remotes/origin/HEAD``)."""
+    for args in (
+        ("rev-parse", "--abbrev-ref", "origin/HEAD"),
+        ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"),
+    ):
+        ref = _git(*args)
+        if ref and "/" in ref:
+            return ref
+    return DEFAULT_UPSTREAM
+
+
+def repo_provenance(upstream: str | None = None) -> dict:
+    """WHICH bytes this run called "the repo".
+
+    A drift page whose repo side is unidentified is unactionable by
+    construction: the reader cannot tell a live hand-patch from an operator
+    running the checker inside a stale checkout. Every field is best-effort —
+    git may be absent — but an unknown is rendered as the literal string
+    ``unknown``, never omitted, so the page never reads as if the question was
+    not asked."""
+    upstream = upstream or default_upstream()
+    head = _git("rev-parse", "HEAD") or "unknown"
+    behind_raw = _git("rev-list", "--count", f"HEAD..{upstream}")
+    try:
+        behind = int(behind_raw) if behind_raw is not None else None
+    except ValueError:
+        behind = None
+    return {
+        "repo_root": str(REPO_ROOT.resolve()),
+        "head": head,
+        "upstream": upstream,
+        "behind": behind,
+    }
+
+
+def repo_provenance_note(provenance: dict) -> str:
+    """One line naming REPO_ROOT, HEAD and the behind-count. Pure / testable."""
+    behind = provenance.get("behind")
+    behind_txt = (
+        f"{behind} commits behind {provenance['upstream']}"
+        if behind is not None
+        else f"behind-count vs {provenance['upstream']} unknown"
+    )
+    return (
+        f"repo side: {provenance['repo_root']} @ HEAD {provenance['head']} "
+        f"({behind_txt})"
+    )
+
+
+def stale_definition_files(entries, upstream: str | None = None) -> list[str]:
     """Definition files whose WORKING-TREE bytes differ from ``origin/HEAD``'s.
 
     This script's entire premise is "the repo file is the intended truth" — so
@@ -238,14 +321,24 @@ def stale_definition_files(entries) -> list[str]:
     branch's definitions against live before merging is a legitimate use, and
     that case would trip this every time. It annotates instead.
 
+    ``upstream`` names the ref to compare against. ``None`` resolves the
+    tracked remote branch (the legacy annotate-only behaviour); ``main()``
+    always passes :func:`default_upstream` instead, because on a feature
+    branch the tracked ref IS the stale bytes and comparing against it can
+    never detect staleness (alpha-engine-config-I9036, deliverable 4).
+
     Returns repo-relative paths, sorted. Empty when git is unavailable — an
     unknown answer is reported as "no note", never as a false reassurance,
     because ``main()`` prints the note only when this is non-empty."""
     if _git("rev-parse", "--is-inside-work-tree") != "true":
         return []
-    # Resolve the tracked remote branch rather than assuming "origin/main".
-    upstream = (_git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
-                or "origin/main")
+    if upstream is None:
+        # Annotate-only callers keep the historical behaviour: prefer the
+        # tracked remote branch. main() NEVER relies on this — it passes
+        # default_upstream() explicitly, because a tracked feature branch is
+        # exactly the ref that makes a stale checkout look current.
+        upstream = (_git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+                    or DEFAULT_UPSTREAM)
     stale: list[str] = []
     for entry in SF_DEFINITIONS:
         rel = (INFRA_DIR / entry["definition_file"]).relative_to(REPO_ROOT)
@@ -328,7 +421,26 @@ def _check_sf(entry: dict) -> list[str]:
     return findings
 
 
-def _alert_on_drift(total_findings: list[str], *, severity: str = "error") -> None:
+def _dedup_key(total_findings: list[str]) -> str:
+    """Dedup key over the finding CONTENT, not its count.
+
+    ``sf_definition_drift_{len(findings)}`` collapsed every 6-finding
+    condition into one page: an unrelated drift arriving inside the dedup
+    window while a first one was open would have been silently dropped. The
+    count is a property of the alert, never an identity of the condition."""
+    digest = hashlib.sha256(
+        "\n".join(sorted(total_findings)).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"sf_definition_drift_{digest}"
+
+
+def _alert_on_drift(
+    total_findings: list[str],
+    *,
+    severity: str = "error",
+    provenance: dict | None = None,
+    stale_note: str = "",
+) -> None:
     """Best-effort SNS/Telegram page via nousergon_lib.alerts — same
     `alpha-engine-alerts` topic every other drift/preflight alert in this
     repo publishes to (see validators/constituents_drift_check.py). Import
@@ -344,8 +456,17 @@ def _alert_on_drift(total_findings: list[str], *, severity: str = "error") -> No
         )
         return
 
+    # The page must carry WHICH repo bytes produced the findings, and must
+    # lead with the stale-checkout warning when one exists — the guard being
+    # visible on stdout while stripped from the page is what let a stale
+    # worktree page production on 2026-08-29.
+    provenance = provenance if provenance is not None else repo_provenance()
+    header = "" if not stale_note else stale_note + "\n"
     message = (
-        f"SF definition drift detected ({len(total_findings)} finding(s)): "
+        header
+        + f"SF definition drift detected ({len(total_findings)} finding(s)) — "
+        + repo_provenance_note(provenance)
+        + ": "
         + "; ".join(total_findings)
     )
     try:
@@ -353,7 +474,7 @@ def _alert_on_drift(total_findings: list[str], *, severity: str = "error") -> No
             message,
             severity=severity,
             source="alpha-engine-data/infrastructure/step-functions/check-definition-drift.py",
-            dedup_key=f"sf_definition_drift_{len(total_findings)}",
+            dedup_key=_dedup_key(total_findings),
             dedup_window_min=60,
         )
         sys.stderr.write(
@@ -392,17 +513,47 @@ def main() -> int:
         total_findings.extend(_check_sf(entry))
 
     if total_findings:
+        # The paging decision compares against the remote's DEFAULT branch,
+        # never the tracked one — see default_upstream().
+        upstream = default_upstream()
+        provenance = repo_provenance(upstream)
         # Printed BEFORE the findings, so it cannot be missed by someone who
         # reads the first line and starts acting (which is exactly what
         # happened on 2026-07-27).
-        stale = stale_definition_files(entries)
-        if stale:
-            print(stale_checkout_note(stale))
+        stale = stale_definition_files(entries, upstream=upstream)
+        stale_note = stale_checkout_note(stale, upstream=upstream) if stale else ""
+        if stale_note:
+            print(stale_note)
+        print(repo_provenance_note(provenance))
         print(f"SF definition drift detected ({len(total_findings)} finding(s)):")
         for f in total_findings:
             print(f"  - {f}")
-        if not args.no_alert:
-            _alert_on_drift(total_findings)
+        if args.no_alert:
+            return 1
+        if stale:
+            # DELIBERATE NON-PAGE — a refusal, not a swallow. Nothing is
+            # discarded: the findings are on stdout above, the stale note
+            # leads them, and the exit code stays 1, so every caller's
+            # failure signal is intact. What is withheld is the PAGE, because
+            # findings derived from bytes that were never on the default
+            # branch cannot distinguish deployment drift from local staleness
+            # — §2.4's premise ("the repo is the only writer") does not hold
+            # for a checkout that is not the repo's default branch. Both
+            # legitimate callers run on main, so no true positive is lost.
+            # Recording surface: stdout + stderr below, and exit code 1.
+            sys.stderr.write(
+                "REFUSING TO PAGE: findings were produced from a stale "
+                f"checkout ({len(stale)} definition file(s) differ from "
+                f"{upstream}). {repo_provenance_note(provenance)}. "
+                "Exit code 1 stands; re-run from a checkout at "
+                f"{upstream} to page.\n"
+            )
+            print(
+                "REFUSING TO PAGE: stale checkout — see the warning above. "
+                "Exit code 1 stands."
+            )
+            return 1
+        _alert_on_drift(total_findings, provenance=provenance, stale_note=stale_note)
         return 1
 
     sf_names = ", ".join(e["sf_name"] for e in entries)

--- a/tests/test_sf_definition_check_drift.py
+++ b/tests/test_sf_definition_check_drift.py
@@ -541,3 +541,245 @@ def test_git_helper_returns_none_on_nonzero_exit(cd, monkeypatch):
     monkeypatch.setattr(cd.subprocess, "run",
                         lambda *a, **k: MagicMock(returncode=1, stdout="x"))
     assert cd._git("rev-parse", "nope") is None
+
+
+# ── paging surface: provenance, refusal, dedup, default-branch resolution ───
+#
+# alpha-engine-config-I9036 (2026-08-29). A local invocation inside a worktree
+# 49 commits behind origin/main produced six ERROR findings across three state
+# machines and PAGED PRODUCTION. There was zero real drift: live, S3-staged and
+# origin/main definitions all matched. The stale-checkout guard above ALREADY
+# detected the condition and printed its warning — to stdout only, while
+# `_alert_on_drift` sent the findings alone. The guard was stripped from the
+# page: the local operator saw the warning, the pager did not.
+
+
+def _git_stub(*, head="a" * 40, behind="0", stale=False, origin_head="origin/main",
+              tracked="origin/feature"):
+    """A `_git` double covering every call the paging path makes."""
+
+    def fake_git(*args):
+        if args[0] == "rev-parse" and "--is-inside-work-tree" in args:
+            return "true"
+        if args[0] == "rev-parse" and args[1:] == ("--abbrev-ref", "origin/HEAD"):
+            return origin_head
+        if args[0] == "symbolic-ref":
+            return origin_head
+        if args[0] == "rev-parse" and "--abbrev-ref" in args and "@{upstream}" in args:
+            return tracked
+        if args[0] == "rev-parse" and args[1:] == ("HEAD",):
+            return head
+        if args[0] == "rev-list":
+            return behind
+        if args[0] == "hash-object":
+            return "local-blob"
+        if args[0] == "rev-parse":  # <upstream>:<path>
+            return "remote-blob" if stale else "local-blob"
+        return None
+
+    return fake_git
+
+
+# ── deliverable 1: the page carries REPO_ROOT + HEAD + behind-count ─────────
+
+
+def test_provenance_note_carries_repo_root_head_and_behind_count(cd):
+    note = cd.repo_provenance_note(
+        {"repo_root": "/Users/x/.worktrees/nousergon-data-i8155",
+         "head": "efd46785" + "0" * 32,
+         "upstream": "origin/main",
+         "behind": 49}
+    )
+    assert "/Users/x/.worktrees/nousergon-data-i8155" in note
+    assert "efd46785" in note
+    assert "49 commits behind origin/main" in note
+
+
+def test_provenance_note_renders_an_unknown_behind_count_explicitly(cd):
+    note = cd.repo_provenance_note(
+        {"repo_root": "/r", "head": "unknown", "upstream": "origin/main", "behind": None}
+    )
+    assert "unknown" in note
+    # The question must never look unasked.
+    assert "origin/main" in note
+
+
+def test_repo_provenance_reports_head_and_behind_count(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_git", _git_stub(head="b" * 40, behind="49"))
+    prov = cd.repo_provenance()
+    assert prov["head"] == "b" * 40
+    assert prov["behind"] == 49
+    assert prov["upstream"] == "origin/main"
+    assert prov["repo_root"] == str(cd.REPO_ROOT.resolve())
+
+
+def test_repo_provenance_survives_git_being_unavailable(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_git", lambda *a: None)
+    prov = cd.repo_provenance()
+    assert prov["head"] == "unknown"
+    assert prov["behind"] is None
+    cd.repo_provenance_note(prov)  # must not raise
+
+
+def test_alert_message_carries_repo_provenance(cd, fake_nousergon_lib_alerts, monkeypatch):
+    monkeypatch.setattr(cd, "_git", _git_stub(head="c" * 40, behind="49"))
+    cd._alert_on_drift(["ne-weekly-freshness-pipeline: definition drift (LIVE vs x)"])
+    message = fake_nousergon_lib_alerts[0]["message"]
+    assert str(cd.REPO_ROOT.resolve()) in message, "page must name WHICH repo it compared"
+    assert "c" * 40 in message, "page must name the HEAD it compared"
+    assert "49 commits behind origin/main" in message
+
+
+def test_alert_message_prepends_the_stale_checkout_note(cd, fake_nousergon_lib_alerts):
+    note = cd.stale_checkout_note(["infrastructure/step_function.json"])
+    cd._alert_on_drift(
+        ["fake-sf: drifted"],
+        provenance={"repo_root": "/r", "head": "d" * 40,
+                    "upstream": "origin/main", "behind": 3},
+        stale_note=note,
+    )
+    message = fake_nousergon_lib_alerts[0]["message"]
+    assert message.startswith(note), "the guard must LEAD the page, not be stripped from it"
+    assert "may be your checkout" in message
+
+
+# ── deliverable 2: a stale checkout must not page at all ────────────────────
+
+
+def _stale_main_env(cd, monkeypatch, *, stale, argv=None):
+    fake_entry = {"sf_name": "ne-weekly-freshness-pipeline",
+                  "definition_file": "step_function.json"}
+    monkeypatch.setattr(cd, "SF_DEFINITIONS", (fake_entry,))
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: [f"{entry['sf_name']}: drifted"])
+    monkeypatch.setattr(cd, "_git", _git_stub(behind="49", stale=stale))
+    monkeypatch.setattr("sys.argv", argv or ["check-definition-drift.py"])
+
+
+def test_main_refuses_to_page_from_a_stale_checkout(cd, monkeypatch, capsys,
+                                                    fake_nousergon_lib_alerts):
+    """The 2026-08-29 false page, as a test."""
+    _stale_main_env(cd, monkeypatch, stale=True)
+    assert cd.main() == 1, "the operator signal (exit code) must be preserved"
+    assert fake_nousergon_lib_alerts == [], "a stale checkout must never page production"
+    captured = capsys.readouterr()
+    assert "REFUSING TO PAGE" in captured.out
+    assert "REFUSING TO PAGE" in captured.err, "the refusal must be loud, not silent"
+    assert "STALE" in captured.out
+
+
+def test_main_still_pages_from_a_clean_checkout(cd, monkeypatch, fake_nousergon_lib_alerts):
+    _stale_main_env(cd, monkeypatch, stale=False)
+    assert cd.main() == 1
+    assert len(fake_nousergon_lib_alerts) == 1, "real drift on main must still page"
+
+
+def test_main_prints_provenance_beside_the_findings(cd, monkeypatch, capsys,
+                                                    fake_nousergon_lib_alerts):
+    _stale_main_env(cd, monkeypatch, stale=False)
+    cd.main()
+    out = capsys.readouterr().out
+    assert str(cd.REPO_ROOT.resolve()) in out
+    assert "49 commits behind origin/main" in out
+
+
+# ── deliverable 3: dedup on content, not on the finding COUNT ───────────────
+
+
+def test_dedup_key_distinguishes_two_unrelated_conditions_of_equal_size(cd):
+    a = [f"sf-a: finding {i}" for i in range(6)]
+    b = [f"sf-b: finding {i}" for i in range(6)]
+    assert cd._dedup_key(a) != cd._dedup_key(b), (
+        "two unrelated 6-finding conditions must not collapse into one page"
+    )
+
+
+def test_dedup_key_is_stable_and_order_insensitive(cd):
+    a = ["x: one", "y: two"]
+    assert cd._dedup_key(a) == cd._dedup_key(list(reversed(a)))
+    assert cd._dedup_key(a) == cd._dedup_key(a)
+
+
+def test_alert_uses_the_content_dedup_key(cd, fake_nousergon_lib_alerts, monkeypatch):
+    monkeypatch.setattr(cd, "_git", _git_stub())
+    findings = ["sf-a: drifted", "sf-b: drifted"]
+    cd._alert_on_drift(findings)
+    key = fake_nousergon_lib_alerts[0]["dedup_key"]
+    assert key == cd._dedup_key(findings)
+    assert key != f"sf_definition_drift_{len(findings)}", (
+        "the key must not be the finding COUNT"
+    )
+
+
+# ── deliverable 4: the paging comparison uses the DEFAULT branch ────────────
+
+
+def test_default_upstream_resolves_the_remotes_default_branch(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_git", _git_stub(origin_head="origin/trunk"))
+    assert cd.default_upstream() == "origin/trunk"
+
+
+def test_default_upstream_falls_back_when_git_cannot_answer(cd, monkeypatch):
+    monkeypatch.setattr(cd, "_git", lambda *a: None)
+    assert cd.default_upstream() == cd.DEFAULT_UPSTREAM == "origin/main"
+
+
+def test_stale_files_use_the_explicit_upstream_not_the_tracked_branch(cd, monkeypatch):
+    """A worktree tracking its own feature branch compares clean against
+    itself — which is precisely how a checkout 49 commits behind main passed
+    the guard."""
+    asked: list[str] = []
+
+    def fake_git(*args):
+        if args[0] == "rev-parse" and "--is-inside-work-tree" in args:
+            return "true"
+        if args[0] == "hash-object":
+            return "local-blob"
+        if args[0] == "rev-parse" and "--abbrev-ref" in args and "@{upstream}" in args:
+            return "origin/fix/i8155-execution-run-date"
+        if args[0] == "rev-parse":
+            asked.append(args[1])
+            # The feature branch's own ref matches; main does not.
+            return "local-blob" if args[1].startswith("origin/fix/") else "remote-blob"
+        return None
+
+    monkeypatch.setattr(cd, "_git", fake_git)
+    assert cd.stale_definition_files(cd.SF_DEFINITIONS) == [], (
+        "baseline: the tracked feature branch hides the staleness"
+    )
+    stale = cd.stale_definition_files(cd.SF_DEFINITIONS, upstream="origin/main")
+    assert stale, "comparing against the default branch must expose it"
+    assert all(ref.startswith("origin/main:") for ref in asked if ":" in ref
+               and not ref.startswith("origin/fix/"))
+
+
+def test_main_compares_against_the_default_branch_not_the_tracked_one(
+    cd, monkeypatch, fake_nousergon_lib_alerts
+):
+    """End-to-end: findings from a feature-branch worktree that is behind main
+    must NOT page, even though @{upstream} says the tree is clean."""
+    fake_entry = {"sf_name": "ne-weekly-freshness-pipeline",
+                  "definition_file": "step_function.json"}
+    monkeypatch.setattr(cd, "SF_DEFINITIONS", (fake_entry,))
+    monkeypatch.setattr(cd, "_check_sf", lambda entry: [f"{entry['sf_name']}: drifted"])
+    monkeypatch.setattr("sys.argv", ["check-definition-drift.py"])
+
+    def fake_git(*args):
+        if args[0] == "rev-parse" and "--is-inside-work-tree" in args:
+            return "true"
+        if args[0] == "rev-parse" and args[1:] == ("--abbrev-ref", "origin/HEAD"):
+            return "origin/main"
+        if args[0] == "rev-parse" and "--abbrev-ref" in args and "@{upstream}" in args:
+            return "origin/fix/i8155-execution-run-date"
+        if args[0] == "rev-parse" and args[1:] == ("HEAD",):
+            return "efd46785" + "0" * 32
+        if args[0] == "rev-list":
+            return "49"
+        if args[0] == "hash-object":
+            return "local-blob"
+        if args[0] == "rev-parse":
+            return "local-blob" if args[1].startswith("origin/fix/") else "remote-blob"
+        return None
+
+    monkeypatch.setattr(cd, "_git", fake_git)
+    assert cd.main() == 1
+    assert fake_nousergon_lib_alerts == []


### PR DESCRIPTION
## What broke

A production ERROR page fired 2026-08-29 on the `alpha-engine-alerts` topic claiming **six** SF-definition-drift findings — `ne-weekly-freshness-pipeline` (70 differing States), `ne-preopen-trading-pipeline` (1: `CodeFreshnessGate`), `ne-postclose-trading-pipeline` (3: `MarketHoursGateChoice`, `NormalizeEODFailureContext`, `PageCaptureSnapshotIrreversibleFailure`).

**All six findings were false. There was zero real drift.**

Measured:

- Live, S3-staged and repo definitions all MATCH for all four state machines, normalized per this script's own rule. All carry `[git:b20e80ccd1eb7059567ef3f8bd4908a83cb1a8fb]` = `origin/main` HEAD. S3 written 2026-08-29T03:01:44–46Z; CFN stack `alpha-engine-orchestration` UPDATE_COMPLETE 03:01:58Z tag `git-sha=b20e80cc`; CFN-owned state machines updated 03:02:22/23Z.
- The alert was reproduced **byte for byte** — including the order of the five named states — by replaying the comparator's normalization using definition bytes from the local worktree `.worktrees/nousergon-data-i8155` (branch `fix/i8155-execution-run-date`, HEAD `efd46785`, **49 commits behind `origin/main`**). `step_function_groom.json` matched there, which is why the alert carried 6 findings and not 8.
- It did NOT come from CI. Both legitimate callers check out `main`: `.github/workflows/deploy-infrastructure.yml:75` (every push to main) and `.github/workflows/sf-arn-drift-check.yml:193` (push-to-main + daily `cron: 30 9 * * *`). All 15 `deploy-infrastructure.yml` runs since 2026-08-28T17:41Z succeeded; on the three failing `sf-arn-drift-check` runs the only failing step was `Scheduled-automation pause still holds (live)` — `sf_definition_drift` itself PASSED.
- The write path needs no change and is untouched here. `infrastructure/deploy-infrastructure.sh` is the sole writer — stamps `[git:$GITHUB_SHA]` onto each `Comment` (lines 96–145), `aws s3 cp` all four stamped files to `s3://alpha-engine-research/infrastructure/` (lines 222–225), then `update-state-machine --definition file://$stamped` from those same bytes (lines 281/299). The `config#2273` single-writer contract is **intact**.

## Root cause

`REPO_ROOT` is resolved from `Path(__file__).parent.parent.parent`, so an out-of-band local invocation inside a stale checkout silently compares **that worktree's** bytes against live and S3 — and pages production with findings that are entirely local delta.

The guard for exactly this already existed. `stale_definition_files()` / `stale_checkout_note()` were written after an identical 2026-07-27 incident (a checkout 9 commits behind produced four confident false findings), and they **fired**. But `main()` printed the note to **stdout only**, while `_alert_on_drift(total_findings)` sent the findings alone. The guard was stripped from the page: the local operator saw the warning, the pager did not.

**The defect is the paging surface**, not the comparator and not the deployment.

## SOTA approach, and the delta

SOTA for a detector that pages: (a) the page carries the full provenance of every input the verdict was computed from, and (b) the detector is **fail-closed against its own preconditions** — it refuses to emit a page it cannot vouch for, rather than emitting one and relying on the reader to notice a caveat printed elsewhere. Both are implemented here. **No delta** — this is the institutional shape, not a staged approximation.

Deliberately *not* done, and why: hard-coding `REPO_ROOT` or making it CI-only would break the standalone/operator-session use the module docstring declares, and would leave the same class open for every other `__file__`-rooted checker. The fix is at the paging boundary, which is where the class lives.

## The four changes

1. **The page names its repo side.** New `repo_provenance()` / `repo_provenance_note()` put `REPO_ROOT` (absolute), `HEAD`, and `N commits behind <upstream>` into the alert body and onto stdout. `_alert_on_drift` gained a `stale_note` parameter and **prepends** it when non-empty, so any future caller that pages while stale carries the guard rather than stripping it. An unknown renders as the literal `unknown`, never omitted — the question must never look unasked.

2. **A stale checkout does not page at all.** `main()` withholds `_alert_on_drift` when any definition file differs from the remote's default branch. This is a **refusal, not a swallow**: findings still print, the stale note still leads them, the refusal is loud on **both stdout and stderr**, and the **exit code stays 1**, so every caller's failure signal is intact. §2.4's premise — "the live definitions are a pure function of the repository" — cannot produce a true positive from bytes that were never on the default branch. Both legitimate callers run on `main`, so no true positive is lost.

3. **`dedup_key` hashes the finding CONTENT**, not its count. It was `f"sf_definition_drift_{len(total_findings)}"`, so two unrelated six-finding conditions collapsed into one page inside the 60-minute dedup window.

4. **The staleness comparison uses the DEFAULT branch when paging.** `stale_definition_files()` resolved `@{upstream}`, which on a feature-branch worktree is that worktree's own remote ref — it compares clean against itself, which is exactly how a checkout 49 commits behind `main` passed the guard. It now takes an explicit `upstream`; `main()` always passes `default_upstream()` (`origin/HEAD`, falling back to `origin/main` when git cannot answer). Annotate-only callers keep the legacy tracked-branch behaviour via `upstream=None`.

## Scope

Two files: `infrastructure/step-functions/check-definition-drift.py` and `tests/test_sf_definition_check_drift.py`. No definition JSON, no deploy script, nothing under `infrastructure/lambdas/`, no workflow change. Nothing to run after merge — the two callers invoke the script unchanged.

## Test plan and actual results

16 new tests, one per deliverable plus the degradation paths. Verified they fail without the fix by restoring `origin/main`'s copy of the script and re-running:

```
15 failed, 39 passed in 0.98s
```

The 16th (`test_main_still_pages_from_a_clean_checkout`) is the regression guard — real drift on `main` must still page — and passes both before and after by design.

Named failures without the fix include `test_main_refuses_to_page_from_a_stale_checkout` (the 2026-08-29 false page, as a test), `test_alert_message_carries_repo_provenance`, `test_alert_message_prepends_the_stale_checkout_note`, `test_dedup_key_distinguishes_two_unrelated_conditions_of_equal_size`, and `test_main_compares_against_the_default_branch_not_the_tracked_one`.

With the fix, the file's suite:

```
54 passed in 1.62s
```

Full suite, CI's `pytest tests/` path, run in the worktree before pushing:

```
6765 passed, 17 skipped, 424 warnings in 251.50s (0:04:11)
```

Zero failures, including no pre-existing ones.

`git check-ignore -v AGENTS.md CLAUDE.md` → both ignored (`.gitignore:59`, `.gitignore:25`); neither is in this diff.

## Found and not fixed here

The condition that loaded the gun is a checkout-hygiene problem, filed separately: 45 `nousergon-data` worktrees under `~/Development/.worktrees/`, most on merged or abandoned branches tens of commits behind `main`. Cross-references `alpha-engine-config-I7920`, `I6587`, `I9035`.


---

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
