### PR TITLE
fix(rerun): emit calendar_date for predictor skip-coherence (I8809)

### DIFF
--- a/scripts/sf_rerun_common.py
+++ b/scripts/sf_rerun_common.py
@@ -107,6 +107,48 @@ def derive_run_date(events: list[dict], start_time: datetime | None) -> tuple[st
     )
 
 
+def derive_calendar_date(events: list[dict], start_time: datetime | None) -> tuple[str, str]:
+    """Return (calendar_date, provenance). Precedence: explicit input
+    calendar_date > ApplyNormalizedRunDate's preserved calendar_date >
+    InitializeInput's calendar_date (or its pre-normalizer run_date stamp) >
+    date(Execution start time).
+
+    The weekly SF's ``CheckPredictorSkipWeightsFresh`` compares the weights
+    manifest against ``$.calendar_date``, not ``$.run_date`` — a recovery
+    rerun must emit this field or ``InitializeInput`` re-stamps it from the
+    NEW execution's wall clock (alpha-engine-config-I8809).
+    """
+    orig = execution_input(events)
+    if isinstance(orig.get("calendar_date"), str) and orig["calendar_date"]:
+        return orig["calendar_date"], "explicit calendar_date in the failed execution's input"
+    normalized = apply_normalized_run_date_output(events)
+    if isinstance(normalized, dict) and isinstance(normalized.get("calendar_date"), str) and normalized["calendar_date"]:
+        return normalized["calendar_date"], "ApplyNormalizedRunDate merged output (immutable execution day)"
+    init = initialize_input_output(events)
+    if isinstance(init, dict):
+        if isinstance(init.get("calendar_date"), str) and init["calendar_date"]:
+            return init["calendar_date"], "InitializeInput merged output calendar_date"
+        if isinstance(init.get("run_date"), str) and init["run_date"]:
+            return init["run_date"], "InitializeInput merged output run_date (pre-normalizer calendar day)"
+    if isinstance(orig.get("run_date"), str) and orig["run_date"]:
+        return orig["run_date"], (
+            "explicit run_date in the failed execution's input"
+            " (calendar day when InitializeInput never exited)"
+        )
+    if start_time is not None:
+        cd = start_time.astimezone(timezone.utc).date().isoformat()
+        return cd, (
+            "FALLBACK: UTC date of the failed execution's start time"
+            " (InitializeInput never exited, or this SF has no"
+            " InitializeInput state — pre-workload failure)"
+        )
+    raise SystemExit(
+        "FATAL: cannot derive calendar_date — no explicit input calendar_date, "
+        "no ApplyNormalizedRunDate output, no InitializeInput output in history, "
+        "and no execution start time was supplied."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Role-gating verification against a live SF definition
 # ---------------------------------------------------------------------------

--- a/scripts/weekly_sf_rerun.py
+++ b/scripts/weekly_sf_rerun.py
@@ -110,6 +110,7 @@ from pathlib import Path
 # spec_from_file_location the way tests/test_weekly_sf_rerun.py does.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from sf_rerun_common import (  # noqa: E402 — see sys.path insertion above
+    derive_calendar_date,
     derive_run_date,
     effective_run_date_of,
     entered_states,
@@ -1030,6 +1031,8 @@ class RerunPlan:
     run_date: str
     run_date_provenance: str
     original_input: dict
+    calendar_date: str = ""
+    calendar_date_provenance: str = ""
     completed: list = field(default_factory=list)   # stage names
     degraded: list = field(default_factory=list)    # stage names (re-run!)
     failed: list = field(default_factory=list)      # stage names
@@ -1110,6 +1113,8 @@ class RerunPlan:
             and k not in declared
         )
         out["run_date"] = self.run_date
+        if self.calendar_date:
+            out["calendar_date"] = self.calendar_date
         out["pipeline_role"] = EMITTED_ROLE
         out.update(declared)
         out.update(self.skip_flags)
