### PR TITLE
fix(rerun): derive run_date from ApplyNormalizedRunDate trading day (I8809)

### DIFF
--- a/scripts/sf_rerun_common.py
+++ b/scripts/sf_rerun_common.py
@@ -63,12 +63,33 @@ def initialize_input_output(events: list[dict]) -> dict | None:
     return None
 
 
+def apply_normalized_run_date_output(events: list[dict]) -> dict | None:
+    """The merged object ``ApplyNormalizedRunDate`` emitted after
+    ``NormalizeRunDates`` — the cycle's TRADING day on ``$.run_date``
+    (alpha-engine-config-I8809). This is the key every artifact prefix and
+    skip-coherence predicate actually use; ``InitializeInput`` only stamps the
+    calendar date before normalization."""
+    for e in events:
+        d = e.get("stateExitedEventDetails")
+        if d is not None and d.get("name") == "ApplyNormalizedRunDate":
+            try:
+                return json.loads(d.get("output") or "null")
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
 def derive_run_date(events: list[dict], start_time: datetime | None) -> tuple[str, str]:
     """Return (run_date, provenance). Precedence: explicit input run_date >
-    InitializeInput's merged output > date(Execution start time)."""
+    ApplyNormalizedRunDate's merged output (trading day) >
+    InitializeInput's merged output (calendar day, pre-normalizer) >
+    date(Execution start time)."""
     orig = execution_input(events)
     if isinstance(orig.get("run_date"), str) and orig["run_date"]:
         return orig["run_date"], "explicit run_date in the failed execution's input"
+    normalized = apply_normalized_run_date_output(events)
+    if isinstance(normalized, dict) and isinstance(normalized.get("run_date"), str) and normalized["run_date"]:
+        return normalized["run_date"], "ApplyNormalizedRunDate merged output of the failed execution (trading day)"
     init = initialize_input_output(events)
     if isinstance(init, dict) and isinstance(init.get("run_date"), str) and init["run_date"]:
         return init["run_date"], "InitializeInput merged output of the failed execution"
@@ -81,8 +102,8 @@ def derive_run_date(events: list[dict], start_time: datetime | None) -> tuple[st
         )
     raise SystemExit(
         "FATAL: cannot derive run_date — no explicit input run_date, no "
-        "InitializeInput output in history, and no execution start time "
-        "was supplied."
+        "ApplyNormalizedRunDate output, no InitializeInput output in history, "
+        "and no execution start time was supplied."
     )
 
 

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -948,7 +948,7 @@ class TestHistoricalWorkStateNames:
 # dispatch is spent (sf-pipeline-policy §2.5).
 # ---------------------------------------------------------------------------
 
-def _history(*, explicit_run_date=None, init_run_date=None, extra_input=None):
+def _history(*, explicit_run_date=None, init_run_date=None, normalized_run_date=None, extra_input=None):
     """Build a minimal synthetic execution-history events list."""
     inp = {"pipeline_role": "watch-rerun"}
     if extra_input:
@@ -962,11 +962,25 @@ def _history(*, explicit_run_date=None, init_run_date=None, extra_input=None):
     if init_run_date is not None:
         out = dict(inp)
         out["run_date"] = init_run_date
+        out["calendar_date"] = init_run_date
         events.append({
             "type": "PassStateExited",
             "stateExitedEventDetails": {
                 "name": "InitializeInput",
                 "output": json.dumps(out),
+            },
+        })
+    if normalized_run_date is not None:
+        base = dict(inp)
+        if init_run_date is not None:
+            base["calendar_date"] = init_run_date
+        base["run_date"] = normalized_run_date
+        base["run_date_family"] = "trading_day"
+        events.append({
+            "type": "PassStateExited",
+            "stateExitedEventDetails": {
+                "name": "ApplyNormalizedRunDate",
+                "output": json.dumps(base),
             },
         })
     return events
@@ -1000,6 +1014,16 @@ class TestRunDateCarriedAcrossUTCMidnight:
         run_date, provenance = mod.derive_run_date(events, late_start)
         assert run_date == "2026-08-15"
         assert "InitializeInput" in provenance
+
+    def test_normalized_trading_day_wins_over_initialize_calendar_day(self, mod):
+        """alpha-engine-config-I8809: Saturday 2026-08-29 run keyed cycle
+        2026-08-28; rerun must carry the trading day or skip-coherence on
+        predictor weights rejects a valid recovery plan."""
+        events = _history(init_run_date="2026-08-29", normalized_run_date="2026-08-28")
+        late_start = datetime(2026, 8, 29, 9, 0, 49, tzinfo=timezone.utc)
+        run_date, provenance = mod.derive_run_date(events, late_start)
+        assert run_date == "2026-08-28"
+        assert "ApplyNormalizedRunDate" in provenance
 
     def test_only_a_genuine_pre_workload_failure_falls_back_to_start_time(self, mod):
         """No explicit run_date, no InitializeInput output at all (the


### PR DESCRIPTION
## Summary
- Weekly SF recovery reruns derived `run_date` from `InitializeInput`'s calendar stamp, which can differ from the cycle's trading day after `NormalizeRunDates` (e.g. Saturday 2026-08-29 → cycle 2026-08-28).
- `derive_run_date()` now prefers `ApplyNormalizedRunDate` merged output over the pre-normalizer calendar date, unblocking skip-coherence for `skip_predictor_training` on valid recovery plans.

## Test plan
- [x] `pytest tests/test_weekly_sf_rerun.py` — 93 passed
- [x] `weekly_sf_rerun.py --dry-run` against failed execution `965d925b-...` — derives `run_date=2026-08-28`, no skip-coherence error

## Cross-references
- alpha-engine-config-I8809
- Recovery target: failed weekly SF `965d925b-f9d6-ce5e-e059-9405433a0724_c0271e3b-a27f-a834-b303-3e3803fffd16`

Model: claude-4.6-opus-high-thinking

Made with [Cursor](https://cursor.com)