### PR TITLE
fix(router): declare KREPIS_EXEC_CONTEXT at every data-collector call site (config-I7409)

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -171,6 +171,32 @@ python3 -m krepis.aws remove-lambda-env \
   --defer-publish --missing-ok \
   "${LAMBDA_ENV_DENIED_KEYS[@]/#/--unset=}"
 
+# ── Router addressing (alpha-engine-config-I7409) ────────────────────────────
+# `$FUNCTION_NAME` never declared KREPIS_EXEC_CONTEXT, so krepis.router
+# silently defaulted every flow-doctor LLM-diagnosis call it makes to
+# 'laptop' — the only environment where the loopback egress proxy this
+# resolves to (127.0.0.1:8990/8980) actually exists — and every diagnosis
+# attempt failed RouterUnresolvable (measured live 2026-08-31 against a SPY
+# cross-source quarantine alert). `lambda` appears on no registry entry's
+# `reachable_from`, deliberately (LLM_MODEL_REGISTRY.yaml): a Lambda has no
+# local egress proxy, so the router edge (litellm_proxy) is its only path,
+# which model-router-policy §3.4a R27a guarantees is offered in every
+# context. Mirrors crucible-research/infrastructure/deploy.sh's
+# `_apply_router_env`. Its OWN credential (ROUTER_CONSUMER_DATA), not
+# LITELLM_MASTER_KEY — krepis.secrets resolves SSM before os.environ, so a
+# shared secret NAME collapses this Lambda into another consumer's identity
+# at the edge (nous-ergon-ops-PR951 registers it).
+echo "  Applying router addressing (merge, not replace)..."
+aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION" 2>/dev/null || sleep 5
+python3 -m krepis.aws merge-lambda-env \
+  --function-name "$FUNCTION_NAME" --region "$REGION" \
+  --set "KREPIS_EXEC_CONTEXT=lambda" \
+  --set "KREPIS_LITELLM_PROXY_URL=${ROUTER_URL:-https://router.nousergon.ai:8443}" \
+  --set "KREPIS_ROUTER_CREDENTIAL_SECRET=${ROUTER_CREDENTIAL_SECRET:-ROUTER_CONSUMER_DATA}" \
+  --set "KREPIS_APPCONFIG_APPLICATION=alpha-engine" \
+  --set "KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry" \
+  --set "KREPIS_APPCONFIG_ENVIRONMENT=production"
+
 # Publish version and update 'live' alias
 echo "  Publishing Lambda version..."
 aws lambda wait function-updated --function-name "$FUNCTION_NAME" --region "$REGION" 2>/dev/null || sleep 5

--- a/infrastructure/lambdas/data-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/data-spot-dispatcher/index.py
@@ -193,6 +193,33 @@ def _bootstrap_spec() -> SpotBootstrapSpec:
             "FLOW_DOCTOR_ENABLED": "1",
             "ALPHA_ENGINE_DEPLOYED": "1",
             "ALPHA_ENGINE_EXPERIMENT_ID": "reference",
+            # Router addressing (alpha-engine-config-I7409). Without
+            # KREPIS_EXEC_CONTEXT this box never declared where it runs, so
+            # krepis.router silently defaulted flow-doctor's diagnosis calls to
+            # 'laptop' and tried the loopback egress proxy that only exists on
+            # the dashboard box — RouterUnresolvable on every attempt (measured
+            # live 2026-08-31, SPY cross-source quarantine diagnosis).
+            # KREPIS_LITELLM_PROXY_URL overrides krepis's loopback default
+            # (127.0.0.1:8980) to the real routed edge — mirrors
+            # eval-judge-spot-dispatcher / thinktank-spot-dispatcher in
+            # crucible-research, which resolve through the SAME edge from the
+            # SAME kind of ephemeral spot box.
+            "KREPIS_EXEC_CONTEXT": os.environ.get("DATA_SPOT_EXEC_CONTEXT", "ec2"),
+            "KREPIS_LITELLM_PROXY_URL": os.environ.get(
+                "DATA_SPOT_ROUTER_URL", "https://router.nousergon.ai:8443"
+            ),
+            "KREPIS_ROUTER_CREDENTIAL_SECRET": os.environ.get(
+                "DATA_SPOT_ROUTER_CREDENTIAL_SECRET", "ROUTER_CONSUMER_DATA"
+            ),
+            "KREPIS_APPCONFIG_APPLICATION": os.environ.get(
+                "DATA_SPOT_APPCONFIG_APPLICATION", "alpha-engine"
+            ),
+            "KREPIS_APPCONFIG_CONFIG_PROFILE": os.environ.get(
+                "DATA_SPOT_APPCONFIG_CONFIG_PROFILE", "llm-model-registry"
+            ),
+            "KREPIS_APPCONFIG_ENVIRONMENT": os.environ.get(
+                "DATA_SPOT_APPCONFIG_ENVIRONMENT", "production"
+            ),
         },
     )
 

--- a/infrastructure/spot_data_phase1.sh
+++ b/infrastructure/spot_data_phase1.sh
@@ -86,6 +86,14 @@ export HOME=/home/ec2-user
 export XDG_CACHE_HOME=/tmp
 export AWS_REGION=us-east-1
 export AWS_DEFAULT_REGION=us-east-1
