### PR TITLE
feat(overseer): register research:spec_promotion in alert_classes (alpha-engine-config-I9273)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -945,6 +945,20 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # overseer-policy.md invariant 4 (alpha-engine-config-I8991): a pageable
+    # class is a CLOSED LOOP or a TRACKED GAP, and there is no third state.
+    # This is the tracked gap, deliberately, rather than an operator_reason.
+    # Declaring it page-only-by-design would be a RULING, and two things make
+    # that ruling premature: (1) the identically-shaped twin
+    # research_cut_promotion_alerts is still grandfathered awaiting its own
+    # disposition under I8996, so closing this one would make two rows
+    # disagree about a question they answer identically; (2) the dominant
+    # firing condition — board_defective, a scanner leaderboard reporting
+    # duplicate arm rows — is a characterised producer fault with a durable
+    # artifact to read (config/apply_audit/scanner_spec_champion/{date}.json
+    # is written BEFORE the engine raises), which is playbook-shaped work and
+    # not inherently human-only. I9316 rules both rows together.
+    migration_issue: alpha-engine-config-I9316
   - class: research_weekly_ledger_alerts
     # alpha-engine-config-I8264 static-chokepoint registration. Emitted by
     # crucible-research/lambda/scanner_handler.py after

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -926,6 +926,25 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: research_spec_promotion_alerts
+    # alpha-engine-config-I9273 static-chokepoint registration. The scanner
+    # SPEC slot's promotion engine (crucible-research/scoring/spec_promotion.py
+    # ::run_spec_promotion, invoked from lambda/scanner_handler.py immediately
+    # after build_scanner_leaderboard) decides which registered arm of
+    # SCANNER_SPECS ranks the live candidate cut. Same FAIL-SOFT + LOUD shape
+    # as research_cut_promotion_alerts above and for the same reason: a
+    # promotion failure never downgrades the already-written candidates.json
+    # (the pointer keeps naming the standing champion), so this alert is the
+    # ONLY signal that no promote/demote/hold decision was recorded for the
+    # cycle. That matters more here than on the cut slot: before this engine
+    # existed the spec champion moved only by a hand-edit of LIVE_CHAMPION,
+    # which is how alpha-engine-config-I7808 produced four weeks of a
+    # leaderboard scoring an arm against itself. The call site publishes with
+    # explicit severity="ERROR".
+    source: "research:spec_promotion"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: research_weekly_ledger_alerts
     # alpha-engine-config-I8264 static-chokepoint registration. Emitted by
     # crucible-research/lambda/scanner_handler.py after


### PR DESCRIPTION
## What & why

`crucible-research-PR761` adds a new fail-soft + loud alert source, `research:spec_promotion`, emitted by `lambda/scanner_handler.py` when the scanner **SPEC** slot's promotion engine (`scoring/spec_promotion.py::run_spec_promotion`) fails to record a decision for a cycle.

An emitter shipped without its `alert_classes` row reds crucible-research's own `alert-class-pr-guard` immediately, and days later silently ejects every entry from `alpha-engine-config`'s merge queue via the fleet drift sweep — measured twice in one session, ~2h of fleet merge throughput (`alpha-engine-config-I7876`, `-I7896`). This is that row.

## Shape

Byte-for-byte the shape of `research_cut_promotion_alerts` immediately above it, and for the same reason: the promotion step never downgrades the already-written `candidates.json` (the champion pointer keeps naming the standing champion), so this alert is the **only** signal that no promote/demote/hold decision was recorded. `severities: [error]` matches the call site's explicit `severity="ERROR"`.

It matters more on this slot than on the cut slot: before `PR761` the spec champion moved only by a hand-edit of `LIVE_CHAMPION`, which is how `alpha-engine-config-I7808` produced four weeks of a leaderboard scoring an arm against itself.

## Test plan

`infrastructure/overseer/playbooks.yaml` parses and the new row sits inside the existing `alert_classes` list with the same four keys as its siblings; this repo's suite is unaffected by a data-only addition. The guard it unblocks is `crucible-research-PR761`'s `pr-added alert source must carry an alert_classes row`, which by design goes green on an **OPEN** PR here — no merge order between the two, and nothing here waits on `PR761`.

## Cross-repo

- `crucible-research-PR761` — the emitter. Order-free with this PR.

---

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)