### PR TITLE
fix(alarms): flip predictor-no-invocations to breaching in BOTH owners (alpha-engine-config-I9467)

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -271,6 +271,9 @@
     },
     "alpha-engine-stage-coverage-sweep-dead": {
       "reason": "ARMED. StageCoverageSweepRan is published FIRST and unconditionally by nousergon_lib.pipeline_status.coverage.publish_sweep at the tail of ne-weekly-freshness-pipeline (Saturday 09:00 UTC) \u2014 a KEPT pipeline under the 2026-08-07 ruling \u2014 so its absence means the reader stopped, never that the week was clean. TreatMissingData=breaching is load-bearing and deliberate (measured live 2026-08-28): notBreaching would render a dead sweep as green, the inversion principles.md 2.7 forbids. EXPECTED RED until the first real sweep publishes, per its own AlarmDescription; it read StateValue=ALARM with ActionsEnabled=true when this entry was written, which is the declared state, not a mute. Born unclassified on creation and reported as [alarm-undeclared] on every run since (alpha-engine-config-I9121)."
+    },
+    "alpha-engine-predictor-inference-no-invocations": {
+      "reason": "alpha-engine-config-I9467 flipped this alarm from TreatMissingData=notBreaching to breaching. It is the daily invocations floor for alpha-engine-predictor-inference and absence IS its signal - while it treated missing data as notBreaching, the one condition it exists to catch (the predictor stopping) rendered green (principles.md 2.7; observability-policy.md OB-9.2a). The producer is running, so this belongs here and not in paused_alarms: replayed over the 30 days to 2026-08-31 via get-metric-data, all 30 daily buckets carried Invocations >= 2, so the flip would have fired zero times over recorded history."
     }
   }
 }

--- a/infrastructure/cloudformation/alpha-engine-orchestration.yaml
+++ b/infrastructure/cloudformation/alpha-engine-orchestration.yaml
@@ -700,7 +700,24 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: alpha-engine-predictor-inference-no-invocations
-      AlarmDescription: Predictor Lambda not invoked (expected daily)
+      # Kept byte-identical to nous-ergon-ops
+      # infrastructure/cloudwatch/alarms/alpha-engine-predictor-inference-no-invocations.json.
+      # This alarm is one of the 21 dual-owned by this stack AND that tree
+      # (alpha-engine-config-I9009): any push to this repo's main re-stamps the
+      # stack's git-sha tag, which forces CloudFormation to reissue
+      # PutMetricAlarm from THESE literal values even when the template body did
+      # not change. So a divergence here silently reverts that tree, with no
+      # CloudFormation-side signal. Change both or neither.
+      AlarmDescription: >-
+        Predictor Lambda not invoked (expected daily). ABSENCE IS THE SIGNAL:
+        TreatMissingData is `breaching` (alpha-engine-config-I9467) because this
+        alarm's entire job is detecting that the predictor stopped running, and
+        `notBreaching` made the one condition it exists to catch render as green
+        (principles.md 2.7; observability-policy.md OB-9.2a). Replayed over the
+        30 days to 2026-08-31 via get-metric-data: all 30 daily buckets carried
+        Invocations >= 2, so this flip would have fired ZERO times — it adds
+        detection without adding pages. Declared armed in
+        nousergon-data/infrastructure/automation_pause.json:armed_alarms.
       Namespace: AWS/Lambda
       MetricName: Invocations
       Dimensions:
@@ -711,7 +728,13 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: LessThanThreshold
-      TreatMissingData: notBreaching  # weekends/holidays
+      # WAS `notBreaching  # weekends/holidays`. That rationale was measured
+      # false: replayed over the 30 days to 2026-08-31, ALL 30 daily buckets
+      # carried Invocations >= 2 (minimum 2 on 2026-08-04), weekends included —
+      # the predictor is invoked every day, so there was never a weekend gap for
+      # notBreaching to protect. What it did instead was render the one
+      # condition this alarm exists to catch as green (alpha-engine-config-I9467).
+      TreatMissingData: breaching
       AlarmActions:
         - !Ref AlertsTopic
 


