### PR TITLE
fix(macro): refuse any write that truncates a macro series (alpha-engine-config-I9256)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -252,6 +252,122 @@ def _existing_last_date(lib, symbol: str) -> "pd.Timestamp | None":
     return last.normalize()
 
 
+# History-truncation tolerance for the macro/sector regression preflight.
+# A legitimate source restatement can drop a handful of rows (a vendor
+# correcting bad prints, a holiday reclassification). Losing more than this
+# many rows, or moving the series' FIRST date forward at all, is a producer
+# defect — see alpha-engine-config-I9256: ``VIX3M`` went 2509 rows ->
+# 16 rows across two consecutive Saturday backfills (2026-08-22 10:42 UTC
+# and 2026-08-29 10:48 UTC) because a 1-row ``reference/price_cache/
+# VIX3M.parquet`` was written wholesale over a 10y ArcticDB series. The
+# pre-existing preflight compared LAST DATE only, so a series that keeps
+# today's date while losing 2493 rows of history passed clean.
+_MACRO_HISTORY_SHRINK_TOLERANCE_ROWS = 5
+
+
+def _series_row_span(series_or_df) -> "tuple[int, pd.Timestamp | None]":
+    """``(n_rows, first_date)`` for a planned Series/DataFrame."""
+    if series_or_df is None:
+        return 0, None
+    idx = series_or_df.index
+    if idx is None or len(idx) == 0:
+        return 0, None
+    first = pd.Timestamp(idx[0])
+    if first.tzinfo is not None:
+        first = first.tz_convert("UTC").tz_localize(None)
+    return len(idx), first.normalize()
+
+
+def _existing_row_span(lib, symbol: str) -> "tuple[int, pd.Timestamp | None]":
+    """``(n_rows, first_date)`` for an existing ArcticDB symbol.
+
+    Returns ``(0, None)`` when the symbol does not exist yet — a first write
+    is never a regression. Any OTHER read failure RAISES: silently treating an
+    unreadable symbol as absent is exactly how a truncating write gets waved
+    through (fail-loud rule, AGENTS.md "no silent degrade on a producer").
+    """
+    try:
+        df = lib.read(symbol).data
+    except Exception as exc:
+        if _symbol_absent(lib, symbol):
+            return 0, None
+        raise RuntimeError(
+            f"Macro history guard: could not read existing ArcticDB symbol "
+            f"{symbol!r} to check for truncation: {exc}"
+        ) from exc
+    if df is None or df.empty:
+        return 0, None
+    first = pd.Timestamp(df.index[0])
+    if first.tzinfo is not None:
+        first = first.tz_convert("UTC").tz_localize(None)
+    return len(df), first.normalize()
+
+
+def _symbol_absent(lib, symbol: str) -> bool:
+    """True when ``symbol`` genuinely does not exist in ``lib``."""
+    try:
+        return not lib.has_symbol(symbol)
+    except Exception:
+        try:
+            return symbol not in set(lib.list_symbols())
+        except Exception:
+            return False
+
+
+def _history_regression(
+    label: str,
+    planned,
+    existing_rows: int,
+    existing_first: "pd.Timestamp | None",
+) -> "str | None":
+    """Return a human-readable regression string, or None when the write is safe."""
+    planned_rows, planned_first = _series_row_span(planned)
+    if existing_rows == 0:
+        return None
+    if planned_rows < existing_rows - _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS:
+        return (
+            f"{label}: planned_rows={planned_rows} < existing_rows={existing_rows} "
+            f"(tolerance {_MACRO_HISTORY_SHRINK_TOLERANCE_ROWS})"
+        )
+    if (
+        planned_first is not None
+        and existing_first is not None
+        and planned_first > existing_first
+    ):
+        return (
+            f"{label}: planned_first={planned_first.date()} > "
+            f"existing_first={existing_first.date()} (history start moved forward)"
+        )
+    return None
+
+
+def _write_macro_series_no_shrink(lib, symbol: str, df: "pd.DataFrame") -> None:
+    """Write a full macro series, REFUSING any write that would truncate it.
+
+    The write boundary is the last line of defence: ``_assert_no_arctic_regression``
+    runs once per backfill over the planned frames, but the per-ticker
+    ``--rebuild-macro`` override and any future call site reach the library
+    directly. A wholesale ``lib.write()`` is destructive — ArcticDB keeps prior
+    versions, but every reader sees the truncated head immediately and the
+    predictor's ``dropna()`` turns one short optional column into a total loss
+    of the regime frame (alpha-engine-config-I9255 / I9256).
+
+    Raises RuntimeError rather than degrading: a producer that has lost its
+    own history must page, not publish.
+    """
+    existing_rows, existing_first = _existing_row_span(lib, symbol)
+    regression = _history_regression(f"macro.{symbol}", df, existing_rows, existing_first)
+    if regression is not None:
+        raise RuntimeError(
+            "Macro write refused — it would TRUNCATE an existing series. "
+            f"{regression}. Source is the price_cache parquet + daily_closes delta; "
+            "check reference/price_cache/"
+            f"{symbol}.parquet row count before re-running. "
+            "See alpha-engine-config-I9256."
+        )
+    lib.write(symbol, df)
+
+
 def _assert_no_arctic_regression(
     bucket: str,
     planned_macro: dict[str, "pd.Series"],
@@ -301,12 +417,18 @@ def _assert_no_arctic_regression(
     for key, series in planned_macro.items():
         planned_last = _planned_last_date(series)
         existing_last = _existing_last_date(macro_lib, key)
-        if planned_last is None or existing_last is None:
-            continue
-        if planned_last < existing_last:
+        if planned_last is not None and existing_last is not None and planned_last < existing_last:
             regressions.append(
                 f"macro.{key}: planned={planned_last.date()} < existing={existing_last.date()}"
             )
+        # HISTORY-length regression (alpha-engine-config-I9256). The last-date
+        # check above is blind to a series that still ends today but has lost
+        # every row before last month — which is exactly how VIX3M went from
+        # 2509 rows to 16 while passing this preflight clean twice.
+        existing_rows, existing_first = _existing_row_span(macro_lib, key)
+        hist = _history_regression(f"macro.{key}", series, existing_rows, existing_first)
+        if hist is not None:
+            regressions.append(hist)
 
     try:
         arctic_syms = set(universe_lib.list_symbols())
@@ -796,14 +918,18 @@ def backfill(
                 if series is not None:
                     macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
                     macro_series_df.index.name = "date"
-                    macro_lib.write(key, to_arctic_safe(macro_series_df))
+                    _write_macro_series_no_shrink(
+                        macro_lib, key, to_arctic_safe(macro_series_df)
+                    )
 
             # Write sector ETFs
             for key in macro:
                 if key.startswith("XL"):
                     sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
                     sector_df.index.name = "date"
-                    macro_lib.write(key, to_arctic_safe(sector_df))
+                    _write_macro_series_no_shrink(
+                        macro_lib, key, to_arctic_safe(sector_df)
+                    )
 
     # ── 5b. Factor-momentum second pass (W2.3, L4469) ────────────────────────
     # ``factor_momentum_ratio`` is a cross-sectional-time-series feature: date

--- a/builders/repair_macro_series.py
+++ b/builders/repair_macro_series.py
@@ -46,6 +46,7 @@ from builders._price_cache_writeboth import (
     price_cache_read_prefixes,
     price_cache_write_prefixes,
 )
+from collectors.daily_closes import _FRED_INDEX_MAP
 from collectors.prices import _CARET_SYMBOLS
 from store.arctic_store import DEFAULT_BUCKET, get_macro_lib
 
@@ -62,8 +63,8 @@ def _yf_symbol(symbol: str) -> str:
     return f"^{symbol}" if symbol in _CARET_SYMBOLS else symbol
 
 
-def fetch_full_history(symbol: str, period: str = DEFAULT_FETCH_PERIOD) -> pd.DataFrame:
-    """Fetch ``period`` of daily OHLCV for ``symbol``. Raises on an empty answer."""
+def _fetch_yfinance(symbol: str, period: str = DEFAULT_FETCH_PERIOD) -> pd.DataFrame:
+    """Fetch ``period`` of daily OHLCV for ``symbol`` from yfinance."""
     import yfinance as yf
 
     from nousergon_lib.yfinance_quiet import yf_quiet
@@ -97,6 +98,79 @@ def fetch_full_history(symbol: str, period: str = DEFAULT_FETCH_PERIOD) -> pd.Da
     if out.empty:
         raise RuntimeError(f"Repair fetch for {symbol} produced an empty frame after cleaning")
     return out
+
+
+def _fetch_fred(symbol: str, period: str = DEFAULT_FETCH_PERIOD) -> pd.DataFrame:
+    """Fetch full history for an index ticker from FRED.
+
+    The four index tickers (``VIX``/``VIX3M``/``TNX``/``IRX``) already have a
+    declared FRED series in ``collectors/daily_closes.py::_FRED_INDEX_MAP`` —
+    that is how ``daily_closes`` gets their DAILY bar, since they are not on
+    polygon. FRED is therefore the canonical, non-yfinance source for exactly
+    these symbols, which matters here: measured 2026-08-29, yfinance answers a
+    ``^VIX3M`` 10y request with 2484 rows from a laptop and **1 row** from an
+    EC2 host in us-east-1 — and the weekly collector runs on EC2.
+    """
+    from collectors.fred_history import fetch_fred_history
+
+    series_id = _FRED_INDEX_MAP.get(symbol)
+    if series_id is None:
+        raise RuntimeError(f"No FRED series declared for {symbol} in _FRED_INDEX_MAP")
+    years = int(period.rstrip("y")) if period.endswith("y") and period[:-1].isdigit() else 10
+    fred_df = fetch_fred_history(series_id, period_years=years)
+    val = fred_df["value"].astype(float)
+    out = pd.DataFrame(
+        {"Open": val, "High": val, "Low": val, "Close": val, "Volume": 0},
+        index=pd.to_datetime(fred_df.index).normalize(),
+    )
+    out = out[~out.index.duplicated(keep="last")].sort_index()
+    out.index.name = "date"
+    if out.empty:
+        raise RuntimeError(f"FRED fetch for {symbol} ({series_id}) returned no rows")
+    return out
+
+
+def fetch_full_history(
+    symbol: str,
+    period: str = DEFAULT_FETCH_PERIOD,
+    source: str = "auto",
+) -> pd.DataFrame:
+    """Fetch full history for ``symbol``, taking the LONGEST answer available.
+
+    ``source="auto"`` (default) queries yfinance and, for symbols with a
+    declared FRED series, FRED as well, and keeps whichever returned more rows.
+    That is deliberate rather than a preference order: the failure this repairs
+    is a source silently answering short, so the repair must never depend on one
+    source being healthy. Every attempt that fails is reported; only ALL of them
+    failing raises.
+    """
+    attempts: list[tuple[str, pd.DataFrame]] = []
+    errors: list[str] = []
+
+    wanted = []
+    if source in ("auto", "yfinance"):
+        wanted.append(("yfinance", _fetch_yfinance))
+    if source in ("auto", "fred") and symbol in _FRED_INDEX_MAP:
+        wanted.append(("fred", _fetch_fred))
+    if not wanted:
+        raise RuntimeError(f"No usable source for {symbol} with source={source!r}")
+
+    for name, fn in wanted:
+        try:
+            df = fn(symbol, period)
+        except Exception as exc:  # noqa: BLE001 - every failure is reported below
+            errors.append(f"{name}: {exc}")
+            continue
+        log.info("%s: %s returned %d rows (%s -> %s)",
+                 symbol, name, len(df), df.index.min().date(), df.index.max().date())
+        attempts.append((name, df))
+
+    if not attempts:
+        raise RuntimeError(f"All sources failed for {symbol}: {'; '.join(errors)}")
+
+    best_name, best = max(attempts, key=lambda kv: len(kv[1]))
+    log.info("%s: using %s (%d rows)", symbol, best_name, len(best))
+    return best
 
 
 def union_no_shrink(existing: pd.DataFrame | None, fetched: pd.DataFrame, label: str) -> pd.DataFrame:
@@ -146,13 +220,14 @@ def repair_symbol(
     bucket: str = DEFAULT_BUCKET,
     s3_prefix: str = "predictor/price_cache/",
     period: str = DEFAULT_FETCH_PERIOD,
+    source: str = "auto",
     dry_run: bool = False,
 ) -> dict:
     """Repair one macro symbol end to end. Returns a per-symbol result dict."""
     s3 = boto3.client("s3")
     macro_lib = get_macro_lib(bucket)
 
-    fetched = fetch_full_history(symbol, period=period)
+    fetched = fetch_full_history(symbol, period=period, source=source)
 
     existing_pq = _read_parquet(s3, bucket, s3_prefix, symbol)
     pq_before = 0 if existing_pq is None else len(existing_pq)
@@ -214,6 +289,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--bucket", default=DEFAULT_BUCKET)
     parser.add_argument("--s3-prefix", default="predictor/price_cache/")
     parser.add_argument("--period", default=DEFAULT_FETCH_PERIOD)
+    parser.add_argument("--source", default="auto", choices=["auto", "yfinance", "fred"],
+                        help="auto (default) takes the LONGEST of yfinance and FRED")
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
@@ -226,6 +303,7 @@ def main(argv: list[str] | None = None) -> int:
             bucket=args.bucket,
             s3_prefix=args.s3_prefix,
             period=args.period,
+            source=args.source,
             dry_run=args.dry_run,
         )
         log.info("repair %s: %s", symbol, json.dumps(res, default=str))

--- a/builders/repair_macro_series.py
+++ b/builders/repair_macro_series.py
@@ -1,0 +1,239 @@
+"""Repair a truncated macro series in the ArcticDB ``macro`` library and its
+price-cache parquet, from the canonical upstream source.
+
+Origin: alpha-engine-config-I9256 / I9255. ``macro/VIX3M`` fell from 2509 rows
+to 16 across the 2026-08-22 and 2026-08-29 Saturday backfills because
+``reference/price_cache/VIX3M.parquet`` had itself been overwritten with a
+1-row yfinance response. ``builders/backfill.py`` then rewrote the ArcticDB
+symbol wholesale from that parquet plus the ~16-trading-day ``daily_closes``
+delta, which is why the surviving window slid forward one week at a time.
+
+This module is the AUTOMATED repair for that class — a committed, idempotent,
+re-runnable CLI rather than an operator procedure. It:
+
+  1. fetches full history for each named symbol from the canonical source
+     (yfinance; ``^``-prefixed for the index tickers, matching
+     ``collectors/prices.py::_CARET_SYMBOLS``),
+  2. UNIONS it with whatever the price-cache parquet and the ArcticDB symbol
+     already hold — existing rows are never dropped, fetched rows win on
+     overlapping dates,
+  3. refuses to write anything that would leave either store with fewer rows
+     than it started with,
+  4. reads both back and reports the row count actually observed.
+
+Run IN-REGION (AGENTS.md: manual one-off production data-repo writes run on an
+EC2 box in the bucket's region, never from the laptop). ``--dry-run`` is
+read-only and safe anywhere.
+
+Usage::
+
+    python -m builders.repair_macro_series --symbols VIX3M
+    python -m builders.repair_macro_series --symbols VIX3M --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import sys
+
+import boto3
+import pandas as pd
+
+from builders._price_cache_writeboth import (
+    price_cache_read_prefixes,
+    price_cache_write_prefixes,
+)
+from collectors.prices import _CARET_SYMBOLS
+from store.arctic_store import DEFAULT_BUCKET, get_macro_lib
+
+log = logging.getLogger(__name__)
+
+# Fetch window. Matches ``collectors/prices.py``'s production ``fetch_period``
+# so a repaired series has exactly the span the weekly refresh would maintain.
+DEFAULT_FETCH_PERIOD = "10y"
+
+_OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+
+
+def _yf_symbol(symbol: str) -> str:
+    return f"^{symbol}" if symbol in _CARET_SYMBOLS else symbol
+
+
+def fetch_full_history(symbol: str, period: str = DEFAULT_FETCH_PERIOD) -> pd.DataFrame:
+    """Fetch ``period`` of daily OHLCV for ``symbol``. Raises on an empty answer."""
+    import yfinance as yf
+
+    from nousergon_lib.yfinance_quiet import yf_quiet
+
+    @yf_quiet
+    def _dl() -> pd.DataFrame:
+        return yf.download(
+            _yf_symbol(symbol),
+            period=period,
+            interval="1d",
+            auto_adjust=True,
+            progress=False,
+            threads=False,
+        )
+
+    raw = _dl()
+    if isinstance(raw.columns, pd.MultiIndex):
+        raw.columns = raw.columns.get_level_values(0)
+    if raw is None or raw.empty or "Close" not in raw.columns:
+        raise RuntimeError(
+            f"Repair fetch for {symbol} ({_yf_symbol(symbol)}) returned no usable rows"
+        )
+    out = raw[[c for c in _OHLCV_COLS if c in raw.columns]].copy()
+    out = out.dropna(subset=["Close"])
+    idx = pd.to_datetime(out.index)
+    if idx.tz is not None:
+        idx = idx.tz_convert("UTC").tz_localize(None)
+    out.index = idx.normalize()
+    out = out[~out.index.duplicated(keep="last")].sort_index()
+    out.index.name = "date"
+    if out.empty:
+        raise RuntimeError(f"Repair fetch for {symbol} produced an empty frame after cleaning")
+    return out
+
+
+def union_no_shrink(existing: pd.DataFrame | None, fetched: pd.DataFrame, label: str) -> pd.DataFrame:
+    """Union ``existing`` and ``fetched`` (fetched wins on overlap); never shrink.
+
+    Raises if the union somehow holds fewer rows than ``existing`` — that would
+    mean a column/index contract violation, and a repair that loses rows is the
+    defect it is repairing.
+    """
+    if existing is None or existing.empty:
+        return fetched
+    common = [c for c in fetched.columns if c in existing.columns]
+    if not common:
+        # Existing store keeps a narrower schema (the macro lib is Close-only).
+        # Project the fetch onto the existing columns so the union is well-formed.
+        common = [c for c in existing.columns if c in fetched.columns]
+    if not common:
+        raise RuntimeError(
+            f"{label}: existing columns {list(existing.columns)} and fetched columns "
+            f"{list(fetched.columns)} do not overlap — refusing to write"
+        )
+    merged = pd.concat([existing[common], fetched[common]])
+    merged = merged[~merged.index.duplicated(keep="last")].sort_index()
+    merged.index.name = existing.index.name or "date"
+    if len(merged) < len(existing):
+        raise RuntimeError(
+            f"{label}: union produced {len(merged)} rows from an existing {len(existing)} — "
+            "refusing to write a shrinking repair"
+        )
+    return merged
+
+
+def _read_parquet(s3, bucket: str, s3_prefix: str, symbol: str) -> pd.DataFrame | None:
+    for prefix in price_cache_read_prefixes(s3_prefix):
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=f"{prefix}{symbol}.parquet")
+        except s3.exceptions.NoSuchKey:
+            continue
+        df = pd.read_parquet(io.BytesIO(obj["Body"].read()))
+        df.index = pd.to_datetime(df.index).normalize()
+        return df
+    return None
+
+
+def repair_symbol(
+    symbol: str,
+    bucket: str = DEFAULT_BUCKET,
+    s3_prefix: str = "predictor/price_cache/",
+    period: str = DEFAULT_FETCH_PERIOD,
+    dry_run: bool = False,
+) -> dict:
+    """Repair one macro symbol end to end. Returns a per-symbol result dict."""
+    s3 = boto3.client("s3")
+    macro_lib = get_macro_lib(bucket)
+
+    fetched = fetch_full_history(symbol, period=period)
+
+    existing_pq = _read_parquet(s3, bucket, s3_prefix, symbol)
+    pq_before = 0 if existing_pq is None else len(existing_pq)
+    merged_pq = union_no_shrink(existing_pq, fetched, f"price_cache.{symbol}")
+
+    try:
+        existing_arctic = macro_lib.read(symbol).data
+        existing_arctic.index = pd.to_datetime(existing_arctic.index).normalize()
+    except Exception:
+        existing_arctic = None
+    arctic_before = 0 if existing_arctic is None else len(existing_arctic)
+
+    close_frame = pd.DataFrame({"Close": fetched["Close"]}, index=fetched.index)
+    close_frame.index.name = "date"
+    merged_arctic = union_no_shrink(existing_arctic, close_frame, f"macro.{symbol}")
+
+    result = {
+        "symbol": symbol,
+        "fetched_rows": len(fetched),
+        "parquet_rows_before": pq_before,
+        "parquet_rows_planned": len(merged_pq),
+        "arctic_rows_before": arctic_before,
+        "arctic_rows_planned": len(merged_arctic),
+        "first_date": str(merged_arctic.index.min().date()),
+        "last_date": str(merged_arctic.index.max().date()),
+        "dry_run": dry_run,
+    }
+
+    if dry_run:
+        result["status"] = "ok_dry_run"
+        return result
+
+    buf = io.BytesIO()
+    merged_pq.to_parquet(buf, engine="pyarrow", compression="snappy")
+    body = buf.getvalue()
+    for prefix in price_cache_write_prefixes(s3_prefix):
+        s3.put_object(Bucket=bucket, Key=f"{prefix}{symbol}.parquet", Body=body)
+
+    macro_lib.write(symbol, merged_arctic)
+
+    readback = macro_lib.read(symbol).data
+    result["arctic_rows_after"] = len(readback)
+    result["arctic_first_after"] = str(pd.Timestamp(readback.index.min()).date())
+    result["arctic_last_after"] = str(pd.Timestamp(readback.index.max()).date())
+    if len(readback) < len(merged_arctic):
+        raise RuntimeError(
+            f"macro.{symbol}: readback {len(readback)} rows < written {len(merged_arctic)}"
+        )
+    pq_after = _read_parquet(s3, bucket, s3_prefix, symbol)
+    result["parquet_rows_after"] = 0 if pq_after is None else len(pq_after)
+    result["status"] = "ok"
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", required=True,
+                        help="comma-separated macro symbols, e.g. VIX3M or VIX3M,HYOAS")
+    parser.add_argument("--bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--s3-prefix", default="predictor/price_cache/")
+    parser.add_argument("--period", default=DEFAULT_FETCH_PERIOD)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    results = []
+    for symbol in [s.strip() for s in args.symbols.split(",") if s.strip()]:
+        res = repair_symbol(
+            symbol,
+            bucket=args.bucket,
+            s3_prefix=args.s3_prefix,
+            period=args.period,
+            dry_run=args.dry_run,
+        )
+        log.info("repair %s: %s", symbol, json.dumps(res, default=str))
+        results.append(res)
+
+    print(json.dumps({"results": results}, default=str, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/collectors/prices.py
+++ b/collectors/prices.py
@@ -38,7 +38,10 @@ import boto3
 import pandas as pd
 import yfinance as yf
 
-from builders._price_cache_writeboth import price_cache_write_prefixes
+from builders._price_cache_writeboth import (
+    price_cache_read_prefixes,
+    price_cache_write_prefixes,
+)
 from nousergon_lib.yfinance_quiet import log_yf_coverage, yf_quiet
 
 logger = logging.getLogger(__name__)
@@ -193,6 +196,61 @@ def _find_stale_fast(
     return stale
 
 
+# Row count below which a "full period" yfinance refresh is treated as
+# SUSPECT and checked against what the price cache already holds.
+# ~400 trading days is ~18 months — far under the 10y (~2500 row) fetch every
+# maintained ticker returns, and comfortably over a genuinely new listing that
+# has no existing parquet to regress. Only frames under this threshold pay the
+# extra S3 GET, so the guard is free on the ~900-ticker happy path.
+_SHORT_FETCH_ROW_THRESHOLD = 400
+
+
+def _is_missing_object(s3, exc: Exception) -> bool:
+    """True when ``exc`` means "this S3 key does not exist" (and nothing else).
+
+    Deliberately narrow: every other failure (throttle, 403, transient network)
+    must NOT be read as "no existing parquet", or a short fetch would overwrite
+    a full history on a blip. Matches both the botocore ``ClientError`` code and
+    the modelled ``s3.exceptions.NoSuchKey`` class name so it holds for real
+    clients and for test doubles alike.
+    """
+    code = getattr(exc, "response", {}).get("Error", {}).get("Code") if hasattr(exc, "response") else None
+    if code in {"NoSuchKey", "NoSuchBucket", "404"}:
+        return True
+    modelled = getattr(getattr(s3, "exceptions", None), "NoSuchKey", None)
+    if isinstance(modelled, type) and isinstance(exc, modelled):
+        return True
+    return type(exc).__name__.lstrip("_") in {"NoSuchKey", "NoSuchBucketError"}
+
+
+def _existing_parquet_rows(s3, bucket: str, s3_prefix: str, ticker: str) -> int | None:
+    """Row count of the ticker's current price-cache parquet, or None if absent.
+
+    Any read failure other than "the object does not exist" RAISES — treating an
+    unreadable parquet as absent would let a short fetch overwrite a full history
+    on a transient S3 error, which is the same silent-degrade this guard exists
+    to stop.
+    """
+    import io as _io
+
+    last_exc: Exception | None = None
+    for prefix in price_cache_read_prefixes(s3_prefix):
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=f"{prefix}{ticker}.parquet")
+        except Exception as exc:  # noqa: BLE001 - classified below, never swallowed
+            if _is_missing_object(s3, exc):
+                continue
+            last_exc = exc
+            continue
+        return len(pd.read_parquet(_io.BytesIO(obj["Body"].read())))
+    if last_exc is not None:
+        raise RuntimeError(
+            f"Short-fetch guard: could not read the existing price-cache parquet "
+            f"for {ticker} to check for truncation: {last_exc}"
+        ) from last_exc
+    return None
+
+
 @yf_quiet
 def _refresh_stale(
     s3,
@@ -263,6 +321,33 @@ def _refresh_stale(
                         idx = idx.tz_convert("UTC").tz_localize(None)
                     new_df.index = idx
                     new_df = new_df.sort_index()
+
+                    # ── Short-fetch guard (alpha-engine-config-I9256) ───────
+                    # yfinance intermittently answers a full-period request with
+                    # a handful of rows (measured 2026-08-29: a 1-row
+                    # ``reference/price_cache/VIX3M.parquet`` written at
+                    # 02:44:23 UTC in the same batch that wrote a full 2515-row
+                    # VIX.parquet). Uploading that wholesale destroys the 10y
+                    # cache, and the Saturday backfill then rewrites ArcticDB
+                    # ``macro/VIX3M`` from it — 2509 rows -> 16, undetected for
+                    # two weeks. A refresh that would SHRINK the cache is a
+                    # failed refresh, not a new truth: skip the upload, count the
+                    # ticker as failed so ``status`` degrades to "partial", and
+                    # leave the good parquet in place.
+                    if len(new_df) < _SHORT_FETCH_ROW_THRESHOLD:
+                        existing_rows = _existing_parquet_rows(
+                            s3, bucket, s3_prefix, ticker
+                        )
+                        if existing_rows is not None and len(new_df) < existing_rows:
+                            logger.error(
+                                "Short-fetch REFUSED for %s: yfinance returned %d rows "
+                                "for period=%s but the existing price-cache parquet has "
+                                "%d — not uploading (existing history preserved). "
+                                "See alpha-engine-config-I9256.",
+                                ticker, len(new_df), fetch_period, existing_rows,
+                            )
+                            failed_tickers.append(ticker)
+                            continue
 
                     # Write locally and upload (Wave 3 PR1: write-both to legacy
                     # ``predictor/price_cache/`` + new ``reference/price_cache/``;

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -228,8 +228,17 @@ def test_backfill_wraps_macro_writes():
     single-source — and defends against a future writer that adds one.
     """
     assert "macro_lib.write(\"features\", to_arctic_safe(macro_df))" in _BACKFILL_SRC
-    assert "macro_lib.write(key, to_arctic_safe(macro_series_df))" in _BACKFILL_SRC
-    assert "macro_lib.write(key, to_arctic_safe(sector_df))" in _BACKFILL_SRC
+    # alpha-engine-config-I9256: the per-symbol raw-series writes now go through
+    # ``_write_macro_series_no_shrink``, which applies the same
+    # ``to_arctic_safe`` payload AND refuses a write that would truncate the
+    # symbol's history. The Categorical-strip chokepoint is unchanged — the
+    # wrapper is a guard in front of it, not a second write path.
+    assert "_write_macro_series_no_shrink(\n                        macro_lib, key, to_arctic_safe(macro_series_df)\n                    )" in _BACKFILL_SRC
+    assert "_write_macro_series_no_shrink(\n                        macro_lib, key, to_arctic_safe(sector_df)\n                    )" in _BACKFILL_SRC
+    assert "lib.write(symbol, df)" in _BACKFILL_SRC, (
+        "the no-shrink wrapper must still terminate in a single lib.write "
+        "boundary — no second, unguarded macro write path."
+    )
 
 
 # ── to_arctic_canonical chokepoint contract ──────────────────────────────────

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -76,6 +76,14 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # separate PR there — pinned here first so this repo's guard is honest
     # about the new PUT site either way.
     "scripts/fault_injection_run.py": 1,
+    # alpha-engine-config-I9256 — the macro-series repair CLI. Its single PUT
+    # site rewrites an EXISTING registered artifact,
+    # s3://alpha-engine-research/reference/price_cache/{symbol}.parquet, whose
+    # freshness is already watched via PRICE_CACHE_FRESHNESS_SENTINEL_KEY. No
+    # new artifact and no new registry row: this is an idempotent repair path
+    # for a symbol the weekly refresh already owns, so it is pinned here at its
+    # true count rather than registered or grandfathered.
+    "builders/repair_macro_series.py": 1,
     # alpha-engine-config-I7167 — the stage-output assertion's own verdict,
     # s3://alpha-engine-research/_stage_outputs/{pipeline}/{run_date}.json.
     # One PUT per weekly run, from the health-observe tail.

--- a/tests/test_macro_history_truncation_guard.py
+++ b/tests/test_macro_history_truncation_guard.py
@@ -1,0 +1,149 @@
+"""Regression tests for alpha-engine-config-I9256 — a macro series that loses
+its history must RAISE, never be written.
+
+Measured origin (2026-08-29, ArcticDB version history for ``macro/VIX3M``):
+
+    ver=353 2026-08-22 09:10:46  rows=2509 first=2016-08-19 last=2026-08-21
+    ver=354 2026-08-22 10:42:40  rows=  16 first=2026-07-31 last=2026-08-21   <-- backfill
+    ver=365 2026-08-29 09:10:52  rows=  21 first=2026-07-31 last=2026-08-28
+    ver=366 2026-08-29 10:48:39  rows=  16 first=2026-08-07 last=2026-08-28   <-- backfill
+
+Both truncating writes kept the LAST date identical, so ``_assert_no_arctic_regression``
+(which compared last dates only) passed clean. These tests fail against the
+pre-fix code.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import builders.backfill as _bf
+
+
+def _series(first: str, n: int) -> pd.Series:
+    idx = pd.bdate_range(first, periods=n)
+    return pd.Series(np.linspace(10.0, 20.0, n), index=idx)
+
+
+def _frame(first: str, n: int) -> pd.DataFrame:
+    s = _series(first, n)
+    df = pd.DataFrame({"Close": s.values}, index=s.index)
+    df.index.name = "date"
+    return df
+
+
+class _FakeLib:
+    """Minimal ArcticDB library stand-in."""
+
+    def __init__(self, data: dict[str, pd.DataFrame] | None = None):
+        self.data = dict(data or {})
+        self.writes: list[tuple[str, int]] = []
+
+    def has_symbol(self, symbol):
+        return symbol in self.data
+
+    def list_symbols(self):
+        return list(self.data)
+
+    def read(self, symbol, **kwargs):
+        if symbol not in self.data:
+            raise KeyError(symbol)
+        return type("R", (), {"data": self.data[symbol]})()
+
+    def tail(self, symbol, n=1, **kwargs):
+        if symbol not in self.data:
+            raise KeyError(symbol)
+        return type("R", (), {"data": self.data[symbol].tail(n)})()
+
+    def write(self, symbol, df, **kwargs):
+        self.data[symbol] = df
+        self.writes.append((symbol, len(df)))
+
+
+# ── the write boundary ───────────────────────────────────────────────────────
+
+def test_write_boundary_refuses_the_measured_vix3m_truncation():
+    """2509 rows -> 16 rows with the SAME last date must raise."""
+    existing = _frame("2016-08-19", 2509)
+    lib = _FakeLib({"VIX3M": existing})
+    planned = existing.tail(16)
+
+    with pytest.raises(RuntimeError, match="would TRUNCATE"):
+        _bf._write_macro_series_no_shrink(lib, "VIX3M", planned)
+
+    assert lib.writes == [], "a refused write must not reach the library"
+    assert len(lib.data["VIX3M"]) == 2509
+
+
+def test_write_boundary_refuses_a_forward_moving_history_start():
+    """Same row count, but the series start slid forward a week — still a loss."""
+    lib = _FakeLib({"VIX3M": _frame("2026-07-31", 16)})
+    planned = _frame("2026-08-07", 16)
+
+    with pytest.raises(RuntimeError, match="history start moved forward"):
+        _bf._write_macro_series_no_shrink(lib, "VIX3M", planned)
+
+
+def test_write_boundary_allows_a_normal_append():
+    lib = _FakeLib({"SPY": _frame("2016-08-19", 2513)})
+    _bf._write_macro_series_no_shrink(lib, "SPY", _frame("2016-08-19", 2514))
+    assert lib.writes == [("SPY", 2514)]
+
+
+def test_write_boundary_allows_a_first_write():
+    lib = _FakeLib({})
+    _bf._write_macro_series_no_shrink(lib, "NEWSYM", _frame("2026-07-23", 26))
+    assert lib.writes == [("NEWSYM", 26)]
+
+
+def test_write_boundary_tolerates_a_small_restatement():
+    """A vendor dropping a couple of bad prints is not a truncation."""
+    lib = _FakeLib({"GLD": _frame("2016-08-19", 2514)})
+    _bf._write_macro_series_no_shrink(lib, "GLD", _frame("2016-08-19", 2512))
+    assert lib.writes == [("GLD", 2512)]
+
+
+def test_write_boundary_raises_when_the_existing_symbol_is_unreadable():
+    """An unreadable existing symbol must not be treated as absent."""
+
+    class _Broken(_FakeLib):
+        def read(self, symbol, **kwargs):
+            raise RuntimeError("s3 timeout")
+
+    lib = _Broken({"VIX3M": _frame("2016-08-19", 2509)})
+    with pytest.raises(RuntimeError, match="could not read existing ArcticDB symbol"):
+        _bf._write_macro_series_no_shrink(lib, "VIX3M", _frame("2026-08-07", 16))
+
+
+# ── the backfill preflight ───────────────────────────────────────────────────
+
+def test_preflight_catches_a_truncation_that_keeps_the_last_date(monkeypatch):
+    """The exact 2026-08-22 shape: last date unchanged, 2509 -> 16 rows."""
+    existing = _frame("2016-08-19", 2509)
+    macro_lib = _FakeLib({"VIX3M": existing})
+    universe_lib = _FakeLib({})
+
+    monkeypatch.setattr(_bf, "get_macro_lib", lambda *a, **k: macro_lib)
+    monkeypatch.setattr(_bf, "get_universe_lib", lambda *a, **k: universe_lib)
+
+    planned_macro = {"VIX3M": existing["Close"].tail(16)}
+
+    with pytest.raises(RuntimeError, match=r"planned_rows=16 < existing_rows=2509"):
+        _bf._assert_no_arctic_regression(
+            "alpha-engine-research", planned_macro, {}, "2026-08-22",
+        )
+
+
+def test_preflight_passes_a_healthy_macro_frame(monkeypatch):
+    existing = _frame("2016-08-19", 2513)
+    macro_lib = _FakeLib({"SPY": existing})
+    universe_lib = _FakeLib({})
+    monkeypatch.setattr(_bf, "get_macro_lib", lambda *a, **k: macro_lib)
+    monkeypatch.setattr(_bf, "get_universe_lib", lambda *a, **k: universe_lib)
+
+    planned_macro = {"SPY": _series("2016-08-19", 2514)}
+    _bf._assert_no_arctic_regression(
+        "alpha-engine-research", planned_macro, {}, "2026-08-29",
+    )

--- a/tests/test_price_cache_writeboth.py
+++ b/tests/test_price_cache_writeboth.py
@@ -191,7 +191,18 @@ def test_prices_refresh_uploads_to_both_prefixes(monkeypatch, tmp_path):
 
     recorded: list[tuple[str, str]] = []
 
+    class _NoSuchKey(Exception):
+        pass
+
     class _RecordingS3:
+        # alpha-engine-config-I9256: the refresh now reads the existing parquet
+        # before overwriting it with a short frame, so the double must model a
+        # missing key rather than lacking ``get_object`` entirely.
+        exceptions = type("E", (), {"NoSuchKey": _NoSuchKey})()
+
+        def get_object(self, Bucket, Key):
+            raise _NoSuchKey(Key)
+
         def upload_file(self, _local, bucket, key):
             recorded.append((bucket, key))
 

--- a/tests/test_prices_short_fetch_guard.py
+++ b/tests/test_prices_short_fetch_guard.py
@@ -1,0 +1,113 @@
+"""Regression test for alpha-engine-config-I9256 — the ORIGIN of the macro
+truncation: ``collectors/prices.py`` uploaded whatever yfinance returned.
+
+Measured 2026-08-29: ``reference/price_cache/VIX3M.parquet`` was 4206 bytes /
+ONE row, written 02:44:23 UTC in the same refresh batch that wrote a full
+2515-row ``VIX.parquet``. A direct ``yf.download('^VIX3M', period='10y')`` run
+minutes later returned 2485 rows, so the short answer was transient — and it
+still destroyed the 10y cache, because the upload is unconditional.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import collectors.prices as _prices
+
+
+def _ohlcv(n: int) -> pd.DataFrame:
+    idx = pd.bdate_range("2016-08-19", periods=n)
+    return pd.DataFrame(
+        {
+            "Open": np.ones(n), "High": np.ones(n), "Low": np.ones(n),
+            "Close": np.linspace(10.0, 20.0, n), "Volume": np.zeros(n),
+        },
+        index=idx,
+    )
+
+
+class _NoSuchKey(Exception):
+    pass
+
+
+class _FakeS3:
+    def __init__(self, objects: dict[str, bytes]):
+        self.objects = dict(objects)
+        self.uploads: list[str] = []
+        self.exceptions = type("E", (), {"NoSuchKey": _NoSuchKey})()
+
+    def get_object(self, Bucket, Key):
+        if Key not in self.objects:
+            raise _NoSuchKey(Key)
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def upload_file(self, path, bucket, key):
+        self.uploads.append(key)
+
+
+def _parquet_bytes(df: pd.DataFrame) -> bytes:
+    buf = io.BytesIO()
+    df.to_parquet(buf, engine="pyarrow", compression="snappy")
+    return buf.getvalue()
+
+
+def _patch_download(monkeypatch, frame: pd.DataFrame):
+    monkeypatch.setattr(
+        _prices.yf, "download", lambda *a, **k: frame, raising=True,
+    )
+
+
+def test_short_fetch_does_not_overwrite_a_full_price_cache(monkeypatch):
+    """The measured VIX3M case: 1-row answer vs a 2515-row parquet."""
+    full = _ohlcv(2515)
+    s3 = _FakeS3({"reference/price_cache/VIX3M.parquet": _parquet_bytes(full)})
+    _patch_download(monkeypatch, _ohlcv(1))
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["VIX3M"], "10y", 50,
+    )
+
+    assert s3.uploads == [], "a shrinking refresh must not be uploaded"
+    assert refreshed == 0
+    assert failed == ["VIX3M"], "the ticker must be reported as failed, not silently skipped"
+
+
+def test_full_fetch_still_uploads(monkeypatch):
+    s3 = _FakeS3({"reference/price_cache/VIX.parquet": _parquet_bytes(_ohlcv(2500))})
+    _patch_download(monkeypatch, _ohlcv(2515))
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["VIX"], "10y", 50,
+    )
+    assert refreshed == 1
+    assert failed == []
+    assert s3.uploads == ["reference/price_cache/VIX.parquet"]
+
+
+def test_short_fetch_for_a_brand_new_ticker_is_allowed(monkeypatch):
+    """A genuinely new listing has no parquet to regress."""
+    s3 = _FakeS3({})
+    _patch_download(monkeypatch, _ohlcv(26))
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["NEWCO"], "10y", 50,
+    )
+    assert refreshed == 1
+    assert failed == []
+    assert s3.uploads == ["reference/price_cache/NEWCO.parquet"]
+
+
+def test_unreadable_existing_parquet_raises_rather_than_overwriting(monkeypatch):
+    class _BrokenS3(_FakeS3):
+        def get_object(self, Bucket, Key):
+            raise RuntimeError("s3 throttled")
+
+    s3 = _BrokenS3({})
+    with pytest.raises(RuntimeError, match="could not read the existing price-cache parquet"):
+        _prices._existing_parquet_rows(
+            s3, "alpha-engine-research", "predictor/price_cache/", "VIX3M",
+        )


