### PR TITLE
test(cost-fanin): classify every weekly stage, so a new one cannot be silent

### DIFF
--- a/infrastructure/cost_fanin_stage_census.json
+++ b/infrastructure/cost_fanin_stage_census.json
@@ -1,0 +1,267 @@
+{
+  "schema": "cost_fanin_stage_census-1.0.0",
+  "comment": "Every work-dispatching stage of ne-weekly-freshness-pipeline, classified by whether it emits an LLM cost record. THE POINT: the coverage block in AggregateCosts declares four stages, and nothing checked the other direction \u2014 a stage could be added to the definition, spend money, and appear in NO set at all. That absence is indistinguishable from a stage that costs nothing (principles.md 2.7: no data is never rendered as green). tests/test_sf_cost_fanin_stage_census.py makes the classification mandatory: a new Lambda or SSM stage fails CI until someone writes down which of the three it is and why. MEASURED BASIS (2026-08-31): the complete set of krepis.llm.LLMClient construction sites in the fleet is crucible-research {evals/judge.py, evals/orchestrator.py, producers/single_agent.py, thinktank/client.py, scripts/live_validate_openrouter_judge.py}, crucible-evaluator {director/agent.py, director/retro.py} and crucible-backtester {replay/runner.py}. Every 'exempt' row below rests on that census; re-measure it before adding one.",
+  "dispositions": {
+    "emits": "Declared in the AggregateCosts coverage block (required_producers or conditional_producers).",
+    "exempt": "The substrate provably contains no paid-model call site. Needs a reason naming why.",
+    "unattributed": "The substrate DOES spend on a paid model and emits no cost record. A DEBT, not an exemption \u2014 must name a tracked issue."
+  },
+  "stages": {
+    "ChallengerShadow": {
+      "disposition": "emits",
+      "substrate": "crucible-research producers/single_agent.py (Lambda alpha-engine-research-runner)",
+      "reason": "Emits single-agent-quant, declared under required_producers. The challenger arm always makes at least one structured model call when it runs, so an empty producer set here is always a defect, never a quiet cycle."
+    },
+    "EvalJudgeProcess": {
+      "disposition": "emits",
+      "substrate": "crucible-research evals/judge.py + evals/orchestrator.py (spot, evals.judge_spot_run)",
+      "reason": "evaljudge-sync required; evaljudge-batch conditional (batch retrieval does not always run)."
+    },
+    "ReplayConcordance": {
+      "disposition": "emits",
+      "substrate": "crucible-backtester replay/runner.py (Lambda alpha-engine-replay-concordance)",
+      "reason": "Emits replay-concordance, declared under required_producers. Every replayed artifact is one paid cheap-model call, and the stage is wall-killed often enough that its budget cannot be sized while its spend is invisible (alpha-engine-config-I7176 item A2)."
+    },
+    "Director": {
+      "disposition": "emits",
+      "substrate": "crucible-evaluator director/agent.py + director/retro.py (Lambda alpha-engine-evaluator-director)",
+      "reason": "director-plan required; director-retro-judge conditional (no prior plan on the first cycle)."
+    },
+    "RAGIngestion": {
+      "disposition": "unattributed",
+      "substrate": "nousergon-lib nousergon_lib/rag/embeddings.py (spot, rag ingestion)",
+      "reason": "Calls the PAID Voyage embedding API (voyage-3-lite) through voyageai.Client directly, not through krepis.llm.LLMClient, so it writes no _cost_raw object and the fan-in check structurally cannot see it. Real spend attributed to nothing. NOT an exemption: recorded here so the silence is a declared debt rather than an absence.",
+      "issue": "alpha-engine-config-I9694"
+    },
+    "Scanner": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/scanner_handler.py",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "ScannerLeaderboard": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/scanner_handler.py (leaderboard mode)",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "SignalsEnvelope": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/signals_envelope_handler.py",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "RationaleClustering": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/rationale_clustering_handler.py",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "EvalRollingMean": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/eval_rolling_mean_handler.py",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "ResearchSelfTest": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/handler.py (self-test mode)",
+      "reason": "no paid-model call site in the substrate. The handler nevertheless calls flush_default_sink() in a finally, so if an LLM call is ever added the producer appears and the fan-in check refuses it as UNDECLARED \u2014 the exemption fails loud rather than absorbing the new spend."
+    },
+    "EvalJudgeSubmitWeekly": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/eval_judge_submit_handler.py",
+      "reason": "Builds the plan manifest and submits the Anthropic Batch. The tokens are billed on retrieval, and the retrieval is EvalJudgeProcess, which declares evaljudge-batch. Requiring a producer here would demand a record for spend that has not happened yet."
+    },
+    "EvalJudgeSubmitFirstSaturday": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/eval_judge_submit_handler.py",
+      "reason": "Same substrate and same reason as EvalJudgeSubmitWeekly \u2014 the monthly-cadence entry point into the identical Lambda."
+    },
+    "AggregateCosts": {
+      "disposition": "exempt",
+      "substrate": "crucible-research lambda/aggregate_costs_handler.py",
+      "reason": "The aggregator itself. It reads the prefix it would have to have written to, so requiring it would be circular; tests/test_sf_cost_fanin_coverage.py asserts the same property from the declaration side."
+    },
+    "ReportCard": {
+      "disposition": "exempt",
+      "substrate": "crucible-evaluator grading/handler.py (Lambda alpha-engine-evaluator)",
+      "reason": "no paid-model call site in the substrate \u2014 the report card scores measured artifacts. The Director is the evaluator's only model caller and it is a separate Lambda and a separate stage. grading/handler.py flushes the sink in a finally regardless."
+    },
+    "EvaluatorDeployDriftCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-evaluator grading/handler.py (drift-probe mode)",
+      "reason": "A deploy-parity probe: it returns the deployed SHA and pin set and returns before any scoring work. no paid-model call site in the substrate."
+    },
+    "EvaluatorDirectorDeployDriftCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-evaluator director/handler.py (drift-probe mode)",
+      "reason": "The Director Lambda invoked in drift-probe mode. It returns before director/agent.py is imported, so the one model call in that image is not reachable on this path; the Director STAGE declares it."
+    },
+    "Counterfactual": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester replay/counterfactual.py (Lambda alpha-engine-replay-counterfactual)",
+      "reason": "no paid-model call site in the substrate \u2014 the counterfactual recomputes outcomes over already-stored replay artifacts. replay/runner.py, the repo's only LLMClient site, is reached from replay/batch.py and lambda_concordance only."
+    },
+    "WeeklyRunDayGate": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor (Lambda alpha-engine-predictor-inference, gate mode)",
+      "reason": "Gate mode \u2014 self-gates Thu/Fri/Sat firings to the one real weekly run. crucible-predictor contains no krepis.llm.LLMClient construction site anywhere in the repo."
+    },
+    "LibPinDriftCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor (Lambda alpha-engine-predictor-inference, gate mode)",
+      "reason": "Gate mode \u2014 compares nousergon-lib pins across the fleet. crucible-predictor contains no krepis.llm.LLMClient construction site anywhere in the repo."
+    },
+    "PipelineContractCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor (Lambda alpha-engine-predictor-inference, gate mode)",
+      "reason": "Gate mode \u2014 asserts the definition's own contract invariants. crucible-predictor contains no krepis.llm.LLMClient construction site anywhere in the repo."
+    },
+    "RegimeSubstrate": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor (Lambda alpha-engine-predictor-regime-substrate)",
+      "reason": "Quantitative regime features. no paid-model call site in the substrate anywhere in crucible-predictor."
+    },
+    "RegimeRetrospectiveEval": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor (Lambda alpha-engine-predictor-regime-retrospective-eval)",
+      "reason": "Scores prior regime calls against realized returns. no paid-model call site in the substrate anywhere in crucible-predictor."
+    },
+    "WeeklyPreflight": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-preflight",
+      "reason": "Preflight sweep over AWS control-plane state. no paid-model call site in the substrate."
+    },
+    "NormalizeRunDates": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-preflight (normalize mode)",
+      "reason": "Resolves run_date to the NYSE trading day. no paid-model call site in the substrate."
+    },
+    "RunScope": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-run-scope",
+      "reason": "Derives per-stage disposition from the execution history. no paid-model call site in the substrate."
+    },
+    "WeeklyCoverageSweep": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-coverage-sweep",
+      "reason": "Rolls up stage-coverage verdicts. no paid-model call site in the substrate."
+    },
+    "SubstrateHealthGate": {
+      "disposition": "exempt",
+      "substrate": "Lambda alpha-engine-substrate-health-gate",
+      "reason": "Pre-spend substrate probe. no paid-model call site in the substrate."
+    },
+    "DispatchWeeklyFreshnessSpot": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-freshness-spot-dispatcher",
+      "reason": "Boots a spot instance and returns. Any model spend belongs to the SSM stage that later runs ON that instance, which is declared separately; attributing it here would double-count."
+    },
+    "RelaunchWeeklyFreshnessSpot": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/weekly-freshness-spot-dispatcher",
+      "reason": "Boots a spot instance and returns. Any model spend belongs to the SSM stage that later runs ON that instance, which is declared separately; attributing it here would double-count."
+    },
+    "DispatchEvalJudgeSpot": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data infrastructure/lambdas/eval-judge-spot-dispatcher",
+      "reason": "Boots the judge spot instance and returns. The judge's spend is declared under EvalJudgeProcess, the stage that runs on it."
+    },
+    "MorningEnrich": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data collectors (data spot)",
+      "reason": "Numerical workload \u2014 OHLCV/intraday collection. no paid-model call site in the substrate."
+    },
+    "DataPhase1": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data collectors (data spot)",
+      "reason": "Numerical workload \u2014 the weekly price-cache refresh. no paid-model call site in the substrate."
+    },
+    "DataPhase2": {
+      "disposition": "exempt",
+      "substrate": "nousergon-data collectors (data spot)",
+      "reason": "Numerical workload \u2014 the second weekly collection phase. no paid-model call site in the substrate."
+    },
+    "PredictorTraining": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor training/ (spot)",
+      "reason": "Numerical workload \u2014 gradient-boosted model training. no paid-model call site in the substrate."
+    },
+    "ResolveZooSpecs": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor training/model_zoo.py (spot)",
+      "reason": "Numerical workload \u2014 listing rotation specs. no paid-model call site in the substrate."
+    },
+    "TrainSpecDispatch": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor training/ (spot map)",
+      "reason": "Numerical workload \u2014 one model-zoo spec's training run. no paid-model call site in the substrate."
+    },
+    "ModelZooSelect": {
+      "disposition": "exempt",
+      "substrate": "crucible-predictor training/model_zoo.py (spot)",
+      "reason": "Numerical workload \u2014 champion selection over trained models. no paid-model call site in the substrate."
+    },
+    "Backtester": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester backtest.py (spot)",
+      "reason": "Numerical workload \u2014 portfolio simulation. no paid-model call site in the substrate."
+    },
+    "PredictorBacktest": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester (spot)",
+      "reason": "Numerical workload \u2014 predictor-signal backtesting. no paid-model call site in the substrate."
+    },
+    "PortfolioOptimizerBacktest": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester optimizer/ (spot)",
+      "reason": "Numerical workload \u2014 portfolio-optimizer backtesting. no paid-model call site in the substrate."
+    },
+    "PitParityLookahead": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester (spot)",
+      "reason": "Numerical workload \u2014 point-in-time lookahead parity. no paid-model call site in the substrate."
+    },
+    "PitParityWalkforward": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester (spot)",
+      "reason": "Numerical workload \u2014 point-in-time walkforward parity. no paid-model call site in the substrate."
+    },
+    "ParityReplay": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester (spot)",
+      "reason": "Numerical workload \u2014 the parity replay leg. no paid-model call site in the substrate."
+    },
+    "PitParityCompare": {
+      "disposition": "exempt",
+      "substrate": "crucible-backtester (spot)",
+      "reason": "Numerical workload \u2014 comparing the two parity legs. no paid-model call site in the substrate."
+    },
+    "EvaluatorDiagnostics": {
+      "disposition": "exempt",
+      "substrate": "crucible-evaluator (spot)",
+      "reason": "Numerical workload \u2014 evaluator diagnostics. no paid-model call site in the substrate."
+    },
+    "EvaluatorOptimize": {
+      "disposition": "exempt",
+      "substrate": "crucible-evaluator (spot)",
+      "reason": "Numerical workload \u2014 guardrail-gated parameter optimization. no paid-model call site in the substrate."
+    },
+    "SaturdayHealthCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-dashboard health_checker.py (dashboard box)",
+      "reason": "Numerical workload \u2014 the weekly health sweep. no paid-model call site in the substrate."
+    },
+    "WeeklySubstrateHealthCheck": {
+      "disposition": "exempt",
+      "substrate": "crucible-dashboard (dashboard box)",
+      "reason": "Numerical workload \u2014 the weekly substrate health sweep. no paid-model call site in the substrate."
+    },
+    "PitParityLookaheadResourceKillCheck": {
+      "disposition": "exempt",
+      "substrate": "krepis.resource_kill probe over the parity spot instance",
+      "reason": "Reads dmesg/exit status to tell an OOM kill from a workload failure. Runs no workload of its own. no paid-model call site in the substrate."
+    },
+    "PitParityWalkforwardResourceKillCheck": {
+      "disposition": "exempt",
+      "substrate": "krepis.resource_kill probe over the parity spot instance",
+      "reason": "Reads dmesg/exit status to tell an OOM kill from a workload failure. Runs no workload of its own. no paid-model call site in the substrate."
+    }
+  }
+}

