### PR TITLE
Preserve state through WriteCompletionMarker for calendar copy

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -7319,6 +7319,7 @@
           "Comment": "Transient S3 fault coverage \u2014 mirrors the SendCommand SDK-transient Retry convention used elsewhere in this SF."
         }
       ],
+      "ResultPath": "$.completion_marker_result",
       "Next": "WriteCompletionMarkerCalendar"
     },
     "NotifyShellRunComplete": {

--- a/tests/test_sf_completion_marker_wiring.py
+++ b/tests/test_sf_completion_marker_wiring.py
@@ -84,6 +84,11 @@ def test_marker_state_shape(weekly_states):
     # that genuinely cannot be written should surface as a real failure,
     # not be silently swallowed the way a non-fatal notify is.
     assert "Catch" not in st
+    assert st["ResultPath"] == "$.completion_marker_result", (
+        "WriteCompletionMarker must preserve state for WriteCompletionMarkerCalendar "
+        "(alpha-engine-config-I8809); without ResultPath the putObject output "
+        "replaces the input and $.calendar_date cannot resolve"
+    )
     (retry,) = st["Retry"]
     assert retry["ErrorEquals"] == ["States.ALL"]
     assert retry["MaxAttempts"] >= 2


### PR DESCRIPTION
## Summary
- Add `ResultPath: $.completion_marker_result` to `WriteCompletionMarker` (mirrors the degraded twin added in alpha-engine-config-I6891)
- Structural test asserts ResultPath is present

## Context
watch-rerun-2026-08-28-10 reached aggregate costs cleanly but failed at `WriteCompletionMarkerCalendar` with `States.Runtime` — `$.calendar_date` missing because `WriteCompletionMarker` replaced the entire state with the S3 putObject response.

## Test plan
- [x] `pytest tests/test_sf_completion_marker_wiring.py::test_marker_state_shape`
- [ ] CI green → merge → deploy-infrastructure → rerun-11

Rehearsal-path: tests/test_sf_completion_marker_wiring.py


Made with [Cursor](https://cursor.com)