### PR TITLE
fix(prices): route caret index tickers through FRED, longest-of-two-sources (I9286)

### DIFF
--- a/collectors/daily_closes.py
+++ b/collectors/daily_closes.py
@@ -150,31 +150,12 @@ def _fred_get_with_retry(params: dict) -> requests.Response:
 # TNX/IRX/TWO/HYOAS), so no conversion is needed before appending to
 # ArcticDB.
 #
-# TWO + HYOAS added 2026-05-10 (Stage 2.5 of regime-conditioning rebuild
-# — plan doc: alpha-engine-docs/private/regime-conditioning-260510.md).
-# Both are FRED-only (no yfinance proxy), so they only flow through the
-# FRED fallback path. Historical backfill is gated on a follow-up PR
-# adding a FRED history fetcher; this PR begins forward-only collection.
-_FRED_INDEX_MAP = {
-    "VIX": "VIXCLS",
-    "VIX3M": "VXVCLS",
-    "TNX": "DGS10",
-    "IRX": "DTB3",
-    # 2Y treasury — enables 10Y-2Y curve slope (recession-focused canonical)
-    # alongside the existing 10Y-3M (TNX-IRX cyclical).
-    "TWO": "DGS2",
-    # ICE BofA US High Yield Index Option-Adjusted Spread, percent.
-    # Major regime indicator that VIX misses — credit widens before vol
-    # spikes in many cycles, and stays wide during recoveries when vol
-    # has already calmed. Institutional risk-factor models include it.
-    "HYOAS": "BAMLH0A0HYM2",
-    # Moody's BAA Corporate Bond Yield Relative to 10Y Treasury, percent.
-    # Full 40y FRED history (1986+) — the credit-regime signal HYOAS can't
-    # provide across the full predictor training corpus (HYOAS is license-
-    # gated to 2023+ on FRED). BBB-rated spread vs HY's below-BBB; both
-    # belong in the institutional credit-regime feature set.
-    "BAA10Y": "BAA10Y",
-}
+# alpha-engine-config-I9286: this used to be a SEPARATE 7-entry literal that
+# had drifted from ``collectors/fred_history.py::FRED_HISTORY_MAP`` (which
+# only carried the 3 FRED-only symbols). Re-exported here as an alias so
+# there is exactly ONE declared ticker -> FRED series id map in the repo —
+# every existing caller of ``_FRED_INDEX_MAP`` in this module is unaffected.
+from collectors.fred_history import FRED_HISTORY_MAP as _FRED_INDEX_MAP
 
 
 def _coalesce_by_source_priority(

--- a/collectors/fred_history.py
+++ b/collectors/fred_history.py
@@ -41,12 +41,32 @@ logger = logging.getLogger(__name__)
 _FRED_BASE = "https://api.stlouisfed.org/fred/series/observations"
 _FRED_TIMEOUT = 30  # longer than _fred_latest's 15s — date-range responses are bigger
 
-# FRED-only symbols that need historical backfill via this module. Map
-# our parquet/ArcticDB ticker key → FRED series id. Mirrors the
-# Stage 2.5 entries in ``collectors/daily_closes._FRED_INDEX_MAP`` for
-# the symbols not on yfinance. Kept separate so changes here don't
-# impact daily_closes' single-latest fetch behaviour.
+# Canonical ticker -> FRED series id map. Historically this module only
+# carried the three FRED-only symbols (TWO/HYOAS/BAA10Y) while
+# ``collectors/daily_closes.py::_FRED_INDEX_MAP`` separately carried the four
+# caret index tickers (VIX/VIX3M/TNX/IRX, for the daily single-latest FRED
+# fallback) PLUS its own copies of TWO/HYOAS/BAA10Y — two maps that had to be
+# kept in sync by hand and had already drifted (this dict was missing the
+# caret tickers daily_closes already knew about).
+#
+# alpha-engine-config-I9286: merged here as the SINGLE declared source.
+# ``daily_closes.py`` now imports this dict as ``_FRED_INDEX_MAP`` rather than
+# defining its own literal. Membership grew from 3 to 7 keys as part of that
+# merge — this is deliberate, not incidental (see the issue's "Merging them
+# is the point" gotcha).
 FRED_HISTORY_MAP: dict[str, str] = {
+    # Caret index tickers — yfinance's ``^``-prefixed indices. Added
+    # 2026-08-29 (I9286): yfinance answers ``^VIX3M`` with 1 row of history
+    # from the EC2 host that runs the weekly collector on some Saturdays
+    # (measured 2026-08-29: 1 row from EC2 vs 2484 from a laptop, in the
+    # same minutes) — the source ``collectors/prices.py`` trusted for these
+    # four tickers' 10y HISTORY fetch was already known-unreliable on the one
+    # host that matters, while the DAILY single-latest fetch in
+    # ``daily_closes.py`` already used FRED for exactly these tickers.
+    "VIX": "VIXCLS",
+    "VIX3M": "VXVCLS",
+    "TNX": "DGS10",
+    "IRX": "DTB3",
     "TWO": "DGS2",
     # ICE BofA US HY Index OAS — only 3y of FRED public history (2023+),
     # license-restricted. Forward observation grows; recent walk-forward

--- a/collectors/prices.py
+++ b/collectors/prices.py
@@ -251,6 +251,54 @@ def _existing_parquet_rows(s3, bucket: str, s3_prefix: str, ticker: str) -> int 
     return None
 
 
+def _longest_of(candidates: list[tuple[str, pd.DataFrame]]) -> tuple[str, pd.DataFrame]:
+    """Pick the longest of several candidate history frames, by row count.
+
+    Deliberate rather than a preference order (mirrors
+    ``builders/repair_macro_series.py::fetch_full_history``): the failure this
+    guards against is a SOURCE answering short, so the selection can't assume
+    any one source is healthy. Raises if every candidate is empty/None.
+    """
+    named = [(name, df) for name, df in candidates if df is not None and not df.empty]
+    if not named:
+        raise RuntimeError("_longest_of: no usable candidate frames")
+    return max(named, key=lambda kv: len(kv[1]))
+
+
+def _fred_ohlcv_for_caret_symbol(ticker: str, period: str) -> "pd.DataFrame | None":
+    """Fetch ``ticker``'s FRED-sourced history, reshaped to the yfinance OHLCV
+    column set. Returns ``None`` (never raises) on any failure — the caller
+    falls back to whatever yfinance answered, since FRED being unavailable
+    must degrade to yfinance rather than to nothing (alpha-engine-config-I9286
+    deliverable 2).
+    """
+    from collectors.fred_history import FRED_HISTORY_MAP, fetch_fred_history, fred_history_to_ohlcv
+
+    series_id = FRED_HISTORY_MAP.get(ticker)
+    if series_id is None:
+        return None
+    years = int(period.rstrip("y")) if period.endswith("y") and period[:-1].isdigit() else 10
+    try:
+        fred_df = fetch_fred_history(series_id, period_years=years)
+        out = fred_history_to_ohlcv(fred_df)
+    except Exception as exc:
+        logger.warning(
+            "FRED history fetch failed for %s (%s): %s — falling back to yfinance",
+            ticker, series_id, exc,
+        )
+        return None
+    idx = pd.to_datetime(out.index)
+    if idx.tz is not None:
+        idx = idx.tz_convert("UTC").tz_localize(None)
+    out.index = idx.normalize()
+    # Match yfinance's minimal OHLCV column set — the FRED shape carries
+    # Adj_Close/VWAP/source too, and letting those vary week-to-week on the
+    # SAME ticker's parquet (yfinance-shaped one week, FRED-shaped the next)
+    # is schema churn the parquet contract doesn't need here.
+    keep = [c for c in ("Open", "High", "Low", "Close", "Volume") if c in out.columns]
+    return out[keep]
+
+
 @yf_quiet
 def _refresh_stale(
     s3,
@@ -321,6 +369,33 @@ def _refresh_stale(
                         idx = idx.tz_convert("UTC").tz_localize(None)
                     new_df.index = idx
                     new_df = new_df.sort_index()
+
+                    # ── FRED longest-of selection for caret index tickers ───
+                    # (alpha-engine-config-I9286). yfinance answers ``^VIX3M``
+                    # with 1 row of history from the EC2 host that runs the
+                    # weekly collector on SOME Saturdays and a full answer on
+                    # others (measured 2026-08-29) — the intermittency behind
+                    # alpha-engine-config-I9324's dead-then-healthy champion
+                    # vintages. FRED already serves these four reliably (it's
+                    # what daily_closes.py's single-latest fallback uses), but
+                    # a hard cutover would make a FRED outage total instead of
+                    # degrading to yfinance — so take whichever answers longer,
+                    # every run, and log which source won.
+                    if ticker in _CARET_SYMBOLS:
+                        fred_df = _fred_ohlcv_for_caret_symbol(ticker, fetch_period)
+                        if fred_df is not None:
+                            source, new_df = _longest_of(
+                                [("yfinance", new_df), ("fred", fred_df)]
+                            )
+                            logger.info(
+                                "%s: source selection -> %s (%d rows)",
+                                ticker, source, len(new_df),
+                            )
+                        else:
+                            logger.info(
+                                "%s: FRED unavailable this run, using yfinance (%d rows)",
+                                ticker, len(new_df),
+                            )
 
                     # ── Short-fetch guard (alpha-engine-config-I9256) ───────
                     # yfinance intermittently answers a full-period request with

--- a/tests/test_fred_history_fetcher.py
+++ b/tests/test_fred_history_fetcher.py
@@ -48,9 +48,23 @@ class TestFredHistoryMap:
 
     def test_no_unintended_entries(self):
         # Stage 2.5b shipped TWO + HYOAS; Stage 2.5c added BAA10Y.
-        # Lock so a future drive-by addition doesn't slip through
-        # unreviewed.
-        assert set(FRED_HISTORY_MAP.keys()) == {"TWO", "HYOAS", "BAA10Y"}
+        # alpha-engine-config-I9286 merged in the four caret index tickers
+        # (VIX/VIX3M/TNX/IRX) that used to live only in
+        # ``collectors/daily_closes.py::_FRED_INDEX_MAP`` — this dict is now
+        # the SINGLE declared ticker -> FRED series id map. Lock the full set
+        # so a future drive-by addition doesn't slip through unreviewed.
+        assert set(FRED_HISTORY_MAP.keys()) == {
+            "VIX", "VIX3M", "TNX", "IRX", "TWO", "HYOAS", "BAA10Y",
+        }
+
+    def test_caret_index_tickers_match_daily_closes_series_ids(self):
+        """The merge must not silently change what any existing caller
+        resolves — VIX/VIX3M/TNX/IRX must map to the exact series ids
+        ``daily_closes.py`` already used before the merge."""
+        assert FRED_HISTORY_MAP["VIX"] == "VIXCLS"
+        assert FRED_HISTORY_MAP["VIX3M"] == "VXVCLS"
+        assert FRED_HISTORY_MAP["TNX"] == "DGS10"
+        assert FRED_HISTORY_MAP["IRX"] == "DTB3"
 
 
 # ── fetch_fred_history ──────────────────────────────────────────────────

--- a/tests/test_prices_caret_fred_routing.py
+++ b/tests/test_prices_caret_fred_routing.py
@@ -1,0 +1,162 @@
+"""alpha-engine-config-I9286 — route the caret index tickers' 10y history
+refresh through FRED as well as yfinance, taking whichever answers longer.
+
+Measured 2026-08-29: ``yf.download('^VIX3M', period='10y')`` returned 2484
+rows from a laptop and 1 row from EC2 host ``i-00b4403ae4eb894cc`` (the box
+that runs the weekly collector), minutes apart. FRED served 2518 rows from
+the same EC2 host in the same run. This is the SOURCE defect behind
+``alpha-engine-config-I9256``'s truncating write and part of
+``alpha-engine-config-I9324``'s intermittent macro outage.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import collectors.prices as _prices
+
+
+def _ohlcv(n: int, start: str = "2016-08-19") -> pd.DataFrame:
+    idx = pd.bdate_range(start, periods=n)
+    return pd.DataFrame(
+        {
+            "Open": np.ones(n), "High": np.ones(n), "Low": np.ones(n),
+            "Close": np.linspace(10.0, 20.0, n), "Volume": np.zeros(n),
+        },
+        index=idx,
+    )
+
+
+class _NoSuchKey(Exception):
+    pass
+
+
+class _FakeS3:
+    def __init__(self, objects: dict[str, bytes] | None = None):
+        self.objects = dict(objects or {})
+        self.uploads: list[str] = []
+        self.exceptions = type("E", (), {"NoSuchKey": _NoSuchKey})()
+
+    def get_object(self, Bucket, Key):
+        if Key not in self.objects:
+            raise _NoSuchKey(Key)
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+    def upload_file(self, path, bucket, key):
+        with open(path, "rb") as f:
+            self.uploads.append((key, f.read()))
+
+
+def _patch_yf_download(monkeypatch, frame: pd.DataFrame):
+    monkeypatch.setattr(_prices.yf, "download", lambda *a, **k: frame, raising=True)
+
+
+def test_fred_wins_over_a_short_yfinance_answer_for_vix3m(monkeypatch):
+    """The exact measured shape: yfinance answers 1 row, FRED answers long."""
+    s3 = _FakeS3()
+    _patch_yf_download(monkeypatch, _ohlcv(1))
+    monkeypatch.setattr(
+        _prices, "_fred_ohlcv_for_caret_symbol",
+        lambda ticker, period: _ohlcv(2518),
+    )
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["VIX3M"], "10y", 50,
+    )
+
+    assert refreshed == 1
+    assert failed == []
+    assert len(s3.uploads) == 1
+    key, body = s3.uploads[0]
+    assert key == "reference/price_cache/VIX3M.parquet"
+    written = pd.read_parquet(io.BytesIO(body))
+    assert len(written) == 2518, "the FRED (longer) answer must be what gets written"
+
+
+def test_yfinance_wins_when_it_answers_longer(monkeypatch):
+    s3 = _FakeS3()
+    _patch_yf_download(monkeypatch, _ohlcv(2500))
+    monkeypatch.setattr(
+        _prices, "_fred_ohlcv_for_caret_symbol",
+        lambda ticker, period: _ohlcv(2000),
+    )
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["VIX3M"], "10y", 50,
+    )
+    assert refreshed == 1
+    key, body = s3.uploads[0]
+    written = pd.read_parquet(io.BytesIO(body))
+    assert len(written) == 2500, "yfinance's longer answer must win"
+
+
+def test_fred_outage_degrades_to_yfinance_not_to_nothing(monkeypatch):
+    """A FRED failure must never turn into a total miss — deliverable 2 of
+    alpha-engine-config-I9286 (union-no-shrink / longest-of, never a hard
+    cutover). ``_fred_ohlcv_for_caret_symbol`` itself never raises (it catches
+    every fetch failure internally and returns None) — this pins that
+    contract at the ``_refresh_stale`` call site."""
+    s3 = _FakeS3()
+    _patch_yf_download(monkeypatch, _ohlcv(2484))
+    monkeypatch.setattr(
+        _prices, "_fred_ohlcv_for_caret_symbol", lambda ticker, period: None,
+    )
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["VIX3M"], "10y", 50,
+    )
+    assert refreshed == 1
+    assert failed == []
+    key, body = s3.uploads[0]
+    written = pd.read_parquet(io.BytesIO(body))
+    assert len(written) == 2484, "yfinance answer must still be used when FRED errors"
+
+
+def test_non_caret_tickers_never_consult_fred(monkeypatch):
+    """A plain equity ticker must not trigger a FRED lookup at all."""
+    s3 = _FakeS3()
+    _patch_yf_download(monkeypatch, _ohlcv(2500))
+    called = []
+    monkeypatch.setattr(
+        _prices, "_fred_ohlcv_for_caret_symbol",
+        lambda ticker, period: called.append(ticker) or None,
+    )
+
+    refreshed, failed = _prices._refresh_stale(
+        s3, "alpha-engine-research", "predictor/price_cache/", ["AAPL"], "10y", 50,
+    )
+    assert refreshed == 1
+    assert called == [], "a non-caret ticker must never reach the FRED path"
+
+
+def test_longest_of_raises_when_every_candidate_is_empty():
+    with pytest.raises(RuntimeError, match="no usable candidate"):
+        _prices._longest_of([("yfinance", pd.DataFrame()), ("fred", None)])
+
+
+def test_longest_of_picks_the_longer_named_candidate():
+    short = _ohlcv(5)
+    long = _ohlcv(50)
+    name, chosen = _prices._longest_of([("yfinance", short), ("fred", long)])
+    assert name == "fred"
+    assert len(chosen) == 50
+
+
+def test_fred_ohlcv_helper_never_raises_on_fetch_failure(monkeypatch):
+    """Unit-level pin of the contract the outage test above relies on:
+    ``_fred_ohlcv_for_caret_symbol`` catches a FRED fetch failure internally."""
+    import collectors.fred_history as _fh
+
+    def _raise(series_id, period_years):
+        raise RuntimeError("FRED_API_KEY not set")
+
+    monkeypatch.setattr(_fh, "fetch_fred_history", _raise)
+    assert _prices._fred_ohlcv_for_caret_symbol("VIX3M", "10y") is None
+
+
+def test_fred_ohlcv_helper_returns_none_for_a_non_fred_symbol():
+    assert _prices._fred_ohlcv_for_caret_symbol("NOTAREALSYM", "10y") is None


### PR DESCRIPTION
## What & why

`alpha-engine-config-I9286` (source half of `alpha-engine-config-I9256`). Measured 2026-08-29: `yf.download('^VIX3M', period='10y')` returns 2484 rows from a laptop and **1 row** from EC2 host `i-00b4403ae4eb894cc` (the box that runs the weekly collector), minutes apart. From the same EC2 host in the same run, FRED returned 2518 rows for the same instrument. `collectors/daily_closes.py` already trusts FRED for these four tickers' DAILY single-latest bar — only the 10y HISTORY refresh in `collectors/prices.py::_refresh_stale` went to yfinance alone, on the one host where yfinance is unreliable for these symbols.

## Change
- `collectors/fred_history.py::FRED_HISTORY_MAP` is now the **single declared** ticker → FRED series id map: merged in the four caret index tickers (VIX/VIX3M/TNX/IRX), growing from 3 to 7 keys. `collectors/daily_closes.py::_FRED_INDEX_MAP` is now an alias import (`from collectors.fred_history import FRED_HISTORY_MAP as _FRED_INDEX_MAP`) rather than a second, independently-maintained literal that had already drifted.
- `collectors/prices.py::_refresh_stale`: for the four `_CARET_SYMBOLS`, fetch FRED history too (`fetch_fred_history` + `fred_history_to_ohlcv`) and keep whichever of yfinance/FRED answered more rows (`_longest_of`) — mirrors `builders/repair_macro_series.py`'s existing longest-of pattern (deliberate, not a preference order: the failure is a source silently answering short). A FRED outage degrades to yfinance, never to nothing. Logs which source won per ticker/run (`%s: source selection -> %s (%d rows)`). Non-caret tickers never consult FRED.

This is the source defect behind `nousergon-data#1583`'s truncating write (merged) and part of the intermittent macro outage tracked in `alpha-engine-config-I9324` — root-cause comment posted directly on that issue.

**No merge-order dependency** — this PR only touches `collectors/*.py`, independent of `nousergon-data-PR1590` (I9287/I9289/I9324 write-boundary guards, which touch `builders/backfill.py` and `weekly_collector.py`).

## Test plan (run BEFORE opening)
- `pytest tests/` — **6814 passed, 17 skipped, 0 failed** (full suite, local, `.venv`)
- New: `tests/test_prices_caret_fred_routing.py` — the measured 1-row-vs-2518-row VIX3M case, yfinance winning when it's longer, FRED-outage degrading to yfinance (never a total miss), non-caret tickers never consulting FRED, `_longest_of`/`_fred_ohlcv_for_caret_symbol` unit contracts
- Updated: `tests/test_fred_history_fetcher.py` — `FRED_HISTORY_MAP` membership pin grown from 3 to 7 keys (deliberate merge, not a drive-by addition), plus a pin that the four caret tickers resolve to the exact series ids `daily_closes.py` already used pre-merge

## Non-inferable gotchas for review
- `_fred_ohlcv_for_caret_symbol` never raises — it catches every FRED fetch failure internally and returns `None so the caller degrades to yfinance. Tested at both the unit level and the `_refresh_stale` call-site level.
- The FRED-shaped frame is trimmed to the plain OHLCV column set before comparison/write so a ticker's parquet schema doesn't churn between yfinance-shaped and FRED-shaped week to week.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132D4f4nt2n76PnRzUbVCba