--- a/tests/test_sf_cost_fanin_stage_census.py
+++ b/tests/test_sf_cost_fanin_stage_census.py
@@ -1,0 +1,218 @@
+"""Every work-dispatching weekly stage is classified for cost attribution.
+
+**The half that was missing.** ``tests/test_sf_cost_fanin_coverage.py`` checks
+the declaration against the definition: every stage NAMED in the
+``AggregateCosts`` coverage block must exist, be a Task, and precede the
+aggregator. That catches a rename. It cannot catch the other direction, which
+is the one that costs money — a stage present in the definition and named in
+NO set at all. Such a stage is not "allowed"; it is *unconsidered*, and its
+silence at fan-in time is indistinguishable from a stage that legitimately
+spends nothing.
+
+That is exactly the shape of ``alpha-engine-config-I7179``, where the
+aggregator was rolling up Think Tank spend while every LLM-calling stage of
+the pipeline emitted nothing, and every scalar on the dashboard was right.
+The fix then was to name four producers. Nothing made the naming *exhaustive*,
+so the next stage added inherits the same silence.
+
+``infrastructure/cost_fanin_stage_census.json`` is that exhaustive statement,
+and this file is what makes it binding: a new Lambda or SSM stage fails CI
+until someone writes down which of three things it is and why. `principles.md`
+2.7 — a component emitting nothing is not healthy, it is unobserved, and *no
+data* is never rendered as green.
+
+**Why three dispositions and not two.** An ``exempt``/``emits`` binary forces
+a stage that really does spend money without emitting into the exempt column,
+where it reads as "costs nothing" forever. ``unattributed`` is the honest
+third answer, and it must carry a tracked issue — so a real gap is a dated
+debt rather than a laundered exemption. ``RAGIngestion`` is the live one:
+measured 2026-08-31, it calls the paid Voyage embedding API through
+``voyageai.Client`` directly rather than through ``krepis.llm.LLMClient``, so
+it writes no ``_cost_raw`` object and the fan-in check structurally cannot see
+it.
+
+**Scope: work-dispatching stages only.** A stage is in scope when it invokes a
+Lambda or runs an SSM shell command — the only two ways this definition causes
+code to execute. ``sns:publish``, ``Pass``, ``Choice``, ``Wait`` and the
+``aws-sdk`` integrations (``s3:putObject``, ``ssm:getCommandInvocation``,
+``dynamodb:putItem``) run no code of ours and cannot call a model. Scoping by
+the mechanism rather than by a hand-kept skip list means a new state is in
+scope the moment it can execute anything.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_INFRA = Path(__file__).resolve().parent.parent / "infrastructure"
+_SF = _INFRA / "step_function.json"
+_CENSUS = _INFRA / "cost_fanin_stage_census.json"
+
+_VALID_DISPOSITIONS = {"emits", "exempt", "unattributed"}
+
+
+def _walk(states: dict):
+    """Every state in the definition, including inside Branches/Iterators."""
+    for name, state in states.items():
+        yield name, state
+        for branch in state.get("Branches", []) or []:
+            yield from _walk(branch["States"])
+        inner = state.get("Iterator") or state.get("ItemProcessor")
+        if inner:
+            yield from _walk(inner["States"])
+
+
+def _work_dispatching(states: dict) -> dict:
+    """Stages that cause code of ours to run: Lambda invoke or SSM shell."""
+    out = {}
+    for name, state in _walk(states):
+        if state.get("Type") != "Task":
+            continue
+        params = state.get("Parameters") or {}
+        resource = state.get("Resource", "")
+        if (
+            params.get("FunctionName")
+            or params.get("DocumentName") == "AWS-RunShellScript"
+            or resource.startswith("arn:aws:lambda")
+        ):
+            out[name] = state
+    return out
+
+
+@pytest.fixture(scope="module")
+def sf() -> dict:
+    return json.loads(_SF.read_text())
+
+
+@pytest.fixture(scope="module")
+def census() -> dict:
+    return json.loads(_CENSUS.read_text())
+
+
+@pytest.fixture(scope="module")
+def stages(sf) -> dict:
+    return _work_dispatching(sf["States"])
+
+
+@pytest.fixture(scope="module")
+def coverage(sf) -> dict:
+    return sf["States"]["AggregateCosts"]["Parameters"]["Payload"]["coverage"]
+
+
+def test_the_scope_filter_finds_stages(stages):
+    """Guards the check itself: an empty scope would pass every test below
+    vacuously, which is the failure mode this whole file exists to refuse."""
+    assert len(stages) >= 40, (
+        f"only {len(stages)} work-dispatching stage(s) found — the scope filter "
+        f"is broken, and a vacuous census is worse than none"
+    )
+
+
+def test_every_work_dispatching_stage_is_classified(stages, census):
+    """The load-bearing assertion. A new Lambda or SSM stage cannot merge
+    without a written answer to 'does this spend money, and where does the
+    record go?'"""
+    missing = sorted(set(stages) - set(census["stages"]))
+    assert not missing, (
+        f"{len(missing)} weekly stage(s) run code and are classified nowhere: "
+        f"{', '.join(missing)}. Add each to "
+        f"infrastructure/cost_fanin_stage_census.json as 'emits' (and declare "
+        f"its producer in the AggregateCosts coverage block), 'exempt' (with a "
+        f"reason naming why its substrate cannot call a paid model), or "
+        f"'unattributed' (with the tracked issue for the gap). An unclassified "
+        f"stage's silence at fan-in time is indistinguishable from a stage that "
+        f"costs nothing."
+    )
+
+
+def test_the_census_names_no_stage_that_left_the_definition(stages, census):
+    """A stale row is a claim about a topology that no longer exists, and it
+    would keep a deleted stage's exemption alive for whatever is added under
+    that name next."""
+    stale = sorted(set(census["stages"]) - set(stages))
+    assert not stale, (
+        f"census names {len(stale)} stage(s) the definition no longer "
+        f"dispatches work to: {', '.join(stale)}"
+    )
+
+
+@pytest.mark.parametrize("field", ["disposition", "substrate", "reason"])
+def test_every_row_is_complete(census, field):
+    bad = sorted(n for n, e in census["stages"].items() if not str(e.get(field, "")).strip())
+    assert not bad, f"census rows with an empty '{field}': {', '.join(bad)}"
+
+
+def test_every_disposition_is_one_of_the_three(census):
+    bad = {
+        n: e.get("disposition")
+        for n, e in census["stages"].items()
+        if e.get("disposition") not in _VALID_DISPOSITIONS
+    }
+    assert not bad, f"unknown disposition(s): {bad}"
+
+
+def test_reasons_are_reasons(census):
+    """A one-word reason ('n/a', 'none', 'no') is an absence wearing a
+    justification's clothes."""
+    thin = sorted(
+        n for n, e in census["stages"].items() if len(e["reason"].split()) < 5
+    )
+    assert not thin, (
+        f"census rows whose reason says nothing: {', '.join(thin)}. The reason "
+        f"has to name why this stage's substrate cannot spend, specifically "
+        f"enough that the next reader can check it."
+    )
+
+
+def test_every_unattributed_row_names_a_tracked_issue(census):
+    """An unattributed row is a DEBT. Without an issue it is a permanent
+    exemption with a more honest label, which is worse than an exemption
+    because it looks like it is being tracked."""
+    bad = sorted(
+        n for n, e in census["stages"].items()
+        if e["disposition"] == "unattributed"
+        and not str(e.get("issue", "")).strip()
+    )
+    assert not bad, (
+        f"unattributed stage(s) with no tracked issue: {', '.join(bad)}"
+    )
+
+
+def test_the_emits_set_is_exactly_the_declared_set(census, coverage):
+    """The census and the coverage block cannot drift.
+
+    Two files stating the same fact is a defect unless something forces them
+    to agree. Declaring a producer without censusing the stage would let the
+    census under-report; censusing a stage as 'emits' without declaring a
+    producer would claim an attribution the aggregator never checks.
+    """
+    censused = {n for n, e in census["stages"].items() if e["disposition"] == "emits"}
+    declared = set(coverage.get("required_producers") or {}) | set(
+        coverage.get("conditional_producers") or {}
+    )
+    assert censused == declared, (
+        f"census 'emits' set and the AggregateCosts coverage block disagree — "
+        f"census only: {sorted(censused - declared)}; "
+        f"coverage only: {sorted(declared - censused)}"
+    )
+
+
+def test_the_live_unattributed_gap_is_still_recorded(census):
+    """RAGIngestion, measured 2026-08-31.
+
+    Pinned so that flipping it to 'exempt' has to happen in a diff someone
+    reads, not in a quiet edit. It becomes 'emits' when the Voyage call is
+    routed through krepis and declares a producer; it becomes 'exempt' only if
+    the paid embedding call leaves the stage entirely.
+    """
+    row = census["stages"].get("RAGIngestion")
+    assert row is not None, "RAGIngestion left the census"
+    assert row["disposition"] in {"unattributed", "emits"}, (
+        f"RAGIngestion is recorded as '{row['disposition']}'. It calls the paid "
+        f"Voyage embedding API (nousergon_lib/rag/embeddings.py, voyageai.Client "
+        f"— not krepis.llm.LLMClient), so it cannot be exempt while that call "
+        f"stands."
+    )


