### PR TITLE
fix(stage-output-sweep): a gated-forever registry row is not an assertable stage output (alpha-engine-config-I9617)

### DIFF
--- a/tests/test_stage_output_sweep.py
+++ b/tests/test_stage_output_sweep.py
@@ -1423,3 +1423,195 @@ class TestAlertBody:
             "unmeasured": [{"stage": "S", "artifact_id": "a", "verdict": sos.UNMEASURED}],
         })
         assert published["kw"]["severity"] == "warn"
+
+
+# ---------------------------------------------------------------------------
+# gated-forever rows (alpha-engine-config-I9617)
+# ---------------------------------------------------------------------------
+
+#: The 2026-08-29 scheduled weekly run, execution
+#: ``965d925b-f9d6-ce5e-e059-9405433a0724_c0271e3b-a27f-a834-b303-3e3803fffd16``:
+#: ran ~5h and ended at the ``DegradedRun`` terminal. Its
+#: ``WeeklySubstrateHealthCheck`` stage logged
+#: ``STAGE OUTPUT MISSING: 6 declared artifact(s) absent or stale for
+#: run_date=2026-08-28``, and every one of the six was a registry row carrying
+#: ``grace_period_cycles: 999`` — a study whose producer auto-skips when its
+#: own precondition is unmet.
+AUG29_RUN_DATE = "2026-08-28"
+AUG29_EXEC_START = datetime(2026, 8, 29, 9, 0, 0, tzinfo=timezone.utc)
+
+#: (artifact_id, s3_key_template, producing stage) — transcribed from
+#: ARTIFACT_REGISTRY.yaml as of 2026-08-31. All eight rows in the live
+#: registry that carry ``grace_period_cycles: 999``; the six the 2026-08-29
+#: run actually reported are the first five plus ``regime_state_dated``.
+AUG29_GATED_ROWS = [
+    ("backtest_gamma_sweep", "backtest/{trading_day}/gamma_sweep.json", "Backtester"),
+    ("backtest_horizon_net_alpha",
+     "backtest/{trading_day}/horizon_net_alpha.json", "Backtester"),
+    ("backtest_model_version_net_alpha",
+     "backtest/{trading_day}/model_version_net_alpha.json", "Backtester"),
+    ("backtest_double_sort", "backtest/{trading_day}/double_sort.json", "Backtester"),
+    ("backtest_sizing_shootout",
+     "backtest/{trading_day}/sizing_shootout.json", "Backtester"),
+    ("regime_state_dated", "regime/{trading_day}.json", "RegimeSubstrate"),
+]
+
+
+class TestAbsenceDeclaredCorrect:
+    def test_grace_999_is_the_legacy_gated_forever_marker(self):
+        reason = sos.absence_declared_correct(
+            _row("a", "k/{date}.json", "Backtester", grace_period_cycles=999)
+        )
+        assert reason and "grace_period_cycles: 999" in reason
+
+    def test_event_driven_names_its_liveness_anchor(self):
+        reason = sos.absence_declared_correct(
+            _row("a", "k/{date}.json", "Backtester",
+                 cadence="event_driven", liveness_via="config_apply_audit")
+        )
+        assert reason and "event_driven" in reason
+        assert "config_apply_audit" in reason
+
+    def test_an_ordinary_grace_period_is_not_a_gate(self):
+        """The predicate keys on the gated-forever marker, not on grace at
+        all. A newly-onboarded row with ``grace_period_cycles: 2`` is still
+        fully assertable — otherwise the fix would silently mute a third of
+        the registry."""
+        assert sos.absence_declared_correct(
+            _row("a", "k/{date}.json", "Backtester", grace_period_cycles=2)
+        ) is None
+        assert sos.absence_declared_correct(
+            _row("a", "k/{date}.json", "Backtester")
+        ) is None
+
+    def test_a_non_numeric_grace_is_not_treated_as_a_gate(self):
+        """Fail toward asserting: an unparseable declaration is not a licence
+        to stop checking."""
+        assert sos.absence_declared_correct(
+            _row("a", "k/{date}.json", "Backtester", grace_period_cycles="lots")
+        ) is None
+
+    def test_declared_outputs_carries_the_reason(self):
+        decl = sos.declared_outputs(
+            [_row("a", "k/{date}.json", "Backtester", grace_period_cycles=999)],
+            pipeline=PIPELINE,
+        )[0]
+        assert decl["absence_declared_correct"]
+
+
+class TestAugust29GatedReplay:
+    """Replays the 2026-08-29 finding set from the recorded registry rows plus
+    the recorded S3 state (none of the six keys existed). Before the fix all
+    six were ``missing`` and the sweep was one ``--enforce`` flip from
+    terminating a four-hour run on them."""
+
+    def _findings(self, *, gated: bool):
+        rows = [
+            _row(aid, tmpl, stage,
+                 **({"grace_period_cycles": 999} if gated else {}))
+            for aid, tmpl, stage in AUG29_GATED_ROWS
+        ]
+        return sos.evaluate(
+            sos.declared_outputs(rows, pipeline=PIPELINE),
+            run_date=AUG29_RUN_DATE,
+            execution_start=AUG29_EXEC_START,
+            head=_head_from({}),
+            cycle_date=AUG29_RUN_DATE,
+        )
+
+    def test_all_six_are_gated_not_missing(self):
+        findings = self._findings(gated=True)
+        assert len(findings) == 6
+        assert {f["verdict"] for f in findings} == {sos.GATED}
+        summary = sos.summarise(findings)
+        assert summary["defects"] == []
+        assert summary["status"] == "ok"
+        assert len(summary["gated"]) == 6
+        assert summary["counts"][sos.GATED] == 6
+
+    def test_the_same_rows_without_the_gate_are_the_recorded_failure(self):
+        """The pre-fix behaviour, asserted so the guard cannot pass by
+        accident: strip the registry's gated-forever marker and the identical
+        S3 state reproduces exactly the six MISSING findings the run logged."""
+        findings = self._findings(gated=False)
+        assert [f["verdict"] for f in findings] == [sos.MISSING] * 6
+        assert sos.summarise(findings)["status"] == "stage_output_missing"
+
+    def test_the_reason_is_on_the_finding_not_swallowed(self):
+        """A row excused with no reason on the surface is indistinguishable
+        from a row nobody checked."""
+        f = self._findings(gated=True)[0]
+        assert "NOT a defect" in f["detail"]
+        assert "missing suppressed" in f["detail"]
+        assert "grace_period_cycles: 999" in f["detail"]
+
+
+class TestGatedRowBothPolarities:
+    def test_a_gated_row_that_did_write_still_reports_wrote(self):
+        """The downgrade only ever applies to a would-be defect. A gated study
+        whose gate DID clear this week is a real, attributable write."""
+        key = f"backtest/{RUN_DATE}/gamma_sweep.json"
+        decls = sos.declared_outputs(
+            [_row("backtest_gamma_sweep", "backtest/{date}/gamma_sweep.json",
+                  "Backtester", grace_period_cycles=999)],
+            pipeline=PIPELINE,
+        )
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({key: EXEC_START + timedelta(hours=2)}),
+            cycle_date=RUN_DATE,
+        )[0]
+        assert f["verdict"] == sos.WROTE
+
+    def test_a_stale_gated_row_is_gated_not_stale(self):
+        """Last cycle's product left behind while this cycle's gate did not
+        clear is the same statement about the gate as an absent key."""
+        key = f"backtest/{RUN_DATE}/gamma_sweep.json"
+        decls = sos.declared_outputs(
+            [_row("backtest_gamma_sweep", "backtest/{date}/gamma_sweep.json",
+                  "Backtester", grace_period_cycles=999)],
+            pipeline=PIPELINE,
+        )
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({key: EXEC_START - timedelta(days=21)}),
+            cycle_date=RUN_DATE,
+        )[0]
+        assert f["verdict"] == sos.GATED
+        assert "stale suppressed" in f["detail"]
+
+    def test_a_mandatory_artifact_absent_still_fails_the_run(self):
+        """The polarity that matters: the excuse is per-row and derived from
+        the registry, never a blanket amnesty. A non-gated declared artifact
+        that nobody wrote is still a defect that exits non-zero under
+        --enforce."""
+        decls = sos.declared_outputs(
+            [_row("backtest_report", "backtest/{date}/report.md", "Backtester"),
+             _row("backtest_gamma_sweep", "backtest/{date}/gamma_sweep.json",
+                  "Backtester", grace_period_cycles=999)],
+            pipeline=PIPELINE,
+        )
+        findings = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({}), cycle_date=RUN_DATE,
+        )
+        summary = sos.summarise(findings)
+        assert [f["artifact_id"] for f in summary["defects"]] == ["backtest_report"]
+        assert [f["artifact_id"] for f in summary["gated"]] == ["backtest_gamma_sweep"]
+        assert summary["status"] == "stage_output_missing"
+
+    def test_unmeasured_is_not_excused_by_the_gate(self):
+        """A check that could not answer is not excused by a gate it never
+        reached — otherwise a permissions regression on a gated row would
+        render as a clean pass."""
+        key = f"backtest/{RUN_DATE}/gamma_sweep.json"
+        decls = sos.declared_outputs(
+            [_row("backtest_gamma_sweep", "backtest/{date}/gamma_sweep.json",
+                  "Backtester", grace_period_cycles=999)],
+            pipeline=PIPELINE,
+        )
+        f = sos.evaluate(
+            decls, run_date=RUN_DATE, execution_start=EXEC_START,
+            head=_head_from({key: "error:403 AccessDenied"}), cycle_date=RUN_DATE,
+        )[0]
+        assert f["verdict"] == sos.UNMEASURED

