### PR TITLE
fix(data-integrity): stop cross_source_gate paging twice per quarantine event

### DIFF
--- a/sources/cross_source_gate.py
+++ b/sources/cross_source_gate.py
@@ -212,10 +212,22 @@ def evaluate(
         "tolerance_bps": tolerance_bps,
         "sources": {c.source: c.price for c in usable},
     }
-    logger.error(
+    # WARNING, not ERROR: this primitive doesn't know whether ITS OWN
+    # withholding of `value` is the caller's actual behavior — the only live
+    # caller (collectors.daily_closes, observer-mode per config#1277 Option A)
+    # does NOT withhold the number from NAV/PnL, it only flags it, and logs
+    # its own accurate ERROR describing that. Logging ERROR here too paged
+    # Flow Doctor twice for one event, with the low-level message claiming a
+    # "value withheld" outcome that was never true for any deployed caller
+    # (2026-08-31, alpha-engine-config-I9xxx). A future enforcement-mode
+    # caller (Option B/C) that DOES withhold the value should log its own
+    # ERROR at the point it actually happens — same reasoning as observer
+    # mode owning its own alert, never doubled up with this one.
+    logger.warning(
         "L1 cross-source QUARANTINE %s @ %s: %s disagree@%.2fbps > tol=%.1fbps "
-        "— value withheld (NOT recorded), discrepancy emitted; investigate before "
-        "downstream NAV/PnL consumes this date",
+        "— value=None in this decision; caller decides whether that value is "
+        "withheld or merely flagged (see the caller's own log for the actual "
+        "outcome)",
         ticker, date, detail, spread_bps, tolerance_bps,
     )
     return GateDecision(

--- a/tests/test_cross_source_gate.py
+++ b/tests/test_cross_source_gate.py
@@ -80,6 +80,26 @@ def test_sources_disagree_quarantined():
     assert "DISAGREE" in d.provenance and "QUARANTINED" in d.provenance
 
 
+def test_quarantine_logs_at_warning_not_error(caplog):
+    """The gate itself must not page: this primitive doesn't know whether ITS
+    withholding of `value` is the caller's actual behavior — the only live
+    caller (collectors.daily_closes, observer-mode) does not withhold the
+    number and logs its own accurate ERROR describing that. An ERROR here
+    too pages Flow Doctor twice for one event with a message that claims a
+    "value withheld" outcome that isn't true for any deployed caller
+    (2026-08-31 regression)."""
+    with caplog.at_level("WARNING", logger="sources.cross_source_gate"):
+        evaluate("XYZ", "2026-06-25", [
+            SourceClose("polygon", 100.00),
+            SourceClose("yfinance", 105.00),
+        ])
+    assert not any(rec.levelname == "ERROR" for rec in caplog.records)
+    assert any(
+        rec.levelname == "WARNING" and "QUARANTINE" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_just_over_tolerance_quarantines():
     # 8 bps spread with default 7.5 bps tolerance -> quarantine.
     base = 100.0


### PR DESCRIPTION
## Summary
- `evaluate()`'s own QUARANTINED log and its only live caller's (`collectors.daily_closes`, observer-mode) log BOTH fire at ERROR for the same event — Flow Doctor paged twice per occurrence (measured live 2026-08-31, SPY @ 2026-08-28).
- The gate's own message ("value withheld — NOT recorded") is never true for any deployed caller: the only live integration is observer-mode, which explicitly does not withhold the value from NAV/PnL. This is why the two paged alerts read as contradictory.
- Downgrades the gate's own log to WARNING — the caller, which knows the real operational consequence, keeps sole ownership of the paged ERROR.

Not an enforcement-behavior change: `GateDecision.value` is still `None` on quarantine, still returned identically to every caller.

## Test plan
- [x] `pytest tests/test_cross_source_gate.py -q` — 13 passed (new regression test pins the gate never logs ERROR)
- [x] `pytest tests/test_cross_source_observer.py tests/test_cross_source_gate.py -q -k "quarantine or QUARANTINE or observer"` — 11 passed

Prepared by: claude-sonnet-5 via [Claude Code](https://claude.com/claude-code)