### PR TITLE
chore(overseer): alert_classes row for predictor unmeasurable-shadow-arm alert (alpha-engine-config-I9336)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -842,6 +842,22 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+  - class: predictor_shadow_leaderboard_unmeasurable_arm
+    # alpha-engine-config-I9336 (crucible-predictor-PR587): a registered
+    # stage=challenger arm (e.g. sota-directional-combine, the champion-arch
+    # candidate) that wrote no comparable shadow prediction within the last
+    # MEASURABILITY_LAG_CYCLES cohort cycles. DELIBERATELY `warning` +
+    # `drain-queue`, never `critical`/`operator` — this is a measurement-
+    # coverage signal (fixed by repairing the shadow write path, or by the
+    # shadow runner's own rotation reaching the starved arm), not a
+    # trading-halt condition, and must not page the one operator chat
+    # (the 2026-08-28 alert-destination-arc lesson: severity alone does not
+    # pick a destination tier, so severity and response are chosen together
+    # here, not severity alone).
+    source: "alpha-engine-predictor/analysis/observe_leaderboard.py::build_observe_leaderboard"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
   - class: predictor_inference
     # alpha-engine-config-I7740 (operator ruling 2026-08-21): new registry
     # row for a previously-undeclared source. One source string covers


### PR DESCRIPTION
## Summary

Companion registry PR for crucible-predictor-PR587 (alpha-engine-config-I9336). That PR adds a `publish_ops_alert` call in `analysis/observe_leaderboard.py::build_observe_leaderboard` (fires when a registered `stage=challenger` arm has written no comparable shadow prediction within the recent cohort window) — `alert-class-pr-guard.yml` correctly failed that PR's CI since the source has no row here.

## Row added

```yaml
- class: predictor_shadow_leaderboard_unmeasurable_arm
  source: "alpha-engine-predictor/analysis/observe_leaderboard.py::build_observe_leaderboard"
  severities: [warning]
  intake: bus
  response: drain-queue
```

- **Class name**: follows the file's existing `predictor_*` convention (matching `predictor_observe_calibration`, `predictor_model_zoo`, etc.) rather than the guard's raw path-derived slug (`alpha_engine_predictor_analysis_observe_leaderboard_py_build`).
- **Severity + response chosen together, deliberately**: `warning` + `drain-queue`, never `critical`/`operator`. A starved shadow arm is a measurement-coverage signal — resolved by repairing the shadow write path, or by the shadow runner's own rotation (`_select_challengers_for_cycle`) reaching the starved arm within `ceil(n/max_n)` cycles — never a trading-halt condition, so it must not page the one operator chat. This is the 2026-08-28 alert-destination-arc lesson: severity alone does not pick a destination tier (that arc found every severity landing in the same chat); severity and response are set together here.

## Test plan

- [x] `python3 infrastructure/overseer/alert_class_pr_guard.py --repo crucible-predictor --repo-root <local crucible-predictor-PR587 worktree> --base <merge-base> --head HEAD --playbooks infrastructure/overseer/playbooks.yaml` — passes with this row (confirmed severity resolves to `warning`, not `dynamic`)
- [x] `python3 -c "import yaml,json,jsonschema; jsonschema.validate(yaml.safe_load(open('infrastructure/overseer/playbooks.yaml')), json.load(open('infrastructure/overseer/playbooks.schema.json')))"` — schema valid
- [x] `PYTHONPATH=. ./.venv/bin/python -m pytest tests/` — 6805 passed, 17 skipped, 0 failed (full suite, run before opening this PR)

MERGE ORDER: either PR first, in either direction — an OPEN PR here carrying this row already satisfies crucible-predictor-PR587's guard check without waiting for merge (per the guard's own design). Companion: crucible-predictor-PR587.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132D4f4nt2n76PnRzUbVCba