### PR TITLE
fix(run-scope): a cycle's scope accumulates — a skip-flagged rerun can no longer clobber a scheduled run (alpha-engine-config-I8811)

### DIFF
--- a/.github/workflows/deploy-weekly-run-scope.yml
+++ b/.github/workflows/deploy-weekly-run-scope.yml
@@ -67,6 +67,25 @@ jobs:
         working-directory: alpha-engine-data
         run: bash infrastructure/lambdas/weekly-run-scope/deploy.sh
 
+      # The merge emits the exact operator command whenever it ships code whose
+      # IAM this workflow is NOT allowed to apply (config#6738,
+      # pull-request-policy §4.2 form 3). github-actions-lambda-deploy has no
+      # iam:PutRolePolicy by design — the single-writer rule adopted after 4
+      # IAM-clobber incidents — so a changed iam-policy.json ships as CODE ONLY
+      # and the grant lags. Deliberately does not fail the job: the code deploy
+      # really did succeed, and the standing detector is
+      # nous-ergon-ops/infrastructure/iam/check-drift.py (every PR + daily
+      # 09:35 UTC), which stays red until the command below is run.
+      - name: Emit operator IAM-apply command if iam-policy.json changed
+        if: always()
+        working-directory: alpha-engine-data
+        run: |
+          CHANGED=$(git diff --name-only HEAD^ HEAD -- infrastructure/lambdas/weekly-run-scope/iam-policy.json || true)
+          if [ -z "${CHANGED}" ]; then echo "iam-policy.json unchanged in this merge — no operator step."; exit 0; fi
+          CMD="AWS_PROFILE=ne-admin bash infrastructure/lambdas/weekly-run-scope/deploy.sh --apply-iam"
+          echo "::warning title=Operator IAM apply required::${CMD}"
+          { echo "### Operator step required"; echo ""; echo "\`infrastructure/lambdas/weekly-run-scope/iam-policy.json\` changed in this merge, and this workflow's OIDC role cannot apply IAM (single-writer rule). Run from a checkout of \`nousergon-data\`:"; echo ""; echo '```'; echo "${CMD}"; echo '```'; echo ""; echo "Until it runs: \`nous-ergon-ops/infrastructure/iam/check-drift.py --lambdas-root ../nousergon-data/infrastructure/lambdas\` stays red (daily 09:35 UTC), and the Lambda logs \`run-scope write DECLINED\` instead of merging (alpha-engine-config-I8811). The fix is SAFE without it — a create-only write cannot clobber."; } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Report deployed version
         working-directory: alpha-engine-data
         run: |

--- a/infrastructure/lambdas/weekly-run-scope/deploy.sh
+++ b/infrastructure/lambdas/weekly-run-scope/deploy.sh
@@ -19,6 +19,21 @@
 #   bash infrastructure/lambdas/weekly-run-scope/deploy.sh --apply-iam # re-apply iam-policy.json only (config#2825)
 #   bash infrastructure/lambdas/weekly-run-scope/deploy.sh --dry-run   # show actions, do not apply
 
+# IAM (alpha-engine-config-I8811): iam-policy.json now grants `s3:GetObject` on
+# `backtest/*/run_scope.json` alongside the existing `s3:PutObject`. The Lambda
+# reads the cycle's existing scope so it can MERGE onto it instead of
+# overwriting it — a skip-flagged recovery rerun must not be able to demote a
+# scheduled run's dispatched stage to DISABLED (see index.py::_persist).
+#
+# The GHA auto-deploy path (`deploy-weekly-run-scope.yml`) ships CODE ONLY: its
+# OIDC role has no iam:PutRolePolicy by design (the fleet single-writer rule
+# adopted after 4 IAM-clobber incidents), so this grant reaches the role only
+# through an operator `--apply-iam` run. That lag is SAFE and does not gate the
+# fix: without `s3:GetObject` the handler falls back to a create-only
+# conditional write (`IfNoneMatch: *`), which cannot merge but also cannot
+# clobber — it declines at ERROR and the cycle keeps the scope it has. Applying
+# the grant upgrades declining into merging.
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/infrastructure/lambdas/weekly-run-scope/iam-policy.json
+++ b/infrastructure/lambdas/weekly-run-scope/iam-policy.json
@@ -24,10 +24,28 @@
       ]
     },
     {
-      "Sid": "WriteRunScopeArtifact",
+      "Sid": "ReadAndWriteRunScopeArtifact",
       "Effect": "Allow",
-      "Action": "s3:PutObject",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
       "Resource": "arn:aws:s3:::alpha-engine-research/backtest/*/run_scope.json"
+    },
+    {
+      "Sid": "ListRunScopePrefixForAbsentKeyDetection",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "backtest/*"
+          ]
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/weekly-run-scope/index.py
+++ b/infrastructure/lambdas/weekly-run-scope/index.py
@@ -28,6 +28,20 @@ row, ``ReportCard``'s and ``Director``'s are the three the history cannot yet
 contain; they resolve from the run's input flags, and each row records which of
 the two sources decided it (``source``).
 
+**One key per cycle, and more than one execution writes it.**
+``backtest/{run_date}/run_scope.json`` is written by the scheduled Saturday run
+and again by every recovery rerun launched against the same cycle — and a rerun
+is launched to redo ONE stage, so it carries a skip-set for everything else.
+Last-writer-wins therefore hands the cycle's scope to its worst-informed
+author: both artifacts on S3 on 2026-08-31 were written by skip-flagged reruns
+(``watch-rerun-2026-08-22-3``; ``watch-rerun-2026-08-28-13``, written
+2026-08-30T18:47Z, a day and a half after the scheduled run wrote that cycle's
+attestation) and both claim ``Backtester: DISABLED`` for cycles whose
+backtester artifacts exist. ``crucible-evaluator-PR289``
+(``alpha-engine-config-I8811``) stopped the consumer acting on that
+contradiction; :func:`_persist` here stops it being written. The rule is that a
+cycle's scope only ever ACCUMULATES — see ``run_scope.merge_run_scopes``.
+
 **Failure posture — deliberately fail-open, and only here.** A scope block that
 could not be built must not kill a run that produced real trading artifacts, so
 the handler catches, publishes nothing, and returns a block whose every stage is
@@ -41,11 +55,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+from datetime import datetime, timezone
 
 import boto3
 from krepis.dates import resolve_trading_day
 
-from run_scope import build_run_scope
+from run_scope import build_run_scope, merge_run_scopes, stamp_provenance
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -96,6 +111,168 @@ def _history(client, execution_arn: str) -> list[dict]:
 def _definition(client, state_machine_arn: str) -> dict:
     described = client.describe_state_machine(stateMachineArn=state_machine_arn)
     return json.loads(described["definition"])