+# Router addressing (alpha-engine-config-I7409) - undeclared before this, krepis defaulted to
+# exec_context=laptop and RouterUnresolvable'd every flow-doctor diagnosis call on this box.
+export KREPIS_EXEC_CONTEXT=ec2
+export KREPIS_LITELLM_PROXY_URL=https://router.nousergon.ai:8443
+export KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_DATA
+export KREPIS_APPCONFIG_APPLICATION=alpha-engine
+export KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry
+export KREPIS_APPCONFIG_ENVIRONMENT=production
 if ! command -v python3.12 >/dev/null 2>&1; then
     echo "ERROR: python3.12 not found on this spot — bootstrap_spot() installs and asserts it. Refusing to fall back to the AMI python3: requirements.txt is resolved against 3.12 and the wheels differ (alpha-engine-config-I7372)." >&2
     exit 1

--- a/infrastructure/spot_data_weekly.sh
+++ b/infrastructure/spot_data_weekly.sh
@@ -704,6 +704,14 @@ export HOME=/home/ec2-user
 export XDG_CACHE_HOME=/tmp
 export AWS_REGION=us-east-1
 export AWS_DEFAULT_REGION=us-east-1
+# Router addressing (alpha-engine-config-I7409) - undeclared before this, krepis defaulted to
+# exec_context=laptop and RouterUnresolvable'd every flow-doctor diagnosis call on this box.
+export KREPIS_EXEC_CONTEXT=ec2
+export KREPIS_LITELLM_PROXY_URL=https://router.nousergon.ai:8443
+export KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_DATA
+export KREPIS_APPCONFIG_APPLICATION=alpha-engine
+export KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry
+export KREPIS_APPCONFIG_ENVIRONMENT=production
 if ! command -v python3.12 >/dev/null 2>&1; then
     echo "ERROR: python3.12 not found on this spot — the bootstrap installs and asserts it. Refusing to fall back to the AMI python3: requirements.txt is resolved against 3.12 and the wheels differ (alpha-engine-config-I7372)." >&2
     exit 1

--- a/infrastructure/spot_morning_enrich.sh
+++ b/infrastructure/spot_morning_enrich.sh
@@ -68,6 +68,14 @@ export HOME=/home/ec2-user
 export XDG_CACHE_HOME=/tmp
 export AWS_REGION=us-east-1
 export AWS_DEFAULT_REGION=us-east-1
+# Router addressing (alpha-engine-config-I7409) - undeclared before this, krepis defaulted to
+# exec_context=laptop and RouterUnresolvable'd every flow-doctor diagnosis call on this box.
+export KREPIS_EXEC_CONTEXT=ec2
+export KREPIS_LITELLM_PROXY_URL=https://router.nousergon.ai:8443
+export KREPIS_ROUTER_CREDENTIAL_SECRET=ROUTER_CONSUMER_DATA
+export KREPIS_APPCONFIG_APPLICATION=alpha-engine
+export KREPIS_APPCONFIG_CONFIG_PROFILE=llm-model-registry
+export KREPIS_APPCONFIG_ENVIRONMENT=production
 if ! command -v python3.12 >/dev/null 2>&1; then
     echo "ERROR: python3.12 not found on this spot — bootstrap_spot() installs and asserts it. Refusing to fall back to the AMI python3: requirements.txt is resolved against 3.12 and the wheels differ (alpha-engine-config-I7372)." >&2
     exit 1


### PR DESCRIPTION
## Summary
- None of the "data-collector" component's LLM-diagnosis call sites declared `KREPIS_EXEC_CONTEXT` — krepis.router silently defaulted every one to `laptop` and tried a loopback egress proxy that doesn't exist off-laptop, failing `RouterUnresolvable` on every diagnosis. Measured live 2026-08-31 against a SPY cross-source-quarantine alert.
- Wires the same 6-variable router-addressing block already proven on `crucible-research`'s Lambdas/spot dispatchers into all 5 call sites: the `alpha-engine-data-collector` Lambda (`infrastructure/deploy.sh`), `data-spot-dispatcher/index.py`'s EC2 spot bootstrap, and the 3 legacy `spot_data_weekly.sh` / `spot_data_phase1.sh` / `spot_morning_enrich.sh` scripts.
- No IAM change — `alpha-engine-data-role` / `alpha-engine-executor-role` already grant `ssm:GetParameter` on `/alpha-engine/*`.

Related: nous-ergon-ops-PR951 (registers the `ROUTER_CONSUMER_DATA` consumer at the router edge), krepis-PR197 (the library-side class fix for undeclared exec_context).

**Merge order:** nous-ergon-ops-PR951 first (and `/alpha-engine/ROUTER_CONSUMER_DATA` must exist in SSM before either merges — see the session's closing report for the one-line command).

`data-spot-dispatcher/index.py` needs its own `deploy.sh --bootstrap` run by an operator after merge — that's this repo's pre-existing convention for that Lambda (managed outside CloudFormation), not new to this change.

## Test plan
- [x] `pytest tests/ -q -k "spot_dispatcher or launcher or krepis_guard or router"` — 57 passed
- [x] `pytest infrastructure/lambdas/data-spot-dispatcher/test_handler.py -q` — 6 passed
- [x] `shellcheck -S error` on all 4 touched shell files — clean

Prepared by: claude-sonnet-5 via [Claude Code](https://claude.com/claude-code)

Rehearsal-path: tests/test_launchers_resolve_the_declared_krepis_guard.py