### PR DESCRIPTION
## What

`macro/VIX3M` in the ArcticDB `macro` library fell from **2509 rows to 16** across two consecutive Saturday backfills, zeroing every `macro_*` feature and `regime_intensity_z` in the meta-model, labelling every training row regime `neutral`, and leaving the predictor with nothing to promote for the 08-21 and 08-28 vintages (`alpha-engine-config-I9255`). This PR fixes the producer so the class cannot recur, and adds the repair path for the instance.

## Measured mechanism

ArcticDB version history for `macro/VIX3M`, read live 2026-08-29 (`AWS_PROFILE=ne-admin`):

```
ver=353 2026-08-22 09:10:46  rows=  2509 first=2016-08-19 last=2026-08-21
ver=354 2026-08-22 10:42:40  rows=    16 first=2026-07-31 last=2026-08-21   <-- weekly backfill
ver=365 2026-08-29 09:10:52  rows=    21 first=2026-07-31 last=2026-08-28
ver=366 2026-08-29 10:48:39  rows=    16 first=2026-08-07 last=2026-08-28   <-- weekly backfill
```

Both truncating writes are the Saturday `builders/backfill.py` §5 macro rewrite, and **both kept the last date identical** — which is exactly why nothing fired.

Three links, each verified:

1. **Origin — `collectors/prices.py::_refresh_stale` uploads whatever yfinance returns.** `reference/price_cache/VIX3M.parquet` is **4206 bytes / ONE row**, written 2026-08-29 02:44:23 UTC in the same refresh batch that wrote a full 2515-row `VIX.parquet`.

   And the short answer is not a blip. `yf.download('^VIX3M', period='10y')` returns **2484 rows from the laptop and 1 row from an EC2 host in us-east-1** — measured on `i-00b4403ae4eb894cc`, same code, same minute, with `^VIX`/`^TNX`/`SPY` unaffected from that host. **The weekly collector runs on EC2**, so this is the standing behaviour of the source the producer trusts. The source fix is `alpha-engine-config-I9286`; this PR stops the damage.
