### PR TITLE
fix(phase-marker-sweep): scope the listing to markers, and name an unreadable one (alpha-engine-config-I9262)

### DIFF
--- a/tests/test_phase_marker_sweep.py
+++ b/tests/test_phase_marker_sweep.py
@@ -93,7 +93,20 @@ def test_sweep_detects_error_marker():
     assert "FileNotFoundError" in result["error_phases"][0]["error"]
 
 
-def test_sweep_unparseable_marker_skipped_not_fatal():
+def test_sweep_unparseable_marker_is_a_named_finding_not_fatal():
+    """An unparseable marker is reported by key — and is NOT scored `ok`.
+
+    Contract change, alpha-engine-config-I9262. This test previously
+    asserted `status == "ok"`: a corrupt marker was warned about and
+    dropped, and the sweep then reported a clean bill of health for a run
+    whose phase outcome it had just failed to read. That is `no data`
+    rendered as green (`principles.md` §2.7), on the one surface that
+    exists to say whether a non-fatal backtester phase errored.
+
+    Still not fatal in the sense the old name meant: the sweep completes,
+    reports every marker it COULD read, and exits 1 (a finding) rather
+    than 2 (a sweep-infra fault).
+    """
     from validators import phase_marker_sweep
 
     fake = _FakeS3({
@@ -102,8 +115,11 @@ def test_sweep_unparseable_marker_skipped_not_fatal():
     })
     with patch.object(phase_marker_sweep, "boto3", MagicMock(client=lambda *a, **k: fake)):
         result = phase_marker_sweep.sweep(run_date="2026-07-18", alert=False)
-    assert result["status"] == "ok"
+    assert result["status"] == "malformed_markers_detected"
     assert result["checked_count"] == 1
+    assert [m["s3_key"] for m in result["malformed_markers"]] == [
+        "backtest/2026-07-18/.phases/corrupt.json"
+    ]
 
 
 def test_sweep_s3_failure_returns_error():
@@ -208,3 +224,139 @@ def test_declared_long_options_still_parse_in_full():
     with patch("validators.phase_marker_sweep.boto3", MagicMock(client=lambda *a, **k: fake)):
         rc = main(["--run-date", "2026-07-18", "--no-alert", "--alert-severity", "warn"])
     assert rc == 0
