### PR TITLE
feat(overseer): lint the three alert-message anti-patterns at PR time (alpha-engine-config-I9460)

### DIFF
--- a/.github/workflows/alert-class-pr-guard.yml
+++ b/.github/workflows/alert-class-pr-guard.yml
@@ -147,3 +147,62 @@ jobs:
           --repo-root "$GITHUB_WORKSPACE/graded"
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"
+
+      # ── ALERT MESSAGE SHAPE (alpha-engine-config-I9460) ──────────────────
+      #
+      # Step 1 above asks: is this alert SOURCE registered? This asks the next
+      # question: can the person who receives the page act on it without asking
+      # anyone anything, and will it stop firing once the condition stops
+      # standing?
+      #
+      # WHAT IT REPLACES. `alpha-engine-config-I9449` swept the fleet for alert
+      # messages defective in SHAPE rather than in truth and fixed the loudest
+      # instances across five repos. Measured from the 633 krepis dedup markers
+      # in s3://alpha-engine-research/_alerts/_dedup/ (publish_count increments
+      # only on a successful publish, so these are real deliveries): 134 pages
+      # in 11 days, 104 of them covered by that sweep. A sweep is a ONE-TIME
+      # cleanup — nothing stopped the class returning on the next PR, and every
+      # instance read as helpful in review, which is why each was written.
+      #
+      # Three rules, each pinned to a real fixed instance in
+      # nousergon-data/tests/test_alert_message_lint.py:
+      #   ALERT001 unanswerable ask   "Review and approve acceleration if the
+      #                                reallocation is intended."
+      #   ALERT002 go look it up      "review the optimizer shadow logs for the
+      #                                driver" / "(detail in journal)"
+      #   ALERT003 run-keyed dedup    freshness_digest_{date}_{fp}, and the
+      #                                router canary's ~430 identical hourly
+      #                                pages for one 18-day condition.
+      #
+      # WARN-ONLY, DELIBERATELY, AND HOW THAT ENDS. This step annotates and
+      # exits 0. It is warn-first because the lint is ONE implementation read
+      # by eleven repos from a floating ref, which is the exact shape that
+      # reverdicted the whole fleet's CI in 32 seconds on 2026-08-28 when a
+      # reusable workflow loaded its guard script unpinned. Warn-only removes
+      # that blast radius entirely while the rule earns its enforcement.
+      # `alpha-engine-config-I9471` carries the flip and the predicate that
+      # clears it.
+      #
+      # WHICH COPY RUNS. Same rule as step 1: a nousergon-data PR is graded by
+      # the lint it SHIPS, so a PR that changes a rule is measured against the
+      # rule it is proposing rather than the one on main.
+      #
+      # A MISSING SCRIPT WARNS RATHER THAN FAILING, FOR THIS STEP ONLY. Step 1
+      # hard-fails on a missing checkout and must keep doing so. Here the file
+      # may legitimately not exist yet: this workflow change and the script
+      # land in different repos, and a hard failure would redden eight repos'
+      # main for the length of that merge window. The enforcement flip converts
+      # BOTH halves — the miss and the findings — in one commit.
+      - name: A PR-added alert message must be actionable (warn-only)
+        run: |
+          set -euo pipefail
+          if [ "${{ github.repository }}" = "nousergon/nousergon-data" ]; then
+            s="$GITHUB_WORKSPACE/graded/infrastructure/overseer/alert_message_lint.py"
+          else
+            s="$GITHUB_WORKSPACE/registry/infrastructure/overseer/alert_message_lint.py"
+          fi
+          if [ ! -f "$s" ]; then
+            echo "::warning title=alert-message-lint::$s is not on nousergon-data main yet, so the alert-message lint did not run. Warn-only by design while alpha-engine-config-I9460 lands across the fleet; alpha-engine-config-I9471 makes this a hard failure."
+            exit 0
+          fi
+          python3 "$s" --repo "${{ github.event.repository.name }}" --repo-root "$GITHUB_WORKSPACE/graded" --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}" --warn-only

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py
@@ -1270,6 +1270,12 @@ def _notify(record: dict, key: str, pipeline_name: str, dispatch: dict) -> bool:
         footer = "_autonomous fix DISABLED (observe-only)_"
     lines.append(footer)
     text = "\n".join(lines)