2. **Amplifier — `builders/backfill.py` rewrites `macro/{sym}` wholesale** from `price_cache parquet ∪ daily_closes delta` with `macro_lib.write(...)`. With a 1-row parquet, the ~16-trading-day delta is the entire series — which is why the surviving window *slid forward one week at a time* rather than staying put.
3. **Blindness — `_assert_no_arctic_regression` compared LAST DATE only.** A series that still ends today while losing 2493 rows of history passed the preflight clean, twice.

## Changes

- **`collectors/prices.py`** — short-fetch guard. A refresh returning fewer rows than the cache already holds is a **failed** refresh: not uploaded, added to `failed_tickers` (so `status` degrades to `partial`), logged at ERROR. Only frames under 400 rows pay the extra `GET`, so the ~900-ticker happy path is unchanged. Absence is classified narrowly (`NoSuchKey`/404 only) — a throttle or a 403 raises rather than being read as "no existing parquet".
- **`builders/backfill.py`** — the regression preflight now also rejects a **row-count shrink** (beyond a 5-row restatement tolerance) and a **forward-moving history start**, for every macro/sector symbol.
- **`builders/backfill.py`** — `_write_macro_series_no_shrink` is now the single macro write boundary and **raises** rather than truncating. This covers the `--rebuild-macro` per-ticker override the preflight does not reach. Fail-loud, per AGENTS.md: a producer that has lost its own history pages, it does not publish.
- **`builders/repair_macro_series.py`** (new) — idempotent, re-runnable repair CLI. Fetches full history from the canonical source, **unions** it with both the parquet and the ArcticDB symbol (existing rows never dropped, fetched wins on overlap), refuses any write that would leave either store smaller, and reads back what it wrote. Automated repair, not an operator procedure.