+
+
+# ── alpha-engine-config-I9262 regressions ────────────────────────────────
+#
+# The 2026-08-29 weekly SF run terminated SubstrateHealthCheckDegraded on a
+# TypeError inside this sweep, not on a health finding. Two independent
+# defects, one test each. Both FAIL on the pre-fix implementation:
+# the first with `TypeError: list indices must be integers or slices, not
+# str`, the second the same way.
+
+
+class _DelimiterAwareS3:
+    """S3 fake that honours ``Delimiter`` the way the real API does.
+
+    With ``Delimiter="/"`` the real ``list_objects_v2`` returns only keys
+    with no further ``/`` after the prefix under ``Contents``; anything
+    deeper is collapsed into ``CommonPrefixes``. The pre-existing
+    ``_FakeS3`` in this module ignores ``Delimiter`` entirely, so it cannot
+    tell the fixed implementation from the broken one — hence this second
+    fake rather than a change to that one (other tests depend on it).
+    """
+
+    def __init__(self, keys_and_bodies: dict[str, bytes]):
+        self._bodies = keys_and_bodies
+
+    def get_paginator(self, name):
+        assert name == "list_objects_v2"
+        outer = self
+
+        class _P:
+            def paginate(self, **kwargs):
+                prefix = kwargs.get("Prefix", "")
+                delimiter = kwargs.get("Delimiter")
+                contents, common = [], set()
+                for k in outer._bodies:
+                    if not k.startswith(prefix):
+                        continue
+                    rest = k[len(prefix):]
+                    if delimiter and delimiter in rest:
+                        common.add(prefix + rest.split(delimiter, 1)[0] + delimiter)
+                    else:
+                        contents.append({"Key": k})
+                page = {}
+                if contents:
+                    page["Contents"] = contents
+                if common:
+                    page["CommonPrefixes"] = [{"Prefix": p} for p in sorted(common)]
+                return [page or {}]
+
+        return _P()
+
+    def get_object(self, Bucket, Key):
+        body = MagicMock()
+        body.read.return_value = self._bodies[Key]
+        return {"Body": body}
+
+
+def test_nested_phase_artifacts_are_not_read_as_markers(monkeypatch):
+    """A phase artifact under .phases/{phase}/ is not a marker.
+
+    Measured live on backtest/2026-08-28/.phases/: simulation_setup.json is
+    a well-formed marker, and simulation_setup/dates.json — declared in
+    that marker's own artifact_keys — is a JSON ARRAY. Without
+    Delimiter="/" the sweep read the array as a marker and died.
+    """
+    from validators import phase_marker_sweep
+
+    s3 = _DelimiterAwareS3({
+        "backtest/2026-08-28/.phases/simulation_setup.json": _marker(
+            "simulation_setup", "ok"
+        ),
+        "backtest/2026-08-28/.phases/simulation_setup/dates.json": json.dumps(
+            ["2026-03-05", "2026-03-06"]
+        ).encode(),
+    })
+    monkeypatch.setattr(
+        phase_marker_sweep, "boto3", MagicMock(client=lambda *a, **k: s3)
+    )
+
+    result = phase_marker_sweep.sweep(run_date="2026-08-28", alert=False)
+
+    assert result["status"] == "ok", result
+    assert result["checked_count"] == 1
+    assert result["error_phases"] == []
+    assert result["malformed_markers"] == []
+
+
+def test_non_dict_top_level_marker_is_a_named_finding_not_a_crash(monkeypatch):
+    """A top-level marker that parses to a non-object is reported, not fatal.
+
+    json.loads accepts an array, so the pre-fix
+    ``except (JSONDecodeError, ValueError)`` guard never saw it. Fail loud
+    with the key named — a marker the sweep cannot read must not be
+    indistinguishable from a healthy phase, and must not present as an
+    opaque stage=s3_list harness fault.
+    """
+    from validators import phase_marker_sweep
+
+    s3 = _DelimiterAwareS3({
+        "backtest/2026-08-28/.phases/good.json": _marker("good", "ok"),
+        "backtest/2026-08-28/.phases/bad.json": json.dumps([1, 2, 3]).encode(),
+    })
+    monkeypatch.setattr(
+        phase_marker_sweep, "boto3", MagicMock(client=lambda *a, **k: s3)
+    )
+
+    result = phase_marker_sweep.sweep(run_date="2026-08-28", alert=False)
+
+    assert result["status"] == "malformed_markers_detected", result
+    assert result["checked_count"] == 1
+    assert [m["s3_key"] for m in result["malformed_markers"]] == [
+        "backtest/2026-08-28/.phases/bad.json"
+    ]
+    assert "list" in result["malformed_markers"][0]["reason"]
+
+
+def test_malformed_marker_exits_1_not_2(monkeypatch):
+    """An unreadable marker is a finding (exit 1), not a sweep-infra fault (2).
+
+    substrate_health_check.sh treats this sweep as a gating check, so the
+    distinction is what separates "a phase marker is broken" from "the
+    sweep could not run" on the surface that reports it.
+    """
+    from validators import phase_marker_sweep
+
+    s3 = _DelimiterAwareS3({
+        "backtest/2026-08-28/.phases/bad.json": json.dumps([1]).encode(),
+    })
+    monkeypatch.setattr(
+        phase_marker_sweep, "boto3", MagicMock(client=lambda *a, **k: s3)
+    )
+
+    rc = phase_marker_sweep.main(
+        ["--run-date", "2026-08-28", "--no-alert"]
+    )
+    assert rc == 1

--- a/validators/phase_marker_sweep.py
+++ b/validators/phase_marker_sweep.py
@@ -68,26 +68,64 @@ _PHASE_PREFIX_TEMPLATE = "backtest/{run_date}/.phases/"
 _ALERT_PREVIEW_LIMIT = 10
 
 