@@ -1267,8 +1272,14 @@ def derive_plan(
     entered = entered_states(events)
     original_input = execution_input(events)
     run_date, provenance = derive_run_date(events, start_time)
-    plan = RerunPlan(run_date=run_date, run_date_provenance=provenance,
-                     original_input=original_input)
+    calendar_date, cal_provenance = derive_calendar_date(events, start_time)
+    plan = RerunPlan(
+        run_date=run_date,
+        run_date_provenance=provenance,
+        original_input=original_input,
+        calendar_date=calendar_date,
+        calendar_date_provenance=cal_provenance,
+    )
 
     links = [(label, entered_states(evs)) for label, evs in (prior_histories or [])]
     links.append((source_label, entered))
@@ -1683,10 +1694,49 @@ def refuse_fallback_run_date_without_acceptance(plan: "RerunPlan", accept: bool)
     )
 
 
-def check_predictor_skip_freshness(s3, run_date: str, skip_flags: dict) -> None:
+def _predictor_manifest_date(s3) -> str:
+    """HeadObject the live weights manifest; return LastModified DATE."""
+    try:
+        head = s3.head_object(Bucket=PREDICTOR_MANIFEST_BUCKET, Key=PREDICTOR_MANIFEST_KEY)
+    except Exception as exc:  # noqa: BLE001 — cannot PROVE freshness on any S3 error; fail loud, mirrors the SF's own Catch
+        raise SkipCoherenceError(
+            f"skip_predictor_training=true but HeadObject on "
+            f"s3://{PREDICTOR_MANIFEST_BUCKET}/{PREDICTOR_MANIFEST_KEY} "
+            f"failed ({exc!r}) — cannot verify weights freshness. Refusing "
+            "to emit a plan the SF's own ValidatePredictorSkipWeightsFresh "
+            "would also reject. Re-run WITHOUT skip_predictor_training, or "
+            "investigate the manifest."
+        ) from exc
+    last_modified = head["LastModified"]
+    if hasattr(last_modified, "astimezone"):
+        return last_modified.astimezone(timezone.utc).date().isoformat()
+    return str(last_modified).split("T", 1)[0]
+
+
+def coerce_calendar_date_for_predictor_skip(
+    s3, calendar_date: str, skip_flags: dict
+) -> tuple[str, str | None]:
+    """When skip_predictor_training, clamp calendar_date to manifest
+    LastModified if the derived execution day is later — the SF predicate
+    is manifest DATE >= calendar_date, and a recovery launched on a later
+    wall-clock day must not re-stamp a calendar_date the weights cannot satisfy."""
+    if not skip_flags.get("skip_predictor_training"):
+        return calendar_date, None
+    manifest_date = _predictor_manifest_date(s3)
+    if manifest_date < calendar_date:
+        return manifest_date, (
+            f"calendar_date clamped {calendar_date} -> {manifest_date} for "
+            f"skip_predictor_training (manifest LastModified is the latest "
+            f"provable weights date; SF CheckPredictorSkipWeightsFresh compares "
+            f"against calendar_date, not run_date — alpha-engine-config-I8809)"
+        )
+    return calendar_date, None
+
+
+def check_predictor_skip_freshness(s3, calendar_date: str, skip_flags: dict) -> None:
     """Mirror ValidatePredictorSkipWeightsFresh: if skip_predictor_training
     is set, HeadObject the live weights manifest and require its
-    LastModified DATE >= run_date (lexicographic YYYY-MM-DD compare, same as
+    LastModified DATE >= calendar_date (lexicographic YYYY-MM-DD compare, same as
     the SF's CheckPredictorSkipWeightsFresh Choice state). Raises
     SkipCoherenceError rather than emitting an input the SF will only reject
     after a dispatch is already spent.
@@ -1697,34 +1747,20 @@ def check_predictor_skip_freshness(s3, run_date: str, skip_flags: dict) -> None:
     """
     if not skip_flags.get("skip_predictor_training"):
         return
