### PR TITLE
chore(overseer): register the thinktank challenger-selection alert class (alpha-engine-config-I9282)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -973,6 +973,22 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+  # alpha-engine-config-I9282 (crucible-research-PR762). The Think Tank
+  # challenger arm writes its leaderboard evidence
+  # (signals_shadow/thinktank_coverage/{date}/signals.json) ONLY when its
+  # declared coverage window is complete. That skip was reported at INFO and
+  # escalated nowhere, so the arm silently stopped contributing cohort dates on
+  # 2026-08-14 and nothing noticed for two weeks — on the producer leaderboard
+  # it read as a THIN arm rather than a DEAD one. This class carries the
+  # now-loud "arm produced no evidence this cycle" event
+  # (champion-challenger-policy.md §3: a no-output cycle is a MISS, not an
+  # omission). Deduped per trading_day at the call site, so a persistent
+  # outage pages once per cycle rather than once per run.
+  - class: research_thinktank_challenger_selection_alerts
+    source: "thinktank:challenger_selection"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
   - class: research_signals_envelope_rejected
     # NOTE: this class emits via ``alerts.publish`` with explicit
     # ``severity="error"`` (not ``publish_observe_alert``), so its


### PR DESCRIPTION
Companion registry row for **`crucible-research-PR762`**. That PR makes an incomplete-coverage cycle publish an observe alert from `thinktank:challenger_selection`, and this repo's registry is where every PR-added alert source must declare its `alert_classes` row — without it the emitted alert is drain-blind.

## Why the alert exists — `alpha-engine-config-I9282`

The Think Tank challenger arm writes its leaderboard evidence (`signals_shadow/thinktank_coverage/{date}/signals.json`) **only when its declared coverage window is complete**. That skip was reported at INFO and escalated nowhere, so the arm silently stopped contributing cohort dates on **2026-08-14** and nothing noticed for two weeks. On the producer leaderboard it read as a *thin* arm rather than a *dead* one.

`champion-challenger-policy.md` §3: *a cycle where an arm produces no output is recorded as a MISS, not omitted; silent absence and a genuine zero must never render identically.*

Root cause of the outage itself (a missing re-cover half in the coverage ledger) is fixed in PR762; this row is what makes the resulting alert reachable.

## The row

```yaml
- class: research_thinktank_challenger_selection_alerts
  source: "thinktank:challenger_selection"
  severities: [warning]
  intake: bus
  response: drain-queue
```

Matches the sibling `research_thinktank_daily_alerts` row. The call site publishes via `publish_observe_alert` (warning-level) and **dedups per `trading_day`**, so a persistent outage pages once per cycle rather than once per run.

## Test plan

- `yaml.safe_load` on the edited file parses, and the new row resolves by `source` lookup — run locally before pushing.
- Scope is exactly one additive `alert_classes` row; no existing row is touched.
- The crucible-research check that demanded this row (`pr-added alert source must carry an alert_classes row`) re-reads the registry on every run and treats an OPEN PR here as satisfying it, so PR762 turns green on this push without waiting for a merge.

## Merge order

Either PR first, in either direction — `crucible-research-PR762` and `nousergon-data-PR<this>` cannot deadlock, since nothing here depends on that PR.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8qrqxTb8AnWHkWwpawADs