### PR TITLE
fix(macro): stale/never-backfilled macro series must be visible or refused (I9287/I9289/I9324)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -68,6 +68,7 @@ from builders._price_cache_writeboth import (
 )
 from builders._constituents_loader import load_constituents_for_run_date
 from builders.daily_append import _scan_universe_and_emit_freshness_receipt
+from collectors.prices import _SUB_SECTOR_ETFS
 
 log = logging.getLogger(__name__)
 
@@ -174,6 +175,24 @@ def _extract_macro_series(price_data: dict[str, pd.DataFrame]) -> dict[str, pd.S
         if stem.startswith("XL") and len(stem) <= 4 and "Close" in df.columns:
             macro[stem] = df["Close"].dropna()
 
+    # alpha-engine-config-I9289 — the 8 sub-sector benchmark ETFs
+    # (collectors/prices.py::_SUB_SECTOR_ETFS) were added to the price
+    # cache's ``_ALWAYS_DOWNLOAD`` list (config#934) but never added HERE,
+    # so ``_write_macro_series_no_shrink``'s raw-series loop below never
+    # wrote their full price-cache history to ArcticDB — only
+    # ``builders/daily_append.py``'s per-day incremental append touched
+    # them. Result: every one of the eight was stuck at exactly one row per
+    # weekday since their 2026-07-23 birth (26 rows measured 2026-08-29)
+    # while every sibling macro symbol carried ~2514 rows from 2016. Adding
+    # them here means the NEXT weekly backfill writes whatever the price
+    # cache actually holds — closing the loop once the parquet itself is
+    # repaired (``builders/repair_macro_series.py --symbols
+    # SMH,IGV,XBI,PPH,XOP,KRE,ITA,GDX``, run in-region per AGENTS.md).
+    for stem in _SUB_SECTOR_ETFS:
+        df = price_data.get(stem)
+        if df is not None and "Close" in df.columns:
+            macro[stem] = df["Close"].dropna()
+
     return macro
 
 
@@ -262,7 +281,39 @@ def _existing_last_date(lib, symbol: str) -> "pd.Timestamp | None":
 # VIX3M.parquet`` was written wholesale over a 10y ArcticDB series. The
 # pre-existing preflight compared LAST DATE only, so a series that keeps
 # today's date while losing 2493 rows of history passed clean.
+#
+# This row-floor-against-the-reference-series guard is also the producer-side
+# deliverable of alpha-engine-config-I9324: four champion predictor vintages
+# (2026-08-12/21/28) trained with all seven macro coefficients at exactly
+# zero because ``macro/VIX3M`` lost coverage intermittently between two
+# otherwise-healthy Saturday runs (08-07 healthy, 08-12 dead, 08-14 healthy).
+# The intermittency traces to yfinance answering ``^VIX3M`` with 1 row on the
+# EC2 host that runs the weekly collector some weeks and a full 2484-row
+# answer other weeks (alpha-engine-config-I9286 routes the four caret index
+# tickers through FRED instead). This guard is the backstop regardless of
+# which upstream call answers short on a given run.
 _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS = 5
+
+# Max-date staleness tolerance for the macro write boundary, in NYSE trading
+# days behind the reference date (alpha-engine-config-I9287). A shrink/
+# first-date check is blind to a series that keeps writing NEW versions
+# without the PAYLOAD ever advancing: ``macro/HYOAS`` recorded continuous
+# weekly + daily ArcticDB versions right through 2026-08-29 while every
+# version's last row stayed 2026-05-07 — 3.5 months stale, 786 rows, never
+# shrinking, so the row-count and first-date guards both passed it clean.
+# 10 trading days (~2 calendar weeks) tolerates a FRED publication lag
+# without flagging routine latency; HYOAS was ~75 trading days stale.
+_MACRO_STALENESS_TOLERANCE_TRADING_DAYS = 10
+
+# Row-count floor (as a fraction of the largest established macro sibling)
+# below which a symbol's FIRST write is logged as a finding rather than
+# silently treated as a healthy new listing (alpha-engine-config-I9289: all
+# eight sub-sector benchmark ETFs were born 2026-07-23 at 26 rows next to
+# ~2514-row siblings, and nothing surfaced it for a month). This never
+# blocks the write — a genuinely short-lived listing (a recent IPO ETF) is
+# legitimate — it only makes the shortfall VISIBLE at birth via a loud log
+# line a health sweep can grep for, rather than a month later.
+_MACRO_FIRST_WRITE_SIBLING_FRACTION = 0.5
 
 
 def _series_row_span(series_or_df) -> "tuple[int, pd.Timestamp | None]":
@@ -341,19 +392,87 @@ def _history_regression(
     return None
 
 
-def _write_macro_series_no_shrink(lib, symbol: str, df: "pd.DataFrame") -> None:
-    """Write a full macro series, REFUSING any write that would truncate it.
+def _staleness_regression(
+    label: str,
+    planned,
+    reference_date: "str | pd.Timestamp | None",
+) -> "str | None":
+    """Return a staleness string when ``planned``'s last row lags ``reference_date``
+    by more than ``_MACRO_STALENESS_TOLERANCE_TRADING_DAYS`` NYSE trading days.
+
+    alpha-engine-config-I9287: catches a rewrite-with-stale-source that the
+    shrink/first-date checks in ``_history_regression`` cannot — a series
+    whose row count and start date never move because its writer keeps
+    re-deriving the same frozen upstream value. ``reference_date=None``
+    (no run_date available to the caller) skips the check rather than
+    guessing "today", since a caller with no reference has no way to know
+    what "stale" means here.
+    """
+    if reference_date is None:
+        return None
+    last = _planned_last_date(planned)
+    if last is None:
+        return None
+    from nousergon_lib.dates import trading_days_stale
+
+    ref = pd.Timestamp(reference_date).date()
+    lag = trading_days_stale(last.date(), ref)
+    if lag > _MACRO_STALENESS_TOLERANCE_TRADING_DAYS:
+        return (
+            f"{label}: last_date={last.date()} is {lag} trading days behind "
+            f"reference={ref} (tolerance {_MACRO_STALENESS_TOLERANCE_TRADING_DAYS}) "
+            "— writer is rewriting a FROZEN upstream value, not advancing it"
+        )
+    return None
+
+
+def _warn_if_short_first_write(lib, symbol: str, df: "pd.DataFrame") -> None:
+    """Log loudly when a symbol's FIRST write is short next to established siblings.
+
+    alpha-engine-config-I9289: a first write is never REFUSED (a genuinely
+    short-lived listing is legitimate), but it must be VISIBLE rather than
+    silently indistinguishable from a healthy new symbol — the sub-sector
+    ETFs sat at 26 rows for a month before anyone noticed. Best-effort: any
+    failure reading a reference sibling only skips the check, it never blocks
+    the write this function does not perform.
+    """
+    try:
+        reference_rows, _ = _existing_row_span(lib, "SPY")
+    except Exception:
+        return
+    if reference_rows <= 0:
+        return
+    planned_rows, _ = _series_row_span(df)
+    if planned_rows < reference_rows * _MACRO_FIRST_WRITE_SIBLING_FRACTION:
+        log.warning(
+            "MACRO_NEW_SYMBOL_SHORT_HISTORY macro.%s: first write carries %d rows "
+            "against SPY's %d (%.0f%% of the %.0f%%-of-siblings floor) — a new "
+            "macro symbol at birth, or a never-backfilled one. See "
+            "alpha-engine-config-I9289.",
+            symbol, planned_rows, reference_rows,
+            100 * planned_rows / reference_rows,
+            100 * _MACRO_FIRST_WRITE_SIBLING_FRACTION,
+        )
+
+
+def _write_macro_series_no_shrink(
+    lib, symbol: str, df: "pd.DataFrame", reference_date: "str | None" = None,
+) -> None:
+    """Write a full macro series, REFUSING any write that would truncate OR
+    silently re-freeze it.
 
     The write boundary is the last line of defence: ``_assert_no_arctic_regression``
     runs once per backfill over the planned frames, but the per-ticker
     ``--rebuild-macro`` override and any future call site reach the library
     directly. A wholesale ``lib.write()`` is destructive — ArcticDB keeps prior
-    versions, but every reader sees the truncated head immediately and the
-    predictor's ``dropna()`` turns one short optional column into a total loss
-    of the regime frame (alpha-engine-config-I9255 / I9256).
+    versions, but every reader sees the truncated (or stale) head immediately
+    and the predictor's ``dropna()`` turns one short optional column into a
+    total loss of the regime frame (alpha-engine-config-I9255 / I9256 / I9287).
 
     Raises RuntimeError rather than degrading: a producer that has lost its
-    own history must page, not publish.
+    own history, or is rewriting a frozen upstream value, must page, not
+    publish. ``reference_date=None`` skips the staleness half of the check
+    (no run_date known to the caller) but still enforces no-shrink.
     """
     existing_rows, existing_first = _existing_row_span(lib, symbol)
     regression = _history_regression(f"macro.{symbol}", df, existing_rows, existing_first)
@@ -365,6 +484,23 @@ def _write_macro_series_no_shrink(lib, symbol: str, df: "pd.DataFrame") -> None:
             f"{symbol}.parquet row count before re-running. "
             "See alpha-engine-config-I9256."
         )
+    # A first write (existing_rows == 0) is never a staleness regression —
+    # there is nothing established to lag behind, matching
+    # ``_history_regression``'s own first-write carve-out.
+    staleness = (
+        _staleness_regression(f"macro.{symbol}", df, reference_date)
+        if existing_rows > 0 else None
+    )
+    if staleness is not None:
+        raise RuntimeError(
+            "Macro write refused — it is a rewrite of a FROZEN source, not an "
+            f"advance. {staleness}. Check reference/price_cache/{symbol}.parquet's "
+            "LastModified and the collector that owns it "
+            "(collectors/fred_history.py for a FRED-only symbol). "
+            "See alpha-engine-config-I9287."
+        )
+    if existing_rows == 0:
+        _warn_if_short_first_write(lib, symbol, df)
     lib.write(symbol, df)
 
 
@@ -429,6 +565,18 @@ def _assert_no_arctic_regression(
         hist = _history_regression(f"macro.{key}", series, existing_rows, existing_first)
         if hist is not None:
             regressions.append(hist)
+        # STALENESS regression (alpha-engine-config-I9287). Neither check
+        # above catches a writer that keeps re-deriving the same frozen
+        # upstream value every run — row count and first date never move,
+        # only the ArcticDB *version* advances. Catch it here too so a
+        # ticker_filter/--rebuild-macro run that bypasses the per-write
+        # boundary still can't leave a symbol silently stuck.
+        stale = (
+            _staleness_regression(f"macro.{key}", series, run_date)
+            if existing_rows > 0 else None
+        )
+        if stale is not None:
+            regressions.append(stale)
 
     try:
         arctic_syms = set(universe_lib.list_symbols())
@@ -913,13 +1061,22 @@ def backfill(
         # VIX/TNX/etc. raw-series persistence so daily_append's read-back
         # loop (macro_lib.read("HYOAS")) resolves after this backfill runs.
         if not dry_run:
-            for key in ["SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO", "HYOAS"]:
+            # alpha-engine-config-I9289: the sub-sector benchmark ETFs join
+            # the raw-series write loop so a repaired price cache (full
+            # history via ``repair_macro_series.py``) actually reaches
+            # ArcticDB on the next Saturday run, rather than staying frozen
+            # at whatever ``daily_append`` alone could accumulate one row
+            # at a time.
+            for key in [
+                "SPY", "VIX", "VIX3M", "TNX", "IRX", "GLD", "USO", "HYOAS",
+                *_SUB_SECTOR_ETFS,
+            ]:
                 series = macro.get(key)
                 if series is not None:
                     macro_series_df = pd.DataFrame({"Close": series}, index=series.index)
                     macro_series_df.index.name = "date"
                     _write_macro_series_no_shrink(
-                        macro_lib, key, to_arctic_safe(macro_series_df)
+                        macro_lib, key, to_arctic_safe(macro_series_df), reference_date=today_str,
                     )
 
             # Write sector ETFs
@@ -928,7 +1085,7 @@ def backfill(
                     sector_df = pd.DataFrame({"Close": macro[key]}, index=macro[key].index)
                     sector_df.index.name = "date"
                     _write_macro_series_no_shrink(
-                        macro_lib, key, to_arctic_safe(sector_df)
+                        macro_lib, key, to_arctic_safe(sector_df), reference_date=today_str,
                     )
 
     # ── 5b. Factor-momentum second pass (W2.3, L4469) ────────────────────────

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -233,8 +233,18 @@ def test_backfill_wraps_macro_writes():
     # ``to_arctic_safe`` payload AND refuses a write that would truncate the
     # symbol's history. The Categorical-strip chokepoint is unchanged — the
     # wrapper is a guard in front of it, not a second write path.
-    assert "_write_macro_series_no_shrink(\n                        macro_lib, key, to_arctic_safe(macro_series_df)\n                    )" in _BACKFILL_SRC
-    assert "_write_macro_series_no_shrink(\n                        macro_lib, key, to_arctic_safe(sector_df)\n                    )" in _BACKFILL_SRC
+    assert (
+        "_write_macro_series_no_shrink(\n"
+        "                        macro_lib, key, to_arctic_safe(macro_series_df), "
+        "reference_date=today_str,\n"
+        "                    )"
+    ) in _BACKFILL_SRC
+    assert (
+        "_write_macro_series_no_shrink(\n"
+        "                        macro_lib, key, to_arctic_safe(sector_df), "
+        "reference_date=today_str,\n"
+        "                    )"
+    ) in _BACKFILL_SRC
     assert "lib.write(symbol, df)" in _BACKFILL_SRC, (
         "the no-shrink wrapper must still terminate in a single lib.write "
         "boundary — no second, unguarded macro write path."

--- a/tests/test_macro_extract_subsector_etfs.py
+++ b/tests/test_macro_extract_subsector_etfs.py
@@ -1,0 +1,43 @@
+"""alpha-engine-config-I9289 — the 8 sub-sector benchmark ETFs must reach
+``_extract_macro_series``'s output so the weekly raw-series write loop in
+``builders.backfill.backfill()`` actually persists their full price-cache
+history to ArcticDB.
+
+Measured 2026-08-29: every one of SMH/IGV/XBI/PPH/XOP/KRE/ITA/GDX held exactly
+26 rows in ``macro`` — one row per weekday since their 2026-07-23 birth —
+because ``_extract_macro_series`` only recognised the fixed ``macro_keys`` set
+plus ``XL*`` sector ETFs. ``builders/daily_append.py``'s per-day incremental
+append is the ONLY writer that ever touched them.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+import builders.backfill as _bf
+from collectors.prices import _SUB_SECTOR_ETFS
+
+
+def _df(n: int) -> pd.DataFrame:
+    idx = pd.bdate_range("2016-08-19", periods=n)
+    return pd.DataFrame({"Close": range(n)}, index=idx)
+
+
+def test_extract_macro_series_includes_all_sub_sector_etfs():
+    price_data = {sym: _df(2514) for sym in _SUB_SECTOR_ETFS}
+    price_data["SPY"] = _df(2514)
+
+    macro = _bf._extract_macro_series(price_data)
+
+    for sym in _SUB_SECTOR_ETFS:
+        assert sym in macro, f"{sym} missing from _extract_macro_series output"
+        assert len(macro[sym]) == 2514
+
+
+def test_extract_macro_series_skips_a_sub_sector_etf_absent_from_price_data():
+    """A sub-sector ETF genuinely missing from the price cache this run must
+    not KeyError — it is absent, not corrupt."""
+    price_data = {"SPY": _df(2514)}
+    macro = _bf._extract_macro_series(price_data)
+    for sym in _SUB_SECTOR_ETFS:
+        assert sym not in macro

--- a/tests/test_macro_history_truncation_guard.py
+++ b/tests/test_macro_history_truncation_guard.py
@@ -137,13 +137,98 @@ def test_preflight_catches_a_truncation_that_keeps_the_last_date(monkeypatch):
 
 
 def test_preflight_passes_a_healthy_macro_frame(monkeypatch):
-    existing = _frame("2016-08-19", 2513)
-    macro_lib = _FakeLib({"SPY": existing})
+    # Current through the reference date — alpha-engine-config-I9287's
+    # staleness check would otherwise fail this "healthy" fixture too.
+    existing = _series("2016-08-19", 2615)
+    existing_frame = pd.DataFrame({"Close": existing.values}, index=existing.index)
+    existing_frame.index.name = "date"
+    macro_lib = _FakeLib({"SPY": existing_frame})
     universe_lib = _FakeLib({})
     monkeypatch.setattr(_bf, "get_macro_lib", lambda *a, **k: macro_lib)
     monkeypatch.setattr(_bf, "get_universe_lib", lambda *a, **k: universe_lib)
 
-    planned_macro = {"SPY": _series("2016-08-19", 2514)}
+    planned_macro = {"SPY": _series("2016-08-19", 2616)}
     _bf._assert_no_arctic_regression(
         "alpha-engine-research", planned_macro, {}, "2026-08-29",
     )
+
+
+# ── staleness regression (alpha-engine-config-I9287) ─────────────────────────
+# ``macro/HYOAS`` recorded continuous weekly + daily ArcticDB versions right
+# through 2026-08-29 while every version's last row stayed 2026-05-07 — row
+# count and first date never moved, so the shrink/first-date checks above
+# passed it clean every single week. Only the max-date lag reveals it.
+
+def test_write_boundary_refuses_the_measured_hyoas_staleness():
+    """786 rows, never shrinking, last row frozen at 2026-05-07 while the
+    reference date is 2026-08-29 — ~75 trading days stale."""
+    lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    # Same row count and start, but the payload never advanced.
+    frozen = _frame("2023-05-09", 786)
+
+    with pytest.raises(RuntimeError, match="rewriting a FROZEN upstream value"):
+        _bf._write_macro_series_no_shrink(lib, "HYOAS", frozen, reference_date="2026-08-29")
+
+    assert lib.writes == [], "a refused write must not reach the library"
+
+
+def test_write_boundary_tolerates_ordinary_publication_lag():
+    """A few trading days behind (FRED publication lag) must NOT raise."""
+    lib = _FakeLib({"SPY": _frame("2016-08-19", 2610)})
+    planned = _frame("2016-08-19", 2612)  # 2 rows fresher, still within tolerance
+
+    _bf._write_macro_series_no_shrink(lib, "SPY", planned, reference_date="2026-08-29")
+    assert lib.writes == [("SPY", 2612)]
+
+
+def test_write_boundary_skips_staleness_check_with_no_reference_date():
+    """``reference_date=None`` (no run_date known to the caller) must not raise —
+    it has no basis to judge staleness, so it defers to the shrink check alone."""
+    lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    frozen = _frame("2023-05-09", 786)
+    _bf._write_macro_series_no_shrink(lib, "HYOAS", frozen)  # no reference_date
+    assert lib.writes == [("HYOAS", 786)]
+
+
+def test_preflight_catches_the_measured_hyoas_staleness(monkeypatch):
+    macro_lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    universe_lib = _FakeLib({})
+    monkeypatch.setattr(_bf, "get_macro_lib", lambda *a, **k: macro_lib)
+    monkeypatch.setattr(_bf, "get_universe_lib", lambda *a, **k: universe_lib)
+
+    planned_macro = {"HYOAS": _series("2023-05-09", 786)}
+    with pytest.raises(RuntimeError, match="trading days behind"):
+        _bf._assert_no_arctic_regression(
+            "alpha-engine-research", planned_macro, {}, "2026-08-29",
+        )
+
+
+# ── first-write visibility (alpha-engine-config-I9289) ───────────────────────
+
+def test_first_write_of_a_short_new_symbol_is_logged_not_blocked(caplog):
+    """The measured sub-sector-ETF shape: 26 rows next to SPY's ~2514 must
+    WRITE (never blocked — a short-lived listing is legitimate) but must be
+    LOUD about it."""
+    lib = _FakeLib({"SPY": _frame("2016-08-19", 2514)})
+    planned = _frame("2026-07-23", 26)
+
+    with caplog.at_level("WARNING"):
+        _bf._write_macro_series_no_shrink(lib, "SMH", planned, reference_date="2026-08-29")
+
+    assert lib.writes == [("SMH", 26)], "a short first write must still succeed"
+    assert any(
+        "MACRO_NEW_SYMBOL_SHORT_HISTORY" in rec.message and "SMH" in rec.message
+        for rec in caplog.records
+    ), "a short first write must log a loud, greppable finding"
+
+
+def test_first_write_of_a_healthy_new_symbol_does_not_warn(caplog):
+    """A first write comparable in length to SPY, and current, should not be
+    flagged."""
+    lib = _FakeLib({"SPY": _frame("2016-08-19", 2514)})
+    planned = _frame("2017-01-27", 2500)  # ends 2026-08-27 — close to reference
+
+    with caplog.at_level("WARNING"):
+        _bf._write_macro_series_no_shrink(lib, "NEWETF", planned, reference_date="2026-08-29")
+
+    assert not any("MACRO_NEW_SYMBOL_SHORT_HISTORY" in rec.message for rec in caplog.records)

--- a/tests/test_weekly_collector_fred_macro_history_wiring.py
+++ b/tests/test_weekly_collector_fred_macro_history_wiring.py
@@ -1,0 +1,47 @@
+"""alpha-engine-config-I9287 — the FRED-only macro history refresh
+(``collectors/fred_history.py::backfill_to_s3``) must run on the weekly
+schedule, not stay a one-shot operator step.
+
+Measured 2026-08-29: ``reference/price_cache/HYOAS.parquet`` last modified
+2026-05-19 and never refreshed since, while ``builders/backfill.py`` rewrote
+``macro/HYOAS`` from it every Saturday — a rewrite-with-frozen-source, not a
+missing writer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WEEKLY_COLLECTOR = Path(__file__).parent.parent / "weekly_collector.py"
+
+
+def _section(src: str, def_line: str) -> str:
+    body = src.split(def_line)[1]
+    next_def = body.find("\ndef ")
+    return body if next_def == -1 else body[:next_def]
+
+
+def test_run_phase1_invokes_fred_history_backfill():
+    src = _WEEKLY_COLLECTOR.read_text()
+    phase1_section = _section(src, "def _run_phase1(")
+    assert "fred_history.backfill_to_s3(" in phase1_section, (
+        "_run_phase1 must schedule collectors.fred_history.backfill_to_s3 — "
+        "without it, TWO/HYOAS/BAA10Y's price-cache parquet is never "
+        "refreshed and the weekly macro rebuild rewrites ArcticDB from a "
+        "frozen source indefinitely."
+    )
+
+
+def test_fred_history_backfill_call_pins_explicit_fred_only_tickers():
+    src = _WEEKLY_COLLECTOR.read_text()
+    phase1_section = _section(src, "def _run_phase1(")
+    call_start = phase1_section.index("fred_history.backfill_to_s3(")
+    call_text = phase1_section[call_start:call_start + 400]
+    assert 'tickers=["TWO", "HYOAS", "BAA10Y"]' in call_text, (
+        "the weekly call must pin an EXPLICIT ticker list, never the "
+        "FRED_HISTORY_MAP default — that map may grow to include the caret "
+        "index tickers (VIX/VIX3M/TNX/IRX), which are collectors/prices.py's "
+        "longest-of-yfinance-and-FRED job (alpha-engine-config-I9286); "
+        "re-deriving them here from FRED alone would silently discard that "
+        "fallback."
+    )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -84,7 +84,7 @@ setup_logging(
     exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
 )
 
-from collectors import constituents, historical_constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data, universe_classification
+from collectors import constituents, historical_constituents, prices, macro, universe_returns, signal_returns, alternative, daily_closes, fundamentals, short_interest, metron_market_data, universe_classification, fred_history
 from builders._price_cache_writeboth import (
     price_cache_read_prefixes as _price_cache_read_prefixes,
     price_cache_write_prefixes as _price_cache_write_prefixes,
@@ -443,6 +443,31 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                     boto3.client("s3"), bucket,
                     writer="nousergon-data:weekly_collector.py",
                 )
+
+    # ── 2b. FRED-only macro history refresh (alpha-engine-config-I9287) ──────
+    # ``collectors/fred_history.py::backfill_to_s3`` was a one-shot operator
+    # step ("Run after Stage 2.5 ships") never wired to any schedule.
+    # Measured 2026-08-29: ``reference/price_cache/HYOAS.parquet`` last
+    # modified 2026-05-19 and never touched since — the weekly ``macro``
+    # rebuild (``builders/backfill.py``) faithfully rewrites
+    # ``macro/HYOAS`` from that frozen parquet every Saturday, so the ArcticDB
+    # symbol never advances even though the writer never stops. Explicit
+    # ``tickers=`` (not ``FRED_HISTORY_MAP`` default) so this call never grows
+    # to cover the caret index tickers (VIX/VIX3M/TNX/IRX) — those are
+    # ``collectors/prices.py``'s longest-of-yfinance-and-FRED job
+    # (alpha-engine-config-I9286); re-deriving them here from FRED alone
+    # would silently discard that fallback logic.
+    if only in (None, "prices", "fred_macro_history"):
+        results["collectors"]["fred_macro_history"] = _phase_collect(
+            reg, "fred_macro_history",
+            lambda: fred_history.backfill_to_s3(
+                bucket=bucket,
+                s3_prefix=price_cfg.get("s3_prefix", "predictor/price_cache/"),
+                tickers=["TWO", "HYOAS", "BAA10Y"],
+                dry_run=dry_run,
+            ),
+            supports_auto_skip=False,
+        )
 
     # ── 3. Slim cache — REMOVED (Wave-4) ─────────────────────────────────────
     # predictor/price_cache_slim/ deleted: every consumer (data macro-breadth


### PR DESCRIPTION
## What & why

Extends the alpha-engine-config-I9256 write-boundary guard (merged `nousergon-data#1583`) to the rest of the "producer writes silent junk" class the dispatch identified as sharing a root cause. Addresses `alpha-engine-config-I9287`, `alpha-engine-config-I9289`, and the producer-side deliverable of `alpha-engine-config-I9324`.

### alpha-engine-config-I9287 — macro/HYOAS frozen at 2026-05-07 for 3.5 months
- **Measured root cause**: `reference/price_cache/HYOAS.parquet` `LastModified` = 2026-05-19, untouched since (`aws s3 ls`, `AWS_PROFILE=ne-admin`, checked 2026-08-29). `collectors/fred_history.py::backfill_to_s3` — the only writer of that parquet — was a one-shot operator step never wired to any schedule. The weekly `builders/backfill.py` macro rebuild faithfully rewrites `macro/HYOAS` from that frozen parquet every Saturday: row count and first date never move (786 rows, unchanging), so the existing shrink/first-date guard passes it clean every week.
- **Fix 1**: `weekly_collector.py` Phase 1 now schedules `fred_history.backfill_to_s3(tickers=["TWO","HYOAS","BAA10Y"])` — an explicit list, never the `FRED_HISTORY_MAP` default, so this call can never grow to cover the caret index tickers that `alpha-engine-config-I9286`'s longest-of-yfinance-and-FRED job in `collectors/prices.py` already owns.
- **Fix 2**: a new per-symbol **max-date staleness** check at the macro write boundary (`_staleness_regression`, tolerance 10 NYSE trading days) in both `_write_macro_series_no_shrink` and `_assert_no_arctic_regression`. Raises `RuntimeError` naming the frozen source — same class as the existing shrink guard. Never applies to a symbol's first write.
- Backfilling `macro/HYOAS` to current is `builders/repair_macro_series.py --symbols HYOAS` — an in-region SSM step (see report to Brian, not run here).

### alpha-engine-config-I9289 — 8 sub-sector ETFs stuck at 26 rows since birth
- **Measured root cause**: `builders/backfill.py::_extract_macro_series` only recognised a fixed `macro_keys` set plus `XL*`-prefixed sector ETFs. SMH/IGV/XBI/PPH/XOP/KRE/ITA/GDX (added to price-cache `_ALWAYS_DOWNLOAD` in config#934) matched neither, so the weekly raw-series write loop never touched them — only `builders/daily_append.py`'s one-row-per-weekday increment did, exactly matching the measured "26 rows since 2026-07-23" shape.
- **Fix**: added all 8 (imported from `collectors.prices._SUB_SECTOR_ETFS`, one declared list) to `_extract_macro_series`'s output and the weekly raw-series write loop, so the next Saturday run persists whatever the price cache holds.
- **Fix (deliverable 4)**: `_warn_if_short_first_write` logs `MACRO_NEW_SYMBOL_SHORT_HISTORY` when a symbol's first write is < 50% of SPY's row count — never blocks the write, makes a short-history symbol visible at birth instead of a month later.
- Backfilling the 8 parquets is `builders/repair_macro_series.py --symbols SMH,IGV,XBI,PPH,XOP,KRE,ITA,GDX` — in-region SSM, not run here.

### alpha-engine-config-I9324 — intermittent macro outage, producer-side row floor
- The row-floor-against-existing guard from `nousergon-data#1583` IS the producer-side deliverable ("asserts a per-symbol row floor against the reference series before the write is considered successful"). This PR documents that linkage in code and names the root cause of the intermittency: `alpha-engine-config-I9286` (yfinance answering `^VIX3M` with 1 row from the EC2 host that runs the weekly collector on some Saturdays and a full answer on others). A comment naming this root cause is being posted on the issue directly.

## Test plan (run BEFORE opening)
- `pytest tests/` — **6815 passed, 17 skipped, 0 failed** (full suite, local, `.venv`)
- New/updated: `tests/test_macro_history_truncation_guard.py` (staleness raise + tolerance + first-write-skip cases), `tests/test_macro_extract_subsector_etfs.py`, `tests/test_weekly_collector_fred_macro_history_wiring.py`, `tests/test_arctic_write_contract.py` (exact-string pin updated for the new `reference_date=` kwarg)

## Non-inferable gotchas for review
- The staleness check is intentionally skipped on a symbol's first write (`existing_rows == 0`) — a first write has nothing established to lag behind.
- The weekly `fred_macro_history` phase passes an **explicit** ticker list rather than the `FRED_HISTORY_MAP` default, specifically so a future merge of that map with the caret-ticker map (I9286) can't silently make this call double-write VIX/VIX3M/TNX/IRX from FRED-only data and discard the longest-of-two-sources fallback.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132D4f4nt2n76PnRzUbVCba