### PR TITLE
Raise ReportCard SF timeout to 600s

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -6694,7 +6694,7 @@
           }
         }
       },
-      "TimeoutSeconds": 300,
+      "TimeoutSeconds": 600,
       "Retry": [
         {
           "ErrorEquals": [

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -146,7 +146,6 @@ _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
         # self-deadlines, which is the rule's second branch.
         ("step_function.json", "RationaleClustering"),
         ("step_function.json", "Counterfactual"),
-        ("step_function.json", "ReportCard"),
         ("step_function.json", "DispatchWeeklyFreshnessSpot"),
         ("step_function_daily.json", "PredictorInference"),
         ("step_function_daily.json", "ReinvokePredictor"),

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -65,7 +65,7 @@ _DEFS = ("step_function.json", "step_function_daily.json", "step_function_eod.js
 _FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
     "alpha-engine-data-spot-dispatcher": 600,
     "alpha-engine-eod-precondition-probe": 30,
-    "alpha-engine-evaluator": 300,
+    "alpha-engine-evaluator": 660,
     "alpha-engine-evaluator-director": 900,
     "alpha-engine-predictor-inference": 900,
     # alpha-engine-config-I7620. Two read-only Step Functions API calls plus a


### PR DESCRIPTION
## Summary
- `ReportCard` `TimeoutSeconds` 300 → 600
- Remove `ReportCard` from `_KNOWN_UNBOUND` in `test_sf_lambda_timeout_ordering.py`

## Context
Recovery reruns 11-12 failed on ReportCard timeout; evaluator companion PR raises Lambda to 660s (SF < function per config-I6855).

Merge order: crucible-evaluator timeout PR deploy first, then this PR.

## Test plan
- [ ] CI green including `test_sf_lambda_timeout_ordering.py`
- [ ] deploy-infrastructure on merge

Rehearsal-path: tests/test_sf_lambda_timeout_ordering.py


Made with [Cursor](https://cursor.com)