### PR TITLE
fix(weekly-sf): every eval-judge fail-open exit names the phase that degraded (alpha-engine-config-I9636)

### DIFF
--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -2084,8 +2084,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Eval is observability per ROADMAP \u00a71635 \u2014 submit failures must NOT halt the pipeline. EvalRollingMean still runs against historical data. alpha-engine-config#6722: routes through MarkEvalJudgeDegraded first.",
-                  "Next": "MarkEvalJudgeDegraded",
+                  "Comment": "Eval is observability per ROADMAP \u00a71635 \u2014 submit failures must NOT halt the pipeline. EvalRollingMean still runs against historical data. alpha-engine-config#6722: routes through MarkEvalJudgeDegraded first. | alpha-engine-config-I9636: routes through ExtractEvalJudgeSubmitFirstSaturdayError first, which stamps the PHASE onto the record the Catch just wrote. Five Catches shared $.eval_judge_error with no discriminator, so 'the submit was refused' and 'the spot box never booted' were the same bytes to every reader.",
+                  "Next": "ExtractEvalJudgeSubmitFirstSaturdayError",
                   "ResultPath": "$.eval_judge_error"
                 }
               ],
@@ -2122,8 +2122,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Eval is observability \u2014 submit failures must NOT halt the pipeline. alpha-engine-config#6722: routes through MarkEvalJudgeDegraded first.",
-                  "Next": "MarkEvalJudgeDegraded",
+                  "Comment": "Eval is observability \u2014 submit failures must NOT halt the pipeline. alpha-engine-config#6722: routes through MarkEvalJudgeDegraded first. | alpha-engine-config-I9636: routes through ExtractEvalJudgeSubmitWeeklyError first, which stamps the PHASE onto the record the Catch just wrote. Five Catches shared $.eval_judge_error with no discriminator, so 'the submit was refused' and 'the spot box never booted' were the same bytes to every reader.",
+                  "Next": "ExtractEvalJudgeSubmitWeeklyError",
                   "ResultPath": "$.eval_judge_error"
                 }
               ],
