### PR TITLE
fix(eval-judge-spot): yq405wh AppConfig on spot box (I9442)

### DIFF
--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh
@@ -64,7 +64,7 @@ ACCOUNT_ID="${ACCOUNT_ID:-711398986525}"
 # In particular EVAL_JUDGE_SPOT_WATCHDOG_SECONDS is NOT set here: the handler
 # refuses to launch when it does not exceed bootstrap + judge budget, and an
 # env override is exactly how that inequality would be broken out of band.
-PROD_ENV='Variables={LOG_LEVEL=INFO,EVAL_JUDGE_SPOT_DISPATCH_ENABLED=true}'
+PROD_ENV='Variables={LOG_LEVEL=INFO,EVAL_JUDGE_SPOT_DISPATCH_ENABLED=true,EVAL_JUDGE_SPOT_APPCONFIG_APPLICATION=yq405wh}'
 
 # Timeout must cover the handler's worst case: launch a spot (RunInstances +
 # state poll; longer on the on-demand fallback after capacity retries) PLUS

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
@@ -242,7 +242,9 @@ KREPIS_ROUTER_CREDENTIAL_SECRET = os.environ.get(
     "EVAL_JUDGE_SPOT_ROUTER_CREDENTIAL_SECRET", "ROUTER_CONSUMER_RESEARCH"
 )
 KREPIS_APPCONFIG_APPLICATION = os.environ.get(
-    "EVAL_JUDGE_SPOT_APPCONFIG_APPLICATION", "alpha-engine"
+    # IAM-scoped AppConfig application for the live registry (yq405wh), not the
+    # legacy alpha-engine id — same fix as crucible-research#778 on submit.
+    "EVAL_JUDGE_SPOT_APPCONFIG_APPLICATION", "yq405wh"
 )
 KREPIS_APPCONFIG_CONFIG_PROFILE = os.environ.get(
     "EVAL_JUDGE_SPOT_APPCONFIG_CONFIG_PROFILE", "llm-model-registry"

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
@@ -134,6 +134,7 @@ class TestBootstrapCommand:
             "KREPIS_EXEC_CONTEXT=ec2",
             "KREPIS_LITELLM_PROXY_URL=https://router.nousergon.ai:8443",
             "KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_RESEARCH",
+            "KREPIS_APPCONFIG_APPLICATION=yq405wh",
             "KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry",
         ):
             assert line in cmd, f"missing from the env file heredoc: {line}"


### PR DESCRIPTION
## Summary
- Default `EVAL_JUDGE_SPOT_APPCONFIG_APPLICATION` to `yq405wh` (was `alpha-engine`) in the spot dispatcher handler and deploy env.
- Pins the router env file written to the eval-judge spot box to the IAM-scoped AppConfig application, matching crucible-research#778 on submit.

## Root cause
`watch-rerun-2026-08-28-5`: spot `judge_spot_run` graded 0/114 — `CapabilityUnavailableError: model group 'low' has no live member declaring capabilities.tool_choice`. The box loaded the stale `alpha-engine` registry; submit already used `yq405wh`.

Rehearsal-path: infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py

## Test plan
- [x] `pytest infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py` (15 passed)
- [x] Live operator step applied: `EVAL_JUDGE_SPOT_APPCONFIG_APPLICATION=yq405wh` on `alpha-engine-research-eval-judge-spot-dispatcher`

Made with [Cursor](https://cursor.com)