### PR TITLE
feat(overseer): register the console's milestone-clause-transition alert class (alpha-engine-config-I9482)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1470,6 +1470,38 @@ alert_classes:
     response: operator
     migration_issue: alpha-engine-config-I3302   # also bypasses the email chokepoint itself
 
+  # -- console (nousergon-console) --
+  # The declared-milestone clause journal (alpha-engine-config-I9482). The
+  # console evaluates the phase-2 exit predicate on every index build and, until
+  # I9482, recorded nothing: two clauses went MET -> UNMET inside three days
+  # (2026-08-28 -> 2026-08-31) and nothing paged. It now emits ONE event per
+  # EPISODE -- a maximal run of consecutive builds in which one clause holds one
+  # non-MET status -- with a symmetric `state: cleared` when the clause returns
+  # to MET. `error` on open (a declared exit criterion regressed, or the console
+  # LOST THE ABILITY to grade one -- detection blindness outranks the defect it
+  # hides, so both are error); `info` on the clear.
+  #
+  # DetailType `nousergon.milestone-clause-transition.v1`; detail carries
+  # `identity_key` (stable across the open/clear pair, and carrying nothing
+  # about the build), `clause_id`, `moved` (the binding that changed, with
+  # before/after) and the milestone roll-up. `intake: bus` -- it is put directly
+  # onto `nousergon-alerts` by the console box under its `nousergon-alerts-put-
+  # events` grant, not through the krepis chokepoint, but lands on the same bus
+  # the drain consumes.
+  - class: console_milestone_clause_transition
+    source: "nousergon.console.milestone-journal"
+    severities: [error, info]
+    intake: bus
+    response: drain-queue
+    # overseer-policy.md invariant 4 (alpha-engine-config-I8991/I8996): a
+    # pageable class needs a declared disposition, and `response: drain-queue`
+    # alone is not one -- it says the drain SEES the event, not what the drain
+    # DOES with it. The per-class disposition here is genuinely open: a clause
+    # regression may warrant a T2 diagnosis turn (which clause, what moved,
+    # which repo owns the fix) or a T0 digest fold when the milestone is
+    # already known to be HOLDING on that clause. Tracked, not guessed.
+    migration_issue: alpha-engine-config-I9482
+
 # ── T1 authority tier — named deterministic remediations (overseer-policy.md §6) ──
 # Each entry is a reviewed, non-agentic automation for a known-shape failure
 # whose root cause AND remediation are stable across ≥3 occurrences. The


### PR DESCRIPTION
Tracker: `alpha-engine-config-I9482` (refs `-I6967`, `-I9083`). Cross-repo, so no closing keyword.

## What & why

The console evaluates the Crucible phase-2 exit predicate on every index build and, until `I9482`, **recorded nothing**: two clauses went MET → UNMET inside three days (c3 `population_completeness.unregistered` 0 → 3, c4 `staleness_honesty.count` 0 → 2, measured live 2026-08-31T15:59Z) and nothing paged. `nousergon-console-PR124` makes each clause transition an event; this is its `alert_classes` row.

Without it, the drain charter's runtime backstop treats every one of those events as a **T3 finding**, because its source matches no row here — so the fix for a silent regression would arrive as registry drift.

## The class

| Field | Value |
|---|---|
| `class` | `console_milestone_clause_transition` |
| `source` | `nousergon.console.milestone-journal` |
| `severities` | `[error, info]` |
| `intake` | `bus` |
| `response` | `drain-queue` |
| `migration_issue` | `alpha-engine-config-I9482` |

One event per **episode** — a maximal run of consecutive builds in which one clause holds one non-MET status — with a symmetric `state: cleared` when the clause returns to MET. `error` on open, both for a clause that regressed and for one the console *lost the ability to grade* (detection blindness outranks the defect it hides); `info` on the clear.

DetailType `nousergon.milestone-clause-transition.v1`. Detail carries `identity_key` (stable across the open/clear pair, and carrying nothing about the build), `clause_id`, `moved` (the binding that changed, with before/after values) and the milestone roll-up.

`intake: bus` — the console box puts these directly onto `nousergon-alerts` under its existing `nousergon-alerts-put-events` grant rather than through the krepis chokepoint, but they land on the bus the drain consumes.

`migration_issue` rather than a bare drain-queue row: `overseer-policy.md` invariant 4 wants a declared disposition, and `drain-queue` says the drain *sees* the event, not what it does with it. Whether a clause regression warrants a T2 diagnosis turn or a T0 digest fold is genuinely open and is tracked in `I9482` rather than guessed here.

## Merge order

Independent of the other two — no ordering constraint, and it can land first so no event is ever unregistered.

1. `nousergon-console-PR124` — the schema and the evaluator, deployed first.
2. `nous-ergon-ops-PR942` — the config, after `PR124` deploys.
3. **this PR** — any time.

## Test plan

`python3 -m pytest tests/test_overseer_playbook_registry.py tests/test_alert_class_registry_drift.py tests/test_alert_class_response_gap.py tests/test_alert_class_pr_guard.py -q` → **126 passed**, run locally before pushing. `find_new_gaps` and `find_stale_grandfather_entries` both clean.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