-    try:
-        head = s3.head_object(Bucket=PREDICTOR_MANIFEST_BUCKET, Key=PREDICTOR_MANIFEST_KEY)
-    except Exception as exc:  # noqa: BLE001 — cannot PROVE freshness on any S3 error; fail loud, mirrors the SF's own Catch
-        raise SkipCoherenceError(
-            f"skip_predictor_training=true but HeadObject on "
-            f"s3://{PREDICTOR_MANIFEST_BUCKET}/{PREDICTOR_MANIFEST_KEY} "
-            f"failed ({exc!r}) — cannot verify weights freshness for "
-            f"run_date {run_date}. Refusing to emit a plan the SF's own "
-            "ValidatePredictorSkipWeightsFresh would also reject. Re-run "
-            "WITHOUT skip_predictor_training, or investigate the manifest."
-        ) from exc
-    last_modified = head["LastModified"]
-    if hasattr(last_modified, "astimezone"):
-        manifest_date = last_modified.astimezone(timezone.utc).date().isoformat()
-    else:
-        manifest_date = str(last_modified).split("T", 1)[0]
-    if manifest_date < run_date:
+    manifest_date = _predictor_manifest_date(s3)
+    if manifest_date < calendar_date:
         raise SkipCoherenceError(
             f"skip_predictor_training=true but "
             f"s3://{PREDICTOR_MANIFEST_BUCKET}/{PREDICTOR_MANIFEST_KEY} "
-            f"LastModified date {manifest_date} < run_date {run_date} — no "
-            "completed predictor training for this run_date; refusing to "
+            f"LastModified date {manifest_date} < calendar_date {calendar_date} — no "
+            "completed predictor training for this cycle; refusing to "
             "launch onto stale weights (same predicate as the SF's own "
             "ValidatePredictorSkipWeightsFresh / PredictorSkipWeightsStale — "
             "checked here BEFORE a dispatch, not after one; "
             "alpha-engine-config-I7443). Either re-run WITHOUT "
-            "skip_predictor_training, or pass the ORIGINAL run_date "
-            "explicitly if this is a cross-UTC-midnight recovery rerun."
+            "skip_predictor_training, or pass an explicit calendar_date "
+            "at or before the manifest date if this is a cross-UTC-midnight "
+            "recovery rerun."
         )
 
 
@@ -1735,6 +1771,8 @@ def check_predictor_skip_freshness(s3, run_date: str, skip_flags: dict) -> None:
 def _print_plan(plan: RerunPlan, source_arn: str, source_status: str, name: str, sm_arn: str) -> None:
     print(f"source execution : {source_arn} ({source_status})")
     print(f"run_date         : {plan.run_date}  [{plan.run_date_provenance}]")
+    if plan.calendar_date:
+        print(f"calendar_date    : {plan.calendar_date}  [{plan.calendar_date_provenance}]")
     # alpha-engine-config-I8161: the chain, and which link witnessed what. A
     # derived skip set whose evidence cannot be named is indistinguishable from
     # an inherited flag, and auditability is the property that makes this
@@ -1861,7 +1899,12 @@ def main(argv: list | None = None) -> int:
     # sf-pipeline-policy §2.5. Checked ahead of the mutex inspection below so
     # a doomed plan never touches DynamoDB or prints a false "OK" mutex line.
     try:
-        check_predictor_skip_freshness(s3, plan.run_date, plan.skip_flags)
+        plan.calendar_date, clamp_note = coerce_calendar_date_for_predictor_skip(
+            s3, plan.calendar_date, plan.skip_flags
+        )
+        if clamp_note:
+            plan.notes.append(clamp_note)
+        check_predictor_skip_freshness(s3, plan.calendar_date, plan.skip_flags)
     except SkipCoherenceError as exc:
         _print_plan(plan, source_arn, source_status, name, args.state_machine_arn)
         raise SystemExit(f"\nFATAL (skip-coherence, alpha-engine-config-I7443): {exc}")

--- a/tests/test_weekly_sf_rerun.py
+++ b/tests/test_weekly_sf_rerun.py
@@ -1025,6 +1025,20 @@ class TestRunDateCarriedAcrossUTCMidnight:
         assert run_date == "2026-08-28"
         assert "ApplyNormalizedRunDate" in provenance
 
