### PR TITLE
[P1/low] feat(overseer): alert_classes row for the R-slot producer arena (alpha-engine-config-I9318)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -787,6 +787,19 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+  - class: backtester_producer_arena
+    # alpha-engine-config-I9318: the R-slot (selection-producer) arena cycle.
+    # Fires only when the cycle comes out `unmeasurable` or `unservable` — i.e.
+    # the slot could not decide the live config/producer_champion.json pointer
+    # on evidence. Distinct from backtester_champion_promotion above, which
+    # alerts when the weekly run RAISES: a cycle that completes and honestly
+    # reports "no arm is measurable" is not an exception, and collapsing the
+    # two would make the drain queue unable to tell a code defect from missing
+    # upstream evidence.
+    source: "alpha-engine-backtester/optimizer/producer_arena.py::run_arena_cycle"
+    severities: [error]
+    intake: bus
+    response: drain-queue
   - class: backtester_live_key_reconciliation
     source: "alpha-engine-backtester/optimizer/live_key_reconciliation.py"
     severities: [critical]

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -800,6 +800,11 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    operator_reason: >-
+      The R-slot arena could not promote or defend the live producer_champion
+      pointer on evidence (unmeasurable or unservable). drain-queue is the
+      closed loop: T0-T3 triage distinguishes code defects from upstream
+      evidence gaps tracked as alpha-engine-config-I9405.
   - class: backtester_live_key_reconciliation
     source: "alpha-engine-backtester/optimizer/live_key_reconciliation.py"
     severities: [critical]


### PR DESCRIPTION
Companion to **crucible-backtester-PR758** (alpha-engine-config-I9318). Adds one
`alert_classes` row.

## Why

PR758 wires the selection-producer slot to `nousergon_lib.arena` and publishes an
ops alert from `optimizer/producer_arena.py::run_arena_cycle` when a cycle comes
out `unmeasurable` or `unservable` — the slot could not decide the live
`config/producer_champion.json` pointer on evidence
(`champion-challenger-policy.md` §11). The backtester's `pr-added alert source
must carry an alert_classes row` check correctly failed until this row exists.

## Why its own class

`backtester_champion_promotion` already covers that repo's weekly run, but it
fires when the run **RAISES**. A cycle that completes and honestly reports "no
arm is measurable" is not an exception. Folding the two together would leave the
drain queue unable to tell a code defect from missing upstream evidence — and for
the first live cycles the second is precisely the expected state, until
crucible-research emits the per-date population series
(alpha-engine-config-I9405).

`intake: bus` / `response: drain-queue` / `severities: [error]` match the sibling
backtester rows and the call site's literal severity.

The source literal uses the canonical `alpha-engine-backtester/` prefix
(alpha-engine-config-I3302 completed that rename), matching
`backtester_champion_promotion` immediately above it; PR758 corrects the call
site to emit the same prefix rather than introducing a second one for the same
repo.

## Merge order

Either PR first, in either direction. PR758's check re-reads this registry on
every run and treats an open PR carrying the row as satisfying it, and nothing
here depends on PR758 — so the two cannot deadlock.

## Test plan

- [x] `playbooks.yaml` parses (`yaml.safe_load`)
- [x] Row shape matches the adjacent backtester classes
- [ ] CI green on this PR

Model: Claude Opus 4.6 (subagent, 2026-08-29 Crucible arc).