### PR DESCRIPTION
## What this fixes

The `AggregateCosts` coverage block declares four stages. `tests/test_sf_cost_fanin_coverage.py` checks *declaration -> definition* — every declared stage exists, is a Task, precedes the aggregator. That catches a rename.

Nothing checked *definition -> declaration*. A stage can be added to `ne-weekly-freshness-pipeline`, spend real money, and appear in **no** set at all. Its silence at fan-in time is then indistinguishable from a stage that legitimately costs nothing — the `alpha-engine-config-I7179` defect's exact shape, recurring because the naming was made correct once and never made exhaustive.

MEASURED 2026-08-31: 51 work-dispatching stages in the weekly definition. Four were classified.

## What lands

- `infrastructure/cost_fanin_stage_census.json` — all 51 stages, each with `disposition`, `substrate`, and a written `reason`.
- `tests/test_sf_cost_fanin_stage_census.py` — a new Lambda or SSM stage fails CI until classified; the census cannot drift from the coverage block; a reason under five words is refused; a stale row naming a departed stage is refused.

**Scope is by mechanism, not by a skip list.** A stage is in scope when it invokes a Lambda or runs `AWS-RunShellScript` — the only two ways this definition executes code of ours. `sns:publish`, `Pass`, `Choice`, `Wait` and the `aws-sdk` integrations run nothing of ours. A new state is therefore in scope the moment it can execute anything, with nobody having to remember to add it.