--- a/validators/stage_output_sweep.py
+++ b/validators/stage_output_sweep.py
@@ -90,6 +90,20 @@ always in the alarming direction. The verdict set keeps the two apart:
                   postclose SF) writing the artifact minutes before this
                   execution started, not of a silent stage. Not a defect;
                   distinct from ``wrote`` so it stays visible in the counts
+  ``gated``       (alpha-engine-config-I9617) the key is absent or stale AND
+                  the registry row itself declares that its absence is
+                  CORRECT — ``cadence: event_driven`` (the sanctioned
+                  contract: absence is expected, liveness is delegated to the
+                  ``liveness_via`` anchor) or the legacy
+                  ``grace_period_cycles: 999`` alias it replaces. These are
+                  gated best-effort studies whose producer auto-skips when its
+                  own precondition is unmet, so a MISSING verdict on them is a
+                  statement about the gate, not about the run. Counted in
+                  NEITHER ``defects`` NOR ``wrote``, and REPORTED by name in
+                  the verdict document and the log — a row excused silently is
+                  indistinguishable from one nobody checks. A gated row that
+                  DID get written still reports ``wrote``: the downgrade only
+                  ever applies to a would-be ``missing``/``stale``
 
 ``unmeasured`` is deliberately NOT silent. Absence of a measurement is a
 first-class finding with its own exit code and its own alert, because the
