### PR TITLE
fix(observability): catch a firing trigger with a silent target + an unprobed event_driven artifact

### DIFF
--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -4223,8 +4223,34 @@ def _run_probe_pass(
         # owning-item join (config-I7730) because that join's budget gate reads
         # this answer — a never-written row cannot page, so it must not spend a
         # GitHub query.
+        #
+        # alpha-engine-config-I8810 — `spec.cadence == "event_driven"` is ALSO
+        # eligible, independent of `result.state`. An event_driven row's OWN
+        # `check_freshness` result is unconditionally `fresh`
+        # (`nousergon_lib.artifact_freshness` short-circuits it before any age
+        # floor is consulted — event_driven has no cadence to be stale against),
+        # so `result.state == "missing"` can never be true for one and this
+        # probe never ran. That is exactly how `thinktank_inst_ownership`
+        # (`data/inst_ownership/latest.json`, shipped 2026-07-13, zero invoker)
+        # stayed invisible: its row declares `liveness_via:
+        # thinktank_coverage_ledger`, so its OWN key was never once checked for
+        # existence by anything — the anchor's freshness was graded, this key's
+        # was not. The probe itself is unchanged (`_prefix_has_ever_been_written`
+        # still answers True/False/None on the artifact's own key), and the
+        # downstream handling is unchanged too: `never_written=True` does not
+        # page (`_alert_decision`'s first gate already excludes `fresh` from
+        # `_ALERTING_STATES`, so an event_driven row was never going to page
+        # regardless) but IS threaded into `check_results.json` per-row
+        # (`_serialize_check_results`) and into the standing digest section
+        # (`_compose_digest`'s `unproduced` list reads `never_written_by_id`
+        # directly, not through `_alert_decision`) — so the gap renders instead
+        # of reading as a healthy `fresh` row forever. `_NEVER_WRITTEN_PROBE_MAX`
+        # still bounds the per-sweep cost.
         never_written: bool | None = None
-        if result.state == "missing" and len(never_written_by_id) < _NEVER_WRITTEN_PROBE_MAX:
+        if (
+            (result.state == "missing" or spec.cadence == "event_driven")
+            and len(never_written_by_id) < _NEVER_WRITTEN_PROBE_MAX
+        ):
             never_written = _prefix_has_ever_been_written(s3_client, spec, result)
             if never_written is not None:
                 never_written = not never_written

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -2014,6 +2014,42 @@ def test_probe_pass_miss_counter_increments_and_resets(fake_s3, monkeypatch,
     assert counts == {"champion_feed": 0}
 
 
+def test_event_driven_row_probes_its_own_key_for_never_written(fake_s3, monkeypatch, fixed_now):
+    """alpha-engine-config-I8810. An event_driven row's OWN `check_freshness`
+    result is unconditionally `fresh` (nousergon_lib's short-circuit — no age
+    floor applies), so `result.state == "missing"` can never gate this probe
+    for one. `thinktank_inst_ownership` (data/inst_ownership/latest.json,
+    liveness_via=thinktank_coverage_ledger) sat undetected this way: its own
+    key was never once checked for existence. The probe must run off
+    `spec.cadence == "event_driven"` too, independent of `result.state`."""
+    import index
+    spec, fresh_result = _event_driven_pair(index, "thinktank_inst_ownership",
+                                            "thinktank_coverage_ledger")
+    monkeypatch.setattr(index, "_check_one",
+                        lambda s3c, sp, now: (fresh_result, None))
+    fake_s3.list_objects_v2 = mock.Mock(return_value={"KeyCount": 0})
+    _pairs, _a, _d, _e, _counts, telemetry = index._run_probe_pass(
+        fake_s3, [spec], {}, fixed_now)
+    assert telemetry["never_written_by_id"] == {"thinktank_inst_ownership": True}
+    fake_s3.list_objects_v2.assert_called_once()
+
+
+def test_event_driven_row_confirmed_written_is_not_flagged(fake_s3, monkeypatch, fixed_now):
+    """The other half: an event_driven row whose own key HAS been written at
+    least once is not a producer-birth gap, so `never_written` is False, not
+    True — the probe distinguishes the two rather than flagging every
+    event_driven row on principle."""
+    import index
+    spec, fresh_result = _event_driven_pair(index, "thinktank_inst_ownership",
+                                            "thinktank_coverage_ledger")
+    monkeypatch.setattr(index, "_check_one",
+                        lambda s3c, sp, now: (fresh_result, None))
+    fake_s3.list_objects_v2 = mock.Mock(return_value={"KeyCount": 1})
+    _pairs, _a, _d, _e, _counts, telemetry = index._run_probe_pass(
+        fake_s3, [spec], {}, fixed_now)
+    assert telemetry["never_written_by_id"] == {"thinktank_inst_ownership": False}
+
+
 def test_prev_miss_counts_roundtrip_via_check_results(fake_s3, fixed_now):
     """_serialize_check_results persists consecutive_miss_runs and
     _load_prev_miss_counts reads them back — the counter needs no new

--- a/infrastructure/pause_reconcile.py
+++ b/infrastructure/pause_reconcile.py
@@ -613,6 +613,57 @@ def reconcile(
             ),
         })
 
+    # ── direction E: an ENABLED trigger whose declared downstream is silent ──
+    # alpha-engine-config-I9469. Direction C answers "the trigger is dark — is
+    # the component it feeds still running some other way." This is the
+    # opposite edge: the trigger IS firing, so a live audit of it alone reads
+    # healthy, and the miss is invisible unless something reads the invocation
+    # count of what it actually fires. `#9469` was found by an AD HOC 7-day
+    # CloudWatch sweep across all 72 Lambdas; this makes that sweep a standing
+    # check instead of something that has to be re-run by hand.
+    #
+    # The candidate that made this look real — `alpha-engine-research-thinktank`
+    # at 0 invocations while `alpha-research-thinktank-daily` fires daily — is
+    # NOT what this direction would have flagged, and that is the point: the
+    # rule's LIVE target (`trigger_targets`, a real `list-targets-by-rule` read)
+    # is `alpha-engine-thinktank-spot-dispatcher`, which had 10 invocations in
+    # the same window. The old Lambda was never a live target — its IAM grant
+    # and EventBridge wiring were already removed under `#5777` — so a
+    # name-similarity guess treated a retired resource as "the declared
+    # downstream" where a target-map read would not have. This direction reads
+    # the target map, never the name, which is why it does not reproduce that
+    # false positive.
+    for t in trigs:
+        name, state = t["name"], t["state"]
+        if state != "ENABLED" or name.startswith(_AWS_MANAGED_PREFIX):
+            continue
+        if name in paused:
+            continue  # a manual-invocation-only trigger left enabled by mistake
+            # is direction A's "running-while-declared-off", not this one.
+        for arn in targets_of(t):
+            for row in _rows_for_target(reg, arn):
+                cid = row["component_id"]
+                if cid in sf_live or _declares_off(row):
+                    # SF-invoked or itself declared off — its own service state
+                    # is graded elsewhere (direction A / direction C); grading
+                    # it again here off a single trigger's silence would just
+                    # be a second, weaker copy of those.
+                    continue
+                if invocations_of(cid) > 0:
+                    continue
+                findings.append({
+                    "kind": "enabled-trigger-silent-target", "trigger": name,
+                    "surface": t["surface"],
+                    "detail": (
+                        f"live State=ENABLED and its live target is "
+                        f"{cid!r} (row lifecycle={_lifecycle(row) or 'in-service'}), "
+                        f"but {cid!r} was invoked 0 times since {since:%Y-%m-%d}. "
+                        "The trigger firing on schedule is not evidence the work "
+                        "happened — read the live target map, not the trigger's own "
+                        "State, before treating an enabled schedule as healthy."
+                    ),
+                })
+
     # ── direction D: paused_alarms vs live CloudWatch, both directions ──────
     # Read-only mirror of `automation_pause.alarm_findings()`: justification is
     # RE-DERIVED here from `m` and `paused_names(m)`, never trusted from a

--- a/tests/test_pause_reconcile.py
+++ b/tests/test_pause_reconcile.py
@@ -168,6 +168,80 @@ def test_dark_and_undeclared_component_fires_for_a_target_behind_dark_triggers(m
         [("dark-and-undeclared-component", "worker")]
 
 
+def test_enabled_trigger_silent_target_fires_when_the_live_target_never_runs(mod):
+    """alpha-engine-config-I9469: an ENABLED schedule whose live target has zero
+    invocations must be a finding — the schedule firing is not evidence the
+    downstream work happened."""
+    findings = _reconcile(
+        mod, manifest=_manifest(),
+        rows={"daily": _row("daily"), "worker": _row("worker", "in-service", substrate="lambda")},
+        triggers=[{"surface": "events", "name": "daily", "state": "ENABLED"}],
+        targets={"daily": ["arn:aws:lambda:us-east-1:1:function:worker"]},
+        ran={"worker": 0},
+    )
+    assert [(f["kind"], f["trigger"]) for f in findings] == \
+        [("enabled-trigger-silent-target", "daily")]
+
+
+def test_enabled_trigger_silent_target_does_not_reproduce_the_i9469_false_positive(mod):
+    """The original 9469 audit flagged `alpha-engine-research-thinktank` (0
+    invocations) off name-similarity to `alpha-research-thinktank-daily`. This
+    direction reads the LIVE target map instead: the rule's real target is the
+    dispatcher, which is invoked, so no finding — the retired Lambda is never
+    even consulted because it is not a live target of anything."""
+    findings = _reconcile(
+        mod, manifest=_manifest(),
+        rows={"alpha-research-thinktank-daily": _row("alpha-research-thinktank-daily"),
+              "alpha-engine-thinktank-spot-dispatcher":
+              _row("alpha-engine-thinktank-spot-dispatcher", "in-service", substrate="lambda")},
+        triggers=[{"surface": "events", "name": "alpha-research-thinktank-daily", "state": "ENABLED"}],
+        targets={"alpha-research-thinktank-daily":
+                 ["arn:aws:lambda:us-east-1:1:function:alpha-engine-thinktank-spot-dispatcher"]},
+        ran={"alpha-engine-thinktank-spot-dispatcher": 10},
+    )
+    assert findings == []
+
+
+def test_enabled_trigger_silent_target_skips_a_target_declared_off(mod):
+    """The target's own row already says it is not expected to run — that is
+    direction A/C's territory, not this one's."""
+    findings = _reconcile(
+        mod, manifest=_manifest(),
+        rows={"daily": _row("daily"), "worker": _row("worker", "retired", substrate="lambda")},
+        triggers=[{"surface": "events", "name": "daily", "state": "ENABLED"}],
+        targets={"daily": ["arn:aws:lambda:us-east-1:1:function:worker"]},
+        ran={"worker": 0},
+    )
+    assert findings == []
+
+
+def test_enabled_trigger_silent_target_skips_an_sf_invoked_target(mod):
+    """A target reached by a live Step Functions definition has other live
+    invocation paths this direction cannot see from the trigger map alone."""
+    findings = _reconcile(
+        mod, manifest=_manifest(),
+        rows={"daily": _row("daily"), "worker": _row("worker", "in-service", substrate="lambda")},
+        triggers=[{"surface": "events", "name": "daily", "state": "ENABLED"}],
+        targets={"daily": ["arn:aws:lambda:us-east-1:1:function:worker"]},
+        ran={"worker": 0}, sf={"worker"},
+    )
+    assert findings == []
+
+
+def test_enabled_trigger_silent_target_skips_a_paused_trigger(mod):
+    """A trigger the manifest declares paused but that is live ENABLED is
+    direction A's `running-while-declared-off` — not duplicated here."""
+    findings = _reconcile(
+        mod, manifest=_manifest(paused={"daily": "ruled off"}),
+        rows={"daily": _row("daily", "deprecated"),
+              "worker": _row("worker", "in-service", substrate="lambda")},
+        triggers=[{"surface": "events", "name": "daily", "state": "ENABLED"}],
+        targets={"daily": ["arn:aws:lambda:us-east-1:1:function:worker"]},
+        ran={"worker": 0},
+    )
+    assert [f["kind"] for f in findings] == ["running-while-declared-off"]
+
+
 # ── the two guards that keep the detector from writing false decisions ───────
 
 def test_a_step_functions_stage_is_not_reported_dark(mod):


### PR DESCRIPTION
## Summary

**alpha-engine-config-I9469** (thinktank): `alpha-engine-research-thinktank` showed 0 invocations in 7 days while `alpha-research-thinktank-daily` (ENABLED, `cron(30 14 * * ? *)`) fired daily. Investigation:

- The Lambda is already correctly retired — registry row `nous-ergon-ops/governance/observability.d/alpha-engine-research-thinktank.yaml` carries `lifecycle: retired` since 2026-08-04 (`alpha-engine-config-I5777`), the SF-role IAM grant on it is already gone (verified live against `alpha-engine-step-functions-role-policy.json`), and `crucible-research`'s deploy path for it is retired (`lambda_deploy_drift.py::RETIRED`, `deploy.sh` comment).
- The rule's LIVE target (`list-targets-by-rule`) is `alpha-engine-thinktank-spot-dispatcher`, which had 10 invocations in the same 7-day window.
- S3 confirms the Think Tank is genuinely producing: `thinktank/ratings/`, `thinktank/challenger_selection/`, `thinktank/events/` all fresh through 2026-08-28 (the most recent trading day at time of check).
- **I9469's finding was a false positive** — the manual audit matched on name-similarity to a retired Lambda instead of reading the rule's live target map. `alpha-engine-config-I5777` remains open only on its last deliverable: physically deleting the now-unreferenced AWS Lambda resource (an irreversible operator step, not done here).

**alpha-engine-config-I8810** (inst_ownership) is a second instance of the same class ("an enabled/declared-live component whose declared downstream produced zero work"), different mechanism: `thinktank_inst_ownership` declares `cadence: event_driven` + `liveness_via: thinktank_coverage_ledger`. `nousergon_lib.artifact_freshness.check_freshness` unconditionally short-circuits `event_driven` rows to `fresh` (no age floor applies), so the existing never-written probe — gated on `result.state == "missing"` — could never run for it. Its own key (`data/inst_ownership/latest.json`) was never once checked for existence; only its liveness_via anchor was graded.

**alpha-engine-config-I8812** (`decision_artifacts/_eval`) was investigated but NOT folded in — see "Not in this PR" below.

## Changes

1. **`infrastructure/pause_reconcile.py`** — new direction E (`enabled-trigger-silent-target`): for every live-ENABLED trigger, resolve its actual target(s) via the existing `trigger_targets()` (a real `list-targets-by-rule`/`get-schedule` read), and flag a target whose invocation count is 0 over the evidence window, when the target's own registry row is in-service (skipping SF-invoked and declared-off targets, which are graded elsewhere). Generalizes the ad hoc 7-day CloudWatch sweep that produced I9469 into a standing check — and a test (`test_enabled_trigger_silent_target_does_not_reproduce_the_i9469_false_positive`) proves it does NOT reproduce the original false positive, because it reads the live target map instead of guessing off the name.

2. **`infrastructure/lambdas/freshness-monitor/index.py`** — widened the never-written probe's eligibility from `result.state == "missing"` to `result.state == "missing" or spec.cadence == "event_driven"`. The probe mechanism (`_prefix_has_ever_been_written`) and downstream handling (non-paging, digest-only, per-row `never_written` field in `check_results.json`) are unchanged — this only makes event_driven rows eligible for the same existing treatment `missing` rows already get.

## Not in this PR: alpha-engine-config-I8812

Live-checked `s3://alpha-engine-research/decision_artifacts/_eval/latest.json` (2026-08-31): it is being actively written TODAY, with `judged_agent_id: "thinktank_theme"` — i.e. the pointer's freshness right now comes from the daily Think Tank's own eval calls (which share the same `judge.py`/`persist_eval_artifact` code path), not from the weekly SF's `EvalJudgeProcess` stage the registry row (`eval_artifact_latest`, `owner_repo: crucible-research`) declares as producer. The shared pointer being fresh no longer certifies the DECLARED producer ran — a producer-attribution defect, not a never-written or trigger-target gap. Fixing it needs tracing `EvalJudgeSubmit/Poll/Process` SF history from 2026-06-27 in `crucible-research`, a different mechanism and repo than either fix here. Reported back to I8812 rather than folded in.

## Testing

- `python3 -m pytest tests/test_pause_reconcile.py infrastructure/lambdas/freshness-monitor/test_handler.py -q` — 265 passed.
- Full repo suite (`python3 -m pytest tests/ -q`): 6888 passed, 2 pre-existing failures in `tests/test_pipeline_status_registry_source_check.py` unrelated to this change (confirmed via `git stash` — fails identically on `main`; caused by an installed `nousergon-lib` pin mismatch, tracked `alpha-engine-config-I9070`/`I9116`).

Closes-when items from I9469 this PR addresses: the check exists and is proven to fail by a test (`test_enabled_trigger_silent_target_fires_when_the_live_target_never_runs`).

Related: `alpha-engine-config-I9469`, `alpha-engine-config-I5777`, `alpha-engine-config-I8810`, `alpha-engine-config-I8812` (cross-repo — closing keywords do not apply; the tracker issue is closed by hand once verified).

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)