## Tests

`tests/test_macro_history_truncation_guard.py` and `tests/test_prices_short_fetch_guard.py` reproduce the measured shapes. Verified to **fail on `origin/main`** and pass here:

- `test_preflight_catches_a_truncation_that_keeps_the_last_date` — the exact 2026-08-22 shape (2509 → 16, last date unchanged).
- `test_short_fetch_does_not_overwrite_a_full_price_cache` — the measured 1-row-vs-2515-row VIX3M case.

Plus: forward-moving history start, normal append, first write, small restatement tolerance, and unreadable-existing-symbol/parquet raising rather than being treated as absent.

Two pre-existing contract tests were updated in the same change, both because production behaviour legitimately moved:
- `tests/test_arctic_write_contract.py::test_backfill_wraps_macro_writes` — pins the new wrapper while asserting it still terminates in a single `lib.write` boundary.
- `tests/test_price_cache_writeboth.py::test_prices_refresh_uploads_to_both_prefixes` — its S3 double now models a missing key, since the refresh reads before overwriting.

Full local suite: **6798 passed, 17 skipped, 0 failed**.

## Repair status

**Done, in-region, verified live.** Run via SSM on `i-00b4403ae4eb894cc` (us-east-1) per the AGENTS.md rule — the laptop did read-only measurement only, and the repair is a committed CLI rather than a procedure handed to an operator:

```
{"symbol": "VIX3M", "fetched_rows": 2518, "parquet_rows_before": 1, "arctic_rows_before": 16,
 "arctic_rows_after": 2519, "arctic_first_after": "2016-08-22", "arctic_last_after": "2026-08-28",
 "parquet_rows_after": 2519, "status": "ok"}
```

Independently re-read from the laptop afterwards (not the writer's own readback): `macro/VIX3M` = **2519 rows, 2016-08-22 → 2026-08-28, zero NaN Close**, and the SPY-indexed overlap `RegimePredictor.build_features` actually consumes is **2514 dates with zero NaN `vix_term_slope`**, against 16 before. The parquet is repaired in the same run, so the next weekly backfill rebuilds from a full series rather than re-truncating.

## Not in scope (filed separately)

- `alpha-engine-config-I9286` — yfinance serves 1 row of `^VIX3M` history to EC2; route the four `_CARET_SYMBOLS` history fetch through the FRED series they already declare. **This is the source fix; this PR is the damage fix.**
- `alpha-engine-config-I9287` — `macro/HYOAS` frozen at 2026-05-07 for 3.5 months while its writer rewrites it weekly.
- `alpha-engine-config-I9288` — three caret-named duplicate keys in `reference/price_cache/`.
- `alpha-engine-config-I9289` — the eight sub-sector benchmark ETFs hold 26 rows each, never history-backfilled.

Refs `alpha-engine-config-I9255`, `alpha-engine-config-I9256`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8qrqxTb8AnWHkWwpawADs