@@ -186,6 +200,7 @@ UNMEASURED = "unmeasured"
 UNRESOLVED = "unresolved"
 SKIPPED = "skipped"
 DRY = "dry"
+GATED = "gated"
 
 #: Verdicts that mean "this run has a data defect".
 DEFECT_VERDICTS = frozenset({MISSING, STALE})
@@ -528,6 +543,65 @@ def load_registry_rows(
     return rows
 
 
+#: The registry cadence symbol meaning "this artifact is written ONLY when a
+#: gated producer decides to write, so its ABSENCE is correct". Declared and
+#: validator-enforced in ``nousergon_lib.artifact_freshness``: an
+#: ``event_driven`` row must name a ``liveness_via`` anchor, so producer
+#: liveness is relocated to a signal that CAN go stale rather than lost.
+_CADENCE_ABSENCE_IS_CORRECT = "event_driven"
+
+#: The legacy magic number ``event_driven`` replaced. Still carried by eight
+#: rows in the live registry (the six gated backtester sub-sweeps,
+#: ``backtest_cov_estimator_sweep`` and ``regime_state_dated``). Recognised
+#: here so a row that has not yet migrated is not falsely asserted against —
+#: the migration is tracked separately; this sweep must not depend on it.
+_LEGACY_GATED_FOREVER_GRACE = 999
+
+
+def absence_declared_correct(row: dict) -> str | None:
+    """Why this registry row's ABSENCE is a declared-correct outcome, or None.
+
+    ``ARTIFACT_REGISTRY.yaml`` already states this rule for the OTHER consumer
+    of the same declarations: ``pipeline_stages[].artifacts`` (read by
+    ``krepis.stage_coverage``) deliberately omits every gated-forever row, and
+    ``validate_artifact_registry.py::_validate_pipeline_stages`` Rule 7 fails
+    the build if one is added back. This sweep derives its assertable set from
+    ``produced_by:`` instead, and so re-admitted exactly the rows that rule
+    excludes — alpha-engine-config-I9617.
+
+    Measured on the 2026-08-29 scheduled weekly run
+    (``965d925b-f9d6-ce5e-e059-9405433a0724_...``): all six reported STAGE
+    OUTPUT MISSING findings were gated-forever rows — the five gated
+    Backtester sub-sweeps plus ``regime_state_dated``. Every one of the run's
+    findings was false, and the sweep is one ``--enforce`` flip away from
+    terminating a four-hour run on them.
+
+    Returns a human-readable reason (rendered into the finding's ``detail``)
+    rather than a bool, because a row excused with no reason on the surface is
+    indistinguishable from a row nobody checked.
+    """
+    if row.get("cadence") == _CADENCE_ABSENCE_IS_CORRECT:
+        anchor = row.get("liveness_via")
+        return (
+            "registry declares cadence: event_driven — absence is the correct "
+            "outcome for a gated producer, and producer liveness is delegated "
+            f"to liveness_via={anchor!r}"
+        )
+    grace = row.get("grace_period_cycles")
+    try:
+        gated_forever = grace is not None and int(grace) >= _LEGACY_GATED_FOREVER_GRACE
+    except (TypeError, ValueError):
+        gated_forever = False
+    if gated_forever:
+        return (
+            f"registry declares grace_period_cycles: {grace} — the legacy "
+            "gated-forever marker (superseded by cadence: event_driven). The "
+            "producer auto-skips when its own precondition is unmet, so this "
+            "key's absence is a statement about the gate, not about the run"
+        )
+    return None
+
+
 def declared_outputs(
     rows: Iterable[dict],
     *,
@@ -555,6 +629,7 @@ def declared_outputs(
                     "bucket": row.get("s3_bucket") or default_bucket,
                     "s3_key_template": row.get("s3_key_template"),
                     "severity": row.get("severity", "warning"),
+                    "absence_declared_correct": absence_declared_correct(row),
                 }
             )
     return out
@@ -754,6 +829,19 @@ def evaluate(
                     f"{age.seconds // 3600}h — the declaring stage did not write "
                     f"it on this run"
                 )
+        # alpha-engine-config-I9617 — the registry's own gated-forever
+        # declaration, applied LAST so it can only ever downgrade a would-be
+        # DEFECT. A gated row that DID get written keeps its `wrote` verdict,
+        # and an `unmeasured` row stays unmeasured: a check that could not
+        # answer is not excused by a gate it never reached.
+        gated_reason = declaration.get("absence_declared_correct")
+        if gated_reason and finding["verdict"] in DEFECT_VERDICTS:
+            was = finding["verdict"]
+            finding["verdict"] = GATED
+            finding["detail"] = (
+                f"{finding['detail']} — NOT a defect ({was} suppressed): "
+                f"{gated_reason}"
+            )
         findings.append(finding)
 
     return findings
@@ -766,6 +854,13 @@ def summarise(findings: Sequence[dict]) -> dict:
         counts[finding["verdict"]] = counts.get(finding["verdict"], 0) + 1
     defects = [f for f in findings if f["verdict"] in DEFECT_VERDICTS]
     unmeasured = [f for f in findings if f["verdict"] in UNMEASURED_VERDICTS]
+    # alpha-engine-config-I9617: surfaced as its own list, not folded into the
+    # green number. A row excused by the registry is a fact about the REGISTRY
+    # that has to stay readable — if a gated study is quietly promoted to a
+    # real producer, or a row's grace marker is wrong, this list is where that
+    # shows up. Silent exclusion would make the sweep's own blind spot
+    # invisible (principles.md §2.7).
+    gated = [f for f in findings if f["verdict"] == GATED]
     if defects:
         status = "stage_output_missing"
     elif unmeasured:
@@ -778,6 +873,7 @@ def summarise(findings: Sequence[dict]) -> dict:
         "checked": len(findings),
         "defects": defects,
         "unmeasured": unmeasured,
+        "gated": gated,
     }
 
 