@@ -2132,7 +2132,7 @@
             },
             "EvalJudgeSubmitOutcome": {
               "Type": "Choice",
-              "Comment": "Branch on Submit's outcome. Replaces EvalJudgePollChoice, which was deleted with the rest of the poll chain (alpha-engine-config-I9329) \u2014 but NOT its fail-soft Default, which is load-bearing and was earned: alpha-engine-config-I9058 records 2026-08-22, when EvalJudgeSubmitWeekly SUCCEEDED while returning status=ERROR in its payload, the chain skipped straight past Process, decision_artifacts/_eval/latest.json was never rewritten, and NOTHING in the run recorded a degradation; the only signal was a freshness row going stale five days later. That Default is preserved verbatim in meaning here. | ORDER MATTERS. The dry branch is FIRST: on the Friday shell run $.research_dry is true and Submit returns the EMPTY sentinel, and we still want the box to boot, import and probe S3 under --preflight-only \u2014 that is the whole point of the keystone, and it is the only path that exercises the new substrate before Saturday. | A REAL EMPTY plan routes to EvalJudgeEmptyPlan instead of to the spot, which is a DELIBERATE deviation from I9329's issue body ('EMPTY continues to route straight to EvalJudgeProcess'): that instruction was written for a Lambda Process that could emit a clean empty result for free. On a spot box the same routing would launch an instance to grade zero artifacts, and judge_spot_run refuses to run without a plan (exit 2), so it would also FAIL the stage. The Pass state emits the identical result shape at no cost. | ended_sync (alpha-engine-config-I9263) and OK both mean 'there is a plan to judge' now that no provider batch exists to poll.",
+              "Comment": "Branch on Submit's outcome. Replaces EvalJudgePollChoice, which was deleted with the rest of the poll chain (alpha-engine-config-I9329) \u2014 but NOT its fail-soft Default, which is load-bearing and was earned: alpha-engine-config-I9058 records 2026-08-22, when EvalJudgeSubmitWeekly SUCCEEDED while returning status=ERROR in its payload, the chain skipped straight past Process, decision_artifacts/_eval/latest.json was never rewritten, and NOTHING in the run recorded a degradation; the only signal was a freshness row going stale five days later. That Default is preserved verbatim in meaning here. | ORDER MATTERS. The dry branch is FIRST: on the Friday shell run $.research_dry is true and Submit returns the EMPTY sentinel, and we still want the box to boot, import and probe S3 under --preflight-only \u2014 that is the whole point of the keystone, and it is the only path that exercises the new substrate before Saturday. | A REAL EMPTY plan routes to EvalJudgeEmptyPlan instead of to the spot, which is a DELIBERATE deviation from I9329's issue body ('EMPTY continues to route straight to EvalJudgeProcess'): that instruction was written for a Lambda Process that could emit a clean empty result for free. On a spot box the same routing would launch an instance to grade zero artifacts, and judge_spot_run refuses to run without a plan (exit 2), so it would also FAIL the stage. The Pass state emits the identical result shape at no cost. | ended_sync (alpha-engine-config-I9263) and OK both mean 'there is a plan to judge' now that no provider batch exists to poll. | alpha-engine-config-I9636: the Default now routes through ExtractEvalJudgeSubmitOutcomeError. MEASURED on the 2026-08-29 scheduled run (execution 965d925b-f9d6-ce5e-e059-9405433a0724_c0271e3b-a27f-a834-b303-3e3803fffd16): EvalJudgeSubmitWeekly SUCCEEDED returning status=ERROR stage=submit error='Error code: 400 ... Your credit balance is too low to access the Anthropic API', this Default fired, and MarkEvalJudgeDegraded recorded a bare boolean. The run's own terminal never mentioned the eval judge; the cause had to be recovered from 7,858 execution-history events two days later. I9058 made this path VISIBLE \u2014 this makes it LEGIBLE. A Choice Default populates no error field on its own, so without this state the one fact the run was holding is discarded at the moment it becomes a degradation.",
               "Choices": [
                 {
                   "And": [
@@ -2187,7 +2187,7 @@
                   "Next": "PrepareEvalJudgeSpotDispatch"
                 }
               ],
-              "Default": "MarkEvalJudgeDegraded"
+              "Default": "ExtractEvalJudgeSubmitOutcomeError"
             },
             "EvalJudgeEmptyPlan": {
               "Type": "Pass",
@@ -2251,8 +2251,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "alpha-engine-config#6722: routes through MarkEvalJudgeDegraded so the run RECORDS that the judge produced nothing, then continues to EvalRollingMean against historical data.",
-                  "Next": "MarkEvalJudgeDegraded",
+                  "Comment": "alpha-engine-config#6722: routes through MarkEvalJudgeDegraded so the run RECORDS that the judge produced nothing, then continues to EvalRollingMean against historical data. | alpha-engine-config-I9636: routes through ExtractEvalJudgeSpotDispatchError first, which stamps the PHASE onto the record the Catch just wrote. Five Catches shared $.eval_judge_error with no discriminator, so 'the submit was refused' and 'the spot box never booted' were the same bytes to every reader.",
+                  "Next": "ExtractEvalJudgeSpotDispatchError",
                   "ResultPath": "$.eval_judge_error"
                 }
               ],
@@ -2314,8 +2314,9 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Next": "MarkEvalJudgeDegraded",
-                  "ResultPath": "$.eval_judge_error"
+                  "Next": "ExtractEvalJudgeSpotBootstrapPollError",
+                  "ResultPath": "$.eval_judge_error",
+                  "Comment": " | alpha-engine-config-I9636: routes through ExtractEvalJudgeSpotBootstrapPollError first, which stamps the PHASE onto the record the Catch just wrote. Five Catches shared $.eval_judge_error with no discriminator, so 'the submit was refused' and 'the spot box never booted' were the same bytes to every reader."
                 }
               ],
               "ResultSelector": {
@@ -2484,8 +2485,8 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Comment": "Eval is observability \u2014 a Process failure must NOT halt the pipeline. Routes through MarkEvalJudgeDegraded then EvalRollingMean, which still runs against historical data. alpha-engine-config#6722.",
-                  "Next": "MarkEvalJudgeDegraded",
+                  "Comment": "Eval is observability \u2014 a Process failure must NOT halt the pipeline. Routes through MarkEvalJudgeDegraded then EvalRollingMean, which still runs against historical data. alpha-engine-config#6722. | alpha-engine-config-I9636: routes through ExtractEvalJudgeProcessTaskError first. Distinct from ExtractEvalJudgeProcessError, which names the CheckEvalJudgeProcessStatus Choice-Default arrival \u2014 the SSM command came back non-Success \u2014 while this one names the sendCommand Task itself failing. Same $.eval_judge_error path, two different incidents.",
+                  "Next": "ExtractEvalJudgeProcessTaskError",
                   "ResultPath": "$.eval_judge_error"
                 }
               ],