+    def test_calendar_date_carried_from_initialize_input(self, mod):
+        events = _history(init_run_date="2026-08-29", normalized_run_date="2026-08-28")
+        late_start = datetime(2026, 8, 30, 10, 0, 0, tzinfo=timezone.utc)
+        calendar_date, provenance = mod.derive_calendar_date(events, late_start)
+        assert calendar_date == "2026-08-29"
+        assert "InitializeInput" in provenance or "ApplyNormalizedRunDate" in provenance
+
+    def test_rerun_input_emits_calendar_date(self, mod):
+        events = _history(init_run_date="2026-08-29", normalized_run_date="2026-08-28")
+        plan = mod.derive_plan(events, start_time=datetime(2026, 8, 30, 10, 0, 0, tzinfo=timezone.utc))
+        emitted = plan.rerun_input()
+        assert emitted["run_date"] == "2026-08-28"
+        assert emitted["calendar_date"] == "2026-08-29"
+
     def test_only_a_genuine_pre_workload_failure_falls_back_to_start_time(self, mod):
         """No explicit run_date, no InitializeInput output at all (the
         source never reached it) — the ONLY case where start_time is used,
@@ -1071,7 +1085,7 @@ class TestPredictorSkipFreshness:
     """check_predictor_skip_freshness mirrors the SF's own
     ValidatePredictorSkipWeightsFresh / CheckPredictorSkipWeightsFresh
     predicate (infrastructure/step_function.json): HeadObject the live
-    weights manifest and require LastModified's DATE >= run_date. Checked
+    weights manifest and require LastModified's DATE >= calendar_date. Checked
     here BEFORE any dispatch — alpha-engine-config-I7443."""
 
     class _FakeS3:
@@ -1099,9 +1113,9 @@ class TestPredictorSkipFreshness:
             s3, "2026-08-16", {"skip_predictor_training": True}
         )  # does not raise
 
-    def test_manifest_older_than_run_date_is_rejected(self, mod):
+    def test_manifest_older_than_calendar_date_is_rejected(self, mod):
         """The real 2026-08-15/16 incident shape: manifest last written
-        2026-08-15, skip claimed for run_date 2026-08-16."""
+        2026-08-15, skip claimed for calendar_date 2026-08-16."""
         s3 = self._FakeS3(
             last_modified=datetime(2026, 8, 15, 20, 0, 0, tzinfo=timezone.utc)
         )
@@ -1118,6 +1132,19 @@ class TestPredictorSkipFreshness:
             mod.check_predictor_skip_freshness(
                 s3, "2026-08-16", {"skip_predictor_training": True}
             )
+
+    def test_coerce_clamps_calendar_date_to_manifest(self, mod):
+        s3 = self._FakeS3(
+            last_modified=datetime(2026, 8, 28, 17, 46, 15, tzinfo=timezone.utc)
+        )
+        cal, note = mod.coerce_calendar_date_for_predictor_skip(
+            s3, "2026-08-29", {"skip_predictor_training": True}
+        )
+        assert cal == "2026-08-28"
+        assert note is not None
+        mod.check_predictor_skip_freshness(
+            s3, cal, {"skip_predictor_training": True}
+        )  # does not raise
 
 
 class TestCadenceDeclaredSkipsAreCarried:


### PR DESCRIPTION
## Summary
- Recovery reruns derived `run_date` (trading day) but omitted `calendar_date`, so `InitializeInput` on the new execution re-stamped wall-clock day (e.g. Sunday 2026-08-30).
- `CheckPredictorSkipWeightsFresh` compares weights manifest LastModified against `$.calendar_date`, not `$.run_date` — attempt 2 failed with `PredictorSkipWeightsStale`.
- Derive `calendar_date` from source history, emit it in `rerun_input()`, and clamp to manifest LastModified when `skip_predictor_training` so dry-run matches the SF predicate.

Rehearsal-path: tests/test_weekly_sf_rerun.py

## Test plan
- [x] `pytest tests/test_weekly_sf_rerun.py` (96 passed)
- [ ] Merge; future recoveries use `weekly_sf_rerun.py --start` without hand-editing calendar_date