@@ -839,6 +935,7 @@ def sweep(
             "findings": [],
             "defects": [],
             "unmeasured": [],
+            "gated": [],
         }
 
     if s3_client is None:
@@ -883,12 +980,21 @@ def sweep(
         "findings": findings,
         "defects": summary["defects"],
         "unmeasured": summary["unmeasured"],
+        "gated": summary["gated"],
     }
 
     logger.info(
         "Stage-output sweep pipeline=%s run_date=%s enforce=%s run_mode=%s: %s",
         pipeline, run_date, enforce, run_mode, summary["counts"],
     )
+
+    if summary["gated"]:
+        logger.info(
+            "STAGE OUTPUT GATED (not defects, alpha-engine-config-I9617): %d "
+            "declared artifact(s) absent whose registry row declares the "
+            "absence correct: %s",
+            len(summary["gated"]), _describe(summary["gated"]),
+        )
 
     if publish:
         _publish_verdict(s3_client, bucket, document)
@@ -1206,8 +1312,14 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
     else:
         logger.info(
-            "Stage-output sweep OK: %d declared artifact(s) written by this run",
+            "Stage-output sweep OK: %d declared artifact(s) written by this run"
+            "%s",
             document["checked"],
+            (
+                f" ({len(document['gated'])} gated row(s) excused by the "
+                f"registry — see the verdict artifact)"
+                if document.get("gated") else ""
+            ),
         )
     return code
 