### PR DESCRIPTION
## What

Two changes that must land together:

1. `infrastructure/cloudformation/alpha-engine-orchestration.yaml` — flips `alpha-engine-predictor-inference-no-invocations` from `TreatMissingData: notBreaching` to `breaching`, and brings its `AlarmDescription` byte-identical to the nous-ergon-ops copy.
2. `infrastructure/automation_pause.json` — declares that alarm in `armed_alarms`.

## Why

`alpha-engine-config-I9467`. That alarm's entire job is detecting that the predictor stopped being invoked, and `notBreaching` made the one condition it exists to catch render as **green** — the inversion `principles.md` §2.7 forbids by name and `observability-policy.md` OB-9.2a rules on. Its own description reads *"Predictor Lambda not invoked (expected daily)"*.

### The dual-ownership trap this avoids (`alpha-engine-config-I9009`)

This alarm is one of the **21 that this stack declares AND that nous-ergon-ops `infrastructure/cloudwatch/alarms/` codifies**. `deploy-infrastructure.yml` stamps the stack's `git-sha` tag on **every** push to this repo's main with no path filter, and a stack-level tag change forces CloudFormation to reissue `PutMetricAlarm` for every taggable resource **from the template's literal values** — even when the template body did not change.

So flipping the alarm only in nous-ergon-ops would have been **silently reverted by the very next push to this repo, including this PR's own merge**, with no CloudFormation-side signal. Both owners change or neither does. The descriptions are byte-identical (verified by comparison, not by eye) so `check-drift.py` sees no divergence.

### The template's stated rationale was measured false

It carried `TreatMissingData: notBreaching  # weekends/holidays`. Replayed with `aws cloudwatch get-metric-data` over the 30 days to 2026-08-31 (`AWS/Lambda Invocations Sum`, `FunctionName=alpha-engine-predictor-inference`, 86400s buckets):

- **30 of 30** daily buckets carry a datapoint, **weekends included**. There was never a weekend gap for `notBreaching` to protect.
- Minimum daily `Sum` = **2** (2026-08-04); maximum 184. The `< 1` threshold never breached either.
- **The flip would have fired zero times over recorded history.** It adds detection without adding pages.

### Why the `armed_alarms` entry is required

`armed_alarms`'s own `_why` establishes that every live alarm with `TreatMissingData=breaching` must be classified into exactly one of the two blocks; `automation_pause.py --check` reports one in neither as `alarm-undeclared` (`alpha-engine-config-I7023`). It goes in `armed_alarms` rather than `paused_alarms` because the producer is **running**, not paused.

## Cross-repo and merge order

- **This PR** (`nousergon-data-PR1605`) — first. The declaration and the template must be in place before the alarm can be reported undeclared, and the template is the copy CloudFormation re-asserts.
- Then `nous-ergon-ops-PR941`, which carries the absence-conformance register, the check, and the same flip in the codified alarm tree.

## Tests

`python3 -m pytest tests/ -q` locally before push: **6883 passed, 17 skipped, 2 failed**. Both failures are `tests/test_pipeline_status_registry_source_check.py[Saturday]` and are **pre-existing on clean `main`** (reproduced at 209316a9 with a clean working tree). The test prints its own root cause: the locally installed `nousergon-lib` is v0.124.96 against a v0.124.102 pin, so it reads SF JSON from the tree and the registry from a stale install. Environment drift, tracked as `alpha-engine-config-I9070` / `-I9116`; CI installs the pin. `tests/test_automation_pause.py` and `tests/test_no_imperative_alarm_authorship.py`: 70 passed, 2 skipped.

Refs `alpha-engine-config-I9467`, `-I9009`, `-I7023`

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)