-def _list_phase_markers(bucket: str, run_date: str) -> list[dict]:
-    """List and parse every phase marker under backtest/{run_date}/.phases/."""
+def _list_phase_markers(bucket: str, run_date: str) -> tuple[list[dict], list[dict]]:
+    """Parse the phase markers directly under backtest/{run_date}/.phases/.
+
+    Returns ``(markers, malformed)`` — the well-formed markers, and one
+    ``{"s3_key", "reason"}`` entry per object under the marker prefix that
+    could not be read as a marker.
+
+    **``Delimiter="/"`` is load-bearing (alpha-engine-config-I9262).** A
+    phase marker declares its own outputs in ``artifact_keys``, and the
+    backtester writes those artifacts one level DOWN, under
+    ``.phases/{phase}/``. Listing the prefix without a delimiter walks that
+    whole subtree and hands this function objects that were never markers.
+    Measured 2026-08-29 on ``backtest/2026-08-28/.phases/``: 26 markers at
+    the top level and 10 nested ``*.json`` artifacts below it, one of which
+    (``simulation_setup/dates.json``) is a JSON **array**. ``json.loads``
+    accepts an array, so the old ``except (JSONDecodeError, ValueError)``
+    guard did not catch it, and ``marker["_s3_key"] = key`` then raised
+    ``TypeError: list indices must be integers or slices, not str``. The
+    caller's blanket ``except`` turned that code fault into
+    ``stage=s3_list``, the shell scored it as a gating failure, and the
+    weekly run terminated ``SubstrateHealthCheckDegraded`` having never
+    computed a phase verdict at all.
+
+    A non-dict body is therefore reported as a NAMED malformed marker
+    rather than crashing the sweep or being silently dropped: a marker this
+    sweep cannot read is exactly the condition it exists to surface, and a
+    skip would make it indistinguishable from a healthy phase.
+    """
     s3 = boto3.client("s3")
     prefix = _PHASE_PREFIX_TEMPLATE.format(run_date=run_date)
     markers: list[dict] = []
+    malformed: list[dict] = []
     paginator = s3.get_paginator("list_objects_v2")
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-        for obj in page.get("Contents", []):
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
+        for obj in page.get("Contents", []) or []:
             key = obj["Key"]
             if not key.endswith(".json"):
                 continue
             body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
             try:
                 marker = json.loads(body)
-            except (json.JSONDecodeError, ValueError):
-                logger.warning("Unparseable phase marker %s — skipping", key)
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.error("Unparseable phase marker %s: %s", key, exc)
+                malformed.append({"s3_key": key, "reason": f"unparseable: {exc}"})
+                continue
+            if not isinstance(marker, dict):
+                logger.error(
+                    "Phase marker %s parsed to %s, not an object — cannot be "
+                    "read as a marker", key, type(marker).__name__,
+                )
+                malformed.append({
+                    "s3_key": key,
+                    "reason": f"parsed to {type(marker).__name__}, expected object",
+                })
                 continue
             marker["_s3_key"] = key
             markers.append(marker)
