### PR TITLE
fix(workflows): two detectors declare that their red is a FINDING (alpha-engine-config-I9169)

### DIFF
--- a/.github/workflows/pause-check-alert.yml
+++ b/.github/workflows/pause-check-alert.yml
@@ -59,6 +59,25 @@ permissions:
   id-token: write   # required for OIDC
   contents: read
 
+# WORKFLOW HEALTH SEMANTICS (alpha-engine-config-I9169).
+# Read by alpha-engine-config's scripts/check_scheduled_workflow_health.py out
+# of THIS file, so the declaration cannot outlive the steps it describes. A
+# non-zero exit at a declared finding step is graded `reporting_findings`
+# (visible, not counted unhealthy, and no "this control has never once
+# succeeded" issue filed against it); a failure ANYWHERE else - checkout, an
+# OIDC role that no longer exists, a dependency install - and a run that never
+# started at all are graded exactly as before. Renaming a step below without
+# updating this list is caught by `--validate-declarations`.
+env:
+  WORKFLOW_HEALTH_SEMANTICS: finding-surface
+  WORKFLOW_HEALTH_FINDING_STEPS: |
+    Scheduled-automation pause still holds (live) — page on drift
+  WORKFLOW_HEALTH_FINDING_ISSUE: alpha-engine-config-I6703
+  WORKFLOW_HEALTH_FINDING_REASON: >-
+    Exits 1 when a trigger listed in automation_pause.json is live
+    ENABLED again - the non-zero exit IS the pause-drift finding, and
+    paging on it is the step's declared job.
+
 jobs:
   check-and-alert:
     runs-on: ubuntu-latest

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -64,6 +64,25 @@ permissions:
   id-token: write   # required for OIDC
   contents: read
 
+# WORKFLOW HEALTH SEMANTICS (alpha-engine-config-I9169).
+# Read by alpha-engine-config's scripts/check_scheduled_workflow_health.py out
+# of THIS file, so the declaration cannot outlive the steps it describes. A
+# non-zero exit at a declared finding step is graded `reporting_findings`
+# (visible, not counted unhealthy, and no "this control has never once
+# succeeded" issue filed against it); a failure ANYWHERE else - checkout, an
+# OIDC role that no longer exists, a dependency install - and a run that never
+# started at all are graded exactly as before. Renaming a step below without
+# updating this list is caught by `--validate-declarations`.
+env:
+  WORKFLOW_HEALTH_SEMANTICS: finding-surface
+  WORKFLOW_HEALTH_FINDING_STEPS: |
+    Drift-check gate (fail the job on any failed check above)
+  WORKFLOW_HEALTH_FINDING_ISSUE: alpha-engine-config-I3697
+  WORKFLOW_HEALTH_FINDING_REASON: >-
+    Every individual drift check runs; this final gate step exits 1 to
+    surface a finding one of them recorded - the aggregator doing its
+    job, not a broken check.
+
 jobs:
   drift-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -76,12 +76,31 @@ permissions:
 env:
   WORKFLOW_HEALTH_SEMANTICS: finding-surface
   WORKFLOW_HEALTH_FINDING_STEPS: |
+    Scheduled-automation pause still holds (live)
+    Overseer playbook arming (declared pause vs live, live)
+    Weekly exercise-cadence drift (manifest vs live SSM)
+    EventBridge SF-ARN drift (codified vs live)
+    SF LoggingConfiguration drift (codified vs live)
+    SF lambda:invoke Lambda-existence check (codified vs live)
+    SF definition drift (codified vs live vs S3-staged)
+    EventBridge Scheduler rule drift (fleet-wide, codified vs live)
+    schedule-manifest.json drift (fleet-wide, vs live AWS)
+    Playbook trigger surface drift (playbooks.yaml vs live AWS)
     Drift-check gate (fail the job on any failed check above)
   WORKFLOW_HEALTH_FINDING_ISSUE: alpha-engine-config-I3697
   WORKFLOW_HEALTH_FINDING_REASON: >-