+    # alert-lint: allow ALERT003 -- this is an INFO-severity per-run RECEIPT, not
+    #   a condition report: it says "the watch ran and here is what it saw about
+    #   this execution". The SF execution IS the episode, so a key that outlived
+    #   one execution would suppress the receipt for the NEXT run of the same
+    #   pipeline -- the opposite of the defect ALERT003 exists to catch. The
+    #   standing conditions this Lambda reports are keyed separately below.
     dedup_key = f"{_FLOW_NAME}:{pipeline_name}:{record.get('execution_arn', key)}"
     try:
         return notify_via_flow_doctor(

--- a/infrastructure/overseer/alert_class_pr_guard.py
+++ b/infrastructure/overseer/alert_class_pr_guard.py
@@ -99,9 +99,12 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Callable, TypeVar
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import alert_class_registry_drift as scan  # noqa: E402
+
+_T = TypeVar("_T")
 
 _GIT = shutil.which("git") or "/usr/bin/git"
 _GH = shutil.which("gh") or "gh"
@@ -152,13 +155,36 @@ def _patterns_from(playbooks: Path) -> list[tuple[str, str, bool]]:
 # ── scanning one repo at one ref ────────────────────────────────────────────
 
 
-def _scan_at(repo_root: Path, ref: str, playbooks_override: Path | None) -> dict[str, set[str]]:
-    """Uncovered source literals in ``repo_root`` at ``ref``.
+def scan_at_ref(repo_root: Path, ref: str, fn: Callable[[Path], _T]) -> _T:
+    """Run ``fn`` against ``repo_root``'s tree as it stands at ``ref``.
 
-    ``ref`` resolving to the checkout's own HEAD is scanned in place; any other
+    ``ref`` resolving to the checkout's own HEAD is read in place; any other
     ref is materialized as a detached ``git worktree`` inside ``repo_root``,
     read, and torn down — the same mechanism ``observability_registry_pr_guard``
     uses, and the reason the caller needs ``fetch-depth: 0``.
+
+    Public and generic because ``alert_message_lint`` needs exactly this
+    base-vs-head materialization and must not carry a second copy of it
+    (``policy-shared-code``): a fork of the worktree teardown is a fork of the
+    ``worktree remove --force`` that keeps a failed run from leaving the graded
+    checkout with a stale registration.
+    """
+    head_sha = _run_git(["rev-parse", "HEAD"], cwd=repo_root).strip()
+    resolved = _run_git(["rev-parse", ref], cwd=repo_root).strip()
+    if resolved == head_sha:
+        return fn(repo_root)
+
+    with tempfile.TemporaryDirectory(prefix="alert-pr-guard-") as tmp:
+        wt = Path(tmp) / "base"
+        _run_git(["worktree", "add", "--detach", "--quiet", str(wt), resolved], cwd=repo_root)
+        try:
+            return fn(wt)
+        finally:
+            _run_git(["worktree", "remove", "--force", str(wt)], cwd=repo_root)
+
+
+def _scan_at(repo_root: Path, ref: str, playbooks_override: Path | None) -> dict[str, set[str]]:
+    """Uncovered source literals in ``repo_root`` at ``ref``.
 
     When the registry file itself lives INSIDE the graded repo (this repo
     grading its own PRs), the ref's OWN copy of ``playbooks.yaml`` is used.
@@ -169,18 +195,7 @@ def _scan_at(repo_root: Path, ref: str, playbooks_override: Path | None) -> dict
         pb = playbooks_override if playbooks_override is not None else root / PLAYBOOKS_REL
         return scan._scan_repo(root, _patterns_from(pb))  # noqa: SLF001
 
-    head_sha = _run_git(["rev-parse", "HEAD"], cwd=repo_root).strip()
-    resolved = _run_git(["rev-parse", ref], cwd=repo_root).strip()
-    if resolved == head_sha:
-        return _do(repo_root)
-
-    with tempfile.TemporaryDirectory(prefix="alert-class-pr-guard-") as tmp:
-        wt = Path(tmp) / "base"
-        _run_git(["worktree", "add", "--detach", "--quiet", str(wt), resolved], cwd=repo_root)
-        try:
-            return _do(wt)
-        finally:
-            _run_git(["worktree", "remove", "--force", str(wt)], cwd=repo_root)
+    return scan_at_ref(repo_root, ref, _do)
 
 
 # ── the pending open companion PR tolerance ─────────────────────────────────

--- a/infrastructure/overseer/alert_message_lint.py
+++ b/infrastructure/overseer/alert_message_lint.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+"""PR-time lint: an alert MESSAGE that is defective in SHAPE fails its own CI.
+
+``alpha-engine-config-I9460``. Companion to :mod:`alert_class_pr_guard`, which
+asks *is this alert source registered*. This module asks the next question:
+*can the person who receives this page act on it without asking anyone
+anything, and will it stop firing when the condition stops standing?*
+
+WHY THIS EXISTS
+---------------
+``alpha-engine-config-I9449`` swept the fleet for alert messages defective in
+shape rather than in truth and fixed the loudest instances across five repos.
+A sweep is a one-time cleanup: nothing stopped the class returning on the next
+PR, and every instance read as *helpful* in review, which is why each was
+written that way in the first place.
+
+Measured scale, from the 633 krepis dedup markers in
+``s3://alpha-engine-research/_alerts/_dedup/`` (``publish_count`` increments
+only on a successful publish, so these are real deliveries): **134 pages over
+11 days**, of which the sweep's fixes covered 104.
+
+THE THREE PATTERNS
+------------------
+``ALERT001`` — **the unanswerable ask.** The message requests a human
+decision, approval or acknowledgement for which there is no channel, no state
+that changes when it is given, and no consequence of never giving it. It fires
+on a schedule and asks the same question every session. Real instance, removed
+in ``crucible-executor-PR518``::
+
+    "... (run_date=...) Review and approve acceleration if the reallocation
+     is intended."
+
+``ALERT002`` — **go look it up.** The message instructs the reader to inspect
+a log, artifact, dashboard or table the emitting code has already read or
+could cheaply read. It converts a detector into a pager. Real instances, fixed
+in ``crucible-executor-PR518`` and ``crucible-dashboard-PR810``::
+
+    "... review the optimizer shadow logs for the driver."
+    "memory budget: BREACH (detail in journal)"
+
+Once the executor tripwire was rewritten to attribute its own driver, a replay
+on 2026-08-31 produced ``driver=predictor_conviction_collapse ... This is an
+UPSTREAM condition`` with no human involved at all.
+
+``ALERT003`` — **run-keyed rather than episode-keyed dedup.** The ``dedup_key``
+embeds a value that changes on every run, so one standing condition mints a
+fresh key and re-pages every run. This is the highest-volume class in the
+fleet by a wide margin: the router canary produced ~430 identical hourly pages
+for a single 18-day condition, and ``freshness_digest_{date}_{fp}`` guaranteed
+a fresh page every calendar day for a condition that had not changed.
+
+ALERT003 IS GRADED IN TWO TIERS, AND THE REASON IS THE FALSE-POSITIVE RATE
+--------------------------------------------------------------------------
+Whether a run-keyed dedup is a defect turns on ONE question the lint cannot
+answer from source alone: *can this condition stand across runs?* A once-per-
+trading-day reconciliation failure keyed on ``{run_date}`` pages once per
+occurrence and is correct. A standing staleness condition keyed on
+``{run_date}`` pages every day forever and is the defect.
+
+So the tell is split by what the interpolated value can POSSIBLY be:
+
+* ``execution`` tier — sub-day clock readings and per-execution identities
+  (``now``, ``timestamp``, ``execution_arn``, ``run_token``, ``instance_id``,
+  ``elapsed``, ``uuid``). These can NEVER be episode identity, under any
+  cadence, because a second run of the same standing condition always mints a
+  different one. No judgement is required and the finding is unconditional.
+
+* ``calendar`` tier — date-granular values (``run_date``, ``date_str``,
+  ``trading_day``, ``today``). Correct exactly when the condition cannot
+  outlive one day. That is a real judgement, so the finding asks for it: fix
+  the key, or record the judgement in a waiver whose reason names why the
+  condition cannot stand. Measured on the fleet as it stands today: 12
+  ``execution``-tier sites and 45 ``calendar``-tier sites, ALL pre-existing
+  and therefore invisible to this lint, which grades only the PR delta.
+
+WHAT IS DELIBERATELY NOT FLAGGED
+--------------------------------
+* ``as_of`` in any spelling. ``crucible-research-PR780`` keys the fixed
+  freshness grouping on ``(driver, upstream_prefix, as_of)``: the upstream
+  artifact's own as-of stamp IS the episode identity there, and it stops
+  moving exactly when the episode closes.
+* Content hashes and fingerprints of the finding set — the correct shape.
+  ``crucible-research/infrastructure/lambda_deploy_drift.py`` keys on
+  ``head_sha[:12], severity``; ``check-definition-drift.py`` keys on a content
+  hash of the findings, replacing a count-based defect;
+  ``leaderboard_producers.py::vacuous_comparison`` keys on champion plus
+  sorted challenger names. All three pass, and are pinned as positive controls
+  in ``tests/test_alert_message_lint.py``.
+* A legitimate **operator-gated security boundary** is NOT ``ALERT001``. That
+  has a detector which stays red until the step runs, so never answering it
+  has a consequence and the loop does close. The lint cannot see the detector,
+  so this is the waiver's primary intended use and its reason must name it.
+
+THE WAIVER, AND WHY IT MUST CARRY A REASON
+-------------------------------------------
+An inline comment on, or within three lines above, the flagged line::
+
+    # alert-lint: allow ALERT003 -- receipt is an info-severity per-run
+    #   acknowledgement; the SF execution IS the episode (see arming.py).
+
+The rule id is required and a reason of at least
+:data:`_MIN_WAIVER_REASON_CHARS` characters is required. **A waiver with no
+reason is itself a finding** (``ALERT000``) — a bare suppression records that
+someone silenced the rule and nothing about why, which is the same defect the
+lint exists to prevent, one level up. ``--list-waivers`` enumerates every
+waiver in a checkout, so the suppression set is a readable artifact rather
+than something only grep knows about.
+
+ONE SCANNER, NOT TWO
+--------------------
+File selection and publish-call extraction come from
+:mod:`alert_class_registry_drift`; base-vs-head materialization comes from
+:func:`alert_class_pr_guard.scan_at_ref`. Nothing about locating an alert call
+site is reimplemented here (``policy-shared-code``) — this module contributes
+only the message-shape rules.
+
+EXIT CODES
+----------
+* ``0`` — no newly-introduced finding (or ``--warn-only``, which never fails).
+* ``1`` — a finding this diff introduced, or UNMEASURED. A lint that cannot
+  read its substrate fails as unmeasured, never as clean.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import alert_class_pr_guard as guard  # noqa: E402
+import alert_class_registry_drift as scan  # noqa: E402
+
+GuardError = guard.GuardError
+
+
+# ── rule definitions ────────────────────────────────────────────────────────
+
+#: Minimum characters of prose in a waiver reason. Short enough that a real
+#: one-line justification clears it; long enough that "n/a", "ok" and "see
+#: above" do not.
+_MIN_WAIVER_REASON_CHARS = 15
+
+#: A candidate message string must look like prose. A bare identifier, a path
+#: fragment or an S3 key is not a message and matching one is noise.
+_MIN_MESSAGE_CHARS = 15
+
+#: ALERT001 — the unanswerable ask.
+#:
+#: Every tell is an IMPERATIVE or a request. Past participles are excluded
+#: deliberately: "mTLS confirmed", "promotion approved" and "receipt
+#: acknowledged" are statements of fact, which is what an alert is supposed to
+#: contain. `\b(?!ed\b)` is not expressible directly, so each verb lists the
+#: inflections that are asks and omits the ones that are facts.
+_ALERT001_TELLS: list[tuple[str, str]] = [
+    (r"\bapprove\b", "asks for an approval"),
+    (r"\bapprovals?\b", "asks for an approval"),
+    (r"\backnowledge\b", "asks for an acknowledgement"),
+    (r"\backnowledge?ments?\b", "asks for an acknowledgement"),
+    (r"\bconfirm\b", "asks the reader to confirm"),
+    (r"\bplease\s+(confirm|verify|review|check|advise|acknowledge)\b",
+     "asks the reader to perform an action"),
+    (r"\bif\s+(this\s+is\s+|the\s+\w+\s+is\s+|it\s+is\s+)?intended\b",
+     "conditions on an intent only a human holds, with no channel to supply it"),
+    (r"\bif\s+(this\s+is\s+)?expected\b",
+     "conditions on an expectation only a human holds, with no channel to supply it"),
+    (r"\bunless\s+(this\s+is\s+)?(expected|intended|deliberate)\b",
+     "conditions on an expectation only a human holds, with no channel to supply it"),
+    (r"\bsign\s*-?\s*off\b", "asks for a sign-off"),
+    (r"\bdecide\s+whether\b", "hands a decision to the reader with no channel"),
+]
+
+#: ALERT002 — go look it up.
+#:
+#: Each tell pairs an INSPECTION VERB with a NAMED PLACE to inspect. The verb
+#: alone is far too loose: "check" appears in half the fleet's prose. The
+#: place alone is looser still. The conjunction is the signal, and it is what
+#: distinguishes "review the optimizer shadow logs for the driver" from
+#: "reviewed 14 units".
+_INSPECTABLE = (
+    r"(?:logs?\b|log\s+group|journal\b|journalctl|artifacts?\b|dashboards?\b|"
+    r"tables?\b|consoles?\b|reports?\b|outputs?\b|cloudwatch\b|s3://|bucket\b|"
+    r"manifest\b|traceback\b|stack\s*trace|transcript\b|payload\b)"
+)
+_ALERT002_TELLS: list[tuple[str, str]] = [
+    (rf"\b(?:review|check|inspect|consult|examine|look\s+at|pull\s+up|"
+     rf"go\s+(?:and\s+)?(?:read|check|look))\s+(?:the\s+|your\s+|its\s+|our\s+)?"
+     # Up to three qualifier words between the verb and the thing to inspect.
+     # "review the optimizer shadow logs for the driver" needs two; a
+     # single-word window silently missed it, which is the whole reason the
+     # pre-fix ref is replayed in the test suite rather than trusted.
+     rf"(?:[\w\-./]+\s+){{0,3}}{_INSPECTABLE}",
+     "tells the reader to inspect something the emitter could read itself"),
+    (r"\b(?:see|refer\s+to|consult)\b[^.]{0,60}?\bfor\s+(?:details?|the\s+driver|"
+     r"the\s+cause|the\s+reason|more|context|diagnosis)\b",
+     "defers the diagnosis to another surface"),
+    (r"\bdetails?\s+in\s+(?:the\s+)?" + _INSPECTABLE,
+     "defers the diagnosis to another surface"),
+    (r"\b(?:investigate|triage|diagnose)\b(?!\s+(?:d|s\b))",
+     "asks the reader to perform the diagnosis the emitter is standing on the data for"),
+    (r"\bssh\s+(?:in|to|into)\b", "asks the reader to go to the box"),
+    (r"\brun\s+`?(?:journalctl|kubectl|aws\s+logs|tail\b)",
+     "asks the reader to run the command the emitter could have run"),
+]
+
+#: ALERT003 tier 1 — values that can NEVER be episode identity.
+_RUNKEY_EXECUTION = re.compile(
+    r"(?:^|_|\.|\b)(?:now|utcnow|timestamp|timestamps|ts|epoch|monotonic|"
+    r"execution_arn|executionarn|execution_id|run_token|run_id|runid|"
+    r"invocation_id|request_id|instance_id|task_arn|pid|uuid|uuid4|token|"
+    r"elapsed|elapsed_s|elapsed_sec|age_sec|age_seconds|duration_s|started_at|"
+    r"finished_at|completed_at)(?:$|_|\b)",
+    re.IGNORECASE,
+)
+
+#: ALERT003 tier 2 — date-granular values. Correct only when the condition
+#: cannot outlive one day; that judgement is the author's to record.
+_RUNKEY_CALENDAR = re.compile(
+    r"(?:^|_|\.|\b)(?:run_date|rundate|date_str|datestr|trading_day|tradingday|"
+    r"today|day|the_date|target_date|cycle_date|calendar_day|business_day|"
+    r"session_date)(?:$|_|\b)",
+    re.IGNORECASE,
+)
+
+#: Never a run key, whatever the tier regexes would otherwise say. ``as_of``
+#: is the upstream artifact's own stamp — it stops moving when the episode
+#: closes, which is precisely what episode identity means
+#: (``crucible-research-PR780``).
+_RUNKEY_EXEMPT = re.compile(r"as_?of", re.IGNORECASE)
+
+#: Sub-day strftime directives inside a key literal: ``{now:%Y-%m-%dT%H:%M}``
+#: mints a new key every minute however the variable is named.
+_SUBDAY_STRFTIME = re.compile(r"%[HIMSfjs]")
+
+#: A tell preceded by one of these is a STATEMENT, not an instruction. The
+#: live false positive that put this here: ``crucible-executor``'s
+#: ``"turnover tripwire: could not read shadow log for %s: %s"`` — a fact about
+#: what the emitter itself failed to do, matched by the same "read ... log"
+#: tell that catches "review the optimizer shadow logs for the driver". A lint
+#: that flags an honest failure report teaches authors to stop writing them.
+_NOT_AN_INSTRUCTION = re.compile(
+    # The leading \b is load-bearing: without it `each\s+` matched inside
+    # "BREACH (" and suppressed `(detail in journal)`, the single
+    # highest-volume ALERT002 instance in the fleet. A cue must be a word.
+    r"\b(?:could\s*n[o']t|cannot|can'?t|couldn'?t|failed\s+to|unable\s+to|"
+    r"did\s*n[o']t|didn'?t|will\s+not|won'?t|no\s+one\s+to|nothing\s+to|"
+    r"already|automatically|we\s+|it\s+|which\s+|that\s+|error\s+|"
+    r"exception\s+|skipp?(?:ed|ing)\s+|while\s+|when\s+|after\s+|before\s+|"
+    r"this\s+|these\s+|each\s+|every\s+|"
+    r"instead\s+of\s+)"
+    r"[^.;]{0,12}$"
+)
+
+
+def _is_instruction(text_lower: str, start: int) -> bool:
+    """Is the tell at ``start`` an imperative aimed at the reader?
+
+    Judged from the ~40 characters preceding it, which is where the negation
+    or the subject sits in every instance in the corpus. Deliberately cheap:
+    a parser would be more precise and would also be a second grammar to
+    maintain for a rule whose whole value is that authors trust its output.
+    """
+    return not _NOT_AN_INSTRUCTION.search(text_lower[max(0, start - 40):start])
+
+
+_RULE_TITLES = {
+    "ALERT000": "waiver with no reason",
+    "ALERT001": "unanswerable ask",
+    "ALERT002": "go look it up",
+    "ALERT003": "run-keyed dedup",
+}
+
+_REMEDY = {
+    "ALERT000": (
+        "A suppression records that someone silenced this rule and nothing about why.\n"
+        "  Write the reason inline:  # alert-lint: allow <RULE> -- <why this call site "
+        "is correct>"
+    ),
+    "ALERT001": (
+        "Delete the ask. If a human decision genuinely IS required, it belongs on the\n"
+        "  Decision Queue with state, not in a message that re-fires tomorrow having\n"
+        "  learned nothing from the last time it was read.\n"
+        "  If this is a genuine operator-gated SECURITY BOUNDARY, it has a detector that\n"
+        "  stays red until the step runs — waive it and name that detector in the reason."
+    ),
+    "ALERT002": (
+        "Move the diagnosis into the detector. The test is whether the emitting code\n"
+        "  has, or can cheaply obtain, the data the message tells the human to fetch.\n"
+        "  Name the driver from a CLOSED set and keep an explicit `unattributed` branch —\n"
+        "  a new failure mode must be reported as new, never rounded to the nearest known\n"
+        "  one. Write the attribution on EVERY run, not only on the alerting path."
+    ),
+    "ALERT003": (
+        "Key on the EPISODE, not the run. The key must be identical on every run for\n"
+        "  which the condition is the same standing condition, and different the moment a\n"
+        "  genuinely new one opens. A fingerprint over the finding set is the usual shape\n"
+        "  (see check-definition-drift.py); an upstream artifact's own as-of stamp is\n"
+        "  another (crucible-research-PR780).\n"
+        "  If this condition genuinely cannot stand across runs, waive it and say why."
+    ),
+}
+
+
+# ── findings ────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule: str
+    relpath: str
+    line: int
+    snippet: str
+    why: str
+
+    @property
+    def fingerprint(self) -> str:
+        """Identity used for the base-vs-head delta.
+
+        Deliberately EXCLUDES the line number. A finding is the same finding
+        after an unrelated edit shifts it down the file; keying on the line
+        would report every pre-existing instance in a touched file as newly
+        introduced, and a lint that cries about code the PR did not write is
+        the one that gets switched off.
+        """
+        digest = hashlib.sha256(
+            f"{self.rule}\0{self.relpath}\0{_normalize(self.snippet)}".encode()
+        ).hexdigest()
+        return digest[:16]
+
+
+@dataclass(frozen=True)
+class Waiver:
+    relpath: str
+    line: int
+    rule: str
+    reason: str
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+# ── waiver parsing ──────────────────────────────────────────────────────────
+
+#: `# alert-lint: allow ALERT003 -- reason` / `-- ` / `— ` / `: ` all accepted;
+#: the separator is not the point, the reason is.
+_WAIVER_RE = re.compile(
+    r"alert-lint\s*:\s*allow\s+(?P<rule>ALERT\d{3}|\*)\s*(?:[-–—:]+\s*(?P<reason>.*))?$",
+    re.IGNORECASE,
+)
+
+#: How many lines ABOVE a finding a waiver may sit. Three, because a long
+#: message literal is routinely wrapped across two or three source lines and
+#: the natural place for the comment is above the whole construct.
+_WAIVER_LOOKBACK = 3
+
+
+def parse_waivers(text: str, relpath: str) -> tuple[list[Waiver], list[Finding]]:
+    """Every waiver in one file, plus an ``ALERT000`` for each with no reason."""
+    waivers: list[Waiver] = []
+    bare: list[Finding] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        match = _WAIVER_RE.search(raw)
+        if not match:
+            continue
+        reason = (match.group("reason") or "").strip().strip("\"'`")
+        rule = match.group("rule").upper()
+        if len(reason) < _MIN_WAIVER_REASON_CHARS:
+            bare.append(
+                Finding(
+                    rule="ALERT000",
+                    relpath=relpath,
+                    line=lineno,
+                    snippet=raw.strip(),
+                    why=(
+                        f"waiver for {rule} carries "
+                        + (f"a {len(reason)}-character reason" if reason else "no reason")
+                        + f"; at least {_MIN_WAIVER_REASON_CHARS} characters are required"
+                    ),
+                )
+            )
+            continue
+        waivers.append(Waiver(relpath=relpath, line=lineno, rule=rule, reason=reason))
+    return waivers, bare
+
+
+def _waived(finding: Finding, waivers: list[Waiver]) -> bool:
+    return any(
+        w.relpath == finding.relpath
+        and w.rule in (finding.rule, "*")
+        and 0 <= finding.line - w.line <= _WAIVER_LOOKBACK
+        for w in waivers
+    )
+
+
+# ── message-string extraction ───────────────────────────────────────────────
+
+
+def _python_message_strings(text: str) -> list[tuple[int, str]]:
+    """``(line, value)`` for every runtime string constant in a Python file.
+
+    Docstrings are excluded — a module that documents the anti-patterns (this
+    one, and the scanner it imports) would otherwise flag itself, which is
+    exactly the trap ``SELF_EXCLUDED_RELPATHS`` was added to the sibling
+    scanner for. f-strings are walked so their literal fragments are read and
+    their interpolations are not.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        # Not measurable by AST. Fall back to a line scan of quoted prose so a
+        # file the parser cannot read is never silently treated as clean.
+        return _quoted_prose_fallback(text)
+
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = getattr(node, "body", None) or []
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                docstrings.add(id(body[0].value))
+
+    # An f-string built from adjacent literals is ONE message and must be read
+    # as one. `crucible-executor`'s pre-fix tripwire wrote:
+    #
+    #     f"abnormally even though each day is under the cap; review "
+    #     f"the optimizer shadow logs for the driver."
+    #
+    # Two `ast.Constant` values inside a single `ast.JoinedStr`, with the tell
+    # straddling the boundary. Reading the parts separately made the single
+    # highest-value ALERT002 instance in the corpus invisible — caught here by
+    # replaying the pre-fix ref, which is the only reason it is not still
+    # invisible.
+    joined_parts: set[int] = set()
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        pieces: list[str] = []
+        for part in node.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                joined_parts.add(id(part))
+                pieces.append(part.value)
+            else:
+                # An interpolation is a value, not prose. A placeholder keeps
+                # the surrounding words from fusing into a phrase nobody wrote.
+                pieces.append(" {} ")
+        out.append((getattr(node, "lineno", 0), "".join(pieces)))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if id(node) in docstrings or id(node) in joined_parts:
+                continue
+            out.append((getattr(node, "lineno", 0), node.value))
+    return out
+
+
+_QUOTED = re.compile(r"""(?P<q>['"])(?P<v>(?:\\.|(?!(?P=q)).){4,})(?P=q)""")
+
+
+def _quoted_prose_fallback(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.lstrip()
+        if stripped.startswith("#"):
+            continue
+        for m in _QUOTED.finditer(raw):
+            out.append((lineno, m.group("v")))
+    return out
+
+
+def _shell_message_strings(text: str) -> list[tuple[int, str]]:
+    """``(line, value)`` for quoted strings on non-comment shell lines.
+
+    ``crucible-dashboard``'s ``box_health.sh`` composed
+    ``"memory budget: BREACH (detail in journal)"`` in a shell function, never
+    inside a publish call, so a lint scoped to publish-call bodies would have
+    missed the single highest-volume ``ALERT002`` instance in the fleet
+    (32 pages in 11 days).
+    """
+    out: list[tuple[int, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        code = raw.split("#", 1)[0] if raw.lstrip().startswith("#") else raw
+        if not code.strip():
+            continue
+        for m in _QUOTED.finditer(code):
+            out.append((lineno, m.group("v")))
+    return out
+
+
+# ── dedup-key extraction ────────────────────────────────────────────────────
+
+
+def _dedup_key_expressions(text: str) -> list[tuple[int, str]]:
+    """``(line, source)`` for every ``dedup_key`` binding in a Python file.
+
+    Covers both shapes the fleet uses: the keyword argument at the publish
+    call, and the local assigned a line or two above it. Both were live in the
+    corpus — ``freshness_monitor`` assigned
+    ``dedup_key = _digest_dedup_key(decisions, now, unproduced)`` and passed
+    the local, so a rule that read only keyword arguments would have missed
+    the instance ``nousergon-data-PR1603`` was opened to fix.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return _dedup_key_expressions_textual(text)
+
+    out: list[tuple[int, str]] = []
+
+    def _record(value: ast.AST, lineno: int) -> None:
+        try:
+            src = ast.unparse(value)
+        except Exception:  # noqa: BLE001 — unparse is best-effort; the segment below is the fallback
+            src = ""
+        out.append((lineno, src))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "dedup_key":
+                    _record(kw.value, getattr(kw.value, "lineno", node.lineno))
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                name = _target_name(target)
+                if name and name.endswith("dedup_key"):
+                    _record(node.value, node.value.lineno)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            name = _target_name(node.target)
+            if name and name.endswith("dedup_key"):
+                _record(node.value, node.value.lineno)
+    return out
+
+
+def _target_name(target: ast.AST) -> str | None:
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return None
+
+
+_DEDUP_TEXTUAL = re.compile(r"""dedup[_-]key\s*[=:]\s*(?P<expr>[^\n]{0,300})""")
+
+
+def _dedup_key_expressions_textual(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        for m in _DEDUP_TEXTUAL.finditer(raw):
+            out.append((lineno, m.group("expr")))
+    return out
+
+
+_SHELL_DEDUP = re.compile(r"--dedup-key[\s'\",=]+(?P<expr>[^\s'\"]{1,200})")
+
+
+def _shell_dedup_key_expressions(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if raw.lstrip().startswith("#"):
+            continue
+        for m in _SHELL_DEDUP.finditer(raw):
+            out.append((lineno, m.group("expr")))
+    return out
+
+
+def classify_dedup_expression(expr: str) -> tuple[str, str] | None:
+    """``(tier, matched)`` when ``expr`` is run-keyed, else ``None``."""
+    scrubbed = _RUNKEY_EXEMPT.sub("", expr)
+    if _SUBDAY_STRFTIME.search(scrubbed):
+        return ("execution", _SUBDAY_STRFTIME.search(scrubbed).group(0))
+    hit = _RUNKEY_EXECUTION.search(scrubbed)
+    if hit:
+        return ("execution", hit.group(0).strip("_."))
+    hit = _RUNKEY_CALENDAR.search(scrubbed)
+    if hit:
+        return ("calendar", hit.group(0).strip("_."))
+    return None
+
+
+# ── the file-level lint ─────────────────────────────────────────────────────
+
+
+def lint_text(text: str, relpath: str) -> tuple[list[Finding], list[Waiver]]:
+    """Every finding and waiver in one file's text. Waivers are NOT applied here."""
+    is_python = relpath.endswith(".py")
+    waivers, findings = parse_waivers(text, relpath)
+
+    strings = _python_message_strings(text) if is_python else _shell_message_strings(text)
+    for lineno, value in strings:
+        if len(value) < _MIN_MESSAGE_CHARS or " " not in value:
+            continue
+        low = value.lower()
+        for pattern, why in _ALERT001_TELLS:
+            m = next((c for c in re.finditer(pattern, low) if _is_instruction(low, c.start())),
+                     None)
+            if m:
+                findings.append(Finding("ALERT001", relpath, lineno, value.strip()[:300],
+                                        f"{why} (matched {m.group(0)!r})"))
+                break
+        for pattern, why in _ALERT002_TELLS:
+            m = next((c for c in re.finditer(pattern, low) if _is_instruction(low, c.start())),
+                     None)
+            if m:
+                findings.append(Finding("ALERT002", relpath, lineno, value.strip()[:300],
+                                        f"{why} (matched {m.group(0)!r})"))
+                break
+
+    exprs = (_dedup_key_expressions(text) if is_python else []) + \
+        _shell_dedup_key_expressions(text)
+    for lineno, expr in exprs:
+        verdict = classify_dedup_expression(expr)
+        if verdict is None:
+            continue
+        tier, matched = verdict
+        why = (
+            f"dedup_key interpolates {matched!r}, a per-execution value that can never "
+            "be episode identity — one standing condition mints a new key every run"
+            if tier == "execution"
+            else
+            f"dedup_key interpolates {matched!r}, so a condition that STANDS for more "
+            "than a day re-pages every day. Correct only if this condition cannot "
+            "outlive one day — say so in a waiver if it cannot"
+        )
+        findings.append(Finding("ALERT003", relpath, lineno, expr.strip()[:300], why))
+
+    return findings, waivers
+
+
+# ── repo scan ───────────────────────────────────────────────────────────────
+
+#: Files graded even though they carry no publish call of their own. A message
+#: is frequently composed in one module and published by another; without
+#: these the ``ALERT002`` instance ``crucible-dashboard-PR810`` fixed would be
+#: out of scope. The filter stays NAME-based and narrow rather than "every
+#: file in the repo": the whole-repo variant flags library prose about alerts.
+_ALERTISH_NAME = re.compile(
+    r"(alert|page[rs]?|notif|tripwire|watchdog|canary|health|digest|monitor|"
+    r"freshness|drift|escalat)", re.IGNORECASE,
+)
+
+
+#: Path segments whose files render to a SCREEN a person chose to open, not to
+#: a page that arrives unasked. "check here during triage" is correct guidance
+#: on a dashboard view and is the anti-pattern in an alert; the difference is
+#: entirely the delivery surface, so it is drawn on the path.
+_UI_PATH_SEGMENTS: frozenset[str] = frozenset(
+    {"views", "pages", "templates", "docs", "notebooks", "examples", "static"}
+)
+
+
+def _in_scope(relpath: str, text: str) -> bool:
+    """A file is graded when it publishes an alert, or is named like an emitter.
+
+    Both halves are needed and neither is sufficient. Publish-call presence
+    alone misses the composer module; the name heuristic alone would pull in
+    unrelated ``*_monitor.py`` helpers that never reach an operator.
+    """
+    if relpath in scan.SELF_EXCLUDED_RELPATHS:
+        return False
+    if relpath == "infrastructure/overseer/alert_message_lint.py":
+        return False
+    parts = Path(relpath).parts[:-1]
+    if any(seg in _UI_PATH_SEGMENTS for seg in parts):
+        return False
+    if scan._PUBLISH_CALL_PATTERN.search(text) or scan._CLI_CALL_PATTERN.search(text):
+        return True
+    # Matched against the whole relative path, not just the basename. Every
+    # Lambda in `nousergon-data` is `index.py`; the emitter identity lives in
+    # its DIRECTORY (`lambdas/freshness-monitor/`, `lambdas/pipeline-watchdog/`).
+    # A basename-only test put `freshness-monitor/index.py` out of scope, and
+    # with it the run-keyed dedup that `nousergon-data-PR1603` exists to fix.
+    return bool(_ALERTISH_NAME.search(relpath))
+
+
+def scan_repo(repo_root: Path) -> tuple[list[Finding], list[Waiver]]:
+    findings: list[Finding] = []
+    waivers: list[Waiver] = []
+    for path in sorted(repo_root.rglob("*.py")) + sorted(repo_root.rglob("*.sh")):
+        rel = path.relative_to(repo_root)
+        if any(p in scan.EXCLUDED_DIR_NAMES or p == ".claude" for p in rel.parts):
+            continue
+        if path.name.endswith("_pb2.py") or scan._is_test_file(path, repo_root):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise GuardError(f"UNREADABLE: {path} ({exc})") from exc
+        relpath = rel.as_posix()
+        if not _in_scope(relpath, text):
+            continue
+        f, w = lint_text(text, relpath)
+        findings.extend(f)
+        waivers.extend(w)
+    return findings, waivers
+
+
+def scan_repo_applied(repo_root: Path) -> dict[str, Finding]:
+    """``{fingerprint: Finding}`` after waivers are applied."""
+    findings, waivers = scan_repo(repo_root)
+    return {f.fingerprint: f for f in findings if not _waived(f, waivers)}
+
+
+# ── reporting ───────────────────────────────────────────────────────────────
+
+
+def _gha_annotation(finding: Finding, *, warn_only: bool) -> str:
+    level = "warning" if warn_only else "error"
+    msg = f"[{finding.rule} {_RULE_TITLES[finding.rule]}] {finding.why}"
+    return f"::{level} file={finding.relpath},line={finding.line},title=alert-message-lint::{msg}"
+
+
+def report(findings: list[Finding], *, warn_only: bool, out) -> None:
+    by_rule: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_rule.setdefault(f.rule, []).append(f)
+
+    verb = "WARN" if warn_only else "FAIL"
+    print(f"\n{verb}: this diff introduced {len(findings)} alert-message finding(s).", file=out)
+    for rule in sorted(by_rule):
+        print(f"\n=== {rule} — {_RULE_TITLES[rule]} "
+              f"({len(by_rule[rule])}) ===", file=out)
+        for f in sorted(by_rule[rule], key=lambda x: (x.relpath, x.line)):
+            print(f"\n  {f.relpath}:{f.line}", file=out)
+            print(f"    {f.snippet}", file=out)
+            print(f"    WHY: {f.why}", file=out)
+        print(f"\n  WHAT TO DO INSTEAD:\n  {_REMEDY[rule]}", file=out)
+    print(
+        "\n  If this call site is a genuine exception, waive it INLINE with a reason:\n"
+        "    # alert-lint: allow <RULE> -- <why this one is correct>\n"
+        "  A waiver with no reason is itself a finding. `--list-waivers` enumerates every\n"
+        "  waiver in the repo, so the suppression set stays readable.\n",
+        file=out,
+    )
+    if warn_only:
+        print(
+            "  WARN-ONLY: this step does not fail the build. It was landed warn-first so a\n"
+            "  change to the shared lint could never redden eleven repos' CI at once "
+            "(alpha-engine-config-I9471 carries the enforcement flip and its predicate).\n",
+            file=out,
+        )
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--repo", required=True, help="canonical name of the repo being graded")
+    ap.add_argument("--repo-root", required=True, help="checkout of --repo, with full history")
+    ap.add_argument("--base", default=None,
+                    help="git ref for the PR's base sha. Omitted: grade the whole checkout.")
+    ap.add_argument("--head", default="HEAD", help="git ref for the PR's head (default: HEAD)")
+    ap.add_argument("--warn-only", action="store_true",
+                    help="report findings as GitHub warning annotations and exit 0")
+    ap.add_argument("--list-waivers", action="store_true",
+                    help="enumerate every alert-lint waiver in the checkout and exit")
+    ap.add_argument("--no-annotations", action="store_true",
+                    help="suppress ::warning/::error workflow commands (local runs)")
+    args = ap.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+
+    if args.list_waivers:
+        try:
+            _, waivers = scan_repo(repo_root)
+        except GuardError as exc:
+            print(f"UNMEASURED: {exc}", file=sys.stderr)
+            return 1
+        print(f"{len(waivers)} alert-lint waiver(s) in {args.repo}:")
+        for w in sorted(waivers, key=lambda x: (x.relpath, x.line)):
+            print(f"  {w.relpath}:{w.line}  {w.rule}  — {w.reason}")
+        return 0
+
+    if not (repo_root / ".git").exists():
+        print(
+            f"UNMEASURED: {repo_root} is not a git checkout — this lint would otherwise "
+            "report green having verified nothing",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"linting: {args.repo} at {repo_root}")
+    print("rules: ALERT001 unanswerable ask · ALERT002 go look it up · "
+          "ALERT003 run-keyed dedup")
+
+    try:
+        head = guard.scan_at_ref(repo_root, args.head, scan_repo_applied)
+        base = (
+            guard.scan_at_ref(repo_root, args.base, scan_repo_applied)
+            if args.base else {}
+        )
+    except GuardError as exc:
+        print(f"UNMEASURED: {exc}", file=sys.stderr)
+        print("A lint that cannot read its substrate fails as unmeasured, never as clean.",
+              file=sys.stderr)
+        return 1
+
+    carried = [f for fp, f in head.items() if fp in base]
+    newly = [f for fp, f in head.items() if fp not in base]
+
+    if carried:
+        print(
+            f"\npre-existing findings NOT gated by this PR ({len(carried)}): "
+            + ", ".join(sorted({f"{f.rule}@{f.relpath}" for f in carried}))
+            + "\n  (alpha-engine-config-I9449's register owns those — this lint only "
+              "reports what THIS diff introduced)"
+        )
+
+    if not newly:
+        print("\nno newly-introduced alert-message finding in this diff.")
+        return 0
+
+    if not args.no_annotations:
+        for f in sorted(newly, key=lambda x: (x.relpath, x.line)):
+            print(_gha_annotation(f, warn_only=args.warn_only))
+
+    report(newly, warn_only=args.warn_only, out=sys.stderr if not args.warn_only else sys.stdout)
+    return 0 if args.warn_only else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/overseer/alert_message_lint.py
+++ b/infrastructure/overseer/alert_message_lint.py
@@ -232,6 +232,10 @@ _RUNKEY_CALENDAR = re.compile(
 #: (``crucible-research-PR780``).
 _RUNKEY_EXEMPT = re.compile(r"as_?of", re.IGNORECASE)
 
+#: A clock reading truncated to a calendar day: `now.date()`, `date.today()`,
+#: `strftime("%Y-%m-%d")` with no time part.
+_DATE_TRUNCATION = re.compile(r"\.date\s*\(\s*\)|\btoday\s*\(\s*\)")
+
 #: Sub-day strftime directives inside a key literal: ``{now:%Y-%m-%dT%H:%M}``
 #: mints a new key every minute however the variable is named.
 _SUBDAY_STRFTIME = re.compile(r"%[HIMSfjs]")
@@ -271,6 +275,20 @@ def _is_sequence_token(text_lower: str, start: int, end: int) -> bool:
         _SEQUENCE_JOINER.match(text_lower[end:end + 3])
         or _SEQUENCE_JOINER_BEFORE.search(text_lower[max(0, start - 3):start])
     )
+
+
+#: A message carrying the Decision Queue's own field shape IS the remedy this
+#: lint recommends, not the defect it names. `engagement-protocol-policy.md`
+#: 6.4b requires an escalation to carry `**Ask:**` / `**Recommendation:**` /
+#: `**SOTA:**` / `**Delta:**`, and a queue item has exactly what ALERT001 says
+#: is missing: a channel, state, and a consequence of never being answered.
+#: Live false positive: `freshness-monitor/index.py` composes a queue item
+#: reading "**Options:** ... B) Acknowledge as expected ...", flagged for
+#: `acknowledge` — the one place in the fleet where asking for an
+#: acknowledgement is correct.
+_DECISION_QUEUE_SHAPE = re.compile(
+    r"\*\*(?:ask|options?|recommendation|sota|delta)\s*:?\*\*", re.IGNORECASE
+)
 
 
 def _is_instruction(text_lower: str, start: int) -> bool:
@@ -596,7 +614,12 @@ def classify_dedup_expression(expr: str) -> tuple[str, str] | None:
         return ("execution", _SUBDAY_STRFTIME.search(scrubbed).group(0))
     hit = _RUNKEY_EXECUTION.search(scrubbed)
     if hit:
-        return ("execution", hit.group(0).strip("_."))
+        # `now.date().isoformat()` reads a clock and then TRUNCATES it to a
+        # day, so it re-pages daily, not per-run. Still run-keyed, but the tier
+        # drives the remediation priority in the register, and calling a
+        # date-granular key "per-execution" overstates it.
+        tier = "calendar" if _DATE_TRUNCATION.search(scrubbed) else "execution"
+        return (tier, hit.group(0).strip("_."))
     hit = _RUNKEY_CALENDAR.search(scrubbed)
     if hit:
         return ("calendar", hit.group(0).strip("_."))
@@ -614,6 +637,8 @@ def lint_text(text: str, relpath: str) -> tuple[list[Finding], list[Waiver]]:
     strings = _python_message_strings(text) if is_python else _shell_message_strings(text)
     for lineno, value in strings:
         if len(value) < _MIN_MESSAGE_CHARS or " " not in value:
+            continue
+        if _DECISION_QUEUE_SHAPE.search(value):
             continue
         low = value.lower()
         for pattern, why in _ALERT001_TELLS:
@@ -712,12 +737,24 @@ def _in_scope(relpath: str, text: str) -> bool:
     parts = Path(relpath).parts[:-1]
     if any(seg in _UI_PATH_SEGMENTS for seg in parts):
         return False
-    if (
+    publishes = bool(
         scan._PUBLISH_CALL_PATTERN.search(text)
         or scan._CLI_CALL_PATTERN.search(text)
         or _EXTRA_PUBLISH_SHAPES.search(text)
-    ):
+    )
+    if publishes:
         return True
+    # A SHELL script that publishes nothing is talking to the terminal of the
+    # person who ran it, and that person can answer, or Ctrl-C. Live false
+    # positive: `pipeline-watchdog/deploy.sh` echoes "Confirm before proceeding
+    # or omit --smoke" -- an interactive prompt, admitted only because
+    # `watchdog` appears in its PATH. The name heuristic exists for the Python
+    # module that COMPOSES a message another module publishes; a shell script
+    # that composes without publishing is an operator script, not an emitter.
+    # Measured: of the six shell files this lint flags, that one is the only
+    # one with zero publish invocations.
+    if relpath.endswith(".sh"):
+        return False
     # Matched against the whole relative path, not just the basename. Every
     # Lambda in `nousergon-data` is `index.py`; the emitter identity lives in
     # its DIRECTORY (`lambdas/freshness-monitor/`, `lambdas/pipeline-watchdog/`).

--- a/infrastructure/overseer/alert_message_lint.py
+++ b/infrastructure/overseer/alert_message_lint.py
@@ -895,7 +895,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"\npre-existing findings NOT gated by this PR ({len(carried)}): "
             + ", ".join(sorted({f"{f.rule}@{f.relpath}" for f in carried}))
-            + "\n  (alpha-engine-config-I9449's register owns those — this lint only "
+            + "\n  (alpha-engine-config-I9491's register owns those — this lint only "
               "reports what THIS diff introduced)"
         )
 

--- a/infrastructure/overseer/alert_message_lint.py
+++ b/infrastructure/overseer/alert_message_lint.py
@@ -256,6 +256,23 @@ _NOT_AN_INSTRUCTION = re.compile(
 )
 
 
+#: A tell joined to its neighbours by an arrow or a slash is a token in a
+#: SEQUENCE, not a verb aimed at anyone. Live false positive:
+#: `saturday-sf-watch-dispatcher`'s receipt says the resilience agent runs
+#: "(diagnose->fix->merge->rerun)" — a description of what the AUTOMATION does,
+#: matched by the same `diagnose` tell that catches "investigate before the
+#: next session".
+_SEQUENCE_JOINER = re.compile(r"^\s*(?:\u2192|->|/|\u2794|\u27a1)")
+_SEQUENCE_JOINER_BEFORE = re.compile(r"(?:\u2192|->|/|\u2794|\u27a1)\s*$")
+
+
+def _is_sequence_token(text_lower: str, start: int, end: int) -> bool:
+    return bool(
+        _SEQUENCE_JOINER.match(text_lower[end:end + 3])
+        or _SEQUENCE_JOINER_BEFORE.search(text_lower[max(0, start - 3):start])
+    )
+
+
 def _is_instruction(text_lower: str, start: int) -> bool:
     """Is the tell at ``start`` an imperative aimed at the reader?
 
@@ -600,15 +617,23 @@ def lint_text(text: str, relpath: str) -> tuple[list[Finding], list[Waiver]]:
             continue
         low = value.lower()
         for pattern, why in _ALERT001_TELLS:
-            m = next((c for c in re.finditer(pattern, low) if _is_instruction(low, c.start())),
-                     None)
+            m = next(
+                (c for c in re.finditer(pattern, low)
+                 if _is_instruction(low, c.start())
+                 and not _is_sequence_token(low, c.start(), c.end())),
+                None,
+            )
             if m:
                 findings.append(Finding("ALERT001", relpath, lineno, value.strip()[:300],
                                         f"{why} (matched {m.group(0)!r})"))
                 break
         for pattern, why in _ALERT002_TELLS:
-            m = next((c for c in re.finditer(pattern, low) if _is_instruction(low, c.start())),
-                     None)
+            m = next(
+                (c for c in re.finditer(pattern, low)
+                 if _is_instruction(low, c.start())
+                 and not _is_sequence_token(low, c.start(), c.end())),
+                None,
+            )
             if m:
                 findings.append(Finding("ALERT002", relpath, lineno, value.strip()[:300],
                                         f"{why} (matched {m.group(0)!r})"))
@@ -657,6 +682,22 @@ _UI_PATH_SEGMENTS: frozenset[str] = frozenset(
 )
 
 
+#: Publish shapes this lint recognises IN ADDITION to the ones the class
+#: scanner matches. `notify_via_flow_doctor` reaches an operator exactly as
+#: `publish_ops_alert` does, but the class scanner does not match it, so
+#: `saturday-sf-watch-dispatcher/index.py` — a live emitter with two dedup keys
+#: — was out of scope entirely until this was added.
+#:
+#: WHY THIS IS NOT ADDED TO THE SHARED SCANNER INSTEAD. Widening
+#: `alert_class_registry_drift._PUBLISH_CALL_PATTERN` would make the CLASS
+#: guard — enforcing, in seven repos, today — start demanding `alert_classes`
+#: rows for every flow-doctor source in the fleet, on the next PR each of those
+#: repos opens. That is a live-guard behaviour change and it belongs in its own
+#: PR with its own row inventory (alpha-engine-config-I9490), not smuggled in
+#: under a warn-only lint.
+_EXTRA_PUBLISH_SHAPES = re.compile(r"notify_via_flow_doctor\s*\(|notify_via_\w+\s*\(")
+
+
 def _in_scope(relpath: str, text: str) -> bool:
     """A file is graded when it publishes an alert, or is named like an emitter.
 
@@ -671,7 +712,11 @@ def _in_scope(relpath: str, text: str) -> bool:
     parts = Path(relpath).parts[:-1]
     if any(seg in _UI_PATH_SEGMENTS for seg in parts):
         return False
-    if scan._PUBLISH_CALL_PATTERN.search(text) or scan._CLI_CALL_PATTERN.search(text):
+    if (
+        scan._PUBLISH_CALL_PATTERN.search(text)
+        or scan._CLI_CALL_PATTERN.search(text)
+        or _EXTRA_PUBLISH_SHAPES.search(text)
+    ):
         return True
     # Matched against the whole relative path, not just the basename. Every
     # Lambda in `nousergon-data` is `index.py`; the emitter identity lives in

--- a/tests/test_alert_message_lint.py
+++ b/tests/test_alert_message_lint.py
@@ -1,0 +1,454 @@
+"""Unit tests for ``infrastructure/overseer/alert_message_lint.py``.
+
+``alpha-engine-config-I9460``. Overseer invariant 13 — a guard is not a guard
+until it has been observed failing — so every rule is asserted on a real
+instance from the corpus in BOTH directions: the pre-fix text must flag, and
+the text the sweep replaced it with must not.
+
+The literals below are quoted from the fleet as it stood, not invented:
+
+* ``crucible-executor`` at ``16574bd`` (the base of ``PR518``) for ALERT001
+  and ALERT002, and at ``4296f76`` for their fixed forms.
+* ``crucible-dashboard`` at ``25bc37ec`` (the base of ``PR810``) for the
+  shell-composed ``(detail in journal)``.
+* ``nousergon-data`` at ``9018a8e5`` (the base of ``PR1603``) for the
+  run-keyed ``_digest_dedup_key(decisions, now, unproduced)``.
+
+The three positive controls named in the issue are pinned too, because the
+expensive failure mode for a lint is not missing a defect — it is flagging a
+correct call site, which gets the whole rule switched off within a week.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_OVERSEER = Path(__file__).resolve().parent.parent / "infrastructure" / "overseer"
+sys.path.insert(0, str(_OVERSEER))
+import alert_message_lint as lint  # noqa: E402
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _rules(text: str, relpath: str = "emitter_alert.py") -> list[str]:
+    findings, waivers = lint.lint_text(text, relpath)
+    return sorted(f.rule for f in findings if not lint._waived(f, waivers))
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True, timeout=60
+    ).stdout
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "--allow-empty", "-m", message)
+    return _git(root, "rev-parse", "HEAD").strip()
+
+
+# ── ALERT001: the unanswerable ask ──────────────────────────────────────────
+
+
+def test_alert001_flags_the_executor_ask_verbatim():
+    """The instance Brian quoted, at the commit that introduced it."""
+    src = '''
+def emit(run_date, detail):
+    publish_ops_alert(
+        f"[executor] Optimizer large rebalance: {detail} (run_date={run_date}) "
+        f"Review and approve acceleration if the reallocation is intended.",
+        severity="WARN", source="executor:optimizer", dedup_key="x",
+    )
+'''
+    assert "ALERT001" in _rules(src)
+
+
+def test_alert001_does_not_flag_the_fixed_form():
+    """``crucible-executor-PR518`` deleted the ask and kept the facts."""
+    src = '''
+def emit(run_date, detail):
+    publish_ops_alert(
+        f"[executor] Optimizer large rebalance: {detail} (run_date={run_date})",
+        severity="WARN", source="executor:optimizer", dedup_key="x",
+    )
+'''
+    assert "ALERT001" not in _rules(src)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Please confirm the reallocation before the next session opens.",
+        "Acknowledge this page so the watchdog stops re-arming the gate.",
+        "Turnover accelerated past the band; approve if intended.",
+        "Position drift exceeded the cap unless this is expected by the desk.",
+        "The rebalance needs sign-off before Monday's open.",
+    ],
+)
+def test_alert001_tells(message: str):
+    assert "ALERT001" in _rules(f'publish_ops_alert("{message}", source="s")')
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Past participles are statements of fact, which is what an alert is for.
+        "mTLS to the vires origin confirmed byte-exact on both sides.",
+        "Champion promotion approved by the weekly gate; version_id recorded.",
+        # An inability, not a request.
+        "cycle indeterminate: monitor probe failed — cannot confirm cycle",
+        "a stage list this card cannot confirm was dispatched",
+    ],
+)
+def test_alert001_does_not_flag_statements_of_fact(message: str):
+    assert "ALERT001" not in _rules(f'publish_ops_alert("{message}", source="s")')
+
+
+# ── ALERT002: go look it up ─────────────────────────────────────────────────
+
+
+def test_alert002_flags_the_executor_shadow_logs_ask_across_fstring_parts():
+    """The tell straddles two adjacent f-string literals, exactly as written.
+
+    Reading the parts separately made this instance invisible — the single
+    highest-value ALERT002 in the corpus — which is why the f-string parts are
+    rejoined before matching.
+    """
+    src = '''
+def emit(rolling_sum, window, run_date):
+    publish_ops_alert(
+        message=(
+            f"[executor] TURNOVER TRIPWIRE (rolling): summed {rolling_sum:.1%} over "
+            f"{len(window)} session(s) (run_date={run_date}). The book is churning "
+            f"abnormally even though each day is under the cap; review "
+            f"the optimizer shadow logs for the driver."
+        ),
+        source="executor:turnover_tripwire",
+    )
+'''
+    assert "ALERT002" in _rules(src)
+
+
+def test_alert002_does_not_flag_the_fixed_attributing_form():
+    """``PR518`` replaced the ask with the driver the emitter had all along."""
+    src = '''
+def emit(attribution):
+    publish_ops_alert(
+        message=(
+            f"[executor] TURNOVER TRIPWIRE (rolling): "
+            f"DRIVER ({attribution['driver']}): {attribution['detail']}"
+        ),
+        source="executor:turnover_tripwire",
+    )
+'''
+    assert "ALERT002" not in _rules(src)
+
+
+def test_alert002_flags_detail_in_journal_composed_in_shell():
+    """``crucible-dashboard``'s ``box_health.sh`` never touched a publish call.
+
+    The message was composed in a shell function and published elsewhere, so a
+    lint scoped to publish-call bodies would have missed 32 of the 134 pages
+    measured over the window.
+    """
+    src = 'emit_line() {\n    echo "memory budget: BREACH (detail in journal)"\n}\n'
+    assert "ALERT002" in _rules(src, "infrastructure/box_health.sh")
+
+
+def test_alert002_does_not_flag_the_fixed_driver_vocabulary():
+    src = 'emit_line() {\n    echo "memory budget: BREACH driver=cgroup-oom-kill unit=$u"\n}\n'
+    assert "ALERT002" not in _rules(src, "infrastructure/box_health.sh")
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Deploy failed at $SHA — auto-reverted. Investigate before re-merging.",
+        "Check CloudWatch logs for details.",
+        "Predictions not written; see the manifest for the cause.",
+        "Promotion refused — inspect s3://alpha-engine-research/weights/meta/.",
+        "The gate breached; check the PHASE_END logs for the first error.",
+    ],
+)
+def test_alert002_tells(message: str):
+    assert "ALERT002" in _rules(f'publish_ops_alert("{message}", source="s")')
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # A fact about what the emitter itself could not do. Flagging this
+        # teaches authors to stop writing honest failure reports.
+        "turnover tripwire: could not read shadow log for %s: %s",
+        "champion_monitor: could not resolve the serving champion version_id",
+        # A statement about this component's own return value.
+        "the weekly-SF silence deadman owns the page; this check reports ONLY_GATE_SKIPS.",
+        # A past-tense report of a completed check.
+        "FATAL: pip check reported non-allowlisted dependency conflicts:",
+    ],
+)
+def test_alert002_does_not_flag_statements(message: str):
+    assert "ALERT002" not in _rules(f'publish_ops_alert("{message}", source="s")')
+
+
+def test_ui_surfaces_are_out_of_scope():
+    """"Check here during triage" is correct guidance on a page someone opened.
+
+    The anti-pattern is defined by the delivery surface: an alert arrives
+    unasked, a dashboard view does not. The line is drawn on the path.
+    """
+    src = 'st.markdown("Warning rows appear below but do not route — check the logs during triage.")'
+    assert lint._in_scope("views/26_Artifact_Freshness.py", src) is False
+    assert lint._in_scope("monitoring/freshness_alert.py", src) is True
+    assert _rules(src, "monitoring/freshness_alert.py") == ["ALERT002"]
+
+
+# ── ALERT003: run-keyed dedup ───────────────────────────────────────────────
+
+
+def test_alert003_flags_the_freshness_digest_run_key():
+    """``nousergon-data-PR1603``'s pre-fix key, assigned to a local.
+
+    The publish call passed the LOCAL, so a rule reading only keyword
+    arguments would have missed the instance the PR exists to fix.
+    """
+    src = '''
+def emit(decisions, now, unproduced):
+    dedup_key = _digest_dedup_key(decisions, now, unproduced)
+    publish_ops_alert("freshness digest", source="freshness-monitor", dedup_key=dedup_key)
+'''
+    findings, _ = lint.lint_text(src, "infrastructure/lambdas/freshness-monitor/index.py")
+    a3 = [f for f in findings if f.rule == "ALERT003"]
+    assert a3 and "per-execution" in a3[0].why
+
+
+def test_alert003_does_not_flag_the_fixed_episode_key():
+    src = '''
+def emit(decisions, unproduced):
+    dedup_key = _digest_dedup_key(decisions, unproduced)
+    publish_ops_alert("freshness digest", source="freshness-monitor", dedup_key=dedup_key)
+'''
+    assert "ALERT003" not in _rules(src, "infrastructure/lambdas/freshness-monitor/index.py")
+
+
+@pytest.mark.parametrize(
+    "expr,tier",
+    [
+        ("f'freshness_digest_{today}_{fp}'", "calendar"),
+        ("f'watchdog:{pipeline}:{record[\"execution_arn\"]}'", "execution"),
+        ("f'lane_never_started:{now:%Y-%m-%dT%H:%M}'", "execution"),
+        ("f'canary-replay:{run_token}'", "execution"),
+        ("f'turnover_tripwire_daily_{run_date}'", "calendar"),
+        ("f'model_zoo_promote_{date_str}'", "calendar"),
+        ("f'predictor_shadow_unmeasurable_{trading_day}'", "calendar"),
+    ],
+)
+def test_alert003_tiers(expr: str, tier: str):
+    assert lint.classify_dedup_expression(expr)[0] == tier
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        # The three positive examples the issue names, verbatim in shape.
+        "f'lambda-deploy-drift-{report[\"head_sha\"][:12]}-{severity}'",
+        "'definition-drift-' + hashlib.sha256(payload).hexdigest()[:12]",
+        "f'{leaderboard_id}_leaderboard_vacuous:{champion_name}:{sorted_challengers}'",
+        # PR780's fixed grouping. `as_of` is the UPSTREAM artifact's own stamp:
+        # it stops moving exactly when the episode closes, which is what
+        # episode identity means.
+        "f'stale-upstream:{driver}:{upstream_prefix}:{as_of}'",
+        "group.episode_key()",
+        "f'freshness_digest_{fingerprint}'",
+    ],
+)
+def test_alert003_passes_the_positive_controls(expr: str):
+    assert lint.classify_dedup_expression(expr) is None
+
+
+def test_alert003_reads_shell_dedup_keys():
+    src = 'python3 -m krepis.alerts publish --source x --dedup-key "drift-$RUN_DATE"\n'
+    assert "ALERT003" in _rules(src, "infrastructure/alert_on_failure.sh")
+
+
+# ── the waiver ──────────────────────────────────────────────────────────────
+
+
+def test_a_waiver_with_a_reason_suppresses():
+    src = '''
+def emit(execution_arn, pipeline):
+    # alert-lint: allow ALERT003 -- info-severity per-run receipt; the SF
+    #   execution IS the episode, per saturday-sf-watch-dispatcher's design.
+    publish_ops_alert("receipt", source="sf-watch", dedup_key=f"watch:{execution_arn}")
+'''
+    assert _rules(src) == []
+
+
+def test_a_waiver_with_no_reason_is_itself_a_finding():
+    src = '''
+def emit(execution_arn):
+    # alert-lint: allow ALERT003
+    publish_ops_alert("receipt", source="sf-watch", dedup_key=f"watch:{execution_arn}")
+'''
+    rules = _rules(src)
+    assert "ALERT000" in rules
+    assert "ALERT003" in rules, "a bare suppression must not suppress"
+
+
+def test_a_waiver_with_a_token_reason_is_a_finding():
+    src = '''
+def emit(execution_arn):
+    # alert-lint: allow ALERT003 -- ok
+    publish_ops_alert("receipt", source="sf-watch", dedup_key=f"watch:{execution_arn}")
+'''
+    assert "ALERT000" in _rules(src)
+
+
+def test_a_waiver_does_not_reach_beyond_its_lookback():
+    src = (
+        "# alert-lint: allow ALERT003 -- a reason long enough to be a real one\n"
+        + "x = 1\n" * 10
+        + 'publish_ops_alert("m", source="s", dedup_key=f"k:{execution_arn}")\n'
+    )
+    assert "ALERT003" in _rules(src)
+
+
+def test_a_waiver_is_rule_specific():
+    src = '''
+def emit(execution_arn):
+    # alert-lint: allow ALERT001 -- this one is about the ask, not the key
+    publish_ops_alert("receipt", source="s", dedup_key=f"watch:{execution_arn}")
+'''
+    assert "ALERT003" in _rules(src)
+
+
+def test_waivers_are_enumerable(tmp_path: Path, capsys):
+    root = tmp_path / "repo"
+    (root / "infrastructure").mkdir(parents=True)
+    (root / "infrastructure" / "alerting.py").write_text(
+        "# alert-lint: allow ALERT003 -- the SF execution IS the episode here\n"
+        'publish_ops_alert("m", source="s", dedup_key=f"k:{execution_arn}")\n'
+    )
+    rc = lint.main(["--repo", "r", "--repo-root", str(root), "--list-waivers"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 alert-lint waiver(s)" in out
+    assert "the SF execution IS the episode here" in out
+
+
+# ── delta behaviour and exit codes ──────────────────────────────────────────
+
+
+_BAD = (
+    'def emit(run_date):\n'
+    '    publish_ops_alert("Turnover accelerated. Review and approve if intended.",\n'
+    '                      source="executor:optimizer", dedup_key="k")\n'
+)
+_CLEAN = 'def emit():\n    publish_ops_alert("Turnover 12.4% over the 9% band.", source="s")\n'
+
+
+def test_a_new_instance_fails_its_own_pr(tmp_path: Path, capsys):
+    root = tmp_path / "repo"
+    _init_repo(root)
+    (root / "alerting.py").write_text(_CLEAN)
+    base = _commit(root, "clean")
+    (root / "alerting.py").write_text(_CLEAN + _BAD)
+    head = _commit(root, "adds the ask")
+
+    rc = lint.main(["--repo", "r", "--repo-root", str(root), "--base", base, "--head", head])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "ALERT001" in captured.err + captured.out
+    assert "Decision Queue" in captured.err, "the failure must say what to do instead"
+
+
+def test_pre_existing_instances_never_fail_an_unrelated_pr(tmp_path: Path, capsys):
+    """The property that keeps a chokepoint from being routed around on day one."""
+    root = tmp_path / "repo"
+    _init_repo(root)
+    (root / "alerting.py").write_text(_BAD)
+    base = _commit(root, "pre-existing")
+    (root / "unrelated.py").write_text("VALUE = 1\n")
+    head = _commit(root, "unrelated change")
+
+    rc = lint.main(["--repo", "r", "--repo-root", str(root), "--base", base, "--head", head])
+    assert rc == 0
+    assert "pre-existing findings NOT gated by this PR (1)" in capsys.readouterr().out
+
+
+def test_an_unrelated_edit_that_shifts_lines_is_not_a_new_finding(tmp_path: Path):
+    """Fingerprints exclude the line number, deliberately.
+
+    Keying on the line would report every pre-existing instance in a touched
+    file as newly introduced, and a lint that cries about code the PR did not
+    write is the one that gets switched off.
+    """
+    root = tmp_path / "repo"
+    _init_repo(root)
+    (root / "alerting.py").write_text(_BAD)
+    base = _commit(root, "pre-existing")
+    (root / "alerting.py").write_text("# a new leading comment\n" * 20 + _BAD)
+    head = _commit(root, "shifts the lines")
+
+    assert lint.main(["--repo", "r", "--repo-root", str(root),
+                      "--base", base, "--head", head]) == 0
+
+
+def test_warn_only_annotates_and_exits_zero(tmp_path: Path, capsys):
+    root = tmp_path / "repo"
+    _init_repo(root)
+    (root / "alerting.py").write_text(_CLEAN)
+    base = _commit(root, "clean")
+    (root / "alerting.py").write_text(_CLEAN + _BAD)
+    head = _commit(root, "adds the ask")
+
+    rc = lint.main(["--repo", "r", "--repo-root", str(root),
+                    "--base", base, "--head", head, "--warn-only"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning file=alerting.py,line=" in out
+    assert "::error" not in out
+
+
+def test_a_non_git_root_is_unmeasured_never_clean(tmp_path: Path, capsys):
+    rc = lint.main(["--repo", "r", "--repo-root", str(tmp_path), "--base", "x"])
+    assert rc == 1
+    assert "UNMEASURED" in capsys.readouterr().err
+
+
+def test_a_bad_ref_is_unmeasured_never_clean(tmp_path: Path, capsys):
+    root = tmp_path / "repo"
+    _init_repo(root)
+    (root / "alerting.py").write_text(_CLEAN)
+    _commit(root, "clean")
+    rc = lint.main(["--repo", "r", "--repo-root", str(root), "--base", "deadbeef"])
+    assert rc == 1
+    assert "UNMEASURED" in capsys.readouterr().err
+
+
+# ── self-exclusion ──────────────────────────────────────────────────────────
+
+
+def test_the_lint_and_the_scanner_do_not_grade_themselves():
+    """Their docstrings spell out every anti-pattern by design.
+
+    The sibling scanner shipped without this and reported three of its own
+    examples as live emitters on its first CI run (``nousergon-data-PR1479``).
+    """
+    findings, _ = lint.scan_repo(Path(__file__).resolve().parent.parent)
+    graded = {f.relpath for f in findings}
+    assert "infrastructure/overseer/alert_message_lint.py" not in graded
+    assert "infrastructure/overseer/alert_class_registry_drift.py" not in graded
+    assert "infrastructure/overseer/alert_class_pr_guard.py" not in graded

--- a/tests/test_alert_message_lint.py
+++ b/tests/test_alert_message_lint.py
@@ -452,3 +452,73 @@ def test_the_lint_and_the_scanner_do_not_grade_themselves():
     assert "infrastructure/overseer/alert_message_lint.py" not in graded
     assert "infrastructure/overseer/alert_class_registry_drift.py" not in graded
     assert "infrastructure/overseer/alert_class_pr_guard.py" not in graded
+
+
+# ── false positives found by calibration, pinned so they stay fixed ─────────
+#
+# Every case below flagged on a real fleet call site and was WRONG. A lint's
+# expensive failure is not the defect it misses — it is the correct call site
+# it flags, because that is what gets the whole rule switched off.
+
+
+def test_a_decision_queue_item_is_the_remedy_not_the_defect():
+    """`**Options:** ... B) Acknowledge as expected ...` — from freshness-monitor.
+
+    ALERT001's own remedy text says a genuine human decision belongs on the
+    Decision Queue with state. A queue item therefore has exactly what the rule
+    says is missing: a channel, state, and a consequence of never answering.
+    """
+    src = (
+        'publish_ops_alert(\n'
+        '    "**Ask:** Investigate why `x` has stopped updating, and either fix the '
+        'producer or acknowledge the staleness is expected right now.",\n'
+        '    source="freshness-monitor")\n'
+    )
+    assert _rules(src) == []
+
+
+def test_an_arrow_joined_vocabulary_is_not_an_instruction():
+    """saturday-sf-watch-dispatcher describes the AGENT's own workflow."""
+    src = (
+        'publish_ops_alert("_autonomous fix LAUNCHING — resilience agent dispatched; '
+        'outcome reported on box completion (diagnose->fix->merge->rerun)_", source="s")'
+    )
+    assert "ALERT002" not in _rules(src)
+
+
+def test_a_shell_script_that_publishes_nothing_is_an_operator_script():
+    """`pipeline-watchdog/deploy.sh` echoes "Confirm before proceeding".
+
+    That is an interactive prompt to the person who ran the script, who can
+    answer it or Ctrl-C — a channel with state. It was in scope only because
+    `watchdog` appears in its PATH.
+    """
+    src = 'echo "WARNING: --smoke will publish a real alert."\necho "Confirm before proceeding or omit --smoke."\n'
+    assert lint._in_scope("infrastructure/lambdas/pipeline-watchdog/deploy.sh", src) is False
+    publishing = src + 'python3 -m krepis.alerts publish --source x --message y\n'
+    assert lint._in_scope("infrastructure/lambdas/pipeline-watchdog/deploy.sh", publishing) is True
+
+
+def test_a_flow_doctor_emitter_is_in_scope():
+    """`notify_via_flow_doctor` reaches an operator; the class scanner misses it.
+
+    `saturday-sf-watch-dispatcher/index.py` and `scheduled-groom-dispatcher/index.py`
+    were out of scope entirely until this shape was added — 4 dedup keys and 6
+    unactionable messages that no guard had ever looked at
+    (``alpha-engine-config-I9490``).
+    """
+    src = 'notify_via_flow_doctor(text, dedup_key=f"w:{execution_arn}", flow_name="x")'
+    assert lint._in_scope("infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py", src)
+    assert "ALERT003" in _rules(src, "infrastructure/lambdas/saturday-sf-watch-dispatcher/index.py")
+
+
+def test_a_clock_truncated_to_a_day_is_graded_calendar_not_execution():
+    """`pipeline-watchdog` keys on `datetime.now(timezone.utc).date().isoformat()`.
+
+    Still run-keyed, but it re-pages daily rather than per-run, and the tier is
+    what sets the remediation priority in the register.
+    """
+    assert lint.classify_dedup_expression(
+        "f'pipeline-watchdog-{sf_label}-{datetime.now(timezone.utc).date().isoformat()}'"
+    ) == ("calendar", "now")
+    assert lint.classify_dedup_expression("f'canary-replay:{run_token}'")[0] == "execution"


### PR DESCRIPTION
## What this is

`alpha-engine-config-I9460`, and the half of `-I9459` that lives here. The two are one deliverable: a guard is worthless in the five repos that do not run it.

`alpha-engine-config-I9449` swept the fleet for alert messages defective in **shape** rather than in truth and fixed the loudest instances across five repos. **That sweep is a one-time cleanup.** Nothing stopped the class returning on the next PR, and every instance read as *helpful* in review — which is exactly why each was written that way. This is the half that changes the future rather than the past.

Measured scale, from the 633 krepis dedup markers in `s3://alpha-engine-research/_alerts/_dedup/` (`publish_count` increments only on a successful publish, so these are real deliveries): **134 pages in 11 days**, 104 of them covered by the sweep.

## The three rules

Each is pinned in `tests/test_alert_message_lint.py` to a real instance the sweep fixed **and** to the text that replaced it.

| rule | tell | real instance |
|---|---|---|
| `ALERT001` unanswerable ask | requests a decision with no channel, no state, no consequence of never answering | `"Review and approve acceleration if the reallocation is intended."` — `crucible-executor-PR518` |
| `ALERT002` go look it up | tells the reader to inspect what the emitter already read | `"review the optimizer shadow logs for the driver"` (PR518); `"(detail in journal)"` — `crucible-dashboard-PR810` |
| `ALERT003` run-keyed dedup | one standing condition mints a fresh key every run | `_digest_dedup_key(decisions, now, unproduced)` — `nousergon-data-PR1603` |

## One scanner, not two (`policy-shared-code`)

File selection and publish-call extraction come from `alert_class_registry_drift`. Base-vs-head materialization comes from `alert_class_pr_guard`, whose private `_scan_at` is generalised into a public `scan_at_ref(root, ref, fn)` so the worktree add/teardown exists once. **Nothing about locating an alert call site is reimplemented** — this module contributes only the message-shape rules.

## ALERT003 is graded in two tiers, because the false-positive rate is the whole game

Whether a run-keyed dedup is a defect turns on one question no static rule can answer: *can this condition stand across runs?* A once-per-trading-day reconciliation failure keyed on `{run_date}` pages once per occurrence and is correct. A standing staleness condition keyed on `{run_date}` pages every day forever and is the defect.

- **`execution` tier** — values that can *never* be episode identity under any cadence: `now`, `execution_arn`, `run_token`, `instance_id`, sub-day `strftime`. No judgement required; the finding is unconditional.
- **`calendar` tier** — date-granular values. Correct exactly when the condition cannot outlive one day. That is a real judgement, so the finding asks for it: fix the key, or record the judgement in a waiver.

## Calibration — measured, not asserted

**Replayed in delta mode over 660 merged commits** (60 per repo × 11 emitting repos):

- **12 commits (1.8%) would have annotated, 14 findings, zero false positives.** Every one is a true positive or a legitimate waiver case — **including the commit that first introduced Brian's quoted "Review and approve acceleration" line, caught at authoring time.**
- **Run base→head over all four sweep PRs** (`executor-518`, `dashboard-810`, `research-780`, `data-1603`): **each introduces zero findings.** A correct fix is not punished.
- **The three positive examples the issue names all pass** and are pinned: `lambda_deploy_drift.py`'s `head_sha[:12]` key, `check-definition-drift.py`'s content hash, `leaderboard_producers.py::vacuous_comparison`.
- **Whole-checkout over the fleet's current `main`: 124 findings** (1 `ALERT001`, 49 `ALERT002`, 11 `ALERT003-execution`, 63 `ALERT003-calendar`) — **all pre-existing and therefore invisible**, because the lint grades the PR delta only. Registered with the full per-repo table and a remediation order in `alpha-engine-config-I9491`.
- **Six false positives were found by calibration and fixed rather than shipped**, each pinned as a regression test. Detail in the commits; the last three were an honest Decision Queue item, an arrow-joined vocabulary (`diagnose->fix->merge->rerun`), and an interactive deploy-script prompt.
- **A coverage gap was found the same way:** the class scanner does not match `notify_via_flow_doctor`, so two live `nousergon-data` emitters — 4 dedup keys and 6 unactionable messages — had never been graded by any guard. The lint now covers them via a lint-local shape; widening the SHARED scanner would change the behaviour of a guard that is enforcing in seven repos today, so that is sequenced separately in `alpha-engine-config-I9490`.

**Four false positives were found by that calibration and fixed rather than shipped:** an honest failure report (`"could not read shadow log for %s"`) read as an instruction; `"this check reports ONLY_GATE_SKIPS"` read as `check reports`; `"pip check reported …"` likewise; and dashboard **view** prose — correct guidance on a page a person chose to open, and an anti-pattern only in a page that arrives unasked, so the line is drawn on the path.

**Two false negatives were found the same way and fixed:** an f-string split across adjacent literals hid `review the optimizer shadow logs` across the boundary, and a basename-only scope test put `lambdas/freshness-monitor/index.py` out of scope entirely — every Lambda here is `index.py`, and the emitter identity lives in the directory.

## The waiver is auditable

```python
# alert-lint: allow ALERT003 -- info-severity per-run receipt; the SF
#   execution IS the episode, per saturday-sf-watch-dispatcher's design.
```

The rule id and a ≥15-character reason are both required, and **a waiver with no reason is itself a finding** (`ALERT000`) — a bare suppression records that someone silenced the rule and nothing about why, which is the same defect one level up. `--list-waivers` enumerates the whole suppression set.

## Warn-only, and how that ends

The workflow step **annotates and exits 0**. It is warn-first because this is **one implementation read by eleven repos from a floating ref** — the exact shape that reverdicted the whole fleet's CI in 32 seconds on 2026-08-28 when a reusable workflow loaded its guard script unpinned. Warn-only removes that blast radius entirely while the rule earns enforcement. A missing script warns rather than failing **for this step only**, so the cross-repo merge window cannot redden anyone; step 1's hard failure on a missing checkout is untouched.

`alpha-engine-config-I9471` carries the enforcement flip and the concrete predicate that clears it.

## Merge order

**This PR merges FIRST.** The other eight carry only the workflow wiring and warn-and-skip until this script exists on `nousergon-data@main`.

`nousergon-lib-PR380` · `crucible-research-PR781` · `crucible-dashboard-PR811` · `crucible-evaluator-PR288` · `crucible-predictor-PR597` · `crucible-backtester-PR760` · `nous-ergon-ops-PR940` · `metron-PR429`

## Testing

`tests/test_alert_message_lint.py` — 54 tests. Full `nousergon-data` suite: 6937 passed, 2 pre-existing failures in `test_pipeline_status_registry_source_check.py` from a stale local `nousergon-lib` install (v0.124.96 vs pinned v0.124.102), which that test diagnoses in its own message and which `alpha-engine-config-I9070` tracks; CI installs the pin.

Tracked: `alpha-engine-config-I9460`, `alpha-engine-config-I9459`.
Filed by this work: `I9471` (enforcement flip + predicate) · `I9472` (metron is off the alert bus) · `I9473` (nous-ergon-ops' 3 unregistered sources) · `I9477` (crucible-executor runs neither guard) · `I9478` (ruling: claude-code-config) · `I9479` (a publish with NO dedup key) · `I9490` (the flow-doctor scanner gap) · `I9491` (the 124-finding register).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

