### PR TITLE
chore(anthropic): remove the dead ANTHROPIC_API_KEY export and test stub (alpha-engine-config-I9295)

### DIFF
--- a/.github/workflows/flow-doctor-fix.yml
+++ b/.github/workflows/flow-doctor-fix.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Generate fix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           python -m flow_doctor.fix.cli generate-fix \
             --issue-number ${{ github.event.issue.number }} \

--- a/tests/test_flow_doctor_wiring.py
+++ b/tests/test_flow_doctor_wiring.py
@@ -58,11 +58,6 @@ def stub_flow_doctor_env(monkeypatch):
     monkeypatch.setenv("TELEGRAM_CHAT_ID", "-100stub")
     monkeypatch.setenv("FLOW_DOCTOR_TELEGRAM_THREAD_CRITICAL", "1")
     monkeypatch.setenv("FLOW_DOCTOR_TELEGRAM_THREAD_OPS_HEALTH", "2")
-    # 0.6.0rc2 soak: flow-doctor.yaml now enables Haiku diagnosis with
-    # api_key: ${ANTHROPIC_API_KEY}. flow-doctor fails loud on an unresolved
-    # ${VAR}, so the wiring tests must seed it (mirrors the runtime, where the
-    # box resolves it from SSM /alpha-engine/ANTHROPIC_API_KEY).
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "stub-anthropic-key")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why

Brian ruled 2026-08-29: *"I will not fund the anthropic account, at this point we shouldn't be using the anthropic api at all."*

`nousergon-data-PR1587` wires the new fleet-wide provider-linkage guard and is **red by design** on exactly two findings, deliberately left unallowlisted there — "it's dead code" is not grounds to pre-clear a credential export rather than remove it. This PR removes them, unblocking that check.

## What

- `.github/workflows/flow-doctor-fix.yml:43` — dropped the `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}` export from the `Generate fix` step.
- `tests/test_flow_doctor_wiring.py` — dropped the matching `monkeypatch.setenv("ANTHROPIC_API_KEY", ...)` stub and its stale comment.

## Verified dead before removal, not assumed

- `flow-doctor`'s `flow_doctor/fix/` package contains **no Anthropic reference of any kind** — `grep -rn ANTHROPIC --include=*.py` over that repo returns only `core/scrubber.py`'s redaction list and a fail-loud test's variable list. The workflow's `generate-fix` entry point therefore never read it.
- `flow-doctor.yaml`'s `diagnosis:` block is already `provider: router` with no `api_key` field, so the test stub's own stated reason ("flow-doctor fails loud on an unresolved \${VAR}") no longer applies.

## Tests

Full local suite on this branch: **6793 passed, 17 skipped**. `tests/test_flow_doctor_wiring.py` and `tests/test_no_secret_environ_reads.py` pass with the stub removed (19 passed) — the latter already lists `ANTHROPIC_API_KEY` among the variables no code may read from the environment, so this change moves the repo into agreement with a guard it already carried.

## Follow-up not in scope

If the `ANTHROPIC_API_KEY` GitHub secret is unused elsewhere in this repo it should be retired too; credential and SSM retirement is tracked on `alpha-engine-config-I9311`.

Related: `alpha-engine-config-I9295`, `-I9263`, `-I9311`; `nousergon-data-PR1587`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8qrqxTb8AnWHkWwpawADs