### PR TITLE
fix(systemd-drift): annotate drift findings with boot-pull.service health (alpha-engine-config-I9444)

### DIFF
--- a/infrastructure/systemd/check-systemd-unit-drift.py
+++ b/infrastructure/systemd/check-systemd-unit-drift.py
@@ -111,6 +111,24 @@ have inherited the same wrong list. Roots are therefore found by walking
 so a checkout that lands on a box is covered the day it lands, with nothing
 to remember to edit. `--codified-root` still works and is ADDITIVE, for a
 tree outside the search bases.
+
+**A drift/uncodified finding is annotated with `boot-pull.service` health
+(2026-08-31, alpha-engine-config-I9444).** Measured live on the trading box
+(ip-172-31-79-214): `daily-news.timer` and `systemd-unit-drift-check.timer`
+both drifted, and the bare finding ("installed (c78dd9556b6a) != repo
+(7cab59f44f9d)") gave no signal that the box's ONLY reconciliation path
+outside a manual install — `boot-pull.service`, per the 2026-07-13 "queue on
+merge, apply on next boot" ruling on config#2352 — had been failing at
+EVERY boot since 2026-08-28 (crucible-executor's `boot-pull-launcher.sh` was
+never copied to `/usr/local/sbin` on this instance, so systemd could not
+exec it). A human reading that finding has to already know boot-pull exists
+and go check it by hand; `_boot_pull_diagnosis()` does that check itself and,
+when boot-pull.service is loaded and its last run did not succeed, appends
+one diagnostic line naming the actual cause. Best-effort and silent
+everywhere boot-pull.service does not apply — the dashboard box (push-
+deployed on merge, no boot-pull), a laptop, or CI — so its own failure to
+run `systemctl` can never affect the exit code or mask the underlying drift
+finding it is only ever adding CONTEXT to, never replacing.
 """
 
 from __future__ import annotations
@@ -118,6 +136,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import socket
+import subprocess
 import sys
 from pathlib import Path
 
@@ -359,6 +378,62 @@ def check_unit(
     return "clean", f"{name}: OK"
 
 
+def _boot_pull_diagnosis(run=None) -> str | None:
+    """If `boot-pull.service` exists on this box and its last run failed, say so.
+
+    Boot-pull is the trading box's ONLY reconciliation path outside a manual
+    `install-*.sh` run (2026-07-13 ruling on config#2352: "queue on merge,
+    apply on next boot") — when it fails, every unit it manages goes stale
+    silently until the next boot, and a bare "installed != repo" finding
+    gives no signal that this is the actual cause rather than an on-box
+    hand-edit (alpha-engine-config-I9444: `boot-pull-launcher.sh` missing
+    from `/usr/local/sbin` left `boot-pull.service` failing at every boot
+    from 2026-08-28 through 2026-08-31, and that is exactly what produced
+    the `daily-news.timer` / `systemd-unit-drift-check.timer` drift this
+    function now names on sight).
+
+    `run` is injectable for tests; production always calls
+    `subprocess.run`. Best-effort and silent on any box without
+    `boot-pull.service` — the dashboard box updates via deploy-on-merge SSM
+    push instead, and this script also runs on a laptop / in CI where
+    `systemctl` may not exist at all — so this is a diagnostic ANNOTATION,
+    never a second source of findings: its own failure must never raise,
+    change the exit code, or mask the drift finding it only adds context to.
+    """
+    runner = run or subprocess.run
+    try:
+        proc = runner(
+            [
+                "systemctl", "show", "boot-pull.service",
+                "--property=LoadState,ActiveState,Result",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+    props = dict(
+        line.split("=", 1) for line in proc.stdout.splitlines() if "=" in line
+    )
+    if props.get("LoadState") != "loaded":
+        return None  # boot-pull.service does not exist on this box
+    result = props.get("Result", "")
+    if props.get("ActiveState") == "failed" or result not in ("", "success"):
+        return (
+            f"boot-pull.service (Result={result or 'unknown'}) is in a FAILED "
+            "state — this box's only reconciliation path outside a manual "
+            "install did not complete its last run, which is the likely cause "
+            "of the drift/uncodified findings above, not an on-box hand-edit; "
+            "see `systemctl status boot-pull.service` and "
+            "/var/log/boot-pull.log on the box (alpha-engine-config-I9444)"
+        )
+    return None
+
+
 def _emit_metrics(counts: dict) -> None:
     """Put the coverage counts to CloudWatch. Best-effort, loudly.
 
@@ -535,6 +610,15 @@ def main() -> int:
             exit_code = max(exit_code, 1)
     if uncodified and args.strict:
         exit_code = max(exit_code, 1)
+
+    # Diagnostic annotation, never a second source of findings: only runs
+    # when there is already something to explain, and never changes
+    # exit_code (computed above) — see _boot_pull_diagnosis's docstring.
+    if buckets["drift"] or uncodified_new:
+        diagnosis = _boot_pull_diagnosis()
+        if diagnosis:
+            print(f"[diagnosis] {diagnosis}")
+            findings.append(diagnosis)
 
     # Console publish runs on EVERY invocation — clean or not, `--report` or
     # not — mirroring crucible-dashboard's box_health_hygiene precedent

--- a/tests/test_systemd_unit_drift_check.py
+++ b/tests/test_systemd_unit_drift_check.py
@@ -4,8 +4,10 @@ Covers the installed-vs-repo systemd unit drift probe: clean match,
 divergence detection, not-installed (box hosts neither pair) as non-error,
 and missing repo source as a config error. No real AWS/systemd access —
 purely local file comparison, so this is a plain tmp-dir fixture test
-(mirrors the module-load pattern used by test_sf_definition_check_drift.py,
-minus the subprocess mocking since this script never shells out to AWS).
+(mirrors the module-load pattern used by test_sf_definition_check_drift.py).
+The one exception is `_boot_pull_diagnosis` (alpha-engine-config-I9444),
+which does shell out to `systemctl` — those tests inject a fake `run`
+callable rather than touching a real subprocess.
 """
 from __future__ import annotations
 
@@ -736,3 +738,108 @@ class TestCodifiedRootDiscovery:
         assert "[clean] ibgateway.service" in cap.out
         assert "disagreeing copies" in cap.out
         assert "ambiguous=1" in cap.out
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+class TestBootPullDiagnosis:
+    """`_boot_pull_diagnosis` (alpha-engine-config-I9444): a drift/uncodified
+    finding is annotated with boot-pull.service health, because a bare
+    hash-mismatch line gives no signal that the box's ONLY reconciliation
+    path outside a manual install failed rather than someone hand-editing a
+    unit file. Diagnostic only — must never raise, never change exit_code,
+    and stay silent everywhere boot-pull.service does not apply."""
+
+    def test_failed_boot_pull_is_named(self, cd):
+        module, _, _ = cd
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _FakeCompleted(0, "LoadState=loaded\nActiveState=failed\nResult=exit-code\n")
+
+        diagnosis = module._boot_pull_diagnosis(run=fake_run)
+        assert diagnosis is not None
+        assert "boot-pull.service" in diagnosis
+        assert "FAILED" in diagnosis
+        assert calls and calls[0][:2] == ["systemctl", "show"]
+
+    def test_healthy_boot_pull_is_silent(self, cd):
+        module, _, _ = cd
+
+        def fake_run(cmd, **kw):
+            return _FakeCompleted(0, "LoadState=loaded\nActiveState=inactive\nResult=success\n")
+
+        assert module._boot_pull_diagnosis(run=fake_run) is None
+
+    def test_box_without_boot_pull_service_is_silent(self, cd):
+        """The dashboard box (push-deployed on merge) has no boot-pull.service
+        at all — `systemctl show` on a unit that was never loaded returns
+        LoadState=not-found, and that must never be reported as a failure."""
+        module, _, _ = cd
+
+        def fake_run(cmd, **kw):
+            return _FakeCompleted(0, "LoadState=not-found\nActiveState=inactive\nResult=success\n")
+
+        assert module._boot_pull_diagnosis(run=fake_run) is None
+
+    def test_missing_systemctl_is_silent_not_raised(self, cd):
+        """A laptop or CI runner has no systemctl at all — this is a
+        diagnostic annotation, not a hard dependency of the check."""
+        module, _, _ = cd
+
+        def fake_run(cmd, **kw):
+            raise FileNotFoundError("systemctl not found")
+
+        assert module._boot_pull_diagnosis(run=fake_run) is None
+
+    def test_nonzero_returncode_is_silent(self, cd):
+        module, _, _ = cd
+
+        def fake_run(cmd, **kw):
+            return _FakeCompleted(1, "")
+
+        assert module._boot_pull_diagnosis(run=fake_run) is None
+
+    def test_main_appends_diagnosis_to_findings_when_boot_pull_failed(self, cd, monkeypatch, capsys):
+        """End-to-end: a drifted unit plus a failed boot-pull.service produces
+        a console/alert finding set that names BOTH — the drift and its
+        likely cause — not the drift alone."""
+        module, script_dir, installed_dir = cd
+        _write(script_dir / "daily-news.service", "UNIT NEW\n")
+        _write(installed_dir / "daily-news.service", "UNIT OLD\n")
+        for name in module.ALL_UNITS:
+            if name != "daily-news.service":
+                _write(script_dir / name, f"UNIT {name}\n")
+
+        monkeypatch.setattr(
+            module,
+            "_boot_pull_diagnosis",
+            lambda: "boot-pull.service (Result=exit-code) is in a FAILED state",
+        )
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        exit_code = module.main()
+        out = capsys.readouterr().out
+
+        assert exit_code == 1, "the diagnosis must never change the drift exit code"
+        assert "[diagnosis] boot-pull.service" in out
+
+    def test_main_does_not_call_diagnosis_when_clean(self, cd, monkeypatch, capsys):
+        """No need to shell out to systemctl on every clean run — the
+        annotation only has something to explain once there is a finding."""
+        module, script_dir, installed_dir = cd
+        for name in module.ALL_UNITS:
+            _write(script_dir / name, f"UNIT {name}\n")
+            _write(installed_dir / name, f"UNIT {name}\n")
+
+        called = []
+        monkeypatch.setattr(module, "_boot_pull_diagnosis", lambda: called.append(1))
+        monkeypatch.setattr("sys.argv", ["check-systemd-unit-drift.py"])
+        code = module.main()
+
+        assert code == 0
+        assert not called, "_boot_pull_diagnosis must not run on a clean box"


### PR DESCRIPTION
## What / why

The `[ERROR] ... systemd unit drift ... daily-news.timer: installed (c78dd9556b6a) != repo (7cab59f44f9d); systemd-unit-drift-check.timer: installed (472ec6741260) != repo (072df5c4128a)` alert on `ip-172-31-79-214` (the trading box, `alpha-engine-executor`, i-018eb3307a21329bf) traced to a broken `boot-pull.service`, not stale repo files.

## Root cause (measured live, 2026-08-31)

- `journalctl -u boot-pull.service` on the box: FAILED at every boot from 2026-08-28 through 2026-08-31 with `Failed to locate executable /usr/local/sbin/boot-pull-launcher.sh: No such file or directory`.
- `/usr/local/sbin/` was empty. `boot-pull.service`'s `ExecStart=/usr/local/sbin/boot-pull-launcher.sh` (crucible-executor PR #495 / alpha-engine-config-I8734) requires `install-boot-pull.sh` to have copied the launcher there — a one-time, hand-run SSM step. `boot-pull.sh`'s normal per-boot cycle re-copies `boot-pull.service` itself on every run but has no equivalent self-heal for the launcher binary, so the launcher going missing on this instance was silently uncaught until this drift alert surfaced it two units downstream.
- Boot-pull is this box's ONLY reconciliation path outside a manual install (2026-07-13 ruling, config#2352: "queue on merge, apply on next boot") — so while it was down, every unit AND every repo checkout (`alpha-engine`, `alpha-engine-config`, `alpha-engine-data`) it manages on this box went stale on every boot, not just the two units the alert named.

## Immediate remediation (done live, verified)

Ran the existing, unmodified `install-boot-pull.sh` over SSM on i-018eb3307a21329bf — re-installed the launcher, re-ran `boot-pull.service` successfully (pulled all three repos to current `origin/main`, reconciled both drifted timers). Re-ran the drift check on the box: `SUMMARY ... drift=0`. The box is clean now.

## What this PR fixes (nousergon-data's own scope)

The crucible-executor-side gap (boot-pull.sh not self-healing its own launcher) is filed separately as `alpha-engine-config-I9444` — this repo cannot touch crucible-executor code.

What nousergon-data *can* fix: the drift finding itself gave zero signal that this was a boot-pull failure rather than an on-box hand-edit. `check-systemd-unit-drift.py` gained `_boot_pull_diagnosis()` — a best-effort `systemctl show boot-pull.service` check that appends one diagnostic line to the finding set (console + channel alert) whenever boot-pull.service is loaded and its last run failed. It only runs when there's already a drift/uncodified-new finding to explain, is silent everywhere boot-pull.service doesn't apply (dashboard box, laptop, CI), and never touches the exit code — pure diagnostic annotation on top of the existing detect → report → console pipeline.

## Tests

7 new cases for `_boot_pull_diagnosis` (failed / healthy / service-absent / no-systemctl / nonzero-exit) plus two end-to-end `main()` wiring tests (diagnosis appended on drift, never invoked on a clean run). `tests/test_systemd_unit_drift_check.py` (49 total in this file) and `tests/test_embedded_systemd_unit_shapes.py` (79) all pass. Full repo suite: 6861 passed / 12 skipped locally (the only two failures seen mid-session were pre-existing local `.venv` staleness against the `nousergon-lib` pin — v0.124.96 installed vs v0.124.102 pinned, self-diagnosed by the test's own error message per alpha-engine-config-I9116/I9070 — not a code defect; reinstalling the pin cleared both).

## Related

- alpha-engine-config-I9444 — the crucible-executor systemic fix (boot-pull self-heal for the launcher binary), tracked separately.

---
Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)