**Three dispositions, not two.** An `emits`/`exempt` binary forces a stage that really does spend without emitting into the `exempt` column, where it reads as "costs nothing" forever. `unattributed` is the honest third answer and must name a tracked issue — `principles.md` §2.7, absence explicit and reasoned rather than silent.

## The live gap this surfaced

One `unattributed` row. `RAGIngestion` calls the paid Voyage embedding API (`nousergon_lib/rag/embeddings.py`, `voyageai.Client`, `voyage-3-lite`) directly rather than through `krepis.llm.LLMClient`, so it writes no `_cost_raw` object and the fan-in check structurally cannot see its spend. Filed as `alpha-engine-config-I9694`; `test_the_live_unattributed_gap_is_still_recorded` pins it so a flip to `exempt` has to happen in a diff someone reads.

## Skipped is not exempt

A stage skipped by a `skip_*` flag emitted no cost record and correctly so; a stage that RAN and emitted nothing is the defect. Those are already told apart at runtime and this PR does not change that: `crucible-research/scripts/cost_coverage.py::evaluate_coverage` builds `expected` as `{cid for stage, ids in required.items() if stage in entered}`, where `entered` comes from the execution's own `get_execution_history` — a declared stage that did not enter drops out of `expected` and is reported under `stages_not_entered`. Verified live on `watch-rerun-2026-08-28-13`, whose verdict read `expected: ['evaljudge-sync'], stages_not_entered: ['ChallengerShadow', 'Director', 'ReplayConcordance']`.

