### PR TITLE
Wire cost-sink addressing into eval-judge spot box

### DIFF
--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
@@ -253,6 +253,20 @@ KREPIS_APPCONFIG_ENVIRONMENT = os.environ.get(
     "EVAL_JUDGE_SPOT_APPCONFIG_ENVIRONMENT", "production"
 )
 
+# ── Cost-sink addressing (config-I7179) ─────────────────────────────────────
+# krepis>=0.57.0 resolves the process-default sink from these two variables.
+# Lambdas get them from crucible-research/infrastructure/deploy.sh; the spot
+# box gets them through ENV_FILE because the judge run is a separate SSM shell.
+# Without them, `default_sink_from_env()` returns None, every judge call is
+# unpriced, and AggregateCosts names EvalJudgeProcess for a missing
+# `evaljudge-sync` producer (measured watch-rerun-2026-08-28-8/9, 2026-08-30).
+KREPIS_COST_SINK_BUCKET = os.environ.get(
+    "EVAL_JUDGE_SPOT_COST_SINK_BUCKET", "alpha-engine-research"
+)
+KREPIS_COST_SINK_PREFIX = os.environ.get(
+    "EVAL_JUDGE_SPOT_COST_SINK_PREFIX", "decision_artifacts/_cost_raw"
+)
+
 INSTANCE_TAG_NAME = "alpha-engine-eval-judge-spot"
 
 
@@ -324,6 +338,8 @@ KREPIS_ROUTER_CREDENTIAL_SECRET={KREPIS_ROUTER_CREDENTIAL_SECRET}
 KREPIS_APPCONFIG_APPLICATION={KREPIS_APPCONFIG_APPLICATION}
 KREPIS_APPCONFIG_CONFIG_PROFILE={KREPIS_APPCONFIG_CONFIG_PROFILE}
 KREPIS_APPCONFIG_ENVIRONMENT={KREPIS_APPCONFIG_ENVIRONMENT}
+KREPIS_COST_SINK_BUCKET={KREPIS_COST_SINK_BUCKET}
+KREPIS_COST_SINK_PREFIX={KREPIS_COST_SINK_PREFIX}
 AWS_REGION={REGION}
 AWS_DEFAULT_REGION={REGION}
 EVAL_JUDGE_ENV

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
@@ -136,6 +136,8 @@ class TestBootstrapCommand:
             "KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_RESEARCH",
             "KREPIS_APPCONFIG_APPLICATION=yq405wh",
             "KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry",
+            "KREPIS_COST_SINK_BUCKET=alpha-engine-research",
+            "KREPIS_COST_SINK_PREFIX=decision_artifacts/_cost_raw",
         ):
             assert line in cmd, f"missing from the env file heredoc: {line}"
 


### PR DESCRIPTION
## Summary
- Write `KREPIS_COST_SINK_BUCKET` and `KREPIS_COST_SINK_PREFIX` into the eval-judge spot box env file (config-I7179 parity with Lambda deploy)
- Structural test asserts both variables appear in the bootstrap heredoc

## Context
watch-rerun-2026-08-28-8/9: eval judge graded 114/114 on spot but `AggregateCosts` failed — `evaljudge-sync` emitted no cost records. Root cause: `eval-judge.env` had router/AppConfig vars but not cost-sink addressing, so `default_sink_from_env()` returned `None`. crucible-research#779 adds flush on exit (necessary but not sufficient without a sink).

## Test plan
- [x] `pytest infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py`
- [ ] CI green → merge → deploy-eval-judge-spot-dispatcher workflow → rerun-10


Made with [Cursor](https://cursor.com)