@@ -2532,8 +2533,9 @@
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Next": "MarkEvalJudgeDegraded",
-                  "ResultPath": "$.eval_judge_error"
+                  "Next": "ExtractEvalJudgeProcessPollError",
+                  "ResultPath": "$.eval_judge_error",
+                  "Comment": " | alpha-engine-config-I9636: routes through ExtractEvalJudgeProcessPollError first, which stamps the PHASE onto the record the Catch just wrote. Five Catches shared $.eval_judge_error with no discriminator, so 'the submit was refused' and 'the spot box never booted' were the same bytes to every reader."
                 }
               ],
               "ResultSelector": {
@@ -2651,7 +2653,7 @@
             },
             "MarkEvalJudgeDegraded": {
               "Type": "Pass",
-              "Comment": "alpha-engine-config#6722: shared convergence for every fail-open exit of the eval-judge chain \u2014 the two Submit Catches, the EvalJudgeSubmitOutcome Default (alpha-engine-config-I9058), the spot dispatch/bootstrap/process Catches and the two liveness gates' Defaults. Threads $.research_degraded_local=true without changing the continuation. Under alpha-engine-config-I9329 the set of arrivals grew from four to eight and now includes SUBSTRATE loss, which is why each arrival first passes through an Extract* state that names its phase: 'the box was reclaimed' and 'the judge under-covered the corpus' are different incidents and must not reach the notifier as one.",
+              "Comment": "alpha-engine-config#6722: shared convergence for every fail-open exit of the eval-judge chain \u2014 the two Submit Catches, the EvalJudgeSubmitOutcome Default (alpha-engine-config-I9058), the spot dispatch/bootstrap/process Catches and the two liveness gates' Defaults. Threads $.research_degraded_local=true without changing the continuation. Under alpha-engine-config-I9329 the set of arrivals grew from four to eight and now includes SUBSTRATE loss, which is why each arrival first passes through an Extract* state that names its phase (alpha-engine-config-I9636: that sentence was ASPIRATIONAL when written \u2014 measured on the live definition 2026-08-31 it held for 2 of the 9 arrivals, and the 2026-08-29 run degraded through one of the 6 that had none. All 9 now have one): 'the box was reclaimed' and 'the judge under-covered the corpus' are different incidents and must not reach the notifier as one.",
               "Result": true,
               "ResultPath": "$.research_degraded_local",
               "Next": "EvalRollingMean"
@@ -3041,6 +3043,83 @@
               "Result": true,
               "ResultPath": "$.research_self_test_invocation_failed",
               "Next": "CheckSkipChallengerShadow"
+            },
+            "ExtractEvalJudgeSubmitWeeklyError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for EvalJudgeSubmitWeekly's fail-open exit. The Catch populates $.eval_judge_error with {Error, Cause}, but ALL FIVE eval-judge Catches write that same path, so the record said a phase had failed without ever saying WHICH. Mirrors ExtractEvalJudgeProcessError, whose Comment states the same obligation for the Choice-Default arrivals. Total by construction: $.eval_judge_error is written by the Catch that routes here, so the .$ reference can never miss.",
+              "Parameters": {
+                "phase": "EvalJudgeSubmitWeekly",
+                "source": "EvalJudgeSubmitWeekly.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeSubmitFirstSaturdayError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for EvalJudgeSubmitFirstSaturday's fail-open exit. The Catch populates $.eval_judge_error with {Error, Cause}, but ALL FIVE eval-judge Catches write that same path, so the record said a phase had failed without ever saying WHICH. Mirrors ExtractEvalJudgeProcessError, whose Comment states the same obligation for the Choice-Default arrivals. Total by construction: $.eval_judge_error is written by the Catch that routes here, so the .$ reference can never miss.",
+              "Parameters": {
+                "phase": "EvalJudgeSubmitFirstSaturday",
+                "source": "EvalJudgeSubmitFirstSaturday.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeSpotDispatchError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for DispatchEvalJudgeSpot's fail-open exit. The Catch populates $.eval_judge_error with {Error, Cause}, but ALL FIVE eval-judge Catches write that same path, so the record said a phase had failed without ever saying WHICH. Mirrors ExtractEvalJudgeProcessError, whose Comment states the same obligation for the Choice-Default arrivals. Total by construction: $.eval_judge_error is written by the Catch that routes here, so the .$ reference can never miss.",
+              "Parameters": {
+                "phase": "EvalJudgeSpotDispatch",
+                "source": "DispatchEvalJudgeSpot.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeSpotBootstrapPollError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for WaitForEvalJudgeSpotBootstrap's fail-open exit. The Catch populates $.eval_judge_error with {Error, Cause}, but ALL FIVE eval-judge Catches write that same path, so the record said a phase had failed without ever saying WHICH. Mirrors ExtractEvalJudgeProcessError, whose Comment states the same obligation for the Choice-Default arrivals. Total by construction: $.eval_judge_error is written by the Catch that routes here, so the .$ reference can never miss.",
+              "Parameters": {
+                "phase": "EvalJudgeSpotBootstrapPoll",
+                "source": "WaitForEvalJudgeSpotBootstrap.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeProcessPollError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for WaitForEvalJudgeProcess's fail-open exit. The Catch populates $.eval_judge_error with {Error, Cause}, but ALL FIVE eval-judge Catches write that same path, so the record said a phase had failed without ever saying WHICH. Mirrors ExtractEvalJudgeProcessError, whose Comment states the same obligation for the Choice-Default arrivals. Total by construction: $.eval_judge_error is written by the Catch that routes here, so the .$ reference can never miss.",
+              "Parameters": {
+                "phase": "EvalJudgeProcessPoll",
+                "source": "WaitForEvalJudgeProcess.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeSubmitOutcomeError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: carry Submit's OWN payload into the degraded record. States.JsonToString is used rather than picking out .status/.error because this Default is reached by TWO different shapes \u2014 a payload with status=ERROR (which has .error) and a payload missing status entirely (which has neither) \u2014 and an unguarded .$ on the second throws States.Runtime on the fail-open path, the config-I2767 shape. $.eval_judge_submit.Payload is total here: this state is reachable only from a lambda:invoke that SUCCEEDED, since a failed invoke takes the Catch instead.",
+              "Parameters": {
+                "phase": "EvalJudgeSubmit",
+                "source": "EvalJudgeSubmitOutcome.Default",
+                "submit_payload.$": "States.JsonToString($.eval_judge_submit.Payload)"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
+            },
+            "ExtractEvalJudgeProcessTaskError": {
+              "Type": "Pass",
+              "Comment": "alpha-engine-config-I9636: name the phase for EvalJudgeProcess's own Task Catch. The seventh of nine arrivals into MarkEvalJudgeDegraded and the last one that named nothing. Total: the Catch that routes here wrote $.eval_judge_error.",
+              "Parameters": {
+                "phase": "EvalJudgeProcess",
+                "source": "EvalJudgeProcess.Catch[States.ALL]",
+                "error.$": "$.eval_judge_error"
+              },
+              "ResultPath": "$.eval_judge_error",
+              "Next": "MarkEvalJudgeDegraded"
             }
           }
         },

--- a/tests/test_sf_choice_guards.py
+++ b/tests/test_sf_choice_guards.py
@@ -325,8 +325,12 @@ def _choice_target(definition: dict, choice_name: str, data) -> str:
         # batch API they existed to drive. The Default is the part that
         # mattered and it is unchanged: a submit payload with no status is
         # still fail-soft THROUGH the degraded marker, not past it.
+        # alpha-engine-config-I9636: the Default's immediate target is now the
+        # phase-naming hop (the ExtractLibPinDriftError shape two entries
+        # above), which continues to MarkEvalJudgeDegraded unchanged. A payload
+        # with no status is still fail-soft THROUGH the degraded marker.
         ("EvalJudgeSubmitOutcome", {"eval_judge_submit": {"Payload": {}}},
-         "MarkEvalJudgeDegraded"),  # eval is observability — fail-soft, marked
+         "ExtractEvalJudgeSubmitOutcomeError"),
         # Healthy-path sanity: the guards must not change live semantics.
         ("WeeklyRunDayGateChoice",
          {"weekly_run_day_gate": {"Payload": {"is_weekly_run_day": False}}},

--- a/tests/test_sf_eval_judge_wiring.py
+++ b/tests/test_sf_eval_judge_wiring.py
@@ -63,6 +63,41 @@ def states(sf) -> dict:
 # ── State presence ────────────────────────────────────────────────────────
 
 
+
+def converges_on(states, start, target, limit=6):
+    """Walk ``Next`` from *start* through Pass hops and report whether *target*
+    is reached.
+
+    alpha-engine-config-I9636. Every one of these assertions used to pin
+    ``catch["Next"] == "MarkEvalJudgeDegraded"`` literally, which pinned the
+    EDGE rather than the INVARIANT — and the invariant is that no eval-judge
+    fail-open exit reaches EvalRollingMean unmarked. The literal form made the
+    correct fix (an Extract* hop that names the phase, the shape
+    ExtractEvalJudgeProcessError has used since I9329) look like a regression
+    in fifteen tests, which is a good way to talk a future session out of
+    naming the phase. This form is strictly stronger: it still fails if the
+    edge stops converging, and it stays true when a hop is inserted.
+    """
+    seen = set()
+    cur = start
+    for _ in range(limit):
+        if cur == target:
+            return True
+        if cur in seen or cur not in states:
+            return False
+        seen.add(cur)
+        state = states[cur]
+        if state.get("Type") != "Pass":
+            return False
+        cur = state.get("Next")
+    return False
+
+
+def phase_named_by(states, name):
+    """The ``phase`` an Extract* hop stamps, or None if *name* stamps none."""
+    return (states.get(name, {}).get("Parameters") or {}).get("phase")
+
+
 class TestStatesPresent:
     def test_all_eval_judge_states_exist(self, states):
         for name in (
@@ -388,7 +423,9 @@ class TestEvalJudgeSubmitContract:
         # MarkEvalJudgeDegraded convergence before EvalRollingMean.
         catch = states[state_name]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "MarkEvalJudgeDegraded"
+        # alpha-engine-config-I9636: through the phase-naming hop.
+        assert converges_on(states, catch["Next"], "MarkEvalJudgeDegraded")
+        assert phase_named_by(states, catch["Next"]) is not None
         assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
 
 
@@ -455,7 +492,17 @@ class TestEvalJudgeSubmitOutcome:
         assert choices[dry_index]["Next"] == "PrepareEvalJudgeSpotDispatch"
 
     def test_default_is_fail_soft_but_marks_degraded(self, states):
-        assert states["EvalJudgeSubmitOutcome"]["Default"] == "MarkEvalJudgeDegraded"
+        # alpha-engine-config-I9636: the Default now names the phase first.
+        # This is the exact edge the 2026-08-29 scheduled run took, carrying an
+        # Anthropic 400 ("credit balance is too low") in
+        # $.eval_judge_submit.Payload.error that nothing recorded.
+        assert converges_on(
+            states, states["EvalJudgeSubmitOutcome"]["Default"],
+            "MarkEvalJudgeDegraded",
+        )
+        assert phase_named_by(
+            states, states["EvalJudgeSubmitOutcome"]["Default"]
+        ) == "EvalJudgeSubmit"
         assert states["MarkEvalJudgeDegraded"]["Type"] == "Pass"
         assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
         assert (
@@ -730,7 +777,9 @@ class TestEvalJudgeProcessContract:
     def test_process_catch_routes_to_rolling_mean_not_failure(self, states):
         catch = states["EvalJudgeProcess"]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "MarkEvalJudgeDegraded"
+        # alpha-engine-config-I9636: through the phase-naming hop.
+        assert converges_on(states, catch["Next"], "MarkEvalJudgeDegraded")
+        assert phase_named_by(states, catch["Next"]) == "EvalJudgeProcess"
         assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
 
 
@@ -760,7 +809,9 @@ class TestBatchChainNonBlocking:
         # convergence, which itself continues to EvalRollingMean unchanged.
         catch = states[state_name]["Catch"][0]
         assert catch["ErrorEquals"] == ["States.ALL"]
-        assert catch["Next"] == "MarkEvalJudgeDegraded"
+        # alpha-engine-config-I9636: through the phase-naming hop.
+        assert converges_on(states, catch["Next"], "MarkEvalJudgeDegraded")
+        assert phase_named_by(states, catch["Next"]) is not None
         assert catch["Next"] != "HandleFailure"
         assert states["MarkEvalJudgeDegraded"]["Next"] == "EvalRollingMean"
 
@@ -1240,7 +1291,10 @@ class TestSyncRungRouting:
             )
         )
         assert any(cond.get("IsPresent") is True for cond in sync["And"])
-        assert states["EvalJudgeSubmitOutcome"]["Default"] == "MarkEvalJudgeDegraded"
+        assert converges_on(
+            states, states["EvalJudgeSubmitOutcome"]["Default"],
+            "MarkEvalJudgeDegraded",
+        )
 
     def test_process_reads_its_inputs_from_submit_not_from_poll(self, states):
         """The reason skipping Poll is safe at all.
@@ -1260,3 +1314,89 @@ class TestSyncRungRouting:
         the next reader to the wrong provider during an incident."""
         raw = json.dumps(sf)
         assert "Calls anthropic.messages.batches.retrieve" not in raw
+
+
+class TestEveryEvalJudgeDegradationNamesItsPhase:
+    """alpha-engine-config-I9636 — the sibling half of
+    ``test_no_eval_judge_failure_path_reaches_rolling_mean_unmarked``.
+
+    That test makes every fail-open exit VISIBLE. This one makes it LEGIBLE.
+    ``MarkEvalJudgeDegraded`` writes ``$.research_degraded_local = true`` and
+    nothing else, so nine distinct incidents — the submit refused for billing,
+    the plan malformed, the spot request unfulfilled, the box never booted, the
+    judge under-covering the corpus — arrived at the notifier as one boolean.
+
+    Its own ``Comment`` has asserted since I9329 that *"each arrival first
+    passes through an Extract* state that names its phase"*. Measured against
+    the live definition on 2026-08-31 that held for 2 of 9. The 2026-08-29
+    scheduled run degraded through one of the other 7 (``EvalJudgeSubmitOutcome``'s
+    Default, on an Anthropic ``400 ... credit balance is too low``), and the
+    cause had to be recovered from 7,858 execution-history events two days
+    later because the run recorded a bare true. A comment is not a mechanism;
+    this is the mechanism.
+    """
+
+    def _arrivals(self, states):
+        out = []
+        for name, body in states.items():
+            edges = [("Next", body.get("Next")), ("Default", body.get("Default"))]
+            edges += [(f"Choices[{i}]", c.get("Next"))
+                      for i, c in enumerate(body.get("Choices", []))]
+            edges += [(f"Catch[{i}]", c.get("Next"))
+                      for i, c in enumerate(body.get("Catch", []))]
+            out += [(name, kind) for kind, tgt in edges
+                    if tgt == "MarkEvalJudgeDegraded"]
+        return out
+
+    def test_every_arrival_is_a_phase_naming_extract(self, states):
+        unnamed = [
+            (name, kind) for name, kind in self._arrivals(states)
+            if not phase_named_by(states, name)
+        ]
+        assert unnamed == [], (
+            "these edges reach MarkEvalJudgeDegraded without naming which "
+            f"phase degraded: {unnamed}. The degraded record is then a bare "
+            "boolean and the run cannot be diagnosed from its own artifacts."
+        )
+
+    def test_the_extracts_write_the_error_path_and_do_not_change_continuation(
+        self, states,
+    ):
+        for name, _ in self._arrivals(states):
+            hop = states[name]
+            assert hop["Type"] == "Pass", name
+            assert hop["ResultPath"] == "$.eval_judge_error", name
+            assert hop["Next"] == "MarkEvalJudgeDegraded", name
+            assert hop["Parameters"].get("source"), (
+                f"{name} names a phase but not the EDGE it came in on; two "
+                "arrivals can share a phase and mean different things"
+            )
+
+    def test_the_submit_outcome_default_carries_the_payload_it_was_holding(
+        self, states,
+    ):
+        """The 2026-08-29 path specifically.
+
+        Submit returned status=ERROR with the provider's own message in
+        ``.error`` and the SF had it in hand at the Choice. Whatever else this
+        hop does, it must not drop that.
+        """
+        hop = states[states["EvalJudgeSubmitOutcome"]["Default"]]
+        carried = json.dumps(hop["Parameters"])
+        assert "$.eval_judge_submit.Payload" in carried
+        # Total-by-construction: JsonToString on the whole Payload, never a
+        # pick of .status/.error, because this Default is reached BOTH by a
+        # payload that has .error and by one that has no status at all, and
+        # the second throws States.Runtime on an unguarded pick.
+        assert "States.JsonToString" in carried
+
+    def test_no_two_arrivals_claim_the_same_phase_and_source(self, states):
+        seen = {}
+        for name, _ in self._arrivals(states):
+            p = states[name]["Parameters"]
+            key = (p["phase"], p["source"])
+            assert key not in seen, (
+                f"{name} and {seen[key]} both report {key} — two incidents "
+                "collapsed into one label is the defect, one layer up"
+            )
+            seen[key] = name

--- a/tests/test_sf_research_predictor_degraded_wiring.py
+++ b/tests/test_sf_research_predictor_degraded_wiring.py
@@ -186,9 +186,27 @@ def test_branch_a_owner_catch_routes_through_a_mark_state(branch_a, owner):
     )
     catch = catches[-1]
     assert catch["ErrorEquals"] == ["States.ALL"]
-    assert catch["Next"].startswith("Mark") and catch["Next"].endswith("Degraded")
-    assert catch["Next"] in branch_a
-    assert branch_a[catch["Next"]]["ResultPath"] == "$.research_degraded_local"
+    # alpha-engine-config-I9636: an owner may route through ONE Extract* Pass
+    # that stamps the phase before the shared Mark*Degraded convergence. Nine
+    # arrivals share MarkEvalJudgeDegraded and it records a bare boolean, so
+    # without the hop "the submit was refused for billing" and "the spot box
+    # never booted" are the same bytes on the execution record — which is
+    # exactly why the 2026-08-29 run's degradation could not be diagnosed from
+    # the record and had to be reconstructed from 7,858 history events. The
+    # hop is bounded at one and must name a phase, so it can never become a
+    # place to hide a continuation change.
+    target = catch["Next"]
+    if target.startswith("Extract"):
+        hop = branch_a[target]
+        assert hop["Type"] == "Pass", target
+        assert hop["ResultPath"].endswith("_error"), target
+        assert hop["Parameters"].get("phase"), (
+            f"{target} is an Extract hop that names no phase — the whole point"
+        )
+        target = hop["Next"]
+    assert target.startswith("Mark") and target.endswith("Degraded")
+    assert target in branch_a
+    assert branch_a[target]["ResultPath"] == "$.research_degraded_local"
 
 
 def test_no_state_writes_the_old_dead_thinktank_path(branch_a, branch_b, states):


### PR DESCRIPTION
Tracker: **alpha-engine-config-I9636**. (Cross-repo — the closing keyword is inert here, so I9636 is closed by hand after this merges and the property is verified on `main`.)

## What was wrong

The 2026-08-29 scheduled weekly run (`965d925b-…_c0271e3b-…`, 5h02m, terminal `DegradedRun`) set `research_predictor_degraded: true` via `weekly_research_predictor_branch_fail_open`, and **the run's own record did not say why**. Recovering the cause took 7,858 execution-history events and two days. It was one line, and the Step Function had been holding it the whole time:

```
id 6413 TaskSucceeded 05:11:40  EvalJudgeSubmitWeekly
  Payload: {"status":"ERROR","stage":"submit",
    "error":"Error code: 400 ... 'Your credit balance is too low to access the Anthropic API'"}
id 6415 EvalJudgeSubmitOutcome -> Default
id 6417 MarkEvalJudgeDegraded          <- writes `true`. Nothing else.
```

`MarkEvalJudgeDegraded` is the shared fail-open convergence for the whole eval-judge chain. Its own `Comment` has asserted since I9329 that *"each arrival first passes through an Extract\* state that names its phase: 'the box was reclaimed' and 'the judge under-covered the corpus' are different incidents and must not reach the notifier as one."*

**Measured against the live definition 2026-08-31: that held for 2 of 9 arrivals.** The comment was a claim; there was no mechanism. Nine distinct incidents — the submit refused for billing, the plan malformed, the spot request unfulfilled, the box never booted, the judge under-covering the corpus — reached the notifier as one boolean.

The 08-29 run degraded through `EvalJudgeSubmitOutcome.Default`, and a Choice Default populates no error field on its own — the exact reason `ExtractEvalJudgeProcessError` exists for the two arrivals that *were* covered.

## What this does

Seven `Extract*` Pass hops, one per unnamed arrival, each stamping `{phase, source}` onto `$.eval_judge_error` and continuing to `MarkEvalJudgeDegraded` unchanged.

The `EvalJudgeSubmitOutcome` hop additionally carries `States.JsonToString($.eval_judge_submit.Payload)` — `JsonToString` rather than a pick of `.status`/`.error`, because that Default is reached **both** by a payload carrying `.error` and by one with no `status` at all, and an unguarded pick on the second throws `States.Runtime` on the fail-open path (the `config-I2767` shape). `$.eval_judge_submit.Payload` is total there: the state is reachable only from a `lambda:invoke` that succeeded, since a failed invoke takes the Catch instead.

## Class, not instance

`TestEveryEvalJudgeDegradationNamesItsPhase` **derives** the arrival set from the definition rather than listing it, and fails on:
- any edge reaching `MarkEvalJudgeDegraded` without naming a phase,
- two arrivals claiming the same `(phase, source)` — two incidents under one label is the defect, one layer up,
- a hop that changes the continuation or writes somewhere other than `$.eval_judge_error`.

It is the sibling of `test_no_eval_judge_failure_path_reaches_rolling_mean_unmarked`, which makes these exits VISIBLE. This makes them LEGIBLE.

## Fifteen tests changed, and why that is the fix and not collateral

Fifteen existing assertions pinned `catch["Next"] == "MarkEvalJudgeDegraded"` **literally** — pinning the EDGE rather than the invariant, which is that no eval-judge fail-open exit reaches `EvalRollingMean` unmarked. They now assert convergence through bounded `Pass` hops via a `converges_on` helper: still red if an exit stops converging, no longer red when a hop that names the phase is inserted. A literal pin made the correct fix look like a regression in fifteen places, which is a good way to talk a future session out of naming the phase.

## Risk, and the I9041 front-load exception

**This changes what the weekly SF executes**, so it lands under `alpha-engine-config-I9041`'s front-load rule — before the 2026-09-05 run rather than after. Stating the risk plainly:

- All seven new states are `Pass` states on **fail-open paths only**. On a run where nothing in the eval-judge chain degrades, **zero of them are entered** and the 09-05 happy path is behaviourally identical.
- The exposure is confined to runs that were *already* degrading, and the one credible failure mode there is a `States.Runtime` in a new hop converting a fail-open into a hard branch failure. Every field reference is total by construction: five hops read `$.eval_judge_error`, which the Catch routing to them just wrote; the sixth reads `$.eval_judge_submit.Payload`, guaranteed by a succeeded invoke. No `States.Format` against unbounded input (`config#1819`).
- All four definitions pass `aws stepfunctions validate-state-machine-definition --type STANDARD --severity WARNING` — the SF deploy is all-or-nothing across all four (the 2026-08-20 freeze).
- No new **substantive** Task state, so no `nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE` entry and no lib pin bump is required (`I7906`'s constraint). `Pass` states were chosen deliberately for this.
- `scripts/weekly_sf_rerun.py`'s `degraded_witness` sets are unchanged and correct: the hops sit immediately before `MarkEvalJudgeDegraded`, which is already the mapped witness, and entering a hop implies entering it.

## Deliberately NOT in this PR

While measuring the terminal I found a **second, distinct instance of the same class**, and I am handing it over rather than bundling it. `$.degraded_summary` is one path that seven `Set*DegradedSummary` states share on a stated last-write-wins convention, so `.reason` names only the **last** family to degrade. On 2026-08-29 four families degraded — `research_predictor` 05:28:55, `health_check` 07:01:21, `report_card` 07:01:34, `aggregate_costs` 07:02:40 — and `describeExecution`'s cause read `reason: weekly_aggregate_costs_fail_open` alone. `sf-telegram-notifier` renders that cause verbatim, so the operator surface inherited the same one-of-four view, and the eval-judge degradation this PR exists to make legible is named nowhere in the run's own verdict.

I built the fix (floor the family set — **derived** from the definition's own `$.*_degraded` writers, because hand-enumerating it missed `scanner_leaderboard_degraded` on the first pass, the `config#5950` O6 shape exactly — then project and render it) and **reverted it from this PR**. Reason: it moves the shared `DegradedRun` terminal, breaks 19 assertions across 8 test files, and those files are adjacent to work other sessions are live in right now. That is not a change to land unattended four days before a run that must not break. The prototype found two edges nobody had noticed reaching the terminal directly — `WriteCompletionMarkerDegradedCalendar.Catch` and `CheckShellRunDegradedOutcome.Choices[0]` — which would have thrown `States.Runtime` at the *last* state of a degraded run; that detail is written into I9636 so the next session does not rediscover it the hard way.

**SOTA / delta:** the institutional fix is both halves at once. The delta is that the second half ships separately, tracked, with its implementation and its two non-obvious edges already specified — not dropped.

## Verification

- `aws stepfunctions validate-state-machine-definition` OK on all four definitions.
- Full `nousergon-data` suite: **6953 passed**, 2 pre-existing failures in `test_pipeline_status_registry_source_check.py`, both on `[Weekday-json_path1]` for `CorrectnessVerdictGate` / `WaitForCorrectnessVerdict` in `step_function_daily.json` — a file this diff does not touch (`git diff --name-only` contains no `*daily*`). They are the `nousergon-lib` pin-lockstep gap tracked as `alpha-engine-config-I9070` / `I9116` and need a lib registry entry plus a pin bump, which is a different lane.

Rehearsal-path: tests/test_sf_eval_judge_wiring.py

The change is reachable only on a degraded eval-judge path, so a live rehearsal cannot exercise it without manufacturing a failure inside the run it is rehearsing. The rehearsal mechanism is therefore the definition-derived contract suite: `TestEveryEvalJudgeDegradationNamesItsPhase` walks every edge into `MarkEvalJudgeDegraded` in the actual `step_function.json` and asserts each names a phase, writes `$.eval_judge_error`, and leaves the continuation unchanged; `test_sf_choice_guards.py::test_partial_payload_routes_to_explicit_path` replays the exact 2026-08-29 payload shape (`{"eval_judge_submit": {"Payload": {}}}`) through the Choice and asserts the route. That is the whole behavioural surface of this diff — there is no code path here that only a live run can reach.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017zXNmESS1mWVMTFbd3ZJ2M