+
+
+class ScopeWriteConflictError(RuntimeError):
+    """Raised when the artifact changed under us on every attempt.
+
+    Loud on purpose. The SF's Catch on ``RunScope`` routes it to
+    ``CheckSkipReportCard`` without failing the weekly run, and the cycle keeps
+    whichever scope is already on S3 — the safe direction, since the thing this
+    module must never do is destroy an established claim.
+    """
+
+
+#: Read-merge-write attempts before giving up. Concurrent RunScope executions
+#: over one ``run_date`` are rare (a rerun launched while the scheduled run is
+#: still going); three attempts turn that from a lost write into a retried one.
+_WRITE_ATTEMPTS = 3
+
+
+def _error_code(exc: Exception) -> str:
+    """The S3 error code off a botocore ``ClientError``, duck-typed.
+
+    Duck-typed rather than ``except ClientError`` so this module keeps its
+    single runtime dependency surface and so the tests can drive every branch
+    with a plain exception carrying a ``response``.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = (response.get("Error") or {}).get("Code")
+        if isinstance(code, str):
+            return code
+    return type(exc).__name__
+
+
+def _read_incumbent(s3, key: str) -> tuple[dict | None, str | None, bool, str]:
+    """The cycle's existing scope artifact, its ETag, and whether we KNOW.
+
+    Returns ``(body, etag, read_ok, note)``. ``read_ok`` is the load-bearing
+    value: True means the incumbent's presence or absence is ESTABLISHED, False
+    means the read itself failed and this execution knows nothing about what is
+    already there. The two are handled differently by :func:`_persist` — an
+    unknown incumbent is never overwritten.
+
+    A 404 is a successful read: the object is established absent. That branch
+    is only reachable because ``iam-policy.json`` also grants a
+    ``backtest/*``-scoped ``s3:ListBucket`` — without it S3 answers 403
+    AccessDenied for a key that does not exist (config#2878), and an absent
+    artifact would be indistinguishable from an unreadable one. Both are safe
+    here, but only one of them can merge.
+    """
+    try:
+        body = s3.get_object(Bucket=BUCKET, Key=key)
+        parsed = json.loads(body["Body"].read())
+        etag = body.get("ETag")
+        if not isinstance(parsed, dict):
+            return None, etag, True, "incumbent body is not a JSON object"
+        return parsed, etag, True, "incumbent read"
+    except Exception as exc:  # noqa: BLE001
+        code = _error_code(exc)
+        if code in ("NoSuchKey", "404", "NoSuchBucket"):
+            return None, None, True, "no incumbent artifact for this cycle"
+        # Every other failure — AccessDenied while the new grant lags the code
+        # deploy, a throttle, a truncated body. NOT fatal, and NOT treated as
+        # absence: `_persist` degrades to a create-only write, which cannot
+        # clobber anything.
+        logger.warning(
+            "could not read the incumbent run scope at s3://%s/%s (%s) — "
+            "falling back to a create-only write, which refuses to overwrite "
+            "an existing artifact rather than clobbering one it cannot read.",
+            BUCKET, key, code,
+        )
+        return None, None, False, f"incumbent unreadable: {code}"
+
+
+def _persist(scope: dict, key: str) -> dict:
+    """Accumulate this execution's scope onto the cycle's, and store it.
+
+    alpha-engine-config-I8811. The write is CONDITIONAL in both directions:
+
+    * incumbent read successfully  -> ``IfMatch`` its ETag, so a concurrent
+      writer between our read and our write loses the race instead of being
+      silently overwritten; a 412 re-reads and re-merges.
+    * incumbent NOT readable       -> ``IfNoneMatch: "*"``, so the write lands
+      only if the key is empty. A 412 here is the guard working: something is
+      already there and this execution cannot merge onto it, so it declines and
+      says so at ERROR rather than replacing a claim it never read.
+
+    The second branch is what makes this fix safe from the moment the code
+    deploys, before the ``s3:GetObject`` grant in ``iam-policy.json`` is
+    applied: without the grant the Lambda cannot merge, but it also cannot
+    destroy — the exact failure this exists to prevent.
+    """
+    s3 = boto3.client("s3")
+    last_error = ""
+    for attempt in range(1, _WRITE_ATTEMPTS + 1):
+        incumbent, etag, read_ok, note = _read_incumbent(s3, key)
+        merged, ledger = merge_run_scopes(incumbent, dict(scope))
+        ledger["incumbent_read"] = {"ok": read_ok, "note": note}
+        ledger["attempt"] = attempt
+        merged["scope_merge"] = ledger
+        for rejected in ledger["rejected"]:
+            # Fail loud: a refused claim is an ERROR line naming both sides, not
+            # a quiet no-op. It is also durable — it ships inside the artifact.
+            logger.error(
+                "run-scope write REFUSED for stage %s: keeping %s established "
+                "by %s; this execution claimed %s. %s "
+                "(alpha-engine-config-I8811)",
+                rejected["stage"], rejected["kept"], rejected["kept_from"],
+                rejected["refused"], rejected["why"],
+            )
+        params = {
+            "Bucket": BUCKET,
+            "Key": key,
+            "Body": json.dumps(merged, indent=2, sort_keys=True).encode("utf-8"),
+            "ContentType": "application/json",
+        }
+        if etag:
+            params["IfMatch"] = etag
+        else:
+            params["IfNoneMatch"] = "*"
+        try:
+            s3.put_object(**params)
+        except Exception as exc:  # noqa: BLE001
+            code = _error_code(exc)
+            if code not in ("PreconditionFailed", "412", "ConditionalRequestConflict"):
+                raise
+            if not read_ok:
+                # Terminal, and correct. We could not read what is there, and
+                # something IS there. Retrying would loop on the same denial.
+                logger.error(
+                    "run-scope write DECLINED at s3://%s/%s — an artifact "
+                    "already exists for this cycle and this execution could "
+                    "not read it (%s), so it will not be overwritten. The "
+                    "cycle keeps the scope it has. Apply the s3:GetObject "
+                    "grant in this lambda's iam-policy.json to restore "
+                    "merging (alpha-engine-config-I8811).",
+                    BUCKET, key, note,
+                )
+                scope["write_declined"] = {
+                    "key": key, "reason": note,
+                    "detail": "an artifact exists and could not be read; "
+                              "refusing to overwrite an unread claim.",
+                }
+                scope["scope_merge"] = ledger
+                return scope
+            last_error = code
+            logger.warning(
+                "run-scope write lost a race at s3://%s/%s (%s, attempt %d/%d)"
+                " — re-reading and re-merging.",
+                BUCKET, key, code, attempt, _WRITE_ATTEMPTS,
+            )
+            continue
+        logger.info(
+            "wrote s3://%s/%s (%s)", BUCKET, key,
+            "merged onto " + str(ledger["incumbent_execution_arn"])
+            if ledger["merged"] else "first writer for this cycle",
+        )
+        return merged
+    raise ScopeWriteConflictError(
+        f"s3://{BUCKET}/{key} changed under every one of {_WRITE_ATTEMPTS} "
+        f"read-merge-write attempts (last: {last_error}). Nothing was written; "
+        "the cycle keeps the scope already on S3."
+    )
 
 
 def handler(event, _context):
@@ -166,13 +343,24 @@ def handler(event, _context):
             f"one. Cause: {type(exc).__name__}."
         )
 
+    scope["written_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    stamp_provenance(scope, execution_arn, scope["written_at"])
     logger.info("run scope: %s", scope["statement"])
 
     if dry_run:
         # The Friday-PM shell run exercises the whole read+derive path (client
-        # construction, the two API grants, the derivation) and writes nothing —
-        # the same dry contract every advisory producer on this pipeline honours.
+        # construction, the API grants, the derivation) and writes nothing —
+        # the same dry contract every advisory producer on this pipeline
+        # honours. It DOES exercise the incumbent read, because that grant is
+        # new (alpha-engine-config-I8811) and a rehearsal that skipped it would
+        # leave a missing `s3:GetObject` to be discovered by the Saturday run
+        # it protects.
         scope["dry_run"] = True
+        if run_date:
+            _, _, read_ok, note = _read_incumbent(
+                boto3.client("s3"), KEY_TEMPLATE.format(run_date=run_date)
+            )
+            scope["incumbent_read"] = {"ok": read_ok, "note": note}
         return scope
 
     if not run_date:
@@ -190,12 +378,4 @@ def handler(event, _context):
         )
         return scope
 
-    key = KEY_TEMPLATE.format(run_date=run_date)
-    boto3.client("s3").put_object(
-        Bucket=BUCKET,
-        Key=key,
-        Body=json.dumps(scope, indent=2, sort_keys=True).encode("utf-8"),
-        ContentType="application/json",
-    )
-    logger.info("wrote s3://%s/%s", BUCKET, key)
-    return scope
+    return _persist(scope, KEY_TEMPLATE.format(run_date=run_date))

--- a/infrastructure/lambdas/weekly-run-scope/run_scope.py
+++ b/infrastructure/lambdas/weekly-run-scope/run_scope.py
@@ -55,6 +55,13 @@ then repeat every week:
     The gate was never entered — the execution ended, or failed, upstream of it.
     Never read as disabled, never read as passing.
 
+One further rule, in section 4 below: the artifact is ONE key per cycle and
+several executions write it, so a row is only ever replaced by a row making a
+STRICTLY STRONGER claim about the same stage (``merge_run_scopes``). A
+skip-flagged recovery rerun can no longer demote a scheduled run's dispatched
+stage to ``DISABLED``, or a deliberate ``DISABLED`` to ``NOT_REACHED``, while a
+rerun that genuinely re-executes a stage still records it.
+
 Nothing here calls AWS; ``index.py`` fetches the definition and the history and
 hands them in. That split is deliberate: it lets the derivation be tested
 against a REAL definition and a REAL execution history as fixtures, which is how
@@ -507,3 +514,243 @@ def graded_stage_names(block: Any) -> list[str]:
         name for name, row in stages.items()
         if isinstance(row, dict) and row.get("disposition") in GRADED_DISPOSITIONS
     )
+
+
+# ---------------------------------------------------------------------------
+# 4. Merge — one cycle's scope, accumulated across every execution that ran it
+# ---------------------------------------------------------------------------
+#
+# ``backtest/{run_date}/run_scope.json`` is ONE key per cycle, and more than one
+# execution writes it: the scheduled Saturday run, then any recovery rerun an
+# operator launches against the same cycle. Until this section existed the last
+# writer won outright, and the last writer is systematically the WORST-informed
+# one — a rerun is launched precisely to redo one stage, so it carries a
+# skip-set for everything else.
+#
+# Both scope artifacts on S3 when this was written were authored that way, not
+# by the run that produced the cycle's numbers:
+#
+#   backtest/2026-08-22/run_scope.json  <- watch-rerun-2026-08-22-3
+#   backtest/2026-08-28/run_scope.json  <- watch-rerun-2026-08-28-13, written
+#                                          2026-08-30T18:47Z, a day and a half
+#                                          AFTER the scheduled run had written
+#                                          that cycle's attestation.json
+#
+# Each claims ``Backtester: DISABLED`` for a cycle whose backtester artifacts
+# demonstrably exist. `crucible-evaluator-PR289` (alpha-engine-config-I8811)
+# fixed the CONSUMER so a scope that contradicts the artifacts can no longer
+# overwrite a measured verdict — it now resolves to an honest UNKNOWN instead of
+# a false PASS. This section fixes the PRODUCER, so the contradiction is not
+# written in the first place.
+#
+# The rule is one line: **a cycle's scope only ever accumulates.** A row is
+# replaced only by a row making a STRICTLY STRONGER claim about the same stage.
+# That is what makes both halves of the requirement hold at once —
+#
+#   * a skip-flagged rerun cannot demote a scheduled run's ENABLED_COMPLETED to
+#     DISABLED, nor a deliberate DISABLED to NOT_REACHED (the race that can
+#     still deny clause 5 after a clean weekly run);
+#   * a rerun that GENUINELY re-runs a stage still records it, because
+#     ENABLED_COMPLETED outranks everything and lands.
+#
+# Immutability was the other candidate and is rejected: it trades a fail-open
+# for a fail-stuck, and a real recovery that executes Backtester must be able to
+# say so.
+
+#: Strength of a row's claim about the cycle. NOT the severity of the outcome —
+#: an ordering over EVIDENCE:
+#:
+#: 0 ``NOT_REACHED``       no evidence at all; the gate was never entered.
+#: 1 ``DISABLED``          a decision was observed — this run skipped the stage.
+#: 2 ``ENABLED_FAILED``    the stage was DISPATCHED (and did not complete).
+#: 3 ``ENABLED_COMPLETED`` the stage was dispatched AND completed.
+#:
+#: 2 sits above 1 because dispatch is a fact about the cycle that a later skip
+#: cannot unmake: if the scheduled run ran Backtester and it failed, a rerun
+#: that skips Backtester has not made the cycle one in which Backtester was
+#: switched off. A disposition outside the closed vocabulary ranks below
+#: everything (``-1``), so it can never displace a recognised row.
+AUTHORITY = {
+    NOT_REACHED: 0,
+    DISABLED: 1,
+    ENABLED_FAILED: 2,
+    ENABLED_COMPLETED: 3,
+}
+
+
+def authority(row: Any) -> int:
+    """The rank of a stage row's claim. Unrecognised ranks below NOT_REACHED."""
+    if not isinstance(row, dict):
+        return -1
+    return AUTHORITY.get(row.get("disposition"), -1)
+
+
+def stamp_provenance(scope: dict, execution_arn: str, recorded_at: str) -> dict:
+    """Record, on every row, WHICH execution established it and when.
+
+    A merged artifact whose rows come from two executions while its top-level
+    ``execution_arn`` names only the last writer is a document that cannot be
+    audited. Every row carries its own author, so a reader can always tell the
+    scheduled run's claims from a rerun's.
+    """
+    for row in (scope.get("stages") or {}).values():
+        if isinstance(row, dict):
+            row.setdefault("recorded_by_execution_arn", execution_arn)
+            row.setdefault("recorded_at", recorded_at)
+    return scope
+
+
+def _recompute(scope: dict) -> dict:
+    """Re-derive counts, graded set and statement from whatever rows survive.
+
+    Never carried over from either input: the statement is the denominator every
+    downstream grade is rendered against, and a stale one is the specific way a
+    surface goes quietly green.
+    """
+    stages = scope.get("stages") or {}
+    counts = {d: 0 for d in sorted(DISPOSITIONS)}
+    unrecognised = 0
+    for row in stages.values():
+        disposition = row.get("disposition") if isinstance(row, dict) else None
+        if disposition in counts:
+            counts[disposition] += 1
+        else:
+            unrecognised += 1
+    scope["counts"] = counts
+    scope["graded_stages"] = sorted(
+        name for name, row in stages.items()
+        if isinstance(row, dict) and row.get("disposition") in GRADED_DISPOSITIONS
+    )
+    if scope.get("degraded"):
+        # A degraded block's statement is not a denominator — it is the
+        # SCOPE UNAVAILABLE sentence, and it survives verbatim. Recomputing it
+        # would render "0 of 0 gated stages ran and are graded", which reads as
+        # a tidy narrow run rather than an unmeasured one. The merge only ever
+        # reaches here with `degraded` still set when there was no incumbent to
+        # merge onto; where there was one, the flag is dropped first and the
+        # surviving rows get a real statement.
+        return scope
+    scope["statement"] = _statement(counts, len(stages))
+    if unrecognised:
+        scope["statement"] += (
+            f" {unrecognised} row(s) carry a disposition outside the closed "
+            "vocabulary and are not graded."
+        )
+    return scope
+
+
+def merge_run_scopes(incumbent: Any, incoming: dict) -> tuple[dict, dict]:
+    """Accumulate ``incoming`` onto the cycle's existing scope. Never raises.
+
+    Returns ``(merged, ledger)``. The ledger is written INTO the artifact as
+    ``scope_merge`` — a refused write that leaves no trace is indistinguishable
+    from a write that never happened, and the whole defect being fixed here is a
+    silent overwrite.
+
+    ``incumbent`` may be anything (absent, a non-dict, a body from an older
+    schema). Anything unusable is treated as no incumbent at all and recorded as
+    such, because refusing to write over an unreadable body would strand the
+    cycle on a corrupt artifact forever.
+    """
+    ledger: dict[str, Any] = {
+        "merged": False,
+        "accepted": [],
+        "rejected": [],
+        "incumbent_execution_arn": None,
+        "incumbent_run_date": None,
+    }
+
+    incoming_stages = incoming.get("stages") if isinstance(incoming, dict) else None
+    if not isinstance(incoming_stages, dict):
+        incoming_stages = {}
+        incoming["stages"] = incoming_stages
+
+    if not isinstance(incumbent, dict) or not isinstance(incumbent.get("stages"), dict):
+        ledger["reason"] = (
+            "no usable incumbent artifact for this cycle — this execution's "
+            "scope is written as-is."
+        )
+        return _recompute(incoming), ledger
+
+    incumbent_stages = incumbent["stages"]
+    ledger.update(
+        merged=True,
+        incumbent_execution_arn=incumbent.get("execution_arn"),
+        incumbent_run_date=incumbent.get("run_date"),
+        incumbent_statement=incumbent.get("statement"),
+        incumbent_degraded=bool(incumbent.get("degraded")),
+    )
+    if incumbent.get("run_date") and incoming.get("run_date") \
+            and incumbent["run_date"] != incoming["run_date"]:
+        # Same key, two different `run_date` fields. Recorded rather than
+        # resolved: the key is the cycle's identity, and a body disagreeing with
+        # it is a fact a reader needs, not one this function should silently
+        # pick a winner for.
+        ledger["run_date_mismatch"] = {
+            "incumbent": incumbent["run_date"], "incoming": incoming["run_date"],
+        }
+
+    merged_stages: dict[str, Any] = {}
+    for name in sorted(set(incumbent_stages) | set(incoming_stages)):
+        held = incumbent_stages.get(name)
+        offered = incoming_stages.get(name)
+        if offered is None:
+            # A stage the incoming derivation does not even mention (a gate
+            # removed from the definition since). Kept: dropping it would shrink
+            # the denominator without saying so.
+            merged_stages[name] = held
+            continue
+        if held is None:
+            merged_stages[name] = offered
+            ledger["accepted"].append({
+                "stage": name, "disposition": offered.get("disposition"),
+                "why": "new stage — the incumbent carried no row for it",
+            })
+            continue
+        if authority(offered) > authority(held):
+            merged_stages[name] = offered
+            ledger["accepted"].append({
+                "stage": name,
+                "was": held.get("disposition"),
+                "now": offered.get("disposition"),
+                "why": "a strictly stronger claim about the same stage",
+            })
+            continue
+        merged_stages[name] = held
+        if offered.get("disposition") != held.get("disposition"):
+            ledger["rejected"].append({
+                "stage": name,
+                "kept": held.get("disposition"),
+                "kept_from": held.get("recorded_by_execution_arn"),
+                "refused": offered.get("disposition"),
+                "refused_from": incoming.get("execution_arn"),
+                "why": (
+                    "a claim about this cycle is only ever replaced by a "
+                    "stronger one; this execution claimed "
+                    f"{offered.get('disposition')} over an established "
+                    f"{held.get('disposition')}."
+                ),
+            })
+
+    merged = dict(incoming)
+    merged["stages"] = merged_stages
+    if merged_stages and merged.get("degraded"):
+        # This execution could not derive a scope, but the cycle HAS one. The
+        # degraded flag would send the consumer to UNKNOWN over rows that are
+        # perfectly good — the same clobber in a different costume. The failure
+        # is kept, in the ledger, where it is a fact about this execution rather
+        # than a verdict about the cycle.
+        ledger["incoming_degraded_reason"] = merged.pop("degraded_reason", None)
+        merged.pop("degraded", None)
+        ledger["incoming_degraded"] = True
+    merged["first_written_at"] = (
+        incumbent.get("first_written_at")
+        or incumbent.get("written_at")
+        or merged.get("written_at")
+    )
+    merged["contributing_executions"] = sorted({
+        arn for row in merged_stages.values()
+        if isinstance(row, dict)
+        and isinstance(arn := row.get("recorded_by_execution_arn"), str) and arn
+    })
+    return _recompute(merged), ledger

--- a/infrastructure/lambdas/weekly-run-scope/test_handler.py
+++ b/infrastructure/lambdas/weekly-run-scope/test_handler.py
@@ -27,12 +27,15 @@ them. A synthetic fixture would have agreed with all four.
 """
 from __future__ import annotations
 
+import io
 import json
+import logging
 import pathlib
 
 import pytest
 
 from run_scope import (
+    AUTHORITY,
     DISABLED,
     DISPOSITIONS,
     ENABLED_COMPLETED,
@@ -44,6 +47,7 @@ from run_scope import (
     entered_sequence,
     gate_decisions,
     graded_stage_names,
+    merge_run_scopes,
     work_entry,
 )
 
@@ -294,12 +298,58 @@ def test_graded_stage_names_withholds_an_unknown_disposition():
 # ---------------------------------------------------------------------------
 
 
-def _index(monkeypatch, *, definition=None, history=None, raises=None):
+class _S3Error(Exception):
+    """A botocore-shaped error. ``index._error_code`` is duck-typed against the
+    ``response`` envelope precisely so these branches can be driven without
+    botocore in the test path."""
+
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+class _FakeS3:
+    """An S3 double with the ONE behaviour this fix depends on: conditional
+    writes.
+
+    ``IfNoneMatch: "*"`` (create-only) and ``IfMatch: <etag>`` (compare-and-swap)
+    are enforced here rather than assumed, because they are the mechanism that
+    makes the guard hold when the Lambda cannot read the incumbent at all.
+    """
+
+    def __init__(self, store=None, *, read_error=None):
+        self.store = dict(store or {})
+        self.etags = {k: f'"etag-{i}"' for i, k in enumerate(self.store)}
+        self.read_error = read_error
+        self.writes = []
+
+    def get_object(self, *, Bucket, Key):  # noqa: N803
+        if self.read_error:
+            raise _S3Error(self.read_error)
+        if Key not in self.store:
+            raise _S3Error("NoSuchKey")
+        body = json.dumps(self.store[Key]).encode()
+        return {"Body": io.BytesIO(body), "ETag": self.etags[Key]}
+
+    def put_object(self, **kwargs):
+        key = kwargs["Key"]
+        if kwargs.get("IfNoneMatch") == "*" and key in self.store:
+            raise _S3Error("PreconditionFailed")
+        if "IfMatch" in kwargs and self.etags.get(key) != kwargs["IfMatch"]:
+            raise _S3Error("PreconditionFailed")
+        self.store[key] = json.loads(kwargs["Body"].decode())
+        self.etags[key] = f'"etag-{len(self.writes)}"'
+        self.writes.append(kwargs)
+        return {}
+
+
+def _index(monkeypatch, *, definition=None, history=None, raises=None, s3=None):
     """Import the handler with boto3 replaced by a recording double."""
     import sys
     import types
 
     written = {}
+    s3 = s3 if s3 is not None else _FakeS3()
 
     class _States:
         def describe_state_machine(self, **_kw):
@@ -313,16 +363,26 @@ def _index(monkeypatch, *, definition=None, history=None, raises=None):
                     return [{"events": history or []}]
             return _P()
 
-    class _S3:
-        def put_object(self, **kwargs):
-            written.update(kwargs)
+    class _RecordingS3:
+        def __getattr__(self, name):
+            attr = getattr(s3, name)
+            if name != "put_object":
+                return attr
+
+            def _put(**kwargs):
+                result = attr(**kwargs)
+                written.clear()
+                written.update(kwargs)
+                return result
+            return _put
 
     fake = types.SimpleNamespace(
-        client=lambda name: _States() if name == "stepfunctions" else _S3()
+        client=lambda name: _States() if name == "stepfunctions" else _RecordingS3()
     )
     monkeypatch.setitem(sys.modules, "boto3", fake)
     sys.modules.pop("index", None)
     import index  # noqa: PLC0415
+    index.fake_s3 = s3
     return index, written
 
 
@@ -468,3 +528,391 @@ def test_a_failed_derivation_grades_nothing_rather_than_failing_the_run(
     # Still persisted: an absent artifact and an unmeasured one must not look
     # the same to the consumer.
     assert written["Key"] == "backtest/2026-08-14/run_scope.json"
+
+
+# ---------------------------------------------------------------------------
+# The clobber guard — one key per cycle, several executions writing it
+# (alpha-engine-config-I8811)
+# ---------------------------------------------------------------------------
+
+_KEY = "backtest/2026-08-14/run_scope.json"
+
+
+def _scheduled_then_rerun(monkeypatch, definition, first_history, second_history):
+    """Write a cycle's scope from one execution, then attempt it from another.
+
+    Both bodies are derived from REAL captured executions, and the second write
+    goes through the same conditional-write path production uses — the store is
+    not hand-assembled between the two.
+    """
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=first_history, s3=s3)
+    scheduled = index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y",
+         "execution_input": {"skip_parity": True}},
+        None,
+    )
+    index2, written = _index(
+        monkeypatch, definition=definition, history=second_history, s3=s3
+    )
+    rerun = index2.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:watch-rerun-2026-08-28-13",
+         "state_machine_arn": "arn:y",
+         "execution_input": {"skip_backtester": True, "skip_parity": True}},
+        None,
+    )
+    return s3, scheduled, rerun, written
+
+
+def test_a_skip_flagged_rerun_cannot_demote_a_scheduled_runs_scope(
+    monkeypatch, definition, real_run_history, all_skip_history, caplog
+):
+    """THE regression, in the exact 2026-08-28 shape.
+
+    A scheduled run writes the cycle's scope; a later skip-flagged recovery
+    rerun runs ``RunScope`` over the same ``run_date`` and derives a scope in
+    which almost nothing ran. Pre-fix, the rerun's body simply replaced the
+    scheduled run's — which is how both artifacts on S3 on 2026-08-31 came to
+    claim ``Backtester: DISABLED`` for cycles whose backtester artifacts exist,
+    and how ``Parity`` came to read ``NOT_REACHED`` on a cycle where it was
+    deliberately ``DISABLED`` by ``skip_parity``.
+
+    Both halves of that matter for clause 5: ``NOT_REACHED`` does not arm
+    ``NOT_IN_SCOPE`` in ``crucible-evaluator``'s
+    ``attestation._mark_scope_out_of_scope`` and ``DISABLED`` does, so the
+    demotion alone is enough to hold ``contamination_verdict`` at UNKNOWN over a
+    clean week.
+    """
+    with caplog.at_level(logging.ERROR):
+        s3, scheduled, rerun, _ = _scheduled_then_rerun(
+            monkeypatch, definition, real_run_history, all_skip_history
+        )
+
+    stored = s3.store[_KEY]
+    # The scheduled run established these; the rerun claimed weaker ones.
+    assert scheduled["stages"]["Parity"]["disposition"] == DISABLED
+    assert scheduled["stages"]["Evaluator"]["disposition"] == ENABLED_COMPLETED
+    assert stored["stages"]["Parity"]["disposition"] == DISABLED
+    assert stored["stages"]["Parity"]["disabled_by"] == "skip_parity"
+    assert stored["stages"]["Evaluator"]["disposition"] == ENABLED_COMPLETED
+    assert stored["stages"]["Parity"]["recorded_by_execution_arn"] == "arn:scheduled"
+
+    # The refusal is DURABLE (in the artifact) and LOUD (an ERROR line naming
+    # both sides) — a guard whose refusal leaves no trace is indistinguishable
+    # from the silent overwrite it replaced.
+    refused = {r["stage"]: r for r in stored["scope_merge"]["rejected"]}
+    assert refused["Parity"]["kept"] == DISABLED
+    assert refused["Parity"]["refused"] == NOT_REACHED
+    assert refused["Evaluator"]["refused"] == DISABLED
+    assert refused["Parity"]["kept_from"] == "arn:scheduled"
+    assert any("write REFUSED for stage Parity" in r.message for r in caplog.records)
+    # The returned block is the merged truth, not this execution's derivation.
+    assert rerun["stages"]["Parity"]["disposition"] == DISABLED
+
+
+def test_the_guard_fails_when_removed(
+    monkeypatch, definition, real_run_history, all_skip_history
+):
+    """Prove the guard is load-bearing: with the merge neutralised, the same
+    two executions reproduce the live defect.
+
+    A guard not verified to fail is not a guard. Neutralising is done by
+    replacing ``merge_run_scopes`` with the pre-fix behaviour — last writer
+    wins — rather than by editing the assertion, so what is demonstrated is the
+    mechanism and not the test.
+    """
+    import index as _probe  # noqa: PLC0415,F401
+
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=real_run_history, s3=s3)
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y", "execution_input": {"skip_parity": True}},
+        None,
+    )
+    index2, _ = _index(monkeypatch, definition=definition, history=all_skip_history, s3=s3)
+    monkeypatch.setattr(
+        index2, "merge_run_scopes",
+        lambda _incumbent, incoming: (incoming, {"merged": False, "accepted": [],
+                                                 "rejected": []}),
+    )
+    index2.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:rerun",
+         "state_machine_arn": "arn:y", "execution_input": {"skip_backtester": True}},
+        None,
+    )
+    # Pre-fix behaviour, reproduced exactly: the scheduled run's deliberate
+    # DISABLED becomes NOT_REACHED, which is what denies clause 5.
+    assert s3.store[_KEY]["stages"]["Parity"]["disposition"] == NOT_REACHED
+    assert s3.store[_KEY]["stages"]["Evaluator"]["disposition"] == DISABLED
+
+
+def test_a_rerun_that_genuinely_re_runs_a_stage_still_records_it(
+    monkeypatch, definition, all_skip_history, real_run_history
+):
+    """The other half of the requirement, and the reason immutability was
+    rejected.
+
+    Reversed order: the skip-flagged shell run writes first, then an execution
+    that really dispatched the stages writes. Every stronger claim lands —
+    otherwise the fix would have traded a fail-open for a fail-stuck, and a
+    genuine recovery could never record what it re-ran.
+    """
+    s3, first, second, _ = _scheduled_then_rerun(
+        monkeypatch, definition, all_skip_history, real_run_history
+    )
+    stored = s3.store[_KEY]
+    assert first["stages"]["Evaluator"]["disposition"] == DISABLED
+    assert stored["stages"]["Evaluator"]["disposition"] == ENABLED_COMPLETED
+    accepted = {a["stage"] for a in stored["scope_merge"]["accepted"]}
+    assert "Evaluator" in accepted
+    assert stored["stages"]["Evaluator"]["recorded_by_execution_arn"] \
+        == "arn:watch-rerun-2026-08-28-13"
+    # Both executions are named on the artifact, per row and in aggregate.
+    assert len(stored["contributing_executions"]) == 2
+
+
+def test_a_failed_derivation_never_erases_an_established_scope(
+    monkeypatch, definition, real_run_history
+):
+    """The fail-open path is itself a clobber vector, and was one.
+
+    A later execution whose derivation raises publishes a block with
+    ``degraded: True`` and zero rows — and the consumer reads ``degraded`` as
+    SCOPE UNKNOWN. Writing that over a good scope would take a measured cycle
+    to unmeasured, which is the same destruction in a different costume.
+    """
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=real_run_history, s3=s3)
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y", "execution_input": {"skip_parity": True}},
+        None,
+    )
+    index2, _ = _index(monkeypatch, raises=RuntimeError("no such execution"), s3=s3)
+    result = index2.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:broken",
+         "state_machine_arn": "arn:y"},
+        None,
+    )
+    stored = s3.store[_KEY]
+    assert "degraded" not in stored
+    assert stored["stages"]["Evaluator"]["disposition"] == ENABLED_COMPLETED
+    assert "RuntimeError" in stored["scope_merge"]["incoming_degraded_reason"]
+    assert result["scope_merge"]["incoming_degraded"] is True
+
+
+def test_an_unreadable_incumbent_is_declined_not_overwritten(
+    monkeypatch, definition, real_run_history, all_skip_history, caplog
+):
+    """The posture while the ``s3:GetObject`` grant lags the code deploy.
+
+    ``deploy-weekly-run-scope.yml`` ships CODE ONLY — its OIDC role has no
+    ``iam:PutRolePolicy`` by design — so the new grant in ``iam-policy.json``
+    reaches the role on a later operator ``--apply-iam``. In between, the
+    Lambda cannot read the incumbent. It must therefore not be able to destroy
+    it either: the write degrades to create-only (``IfNoneMatch: "*"``), S3
+    itself refuses it, and the handler declines at ERROR. The fix is safe from
+    the moment the code lands, not from the moment the grant does.
+    """
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=real_run_history, s3=s3)
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y", "execution_input": {"skip_parity": True}},
+        None,
+    )
+    established = json.loads(json.dumps(s3.store[_KEY]))
+
+    s3.read_error = "AccessDenied"
+    index2, _ = _index(monkeypatch, definition=definition, history=all_skip_history, s3=s3)
+    with caplog.at_level(logging.ERROR):
+        result = index2.handler(
+            {"run_date": "2026-08-15", "execution_arn": "arn:rerun",
+             "state_machine_arn": "arn:y"},
+            None,
+        )
+    assert s3.store[_KEY] == established          # untouched
+    assert result["write_declined"]["key"] == _KEY
+    assert "AccessDenied" in result["write_declined"]["reason"]
+    assert any("write DECLINED" in r.message for r in caplog.records)
+
+
+def test_the_first_write_of_a_cycle_is_create_only(
+    monkeypatch, definition, real_run_history
+):
+    """No incumbent -> ``IfNoneMatch: "*"``. A concurrent execution that wrote
+    between our read and our write loses the race instead of being silently
+    replaced."""
+    index, written = _index(
+        monkeypatch, definition=definition, history=real_run_history
+    )
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y"},
+        None,
+    )
+    assert written["IfNoneMatch"] == "*"
+    assert "IfMatch" not in written
+
+
+def test_a_merge_write_is_compare_and_swap(
+    monkeypatch, definition, real_run_history, all_skip_history
+):
+    """Incumbent read -> ``IfMatch`` its ETag. Read-merge-write without a
+    condition is a race with a longer window, not a fix."""
+    s3, _, _, written = _scheduled_then_rerun(
+        monkeypatch, definition, real_run_history, all_skip_history
+    )
+    assert written["IfMatch"].startswith('"etag-')
+    assert "IfNoneMatch" not in written
+
+
+def test_a_lost_race_is_retried_against_the_new_incumbent(
+    monkeypatch, definition, real_run_history, all_skip_history
+):
+    """A 412 on a MERGE write means somebody else wrote between our read and
+    our put. That is a retry, not a refusal — the merge is simply recomputed
+    against what is now there."""
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=real_run_history, s3=s3)
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y", "execution_input": {"skip_parity": True}},
+        None,
+    )
+    real_put = s3.put_object
+    calls = {"n": 0}
+
+    def _flaky(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            s3.etags[_KEY] = '"etag-moved"'   # somebody else wrote first
+            raise _S3Error("PreconditionFailed")
+        return real_put(**kwargs)
+
+    s3.put_object = _flaky
+    index2, _ = _index(monkeypatch, definition=definition, history=all_skip_history, s3=s3)
+    index2.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:rerun",
+         "state_machine_arn": "arn:y"},
+        None,
+    )
+    assert calls["n"] == 2
+    assert s3.store[_KEY]["stages"]["Parity"]["disposition"] == DISABLED
+
+
+def test_a_permanent_race_raises_rather_than_forcing_the_write(
+    monkeypatch, definition, real_run_history, all_skip_history
+):
+    """Exhausting the attempts raises. The SF's Catch on ``RunScope`` routes it
+    to ``CheckSkipReportCard`` without failing the weekly run, and the cycle
+    keeps the scope already on S3 — never a forced overwrite."""
+    s3 = _FakeS3()
+    index, _ = _index(monkeypatch, definition=definition, history=real_run_history, s3=s3)
+    index.handler(
+        {"run_date": "2026-08-15", "execution_arn": "arn:scheduled",
+         "state_machine_arn": "arn:y"},
+        None,
+    )
+
+    def _always_conflict(**_kwargs):
+        raise _S3Error("PreconditionFailed")
+
+    s3.put_object = _always_conflict
+    index2, _ = _index(monkeypatch, definition=definition, history=all_skip_history, s3=s3)
+    with pytest.raises(index2.ScopeWriteConflictError):
+        index2.handler(
+            {"run_date": "2026-08-15", "execution_arn": "arn:rerun",
+             "state_machine_arn": "arn:y"},
+            None,
+        )
+
+
+def test_the_dry_run_exercises_the_incumbent_read_and_writes_nothing(
+    monkeypatch, definition, real_run_history
+):
+    """The Friday rehearsal is where a missing grant must surface — a rehearsal
+    that skipped the new read would leave it to be discovered by the Saturday
+    run it exists to protect."""
+    s3 = _FakeS3(read_error="AccessDenied")
+    index, written = _index(
+        monkeypatch, definition=definition, history=real_run_history, s3=s3
+    )
+    result = index.handler(
+        {"run_date": "2026-08-14", "execution_arn": "a", "state_machine_arn": "b",
+         "dry_run": True},
+        None,
+    )
+    assert result["dry_run"] is True
+    assert result["incumbent_read"]["ok"] is False
+    assert "AccessDenied" in result["incumbent_read"]["note"]
+    assert written == {}
+    assert s3.store == {}
+
+
+# ---------------------------------------------------------------------------
+# The merge rule itself
+# ---------------------------------------------------------------------------
+
+
+def test_authority_ranks_dispatch_above_a_later_skip():
+    """The ordering IS the rule, so it is asserted directly rather than only
+    through its consequences. Dispatch is a fact about the cycle that a later
+    skip cannot unmake; an absence of evidence ranks below a decision."""
+    assert AUTHORITY[NOT_REACHED] < AUTHORITY[DISABLED] \
+        < AUTHORITY[ENABLED_FAILED] < AUTHORITY[ENABLED_COMPLETED]
+
+
+@pytest.mark.parametrize(
+    "held,offered,expected",
+    [
+        (ENABLED_COMPLETED, DISABLED, ENABLED_COMPLETED),
+        (ENABLED_COMPLETED, NOT_REACHED, ENABLED_COMPLETED),
+        (ENABLED_FAILED, DISABLED, ENABLED_FAILED),
+        (DISABLED, NOT_REACHED, DISABLED),
+        (NOT_REACHED, DISABLED, DISABLED),
+        (NOT_REACHED, ENABLED_COMPLETED, ENABLED_COMPLETED),
+        (ENABLED_FAILED, ENABLED_COMPLETED, ENABLED_COMPLETED),
+        (ENABLED_COMPLETED, "PROBABLY_FINE", ENABLED_COMPLETED),
+    ],
+)
+def test_a_row_is_replaced_only_by_a_strictly_stronger_claim(held, offered, expected):
+    incumbent = {"run_date": "2026-08-14", "execution_arn": "arn:first",
+                 "stages": {"Parity": {"disposition": held,
+                                       "recorded_by_execution_arn": "arn:first"}}}
+    incoming = {"run_date": "2026-08-14", "execution_arn": "arn:second",
+                "stages": {"Parity": {"disposition": offered,
+                                      "recorded_by_execution_arn": "arn:second"}}}
+    merged, ledger = merge_run_scopes(incumbent, incoming)
+    assert merged["stages"]["Parity"]["disposition"] == expected
+    assert merged["counts"][expected] == 1 if expected in DISPOSITIONS else True
+    assert ledger["merged"] is True
+
+
+def test_the_merge_never_raises_on_a_degenerate_incumbent():
+    """An unreadable or foreign incumbent must not strand a cycle forever on a
+    corrupt artifact — it is treated as no incumbent and recorded as such."""
+    incoming = {"run_date": "2026-08-14", "stages":
+                {"Parity": {"disposition": DISABLED}}}
+    for junk in (None, "", [], {"stages": "nope"}, {}):
+        merged, ledger = merge_run_scopes(junk, json.loads(json.dumps(incoming)))
+        assert merged["stages"]["Parity"]["disposition"] == DISABLED
+        assert ledger["merged"] is False
+
+
+def test_the_merged_statement_is_recomputed_not_carried():
+    """The statement is the denominator every downstream grade is rendered
+    against. Carrying either input's is how a surface goes quietly green."""
+    incumbent = {"run_date": "2026-08-14", "statement": "stale.",
+                 "stages": {"A": {"disposition": ENABLED_COMPLETED},
+                            "B": {"disposition": ENABLED_COMPLETED}}}
+    incoming = {"run_date": "2026-08-14", "statement": "also stale.",
+                "stages": {"A": {"disposition": NOT_REACHED},
+                           "C": {"disposition": DISABLED}}}
+    merged, _ = merge_run_scopes(incumbent, incoming)
+    assert merged["statement"] == (
+        "2 of 3 gated stages ran and are graded; 1 disabled by operator flag."
+    )
+    assert merged["graded_stages"] == ["A", "B"]


### PR DESCRIPTION
## What this fixes

`backtest/{run_date}/run_scope.json` is **one key per cycle and several executions write it** — the scheduled Saturday run, then every recovery rerun launched against the same cycle. A rerun exists to redo *one* stage, so it carries a skip-set for everything else. Last-writer-wins therefore hands the cycle's scope to its **worst-informed author**.

Both scope artifacts on S3 on 2026-08-31 were written that way, not by the run that produced the numbers:

| Key | Author | Written | Claims |
|---|---|---|---|
| `backtest/2026-08-22/run_scope.json` | `watch-rerun-2026-08-22-3` | 2026-08-22 08:58Z | `Backtester: DISABLED` |
| `backtest/2026-08-28/run_scope.json` | `watch-rerun-2026-08-28-13` | 2026-08-30 18:47Z | `Backtester: DISABLED` |

The second was written **a day and a half after** the scheduled run wrote that cycle's `attestation.json`, and both claim `Backtester: DISABLED` for cycles whose backtester artifacts demonstrably exist.

`crucible-evaluator-PR289` (`alpha-engine-config-I8811`, merged 2026-08-31, live on `alpha-engine-evaluator:live` v213) fixed the **consumer**: a scope contradicted by the artifacts can no longer overwrite a measured verdict, so the composition that published a combined **PASS** over a week whose `pit_parity` reported **FAIL** now resolves to an honest `UNKNOWN`. It did **not** stop the clobbering. This PR fixes the **producer**.

## The rule

**A cycle's scope only ever ACCUMULATES.** A row is replaced only by a row making a strictly stronger claim about the same stage:

```
NOT_REACHED(0) < DISABLED(1) < ENABLED_FAILED(2) < ENABLED_COMPLETED(3)
```

Dispatch outranks a later skip because dispatch is a fact about the cycle a rerun cannot unmake. Both halves of the requirement then hold at once:

- a skip-flagged rerun cannot demote a scheduled run's `ENABLED_COMPLETED` to `DISABLED`, nor a deliberate `DISABLED` to `NOT_REACHED`;
- a rerun that **genuinely re-executes** a stage still records it — `ENABLED_COMPLETED` outranks everything and lands.

Immutability was the other candidate and is **rejected**: it trades a fail-open for a fail-stuck, and a real recovery that executes Backtester must be able to say so.

## Changes

- `run_scope.py` — `AUTHORITY`, `merge_run_scopes()`, `stamp_provenance()`, `_recompute()`. Pure and fixture-tested; every row carries the execution that established it, and the statement (the denominator every downstream grade renders against) is always recomputed, never carried.
- `index.py::_persist` — read-merge-**conditional**-write. `IfMatch` on a read incumbent (a concurrent writer loses the race instead of being silently overwritten; two retries), `IfNoneMatch: "*"` when the incumbent could **not** be read.
- The **fail-open degraded path was itself a clobber vector**: an execution whose derivation raises published `degraded: true` with zero rows, which the consumer reads as SCOPE UNKNOWN. It no longer erases an established scope — the failure goes into the merge ledger.
- Every refusal is **durable** (`scope_merge.rejected`, inside the artifact) and **loud** (an ERROR line naming both sides). No bare `except: pass`, no silent `return None`; an exhausted race raises `ScopeWriteConflictError`, which the SF's existing Catch on `RunScope` routes to `CheckSkipReportCard` without failing the run.
- `iam-policy.json` — `s3:GetObject` plus the `backtest/*`-scoped `s3:ListBucket` the `iam-getobject-listbucket-lint` requires (403-not-404, config#2878).
- `deploy.sh` + `.github/workflows/deploy-weekly-run-scope.yml` — the merge emits the exact `--apply-iam` command (pull-request-policy §4.2 form 3, mirroring `deploy-pipeline-watchdog.yml`); the standing detector is `nous-ergon-ops/infrastructure/iam/check-drift.py` (every PR + daily 09:35 UTC).

**No post-merge step is required for this fix to work.** The OIDC deploy role has no `iam:PutRolePolicy` by design (fleet single-writer rule, after 4 IAM-clobber incidents), so the grant reaches the role on a later operator `--apply-iam`. In between, the Lambda **cannot merge but also cannot destroy**: the write degrades to create-only and S3 itself refuses it. Applying the grant upgrades *declining* into *merging*. The Friday rehearsal (`dry_run`) now exercises the read, so a missing grant surfaces there rather than on the Saturday run it protects.

## Proving the guard fails

`test_the_guard_fails_when_removed` runs the same two **real captured executions** with `merge_run_scopes` replaced by pre-fix last-writer-wins, and asserts the live defect reproduces: `Parity` DISABLED → NOT_REACHED, `Evaluator` ENABLED_COMPLETED → DISABLED. `test_a_skip_flagged_rerun_cannot_demote_a_scheduled_runs_scope` is the same sequence with the guard in place and asserts the scheduled run's claims survive, that the refusal is in the artifact, and that it logged at ERROR. 49 tests pass; the full repo suite is green (6863 passed, 12 skipped).

## Clause 5

`NOT_REACHED` does **not** arm `NOT_IN_SCOPE` in `crucible-evaluator`'s `attestation._mark_scope_out_of_scope`; `DISABLED` does. The demotion alone was therefore enough to hold `contamination_verdict` at UNKNOWN over a clean week. Run against the merged consumer code on `crucible-evaluator@origin/main`:

| Scope body | `contamination_scope().in_scope` | Effect |
|---|---|---|
| scheduled run only | `False` | `NOT_IN_SCOPE` → excluded → combined PASS |
| pre-fix (rerun clobbers) | `True` | `UNKNOWN` → clause 5 denied |
| post-fix (merged) | `False` | `NOT_IN_SCOPE` → excluded → combined PASS |

## Related

- `crucible-evaluator-PR289` — the consumer half, already merged and live. Merge order: it was first; this PR is independent of it and can merge at any time.
- `nousergon-data-PR1609` — bumps the 32 lib-pin surfaces to `v0.124.104` on a different branch. **This PR touches none of them**; merge order between the two does not matter.
- Tracker: `alpha-engine-config-I8811`. Cross-repo closing keywords are inert against `alpha-engine-config` — close it by hand after merge.

## Out of scope, found while here

`crucible-evaluator`'s `attestation.contamination_scope()` promises to accept "the raw `run_scope.json` body **or** the already-normalized block", and detects the difference by testing for `graded_stages` — a key **both** shapes carry. Handed a raw producer body it therefore reads `disabled_stages` off a body that has none and returns `in_scope: True` unconditionally. The live card path (`aggregate.py`) passes the normalized block, so this is latent, not firing. Not fixed here — different repo, and out of this PR's scope.

## Test plan (run BEFORE opening this PR)

- `python3 -m pytest infrastructure/lambdas/weekly-run-scope/test_handler.py -q` → **49 passed** (the gate `.github/workflows/ci.yml` globs and the one `_shared/run_handler_tests.sh` runs at deploy time).
- `python3 -m pytest tests/ -q --ignore=tests/live_smoke --ignore=tests/integration` → **6863 passed, 12 skipped** (includes `test_lib_pin_lockstep.py`, `test_run_scope_wiring.py`, `test_iam_actions_exist.py`, `test_deploy_blast_radius.py`, `test_apply_iam_is_iam_only.py`, `test_scheduled_workflow_reachability.py`).
- `python3 infrastructure/lambdas/_shared/check_iam_getobject_listbucket.py` → OK.
- `python3 scripts/lint_extras.py .` → OK.
- Cross-repo consumer check, run locally against `crucible-evaluator@origin/main`: the merged artifact through `grading.run_scope.read_run_scope` → `MEASURED`, then `attestation.contamination_scope` → `in_scope: False` (the clause-5 table above).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