### PR DESCRIPTION
## What was wrong

The 2026-08-29 scheduled weekly run (`965d925b-f9d6-ce5e-e059-9405433a0724_c0271e3b-a27f-a834-b303-3e3803fffd16`) logged, from `WeeklySubstrateHealthCheck`:

```
STAGE OUTPUT MISSING: 6 declared artifact(s) absent or stale for run_date=2026-08-28:
  Backtester→backtest_gamma_sweep (missing); …→backtest_horizon_net_alpha;
  …→backtest_model_version_net_alpha; …→backtest_double_sort;
  …→backtest_sizing_shootout; RegimeSubstrate→regime_state_dated
```

**All six are registry rows carrying `grace_period_cycles: 999`** — gated best-effort studies whose producer auto-skips when its own precondition is unmet (`backtest.py::run_gamma_sweep_stage` L3007: `gamma_sweep: skipped — <reason>`). Every finding the run reported was false, and there are **eight** such rows in the live registry, all on this pipeline.

`ARTIFACT_REGISTRY.yaml` already states the rule — for the *other* consumer of the same declarations. `pipeline_stages[].artifacts` (read by `krepis.stage_coverage`) deliberately omits every gated-forever row, and `validate_artifact_registry.py::_validate_pipeline_stages` **Rule 7** fails the build if one is added back. This sweep derives its assertable set from `produced_by:` instead, and so re-admitted exactly the rows that rule excludes. Two consumers, one registry, one of them ignoring the registry's own stated posture.

## The fix

Derived from the registry, not an allowlist. `absence_declared_correct(row)` returns a **reason** when the row declares:

* `cadence: event_driven` — the sanctioned, validator-enforced contract (`nousergon_lib.artifact_freshness`): absence is correct, producer liveness delegated to the `liveness_via` anchor; or
* `grace_period_cycles: 999` — the legacy magic number `event_driven` was written to replace, still carried by all eight live rows. Recognised here so a row that has not migrated is not falsely asserted; this sweep must not depend on that migration.

A would-be `missing`/`stale` verdict on such a row downgrades to a new **`gated`** verdict carrying that reason in `detail`. Applied last in `evaluate()`, so it can only ever downgrade a would-be defect.

## Both polarities

| case | verdict |
|---|---|
| gated row, key absent | `gated` (not a defect, not counted green) |
| gated row that DID write | `wrote` — the gate cleared, that is a real write |
| gated row, S3 403 / unresolvable template | `unmeasured` — a check that could not answer is not excused by a gate it never reached |
| **non-gated** declared artifact absent | `missing` — still a defect, still exit 1 under `--enforce` |
| ordinary `grace_period_cycles: 2` | fully assertable |
| non-numeric grace value | fully assertable (fail toward asserting) |

## Excused, never silent

`gated` is its own list on the verdict document (`_stage_outputs/{pipeline}/{run_date}.json`) and its own INFO line naming each row, including on the OK path. A row excused with no reason on the surface is indistinguishable from a row nobody checks (`principles.md` §2.7) — and this is exactly the population that would be silently muted if a gated study were ever promoted to a real producer.

Schema change is **additive only** (S3 contract safety): one new key, one new verdict value. No consumer outside this module parses the document.

## Tests

`TestAugust29GatedReplay` replays the recorded run from the recorded registry rows plus the recorded S3 state (none of the six keys existed) and asserts **both directions**: six `gated` after the fix, and the identical rows with the marker stripped reproducing exactly the six `missing` findings the run logged. A guard that cannot reproduce the incident is not verified.

`python3 -m pytest -q` → **6961 passed, 17 skipped**, plus 2 pre-existing failures in `tests/test_pipeline_status_registry_source_check.py` that the test's own provenance note diagnoses: the local venv holds nousergon-lib **v0.124.21** against a `requirements.txt` pin of **v0.124.104**. `git grep CorrectnessVerdictGate origin/main -- src/nousergon_lib/pipeline_status/registry.py` confirms the pinned version has both states, so this is the tracked environment drift (`alpha-engine-config-I9070` / `I9116`), not SF-definition drift. CI installs the pin.

## Verified live

Against the real 2026-08-29 artifacts (`AWS_PROFILE=ne-admin`, read-only):

* `python -m validators.phase_marker_sweep --run-date 2026-08-28 --no-alert` → `checked=26 error=0 malformed=0`, **exit 0**. This is the check that actually gated the run (`EXIT 1 — 1 gating check(s) failed: phase marker sweep (rc=2)`); the `rc=2` was the `TypeError` fixed by #1582, merged 2026-08-29T15:41Z, 1h40m **after** that run started.
* `python -m validators.stage_output_sweep --run-date 2026-08-28 --registry <live ARTIFACT_REGISTRY.yaml>` reproduced the finding set on `main`, and reports the gated rows as `gated` on this branch.

## Scope

Class swept: `stage_output_sweep` is the only registry consumer with this shape. `krepis.stage_coverage` reads the `pipeline_stages` assertable lists (Rule 7 enforced); the freshness monitor honours `grace_period_cycles` in `nousergon_lib.artifact_freshness`; `freshness-monitor/index.py::_cause_group_key` reads `produced_by` only for alert grouping, never as an assertion; `infrastructure/preflight_sweep.py` reads hand-declared stage upstreams, not registry rows.

Out of scope, filed separately: migrating the eight `grace_period_cycles: 999` rows to `cadence: event_driven` + `liveness_via`, which removes the liveness blind spot the magic number creates.

Tracker: `alpha-engine-config-I9617` (cross-repo — no closing keyword; the issue is closed by hand after a scheduled run is read back).

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)