-    Every individual drift check runs; this final gate step exits 1 to
-    surface a finding one of them recorded - the aggregator doing its
-    job, not a broken check.
+    Ten independent drift detectors plus the gate that reddens the job
+    on any of them. Each exits 1 when codified state and live AWS have
+    diverged - the finding, not a broken check. All ten are
+    continue-on-error and still report conclusion=failure to the jobs API,
+    so each must be named here or the workflow stays un-muted: measured
+    2026-08-31 over the 14-day window, the FIRST failing step was
+    'Scheduled-automation pause still holds (live)' 42 times, the gate 15,
+    'SF definition drift' 3 and the lambda-existence check once.
+    'Configure AWS credentials via OIDC', 'Publish the arming record'
+    and 'Paused-component alarm actions reconciled with the manifest'
+    are deliberately NOT declared: the last is REMEDIATION, and a
+    remediation step failing is a real break, not a finding.
 
 jobs:
   drift-check:


### PR DESCRIPTION
Tracker: alpha-engine-config-I9169

## What this is

Two detectors in this repo exit non-zero **because they found something**. The sched-health reconciler grades on run conclusion alone, so both read `failing` — which sends a reader to repair a control that is working.

`alpha-engine-config-PR9696` gives a workflow a way to say so **in its own file**. This PR is this repo's half of that.

## What was measured (2026-08-31, live)

Failing step read from `GET /repos/nousergon/nousergon-data/actions/runs/{id}/jobs` for each workflow's five most recent failing runs on `main`:

| workflow | graded | failing step | runs |
|---|---|---|---|
| `pause-check-alert.yml` | `failing` | `Scheduled-automation pause still holds (live) — page on drift` | 5 of 5 |
| `sf-arn-drift-check.yml` | `failing` | ten drift detectors **plus** `Drift-check gate (fail the job on any failed check above)` | 61 failing runs in the window |

The first pages when a trigger listed in `automation_pause.json` is live ENABLED again — that page **is** the step's declared job (findings tracked at `alpha-engine-config-I6703`).

The second needed the whole detector set, not just the gate (`alpha-engine-config-I3697`). Declaring the gate alone was measured and **did not work**: over the 14-day window the *first* failing step was `Scheduled-automation pause still holds (live)` 42 times, the gate only 15, `SF definition drift` 3 and the lambda-existence check once. Every one of the ten detectors is `continue-on-error`, and **a `continue-on-error` step still reports `conclusion: failure` to the jobs API** — so the reconciler saw an undeclared step name on 46 of 61 failing runs and correctly refused to mute. All ten are now named.

Three steps are deliberately **not** declared: `Configure AWS credentials via OIDC`, `Publish the arming record`, and `Paused-component alarm actions reconciled with the manifest (live)`. The last is **remediation**, not detection — a remediation step failing is a real break.

## Semantics

A declared finding step's non-zero exit grades `reporting_findings` — visible on the console and in the report, **not** counted unhealthy, and no `[sched-health]` issue filed. Everything else is unchanged:

- a failure at any other step keeps the original grade — and if **any** failing run in the window failed elsewhere, the whole workflow keeps it;
- a `startup_failure` / `timed_out` / `action_required` run keeps the original grade: a finding surface that cannot start is dark;
- `no_runs` / `throttled` untouched.

## Testing

- `pytest -q` — **6966 passed, 17 skipped, 2 failed**. Both failures are `tests/test_pipeline_status_registry_source_check.py`, pre-existing and unrelated: the test's own message names the cause (`installed nousergon-lib v0.124.21` vs `requirements.txt` pin `v0.124.104` — a local environment drift tracked as `alpha-engine-config-I9070`, not SF drift). CI installs the pin, so they are green there.
- Every workflow file parses (`yaml.safe_load` over `.github/workflows/*.y*ml`).
- `workflow_health_semantics.py --workflow-dir .github/workflows` from the PR9696 branch: **2 declared finding surfaces, all valid** — each of the 11 declared step names matched a step that exists in the same file.
- **Live dry-run** of PR9696's reconciler against this repo: `total=43 unhealthy=3` → **`unhealthy=2`**. `pause-check-alert.yml` `failing` → `reporting_findings`. `sf-arn-drift-check.yml` stayed `failing` under the gate-only declaration, which is what surfaced the `continue-on-error` finding above.

The declarations are inert until PR9696 merges (nothing reads these keys today), and they are plain workflow-level environment entries, so they cannot change any job's behaviour.

## Cross-repo

- `alpha-engine-config-PR9696` — the reader and the CI guard. **Merge first.**
- `nous-ergon-ops-PR957` — the same declaration for four detectors there. **Merged 2026-09-01T03:48Z.**
- `nous-ergon-ops-PR959` — the same `continue-on-error` widening for `iam-drift-check.yml`.

Order matters only for when the effect appears, not for correctness: merged alone, these keys are unread environment variables.

---

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)