**Nothing in this census is exempt for having been skipped.** Every `exempt` reason is a claim about the *substrate* — that the code the stage runs contains no paid-model call site — which is true on every run, skipped or not. That is deliberate: a skip-derived exemption would be a fact about one execution masquerading as a fact about the topology, and it would go stale the first time the flag flipped.

This matters more than usual right now. Every SUCCEEDED weekly execution in the last three weeks is either a Thu/Fri `WeeklyRunDayGate` Succeed-skip or a `watch-rerun` carrying 21-22 skip flags; `watch-rerun-2026-08-28-13` entered 123 of 465 states and did not enter `AggregateCosts` at all. So no recent green run is evidence that the producer set is correct — it is evidence the stage was skipped. This census is derived from the **definition**, never from what a run happened to emit, which is why it can establish the set before the 2026-09-05 canonical run rather than after it. The all-skipped-rerun-reports-SUCCEEDED defect itself is `alpha-engine-config-I9693` and is deliberately out of scope here.

## Measured basis for the exemptions

The complete set of `krepis.llm.LLMClient` construction sites in the fleet, measured against `origin/main` of every repo on 2026-08-31:

- `crucible-research`: `evals/judge.py`, `evals/orchestrator.py`, `producers/single_agent.py`, `thinktank/client.py`, `scripts/live_validate_openrouter_judge.py`
- `crucible-evaluator`: `director/agent.py`, `director/retro.py`
- `crucible-backtester`: `replay/runner.py`

`crucible-predictor`, `nousergon-data`, `nousergon-lib`, `crucible-executor` and `crucible-dashboard` have none. Every `exempt` row rests on that census and says so.

## Testing

`pytest tests/` — 6977 passed, 17 skipped, 2 failed. Both failures are `tests/test_pipeline_status_registry_source_check.py` on the **weekday** SF, and the assertion prints its own diagnosis: installed `nousergon-lib` is `v0.124.21` against a `v0.124.104` pin (`alpha-engine-config-I9070`). Untouched by this PR; CI installs the pin.

No post-merge step. Test-and-declaration only — no Lambda, no SF deployment, no IAM.

Refs `alpha-engine-config-I9692`. Out-of-scope findings filed: `alpha-engine-config-I9694`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNPRFcn3jXegskpo8UPxWk