-    return markers
+    return markers, malformed
 
 
 def sweep(
@@ -110,12 +148,13 @@ def sweep(
         alert_severity: severity tag for the published alert.
 
     Returns:
-        dict with keys: status (`ok` | `phase_errors_detected` | `error`),
-        run_date, checked_count, error_phases (list of
-        {phase, error, s3_key}).
+        dict with keys: status (`ok` | `phase_errors_detected` |
+        `malformed_markers_detected` | `error`), run_date,
+        checked_count, error_phases (list of {phase, error, s3_key}),
+        malformed_markers (list of {s3_key, reason}).
     """
     try:
-        markers = _list_phase_markers(bucket, run_date)
+        markers, malformed_markers = _list_phase_markers(bucket, run_date)
     except Exception as exc:
         logger.exception("Phase marker list/read failed")
         return {"status": "error", "error": str(exc), "stage": "s3_list"}
@@ -131,16 +170,34 @@ def sweep(
     ]
 
     logger.info(
-        "Phase marker sweep run_date=%s: checked=%d error=%d",
-        run_date, len(markers), len(error_phases),
+        "Phase marker sweep run_date=%s: checked=%d error=%d malformed=%d",
+        run_date, len(markers), len(error_phases), len(malformed_markers),
     )
 
+    if error_phases:
+        status = "phase_errors_detected"
+    elif malformed_markers:
+        # A marker that cannot be read is a finding with a name, not a pass
+        # and not a harness fault (alpha-engine-config-I9262).
+        status = "malformed_markers_detected"
+    else:
+        status = "ok"
+
     result = {
-        "status": "phase_errors_detected" if error_phases else "ok",
+        "status": status,
         "run_date": run_date,
         "checked_count": len(markers),
         "error_phases": error_phases,
+        "malformed_markers": malformed_markers,
     }
+
+    if malformed_markers:
+        logger.error(
+            "MALFORMED PHASE MARKERS: %d object(s) under backtest/%s/.phases/ "
+            "could not be read as markers: %s",
+            len(malformed_markers), run_date,
+            [m["s3_key"] for m in malformed_markers],
+        )
 
     if error_phases and alert:
         try:
@@ -228,6 +285,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         logger.error("Phase-marker sweep failed at stage=%s: %s",
                      result.get("stage"), result.get("error"))
         return 2
+
+    if result["status"] == "malformed_markers_detected":
+        logger.error(
+            "MALFORMED PHASE MARKERS: %d object(s) unreadable as markers on "
+            "run_date=%s: %s",
+            len(result["malformed_markers"]),
+            args.run_date,
+            [m["s3_key"] for m in result["malformed_markers"]],
+        )
+        return 1
 
     if result["status"] == "phase_errors_detected":
         logger.error(


### PR DESCRIPTION
Tracked issue: `alpha-engine-config-I9262` (cross-repo tracker — GitHub closing keywords are inert across repositories, so this does not auto-close; the issue is closed by hand after merge with the verified property named).

## What

The 2026-08-29 weekly SF run reached `SubstrateHealthCheckDegraded` on a `TypeError` inside this sweep, not on a health finding.

```
File "validators/phase_marker_sweep.py", line 88, in _list_phase_markers
  marker["_s3_key"] = key
TypeError: list indices must be integers or slices, not str
...
substrate_health_check.sh: EXIT 1 — 1 gating check(s) failed: phase marker sweep (rc=2)
```

Evidence: `s3://alpha-engine-research/_ssm_logs/substrate-health-check/2026-08-29/ip-172-31-42-218.ec2.internal-140111Z-965d925b-....log`. The `STAGE OUTPUT MISSING: 6 declared artifact(s)` line in the same log is **not** the cause — it is stamped `[OBSERVE mode — exiting 0 by design]`. The phase marker sweep was the only gating check that failed, and it failed on a crash.

## Root cause

`_list_phase_markers` paginated `backtest/{run_date}/.phases/` with **no `Delimiter`**, so it walked the whole subtree and read the phase *artifacts* the markers themselves declare in `artifact_keys`. Measured on `backtest/2026-08-28/.phases/`: 26 markers at the top level, and 10 nested `*.json` artifacts below it —

```
executor_optimizer/executor_rec.json
predictor_data_prep/{metadata,predictions_by_date,sector_map,trading_dates}.json
predictor_feature_maps_bulk_load/{atr_by_ticker,coverage_by_ticker}.json
predictor_single_run/single_stats.json
simulate/portfolio_stats.json
simulation_setup/dates.json      <-- a JSON ARRAY
```

`json.loads` accepts an array, so the existing `except (JSONDecodeError, ValueError)` guard never saw it. `sweep()`'s blanket `except` then converted a code fault into `{"status": "error", "stage": "s3_list"}`, which the shell scored as a gating failure — a harness fault reported as a substrate health finding, with the run's actual phase verdict never computed. The same subdirectory layout is present under `backtest/2026-08-21/.phases/`, so this is not new to 2026-08-28.

## Change

- `Delimiter="/"` on the `paginate` call. Nested artifacts are not markers and must never be read as such. Primary fix.
- A body that parses to a non-`dict` is reported as a **named** malformed marker rather than crashing. Fail loud with the key.

### Contract change

An unreadable marker no longer scores `ok`. It previously warned and dropped, and the sweep then reported a clean bill of health for a run whose phase outcome it had just failed to read — `no data` rendered as green (`principles.md` §2.7) on the one surface that exists to say whether a non-fatal backtester phase errored. New status `malformed_markers_detected` exits **1** (a finding) rather than **2** (a sweep-infra fault); report-not-abort is unchanged, and `substrate_health_check.sh` already gates on any non-zero.

`tests/test_phase_marker_sweep.py::test_sweep_unparseable_marker_skipped_not_fatal` is renamed and its assertion updated, with the rationale in its docstring.

## Not softened

The sweep still reports every `status=error` marker and still exits non-zero. Nothing here changes what it reports.

## Tests

Three new regressions plus the updated one. Verified failing on `main` — the first two with the exact production `TypeError`. A second S3 fake (`_DelimiterAwareS3`) was needed because the pre-existing `_FakeS3` ignores `Delimiter` and so cannot tell the fixed implementation from the broken one.

Full local suite: **6789 passed, 17 skipped**.

## Cross-repo

Same weekly run, independent defects, no shared files — **merge order does not matter**:

- `crucible-research-PR757` — `alpha-engine-config-I9261`, cost fan-in coverage reads `_cost_raw/{run_date}/` while producers partition by UTC record `ts`.

Not fixed here, filed: `alpha-engine-config-I9263`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
