### PR TITLE
fix(sf): the stage-timeout guard was blind to 7 real defects (alpha-engine-config-I9702)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -137,8 +137,24 @@ jobs:
       # findings, remediation never reached. Repair-then-verify also makes the
       # verify meaningful: a `--check` failure now means remediation ran and did
       # not hold, which is the escalation-worthy condition.
+      #
+      # NOT `continue-on-error`, and it carries an `id` (alpha-engine-config-
+      # I9702 arc, 2026-09-01). This step is REMEDIATION, and the gate's own
+      # comment below already says so — "a remediation step failing is a real
+      # break, not a finding" — but the step was tolerated anyway and was the
+      # ONE step in this workflow with no `id`, so the outcome aggregator that
+      # covers its ten siblings could not see it at all.
+      #
+      # What that hid, measured 2026-09-01 on run 33518203668: every invocation
+      # has been dying on `AccessDenied ... not authorized to perform:
+      # cloudwatch:DisableAlarmActions`. The self-healing loop has never once
+      # been able to heal. Tolerated and unnamed, that read as "remediation ran,
+      # drift persists" rather than "remediation is not permitted", so the
+      # verify step below reported the same five findings run after run — first
+      # failing step 42 times in the 14 days to 2026-08-31 — and the real cause
+      # was a missing IAM action nobody was looking for.
       - name: Paused-component alarm actions reconciled with the manifest (live)
-        continue-on-error: true
+        id: pause_remediation
         run: python3 infrastructure/automation_pause.py --enforce --alarms-only
 
       # Brian ruling 2026-08-07: all scheduled automation paused except the
@@ -211,6 +227,21 @@ jobs:
         id: sf_logging_drift
         continue-on-error: true
         run: python3 infrastructure/step-functions/check-drift.py
+
+      # alpha-engine-config-I9702. The sibling above asks whether a referenced
+      # Lambda EXISTS; this asks whether the timeout this repo has codified for
+      # it is still the timeout it carries. Those timeouts are what
+      # tests/test_sf_lambda_timeout_ordering.py grades every stage's declared
+      # `TimeoutSeconds` against, and they are deployed from four other
+      # repositories — so the table drifts on someone else's merge and nothing
+      # here notices. The assertion existed as a test guarded by
+      # `SF_TIMEOUT_LIVE_CHECK`, set in no workflow anywhere, and had therefore
+      # never run. Belongs on this trigger set by this file's own criterion:
+      # it reads live AWS.
+      - name: Lambda timeout drift (codified table vs live)
+        id: lambda_timeout_drift
+        continue-on-error: true
+        run: python3 infrastructure/step-functions/check-lambda-timeout-drift.py
 
       - name: SF lambda:invoke Lambda-existence check (codified vs live)
         id: sf_lambda_existence
@@ -319,6 +350,7 @@ jobs:
             eventbridge_arn_drift=${{ steps.eventbridge_arn_drift.outcome }}
             sf_logging_drift=${{ steps.sf_logging_drift.outcome }}
             sf_lambda_existence=${{ steps.sf_lambda_existence.outcome }}
+            lambda_timeout_drift=${{ steps.lambda_timeout_drift.outcome }}
             sf_definition_drift=${{ steps.sf_definition_drift.outcome }}
             scheduler_rule_drift=${{ steps.scheduler_rule_drift.outcome }}
             schedule_manifest_drift=${{ steps.schedule_manifest_drift.outcome }}

--- a/infrastructure/sf_definitions.py
+++ b/infrastructure/sf_definitions.py
@@ -1,0 +1,271 @@
+"""One walk of the codified Step Functions definitions, shared by every checker.
+
+WHY THIS MODULE EXISTS (alpha-engine-config-I9702 arc, 2026-09-01).
+
+Two checkers in this repo each carried their own private copy of "find every
+`lambda:invoke` state and reduce its `FunctionName` to a bare function name":
+
+  * ``infrastructure/step-functions/check-lambda-existence.py`` — correct. It
+    matches the `.waitForTaskToken`/`.sync` resource variants and normalizes
+    all three `FunctionName` shapes through ``_FULL_ARN_RE``.
+  * ``tests/test_sf_lambda_timeout_ordering.py`` — wrong, in three ways at
+    once, and silently:
+
+      1. ``raw.split(":")[-2]`` on a full ARN yields the literal string
+         ``"function"``, not the function name. Four states carry a full ARN:
+         `SubstrateHealthGate` (weekly) and `WaitForCodeFreshness`,
+         `WaitForCorrectnessVerdict`, `WaitForMorningPlanner` (preopen).
+      2. The completeness check that exists PRECISELY to stop a state being
+         skipped silently — "a function missing from the map is an unchecked
+         stage, not a passing one" — carried ``not fn.startswith("function")``,
+         so it whitelisted exactly the mis-parse in (1). The guard against
+         silent exemption exempted them silently.
+      3. ``resource.endswith(":lambda:invoke")`` misses the `.waitForTaskToken`
+         and `.sync` variants entirely.
+
+    Net effect measured 2026-09-01: three preopen states declared
+    ``TimeoutSeconds: 65`` against a 30s function, and one weekly state
+    declared 90 against a 90s function, and the guard whose whole job is to
+    catch that reported green for both — for as long as it has existed.
+
+    It also walked only three of the four codified definitions, so every
+    `lambda:invoke` state in ``step_function_groom.json`` had never been
+    checked at all. Three of its four synchronous states were inverted.
+
+That is the "a contract restated twice has already drifted" class. The fix is
+not to repair the second copy; it is to delete it. Both checkers now import
+from here, so a definition shape this module cannot parse fails BOTH of them
+rather than passing one silently.
+
+THE `.waitForTaskToken` CARVE-OUT IS SEMANTIC, NOT AN EXEMPTION. For a
+synchronous ``lambda:invoke`` the state's ``TimeoutSeconds`` and the function's
+own ``Timeout`` are two ceilings on the SAME wait, and only the smaller fires —
+so the state's must be the smaller or it describes nothing. For
+``lambda:invoke.waitForTaskToken`` they measure DIFFERENT things: the function
+returns immediately after handing off a task token, and the state's timeout
+bounds how long the pipeline waits for something else to call
+``SendTaskSuccess``. A state timeout far above the function timeout is the
+CORRECT shape there (``LaunchGroomSpot`` declares 13800s against a 300s
+function and is right to). ``is_ordering_governed`` is where that distinction
+lives, so no caller has to re-derive it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+_INFRA = Path(__file__).resolve().parent
+
+# repo definition file -> live state machine name. The SINGLE codified list;
+# check-lambda-existence.py and the timeout-ordering guard both read it, so a
+# definition added to the fleet is covered by both or by neither — never by one.
+SF_DEFINITIONS: tuple[dict[str, str], ...] = (
+    {"sf_name": "ne-weekly-freshness-pipeline", "definition_file": "step_function.json"},
+    {"sf_name": "ne-preopen-trading-pipeline", "definition_file": "step_function_daily.json"},
+    {"sf_name": "ne-postclose-trading-pipeline", "definition_file": "step_function_eod.json"},
+    {"sf_name": "alpha-engine-groom-dispatch", "definition_file": "step_function_groom.json"},
+)
+
+DEFINITION_FILES: tuple[str, ...] = tuple(d["definition_file"] for d in SF_DEFINITIONS)
+
+LAMBDA_INVOKE_RESOURCE_RE = re.compile(
+    r"^arn:aws:states:::lambda:invoke(\.(waitForTaskToken|sync|sync:2))?$"
+)
+
+# A full Lambda ARN, with an optional :version-or-alias qualifier.
+_FULL_ARN_RE = re.compile(r"^arn:aws:lambda:[\w-]+:\d+:function:([^:]+)(:.+)?$")
+
+# Lambda's hard service maximum. A function AT this value cannot be raised, so
+# the SF-vs-function ordering rule inverts for it — see the timeout-ordering
+# guard's `_SERVICE_MAX_GUARD_BAND`.
+LAMBDA_SERVICE_MAX_SEC = 900
+
+
+@dataclass(frozen=True)
+class LambdaInvokeState:
+    """One `lambda:invoke` task state, with everything a checker needs.
+
+    ``function_name`` is the raw value as written in the definition, or None
+    when the state declares no ``Parameters.FunctionName`` at all — absent and
+    empty are different defects and a checker should be able to say which;
+    ``normalized_name`` is the bare name the Lambda API accepts. Both are kept
+    because an error message naming only the normalized form sends a reader
+    looking for a string that does not appear in the file.
+    """
+
+    definition_file: str
+    state_name: str
+    function_name: str | None
+    normalized_name: str | None
+    timeout_seconds: int | None
+    resource: str
+
+    @property
+    def is_ordering_governed(self) -> bool:
+        """True when the state timeout and the function timeout bound the same wait.
+
+        False for ``.waitForTaskToken``, where the state's timeout bounds a
+        callback the function does not participate in — see the module
+        docstring. ``.sync`` is governed: the service polls the invocation to
+        completion, so the function's own ceiling still fires first.
+        """
+        return not self.resource.endswith(".waitForTaskToken")
+
+
+def normalize_function_name(raw: str) -> str:
+    """Reduce a `FunctionName` value to the bare name the Lambda API accepts.
+
+    Handles all three shapes this fleet's definitions use: a bare name, a bare
+    name with a ``:version-or-alias`` qualifier, and a full ARN with or without
+    that qualifier.
+    """
+    match = _FULL_ARN_RE.match(raw)
+    if match:
+        return match.group(1)
+    return raw.split(":", 1)[0]
+
+
+def load_definition(definition_file: str) -> dict:
+    """Parse one codified definition. Raises rather than returning a sentinel.
+
+    A checker that treats an unparseable definition as "no states to check"
+    reports green on the one condition it most needs to report.
+    """
+    return json.loads((_INFRA / definition_file).read_text(encoding="utf-8"))
+
+
+def lambda_invoke_states(
+    definition_file: str, states: dict | None = None
+) -> Iterator[LambdaInvokeState]:
+    """Every `lambda:invoke` state in one definition, recursing every nesting.
+
+    Descends `Parallel` branches and `Map` iterators (both the older
+    ``Iterator`` key and the newer ``ItemProcessor``): the weekly pipeline's
+    Scanner, every spot-bearing stage and the whole parity chain live inside
+    `ResearchPredictorParallel` or `ParityParallel`, so a top-level-only walk
+    would exempt the majority of the pipeline while looking complete.
+    """
+    if states is None:
+        states = load_definition(definition_file)["States"]
+    for state_name, body in states.items():
+        resource = body.get("Resource")
+        if isinstance(resource, str) and LAMBDA_INVOKE_RESOURCE_RE.match(resource):
+            raw = (body.get("Parameters") or {}).get("FunctionName")
+            raw = raw if isinstance(raw, str) and raw else None
+            yield LambdaInvokeState(
+                definition_file=definition_file,
+                state_name=state_name,
+                function_name=raw,
+                normalized_name=normalize_function_name(raw) if raw else None,
+                timeout_seconds=body.get("TimeoutSeconds"),
+                resource=resource,
+            )
+        for branch in body.get("Branches") or []:
+            yield from lambda_invoke_states(definition_file, branch.get("States") or {})
+        nested = body.get("Iterator") or body.get("ItemProcessor")
+        if isinstance(nested, dict) and "States" in nested:
+            yield from lambda_invoke_states(definition_file, nested["States"])
+
+
+def all_lambda_invoke_states() -> Iterator[LambdaInvokeState]:
+    """Every `lambda:invoke` state across every codified definition."""
+    for definition_file in DEFINITION_FILES:
+        yield from lambda_invoke_states(definition_file)
+
+
+# ── The codified live-timeout table ──────────────────────────────────────────
+#
+# A CLAIM about the live AWS account, not a fact derived from this repo. The
+# functions are deployed from four other repositories, so nothing in a merge
+# here moves them and nothing here notices when they move. Two readers keep it
+# honest, and they must read the SAME declaration or the honesty is theatre:
+#
+#   * tests/test_sf_lambda_timeout_ordering.py — grades each definition's
+#     declared stage timeout against it, in CI, with no credentials.
+#   * infrastructure/step-functions/check-lambda-timeout-drift.py — grades the
+#     table itself against live AWS, on the daily credentialed drift workflow.
+#
+# The second reader is new (alpha-engine-config-I9702 arc, 2026-09-01). The
+# equivalent assertion existed before only as a test guarded by
+# `SF_TIMEOUT_LIVE_CHECK`, an environment variable set in no workflow in this
+# repo — so the check that proves this table is not stale had never run.
+# Live function timeouts, measured 2026-08-11 via
+# `aws lambda get-function-configuration --query Timeout`.
+CODIFIED_FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
+    "alpha-engine-data-spot-dispatcher": 600,
+    "alpha-engine-eod-precondition-probe": 30,
+    "alpha-engine-evaluator": 660,
+    "alpha-engine-evaluator-director": 900,
+    "alpha-engine-predictor-inference": 900,
+    # alpha-engine-config-I7620. Two read-only Step Functions API calls plus a
+    # pure in-memory derivation — no S3 reads, no spot, no model call. Matches
+    # the --bootstrap timeout in
+    # infrastructure/lambdas/weekly-run-scope/deploy.sh; a generous ceiling here
+    # would let an advisory state hold the tail of the weekly run.
+    "alpha-engine-weekly-run-scope": 60,
+    # alpha-engine-config-I8214. ListExecutions + one DescribeExecution and
+    # GetExecutionHistory per contributing execution, a prefix listing, one
+    # PUT and one marker read-modify-write. Bounded by the cycle's execution
+    # count (single digits), not by the ticker universe. Matches the
+    # --bootstrap timeout in
+    # infrastructure/lambdas/weekly-coverage-sweep/deploy.sh; the SF state's
+    # 240s ceiling is deliberately below it so the SF is the one that binds.
+    # MEASURED 2026-08-22 on the first live invocation: 29.4s at 1024 MB,
+    # 675 MB peak, over a 40-execution walk. The original 120s/256 MB sizing
+    # timed out — at 256 MB the function used 256 of 256 and Lambda scales CPU
+    # with memory, so it was CPU-throttled as well as memory-starved.
+    "alpha-engine-weekly-coverage-sweep": 300,
+    "alpha-engine-predictor-regime-retrospective-eval": 600,
+    "alpha-engine-predictor-regime-substrate": 300,
+    "alpha-engine-replay-concordance": 900,
+    "alpha-engine-replay-counterfactual": 600,
+    "alpha-engine-research-aggregate-costs": 300,
+    # alpha-engine-research-eval-judge-poll and -process were RETIRED by
+    # alpha-engine-config-I9329: the poll states existed to drive a provider
+    # batch API that no longer exists (-I9263), and Process moved onto a
+    # dedicated EC2 spot box because the judge covered 8-15 of ~83 artifacts
+    # inside a 900s function. Their rows are removed rather than left behind —
+    # an entry naming a function no SF invokes is an unchecked claim, and
+    # test_the_codified_function_timeouts_match_live would then assert against
+    # a function whose only remaining property is that it is dead.
+    "alpha-engine-research-eval-judge-submit": 300,
+    # The dispatcher that replaces them. 600s covers the handler's worst case:
+    # a spot launch with capacity rotation and an on-demand fallback, plus the
+    # full 300s SSM-online wait, before the async detached send-command. It
+    # does NOT wait for the bootstrap — the SF's own poll loop does that.
+    # Matches --bootstrap's FN_TIMEOUT in
+    # infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh.
+    "alpha-engine-research-eval-judge-spot-dispatcher": 600,
+    # 300 -> 900 by crucible-research infrastructure/deploy.sh in the
+    # alpha-engine-config-I9102 arc (both create AND update paths — the sizing
+    # previously lived only on create, so no merge could ever re-size the live
+    # function). Pinned at the service maximum because the handler is now
+    # self-deadlining; see the guard-band entry below.
+    "alpha-engine-research-eval-rolling-mean": 900,
+    "alpha-engine-research-rationale-clustering": 900,
+    "alpha-engine-research-runner": 900,
+    # 300 -> 450 by crucible-research-PR601 (p95 x 1.5). The Scanner states
+    # moved 600 -> 440 in the same arc so the SF budget binds again.
+    "alpha-engine-research-scanner": 450,
+    "alpha-engine-research-signals-envelope": 300,
+    "alpha-engine-weekly-freshness-spot-dispatcher": 600,
+    "alpha-engine-weekly-preflight": 120,
+    # ── Newly VISIBLE, not newly added (alpha-engine-config-I9702 arc,
+    # 2026-09-01). These three were invoked all along; the old parser reduced
+    # their full-ARN `FunctionName` to the literal "function" and the
+    # completeness guard whitelisted that string, so no row was ever demanded
+    # for them and no ordering assertion ever ran against them.
+    #
+    # MEASURED 2026-09-01, CloudWatch AWS/Lambda Duration, trailing 45 days:
+    #   alpha-engine-ssm-liveness-poller       291 invocations, p95 357ms, max 410ms
+    #   alpha-engine-substrate-health-gate      37 invocations, p95 3.55s,  max 3.57s
+    #   alpha-engine-scheduled-groom-dispatcher 2856 invocations, p95 22.2s,
+    #                                           p99 87.6s, max 195.8s
+    "alpha-engine-ssm-liveness-poller": 30,
+    "alpha-engine-substrate-health-gate": 90,
+    "alpha-engine-scheduled-groom-dispatcher": 300,
+}

--- a/infrastructure/step-functions/check-lambda-existence.py
+++ b/infrastructure/step-functions/check-lambda-existence.py
@@ -55,34 +55,40 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 
-# repo definition file -> live state machine name. Mirrors
-# check-definition-drift.py's SF_DEFINITIONS mapping (this script defines its
-# own copy rather than importing that hyphenated-filename module, matching
-# how check-drift.py in this same directory is also self-contained).
-SF_DEFINITIONS: tuple[dict, ...] = (
-    {"sf_name": "ne-weekly-freshness-pipeline", "definition_file": "step_function.json"},
-    {"sf_name": "ne-preopen-trading-pipeline", "definition_file": "step_function_daily.json"},
-    {"sf_name": "ne-postclose-trading-pipeline", "definition_file": "step_function_eod.json"},
-    {"sf_name": "alpha-engine-groom-dispatch", "definition_file": "step_function_groom.json"},
+from infrastructure.sf_definitions import (  # noqa: E402
+    SF_DEFINITIONS,
+    lambda_invoke_states,
+    normalize_function_name as _normalize_function_name,
 )
 
-_LAMBDA_INVOKE_RESOURCE_RE = re.compile(
-    r"^arn:aws:states:::lambda:invoke(\.(waitForTaskToken|sync|sync:2))?$"
-)
-# Bare-name shape Lambda function names are allowed to take (letters, digits,
-# - and _, up to 64 chars) — used only to sanity-check extraction, not to
-# validate AWS's actual rules.
-_FULL_ARN_RE = re.compile(r"^arn:aws:lambda:[\w-]+:\d+:function:([^:]+)(:.+)?$")
 
+def _walk_states(states: dict) -> list[dict]:
+    """Thin adapter over the shared walk, kept so this module's unit tests
+    exercise the SHARED implementation rather than a second copy of it.
 
+    ``definition_file`` is irrelevant when ``states`` is supplied — the walk
+    only uses it to label results — so a placeholder is passed.
+    """
+    return [
+        {"state_name": s.state_name, "function_name": s.function_name}
+        for s in lambda_invoke_states("<in-memory>", states)
+    ]
+
+# SF_DEFINITIONS, the lambda:invoke walk and the FunctionName normalizer all
+# moved to `infrastructure/sf_definitions.py` (alpha-engine-config-I9702 arc,
+# 2026-09-01). This script's copies were the CORRECT ones; the second copy —
+# in tests/test_sf_lambda_timeout_ordering.py — had drifted and was wrong in
+# three ways, exempting four states from that guard for its whole life. The
+# defect was not in either copy but in there being two, so the fix is one
+# module both import rather than a repair to the broken half.
 def _load_definition(definition_file: str) -> tuple[dict | None, str | None]:
     """Load one SF definition JSON. Returns (definition, error)."""
     path = REPO_ROOT / "infrastructure" / definition_file
@@ -94,43 +100,6 @@ def _load_definition(definition_file: str) -> tuple[dict | None, str | None]:
         return None, f"{path} is not valid JSON: {exc}"
 
 
-def _normalize_function_name(raw: str) -> str:
-    """Reduce a FunctionName value (bare name, full ARN, or name/ARN with a
-    :version-or-alias qualifier) to the bare function name `lambda
-    get-function --function-name` accepts."""
-    m = _FULL_ARN_RE.match(raw)
-    if m:
-        return m.group(1)
-    # Bare name, possibly with a :qualifier suffix (e.g. "name:live").
-    return raw.split(":", 1)[0]
-
-
-def _walk_states(states: dict) -> list[dict]:
-    """Recursively collect every Task state whose Resource targets
-    lambda:invoke (any .waitForTaskToken/.sync suffix), across Map
-    (Iterator/ItemProcessor) and Parallel (Branches) nesting."""
-    found: list[dict] = []
-    for state_name, state in states.items():
-        if state.get("Type") == "Task":
-            resource = state.get("Resource", "")
-            if _LAMBDA_INVOKE_RESOURCE_RE.match(resource):
-                params = state.get("Parameters", {}) or {}
-                function_name = params.get("FunctionName")
-                found.append(
-                    {"state_name": state_name, "function_name": function_name}
-                )
-        # Map state (older "Iterator" key, newer "ItemProcessor" key).
-        for nested_key in ("Iterator", "ItemProcessor"):
-            nested = state.get(nested_key)
-            if isinstance(nested, dict) and "States" in nested:
-                found.extend(_walk_states(nested["States"]))
-        # Parallel state.
-        for branch in state.get("Branches", []) or []:
-            if "States" in branch:
-                found.extend(_walk_states(branch["States"]))
-    return found
-
-
 def _discover_referenced_functions(sf_name: str, definition_file: str) -> list[dict]:
     """Return one entry per lambda:invoke state discovered in the codified
     definition, or a single error entry if the file can't be loaded/parsed."""
@@ -138,19 +107,15 @@ def _discover_referenced_functions(sf_name: str, definition_file: str) -> list[d
     if error is not None:
         return [{"sf_name": sf_name, "definition_file": definition_file, "error": error}]
 
-    states = definition.get("States", {})
-    invokes = _walk_states(states)
-
     results: list[dict] = []
-    for inv in invokes:
-        function_name = inv["function_name"]
-        if not function_name or not isinstance(function_name, str):
+    for state in lambda_invoke_states(definition_file, definition.get("States", {})):
+        if not state.function_name:
             results.append({
                 "sf_name": sf_name,
                 "definition_file": definition_file,
-                "state_name": inv["state_name"],
+                "state_name": state.state_name,
                 "error": (
-                    f"state {inv['state_name']!r} targets lambda:invoke but "
+                    f"state {state.state_name!r} targets lambda:invoke but "
                     f"has no (or non-string) Parameters.FunctionName"
                 ),
             })
@@ -158,9 +123,9 @@ def _discover_referenced_functions(sf_name: str, definition_file: str) -> list[d
         results.append({
             "sf_name": sf_name,
             "definition_file": definition_file,
-            "state_name": inv["state_name"],
-            "function_name": function_name,
-            "normalized_name": _normalize_function_name(function_name),
+            "state_name": state.state_name,
+            "function_name": state.function_name,
+            "normalized_name": state.normalized_name,
         })
     return results
 

--- a/infrastructure/step-functions/check-lambda-timeout-drift.py
+++ b/infrastructure/step-functions/check-lambda-timeout-drift.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""check-lambda-timeout-drift.py — the codified Lambda timeout table vs live AWS.
+
+`sf-pipeline-policy.md` §2.4: verification reads the DEPLOYED artifact, never
+the source that claims to produce it.
+
+`infrastructure/sf_definitions.py::CODIFIED_FUNCTION_TIMEOUTS_SEC` is what the
+timeout-ordering guard grades every stage's declared `TimeoutSeconds` against.
+It is a claim about the live account — the functions are deployed from four
+other repositories, so no merge here moves them and nothing here notices when
+they move. A stage timeout graded against a stale table is graded against
+nothing.
+
+WHY THIS SCRIPT EXISTS (alpha-engine-config-I9702 arc, 2026-09-01). The
+assertion already existed, as `test_the_codified_function_timeouts_match_live`
+in tests/test_sf_lambda_timeout_ordering.py — skipped unless
+`SF_TIMEOUT_LIVE_CHECK` is set, and that variable is set in NO workflow in this
+repo. The one test proving the table was not a stale claim had never executed.
+Measured 2026-09-01 by running it by hand: the table happened to be accurate,
+which is luck, not enforcement.
+
+It lives here, beside its sibling drift checkers, because it compares CODIFIED
+source against LIVE AWS — the criterion `sf-arn-drift-check.yml`'s header sets
+for belonging on that workflow's trigger set (post-merge and daily, never on a
+PR, so a red a PR author did not cause can never sit on their change).
+
+A missing function is drift, not an absence: the ordering guard demands a row
+for every invoked function, so a row naming a function that does not exist
+means the guard is asserting against a ghost.
+
+Usage:
+  ./infrastructure/step-functions/check-lambda-timeout-drift.py
+
+Exit 0 when every codified timeout matches live; 1 on any drift; 2 on an AWS
+call failure (an AccessDenied must never be reported as "no drift").
+
+Requires `lambda:GetFunction` — the same grant
+`check-lambda-existence.py` already relies on, on the same
+`github-actions-iam-drift-check` OIDC role.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from infrastructure.sf_definitions import (  # noqa: E402
+    CODIFIED_FUNCTION_TIMEOUTS_SEC,
+    all_lambda_invoke_states,
+)
+
+
+def _live_timeout(function_name: str) -> int | None:
+    """The live `Timeout`, or None when the function does not exist.
+
+    Raises on any other failure. A checker that maps AccessDenied onto "no
+    drift" reports green on the one condition it most needs to report — the
+    exact shape that let a `cloudwatch:DisableAlarmActions` denial hide behind
+    `continue-on-error` on this same workflow for 42 runs.
+    """
+    proc = subprocess.run(
+        [
+            "aws", "lambda", "get-function",
+            "--function-name", function_name,
+            "--query", "Configuration.Timeout",
+            "--output", "text",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return int(proc.stdout.strip())
+    if "ResourceNotFoundException" in proc.stderr:
+        return None
+    raise RuntimeError(
+        f"aws lambda get-function --function-name {function_name} failed "
+        f"(rc={proc.returncode}): {proc.stderr.strip()}"
+    )
+
+
+def main() -> int:
+    invoked = {s.normalized_name for s in all_lambda_invoke_states()}
+    findings: list[str] = []
+
+    for function_name, codified in sorted(CODIFIED_FUNCTION_TIMEOUTS_SEC.items()):
+        try:
+            live = _live_timeout(function_name)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        if live is None:
+            findings.append(
+                f"[function-missing] {function_name}: codified {codified}s, "
+                "no such function live"
+            )
+        elif live != codified:
+            findings.append(
+                f"[timeout-drift] {function_name}: codified {codified}s, live {live}s"
+            )
+
+    # A row for a function no definition invokes is an unchecked claim that
+    # reads as coverage — the shape the retired eval-judge rows were removed
+    # for on 2026-08-29.
+    for function_name in sorted(set(CODIFIED_FUNCTION_TIMEOUTS_SEC) - invoked):
+        findings.append(
+            f"[codified-but-uninvoked] {function_name}: in the table, invoked by "
+            "no codified SF state — remove the row or wire the state"
+        )
+
+    if findings:
+        print(f"Lambda timeout drift detected ({len(findings)} finding(s)):")
+        for finding in findings:
+            print(f"  {finding}")
+        print(
+            "\nFix: re-measure and update CODIFIED_FUNCTION_TIMEOUTS_SEC in "
+            "infrastructure/sf_definitions.py, and re-derive every stage "
+            "TimeoutSeconds that grades against the changed row."
+        )
+        return 1
+
+    print(
+        f"OK: all {len(CODIFIED_FUNCTION_TIMEOUTS_SEC)} codified Lambda timeouts "
+        "match live"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -7874,7 +7874,7 @@
           "instance_id.$": "$.ec2_instance_id[0]"
         }
       },
-      "TimeoutSeconds": 90,
+      "TimeoutSeconds": 30,
       "Retry": [
         {
           "ErrorEquals": [

--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -736,7 +736,7 @@
           "step": "code-freshness-gate"
         }
       },
-      "TimeoutSeconds": 65,
+      "TimeoutSeconds": 20,
       "Retry": [
         {
           "ErrorEquals": [
@@ -897,7 +897,7 @@
           "step": "correctness-verdict-gate"
         }
       },
-      "TimeoutSeconds": 65,
+      "TimeoutSeconds": 20,
       "Retry": [
         {
           "ErrorEquals": [
@@ -1337,7 +1337,7 @@
           "step": "morning-planner"
         }
       },
-      "TimeoutSeconds": 65,
+      "TimeoutSeconds": 20,
       "Retry": [
         {
           "ErrorEquals": [

--- a/infrastructure/step_function_groom.json
+++ b/infrastructure/step_function_groom.json
@@ -22,7 +22,7 @@
         "FunctionName": "alpha-engine-scheduled-groom-dispatcher",
         "Payload.$": "States.JsonMerge($.schedInput, $.decideMarker, false)"
       },
-      "TimeoutSeconds": 360,
+      "TimeoutSeconds": 240,
       "Retry": [
         {
           "ErrorEquals": [
@@ -223,7 +223,7 @@
                 "ResultPath": "$.markerCheckError"
               }
             ],
-            "TimeoutSeconds": 360
+            "TimeoutSeconds": 240
           },
           "CheckRetryBudget": {
             "Type": "Choice",
@@ -490,7 +490,7 @@
           "schedule": "end-of-sf-sweep"
         }
       },
-      "TimeoutSeconds": 360,
+      "TimeoutSeconds": 240,
       "Retry": [
         {
           "ErrorEquals": [

--- a/tests/test_sf_lambda_timeout_ordering.py
+++ b/tests/test_sf_lambda_timeout_ordering.py
@@ -49,8 +49,10 @@ is skipped without credentials and is what proves it has not.
 
 from __future__ import annotations
 
+import datetime as _dt
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Iterator
 
@@ -58,70 +60,24 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _INFRA = _REPO_ROOT / "infrastructure"
-_DEFS = ("step_function.json", "step_function_daily.json", "step_function_eod.json")
+sys.path.insert(0, str(_REPO_ROOT))
 
-# Live function timeouts, measured 2026-08-11 via
-# `aws lambda get-function-configuration --query Timeout`.
-_FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
-    "alpha-engine-data-spot-dispatcher": 600,
-    "alpha-engine-eod-precondition-probe": 30,
-    "alpha-engine-evaluator": 660,
-    "alpha-engine-evaluator-director": 900,
-    "alpha-engine-predictor-inference": 900,
-    # alpha-engine-config-I7620. Two read-only Step Functions API calls plus a
-    # pure in-memory derivation — no S3 reads, no spot, no model call. Matches
-    # the --bootstrap timeout in
-    # infrastructure/lambdas/weekly-run-scope/deploy.sh; a generous ceiling here
-    # would let an advisory state hold the tail of the weekly run.
-    "alpha-engine-weekly-run-scope": 60,
-    # alpha-engine-config-I8214. ListExecutions + one DescribeExecution and
-    # GetExecutionHistory per contributing execution, a prefix listing, one
-    # PUT and one marker read-modify-write. Bounded by the cycle's execution
-    # count (single digits), not by the ticker universe. Matches the
-    # --bootstrap timeout in
-    # infrastructure/lambdas/weekly-coverage-sweep/deploy.sh; the SF state's
-    # 240s ceiling is deliberately below it so the SF is the one that binds.
-    # MEASURED 2026-08-22 on the first live invocation: 29.4s at 1024 MB,
-    # 675 MB peak, over a 40-execution walk. The original 120s/256 MB sizing
-    # timed out — at 256 MB the function used 256 of 256 and Lambda scales CPU
-    # with memory, so it was CPU-throttled as well as memory-starved.
-    "alpha-engine-weekly-coverage-sweep": 300,
-    "alpha-engine-predictor-regime-retrospective-eval": 600,
-    "alpha-engine-predictor-regime-substrate": 300,
-    "alpha-engine-replay-concordance": 900,
-    "alpha-engine-replay-counterfactual": 600,
-    "alpha-engine-research-aggregate-costs": 300,
-    # alpha-engine-research-eval-judge-poll and -process were RETIRED by
-    # alpha-engine-config-I9329: the poll states existed to drive a provider
-    # batch API that no longer exists (-I9263), and Process moved onto a
-    # dedicated EC2 spot box because the judge covered 8-15 of ~83 artifacts
-    # inside a 900s function. Their rows are removed rather than left behind —
-    # an entry naming a function no SF invokes is an unchecked claim, and
-    # test_the_codified_function_timeouts_match_live would then assert against
-    # a function whose only remaining property is that it is dead.
-    "alpha-engine-research-eval-judge-submit": 300,
-    # The dispatcher that replaces them. 600s covers the handler's worst case:
-    # a spot launch with capacity rotation and an on-demand fallback, plus the
-    # full 300s SSM-online wait, before the async detached send-command. It
-    # does NOT wait for the bootstrap — the SF's own poll loop does that.
-    # Matches --bootstrap's FN_TIMEOUT in
-    # infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh.
-    "alpha-engine-research-eval-judge-spot-dispatcher": 600,
-    # 300 -> 900 by crucible-research infrastructure/deploy.sh in the
-    # alpha-engine-config-I9102 arc (both create AND update paths — the sizing
-    # previously lived only on create, so no merge could ever re-size the live
-    # function). Pinned at the service maximum because the handler is now
-    # self-deadlining; see the guard-band entry below.
-    "alpha-engine-research-eval-rolling-mean": 900,
-    "alpha-engine-research-rationale-clustering": 900,
-    "alpha-engine-research-runner": 900,
-    # 300 -> 450 by crucible-research-PR601 (p95 x 1.5). The Scanner states
-    # moved 600 -> 440 in the same arc so the SF budget binds again.
-    "alpha-engine-research-scanner": 450,
-    "alpha-engine-research-signals-envelope": 300,
-    "alpha-engine-weekly-freshness-spot-dispatcher": 600,
-    "alpha-engine-weekly-preflight": 120,
-}
+from infrastructure.sf_definitions import (  # noqa: E402
+    CODIFIED_FUNCTION_TIMEOUTS_SEC,
+    DEFINITION_FILES as _DEFS,
+    LAMBDA_SERVICE_MAX_SEC as _LAMBDA_SERVICE_MAX_SEC,
+    lambda_invoke_states as _shared_lambda_invoke_states,
+)
+
+# The codified live-timeout table moved to `infrastructure/sf_definitions.py`
+# (alpha-engine-config-I9702 arc, 2026-09-01). It is a claim about the live AWS
+# account, and the test that proves it — `test_the_codified_function_timeouts_
+# match_live` — is skipped without credentials, which is every CI run of this
+# suite. Set NOWHERE in any workflow, it had therefore never executed once.
+# Living in a module rather than a test file lets the daily drift workflow, which
+# does hold credentials, run the same comparison against the same declaration:
+# `infrastructure/step-functions/check-lambda-timeout-drift.py`.
+_FUNCTION_TIMEOUTS_SEC = CODIFIED_FUNCTION_TIMEOUTS_SEC
 
 # States whose SF budget is >= the function timeout, measured 2026-08-11.
 #
@@ -134,6 +90,8 @@ _FUNCTION_TIMEOUTS_SEC: dict[str, int] = {
 #
 # Pinned as an exact set: the gap cannot widen while that issue is open, and
 # an entry cannot outlive its fix without failing.
+_KNOWN_UNBOUND_EXPIRY = "2026-10-01"
+
 _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
     {
         ("step_function.json", "SignalsEnvelope"),
@@ -154,10 +112,6 @@ _KNOWN_UNBOUND: frozenset[tuple[str, str]] = frozenset(
     }
 )
 
-
-# Lambda's hard service maximum. A function AT this value cannot be raised, so
-# the SF-vs-function ordering rule inverts for it — see the module docstring.
-_LAMBDA_SERVICE_MAX_SEC = 900
 
 # States deliberately declaring a guard band ABOVE a service-max function.
 # Not exceptions to the rule; instances of the rule's second branch.
@@ -211,25 +165,31 @@ _SERVICE_MAX_GUARD_BAND: dict[tuple[str, str], int] = {
 }
 
 
-def _lambda_invoke_states(states: dict) -> Iterator[tuple[str, str, int | None]]:
-    """``(state_name, function_base_name, TimeoutSeconds)`` for every lambda:invoke.
+def _lambda_invoke_states(definition: str) -> Iterator[tuple[str, str, int | None]]:
+    """``(state_name, function_base_name, TimeoutSeconds)`` per ORDERING-GOVERNED state.
 
-    Recurses into Parallel branches and Map iterators — the weekly Scanner
-    lives inside ``ResearchPredictorParallel``, and a top-level-only scan
-    would silently exempt it, which is the state this test exists for.
+    Delegates to ``infrastructure.sf_definitions``, which is the single walk
+    ``check-lambda-existence.py`` also uses. This test previously carried its
+    own copy, and that copy was wrong in three ways at once — see that module's
+    docstring for the full account. The short version: a full-ARN
+    ``FunctionName`` parsed to the literal string ``"function"``, the
+    completeness guard below whitelisted exactly that mis-parse, and the
+    ``.waitForTaskToken``/``.sync`` resource variants were not matched at all.
+    Four states were therefore exempt from this file for its whole life, three
+    of them on the preopen trading pipeline, and a fourth definition
+    (``step_function_groom.json``) was never walked here at all.
+
+    ``.waitForTaskToken`` states are filtered out because for them the state
+    timeout and the function timeout bound DIFFERENT waits — the function
+    returns after handing off a token and the state waits for someone else to
+    call ``SendTaskSuccess`` — so the ordering rule does not apply. That is a
+    semantic exclusion, not an exemption, and it lives in
+    ``LambdaInvokeState.is_ordering_governed`` so no caller re-derives it.
     """
-    for name, body in states.items():
-        resource = body.get("Resource")
-        if isinstance(resource, str) and resource.endswith(":lambda:invoke"):
-            raw = str((body.get("Parameters") or {}).get("FunctionName") or "")
-            # Either "name:alias" or a full ARN with an optional alias suffix.
-            base = raw.split(":")[-2] if raw.startswith("arn:") else raw.split(":")[0]
-            yield name, base, body.get("TimeoutSeconds")
-        for branch in body.get("Branches") or []:
-            yield from _lambda_invoke_states(branch.get("States") or {})
-        iterator = body.get("Iterator") or body.get("ItemProcessor")
-        if iterator:
-            yield from _lambda_invoke_states(iterator.get("States") or {})
+    for state in _shared_lambda_invoke_states(definition):
+        if not state.is_ordering_governed:
+            continue
+        yield state.state_name, state.normalized_name, state.timeout_seconds
 
 
 def _states(definition: str) -> dict:
@@ -245,7 +205,7 @@ def test_every_lambda_invoke_declares_a_timeout(definition: str) -> None:
     """
     missing = sorted(
         name
-        for name, _, timeout in _lambda_invoke_states(_states(definition))
+        for name, _, timeout in _lambda_invoke_states(definition)
         if timeout is None and (definition, name) not in _KNOWN_UNBOUND
     )
     assert not missing, f"{definition}: lambda:invoke states with no TimeoutSeconds: {missing}"
@@ -259,7 +219,7 @@ def test_the_declared_stage_timeout_is_the_one_that_binds(definition: str) -> No
     error an operator sees is not reproducible. Greater is decorative.
     """
     violations: list[str] = []
-    for name, fn, timeout in _lambda_invoke_states(_states(definition)):
+    for name, fn, timeout in _lambda_invoke_states(definition):
         if (definition, name) in _KNOWN_UNBOUND:
             continue
         fn_timeout = _FUNCTION_TIMEOUTS_SEC.get(fn)
@@ -302,8 +262,13 @@ def test_every_invoked_function_has_a_codified_timeout(definition: str) -> None:
     unknown = sorted(
         {
             fn
-            for _, fn, _ in _lambda_invoke_states(_states(definition))
-            if fn not in _FUNCTION_TIMEOUTS_SEC and not fn.startswith("function")
+            for _, fn, _ in _lambda_invoke_states(definition)
+            # No name-shaped carve-out here. This filter used to read
+            # `and not fn.startswith("function")`, which excluded precisely the
+            # states whose full-ARN FunctionName the old parser reduced to the
+            # literal string "function" — the guard against silent exemption
+            # was the thing granting it.
+            if fn not in _FUNCTION_TIMEOUTS_SEC
         }
     )
     assert not unknown, (
@@ -314,13 +279,13 @@ def test_every_invoked_function_has_a_codified_timeout(definition: str) -> None:
 
 def test_the_known_unbound_set_contains_no_stale_entries() -> None:
     """An exception that outlives its fix silently exempts a healthy stage."""
-    live = {(d, name) for d in _DEFS for name, _, _ in _lambda_invoke_states(_states(d))}
+    live = {(d, name) for d in _DEFS for name, _, _ in _lambda_invoke_states(d)}
     stale = sorted(entry for entry in _KNOWN_UNBOUND if entry not in live)
     assert not stale, f"_KNOWN_UNBOUND names states that no longer exist: {stale}"
 
     still_broken = set()
     for definition, name in _KNOWN_UNBOUND:
-        for state, fn, timeout in _lambda_invoke_states(_states(definition)):
+        for state, fn, timeout in _lambda_invoke_states(definition):
             if state != name:
                 continue
             fn_timeout = _FUNCTION_TIMEOUTS_SEC.get(fn)
@@ -354,6 +319,117 @@ def test_the_codified_function_timeouts_match_live() -> None:
         if live != codified:
             drift.append(f"{fn}: codified {codified}s, live {live}s")
     assert not drift, "\n  ".join(drift)
+
+
+def test_the_known_unbound_set_has_not_outlived_its_deadline() -> None:
+    """An exemption with no deadline is not a deferral, it is a decision.
+
+    Measured across the fleet 2026-09-01: 47 non-empty suppression collections
+    hold 277 live entries between them, and NOT ONE of them fails when an entry
+    ages. Fifteen of twenty-six sampled had not changed by a single entry since
+    the day they were created, and thirteen of the twenty that cite an issue
+    outlive an issue that is already CLOSED — the ticket gets verified and
+    closed, the exemption stays, and from then on nothing in the repo or the
+    backlog knows the defect is still live.
+
+    This set is the best-behaved of them (21 -> 11 over 19 days, four shrink
+    events) and it still has no deadline, which is why the deadline goes here
+    first. When this fails, the fix is to drain entries — never to move the
+    date without a written reason in the same diff.
+    """
+    if not _KNOWN_UNBOUND:
+        return
+    deadline = _dt.date.fromisoformat(_KNOWN_UNBOUND_EXPIRY)
+    today = _dt.date.today()
+    assert today <= deadline, (
+        f"_KNOWN_UNBOUND still holds {len(_KNOWN_UNBOUND)} entries past its "
+        f"{_KNOWN_UNBOUND_EXPIRY} deadline: {sorted(_KNOWN_UNBOUND)}. "
+        "Each is a stage whose declared timeout cannot bind. Fix them, or move "
+        "the deadline WITH a written reason in the same diff — "
+        "alpha-engine-config-I6897."
+    )
+
+
+def test_every_codified_definition_is_walked() -> None:
+    """The guard covered three definitions; four are codified.
+
+    `step_function_groom.json` was never walked here, so its `lambda:invoke`
+    states had no ordering coverage at all — and three of its four synchronous
+    states were inverted (360s declared against a 300s function). Pinning the
+    count against the shared module's list is what stops a fifth definition
+    being added to the fleet and silently escaping this file.
+    """
+    from infrastructure.sf_definitions import SF_DEFINITIONS
+
+    assert set(_DEFS) == {d["definition_file"] for d in SF_DEFINITIONS}
+    assert len(_DEFS) == 4
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("alpha-engine-weekly-preflight", "alpha-engine-weekly-preflight"),
+        ("alpha-engine-predictor-inference:live", "alpha-engine-predictor-inference"),
+        (
+            "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-ssm-liveness-poller",
+            "alpha-engine-ssm-liveness-poller",
+        ),
+        (
+            "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-evaluator:live",
+            "alpha-engine-evaluator",
+        ),
+    ],
+)
+def test_a_full_arn_function_name_resolves_to_the_function(raw: str, expected: str) -> None:
+    """The regression test for the defect this file was blind to.
+
+    The old parser took ``raw.split(":")[-2]`` and returned the literal
+    ``"function"`` for every full ARN, and the completeness guard then
+    whitelisted names starting with ``"function"``. Four states were exempt
+    from every assertion in this file for its whole life. All three
+    `FunctionName` shapes the fleet's definitions actually use are pinned here.
+    """
+    from infrastructure.sf_definitions import normalize_function_name
+
+    assert normalize_function_name(raw) == expected
+
+
+def test_no_state_resolves_to_a_placeholder_function_name() -> None:
+    """The shape of the old bug, asserted directly against the live definitions.
+
+    A `normalized_name` of "function" (or empty) means the parser did not
+    understand the `FunctionName` it was given. That must be a failure, never a
+    quiet skip — the previous version of this guard turned exactly that
+    condition into an exemption.
+    """
+    from infrastructure.sf_definitions import all_lambda_invoke_states
+
+    bad = [
+        (s.definition_file, s.state_name, s.function_name)
+        for s in all_lambda_invoke_states()
+        if s.normalized_name in {None, "", "function"}
+    ]
+    assert not bad, f"FunctionName values the walk could not resolve: {bad}"
+
+
+def test_wait_for_task_token_states_are_excluded_from_the_ordering_rule() -> None:
+    """The carve-out is semantic and must stay narrow.
+
+    ``LaunchGroomSpot`` declares 13800s against a 300s function and is CORRECT:
+    the function returns after handing off a task token, so the state's timeout
+    bounds a callback wait the function is not part of. Every OTHER groom state
+    invokes the same Lambda synchronously and is governed. If this ever selects
+    more than the task-token states, the ordering rule has been quietly widened
+    into an exemption.
+    """
+    from infrastructure.sf_definitions import all_lambda_invoke_states
+
+    exempt = {
+        (s.definition_file, s.state_name)
+        for s in all_lambda_invoke_states()
+        if not s.is_ordering_governed
+    }
+    assert exempt == {("step_function_groom.json", "LaunchGroomSpot")}
 
 
 # ── SSM sendCommand stages (alpha-engine-config-I6948) ───────────────────────
@@ -452,7 +528,15 @@ def test_ssm_kills_the_command_before_the_state_gives_up(definition: str) -> Non
     assert not violations, f"{definition}:\n  " + "\n  ".join(violations)
 
 
-@pytest.mark.parametrize("definition", _DEFS)
+# The groom dispatch SF drives spot boxes through its dispatcher Lambda and a
+# task token, never through ssm:sendCommand — so an empty scan there is the
+# correct answer, not a broken walk. Naming it explicitly rather than dropping
+# the assertion keeps the non-emptiness guarantee for every definition that
+# does carry sendCommand stages.
+_DEFS_WITH_SSM_SEND_COMMAND = tuple(d for d in _DEFS if d != "step_function_groom.json")
+
+
+@pytest.mark.parametrize("definition", _DEFS_WITH_SSM_SEND_COMMAND)
 def test_the_ssm_scan_is_not_empty(definition: str) -> None:
     """A recursion bug would make every assertion above vacuously true.
 


### PR DESCRIPTION
## What this is

`tests/test_sf_lambda_timeout_ordering.py` grades every `lambda:invoke` stage's declared `TimeoutSeconds` against the invoked function's own timeout — only the smaller of the two ever fires, so a state declaring the larger describes nothing. The guard is well-built. It was blind in four independent ways, all silent, and seven real defects were live behind it.

## The four blind spots

1. **A full-ARN `FunctionName` parsed to the literal string `"function"`.** `raw.split(":")[-2]` on `arn:aws:lambda:us-east-1:...:function:alpha-engine-ssm-liveness-poller` returns `"function"`. Four states carry a full ARN.
2. **The completeness guard whitelisted exactly that mis-parse.** Its docstring reads "a function missing from the map is an unchecked stage, not a passing one" — and the filter was `if fn not in _FUNCTION_TIMEOUTS_SEC and not fn.startswith("function")`. The guard against silent exemption was the thing granting it.
3. **`.waitForTaskToken` / `.sync` resource variants were never matched** (`resource.endswith(":lambda:invoke")`).
4. **Three of four codified definitions were walked.** `step_function_groom.json` had no ordering coverage at all.

## The seven defects, fixed from measurement

Every value is derived from CloudWatch `AWS/Lambda Duration` over the trailing 45 days, measured 2026-09-01 — none is an allowlist entry.

| Definition | State | Was | Now | Function timeout | Measured |
|---|---|---|---|---|---|
| `step_function.json` | `SubstrateHealthGate` | 90 | 30 | 90 | p95 3.55s, max 3.57s, n=37 |
| `step_function_daily.json` | `WaitForCodeFreshness` | 65 | 20 | 30 | p95 357ms, max 410ms, n=291 |
| `step_function_daily.json` | `WaitForCorrectnessVerdict` | 65 | 20 | 30 | " |
| `step_function_daily.json` | `WaitForMorningPlanner` | 65 | 20 | 30 | " |
| `step_function_groom.json` | `DecideLaunches` | 360 | 240 | 300 | p99 87.6s, max 195.8s, n=2856 |
| `step_function_groom.json` | `CheckCompletionMarkerTaskToken` | 360 | 240 | 300 | " |
| `step_function_groom.json` | `DispatchEndOfSfSweep` | 360 | 240 | 300 | " |

Three of these sit on the **preopen trading pipeline**, each declaring more than twice the ceiling that actually governs it.

`LaunchGroomSpot` declares 13800s against the same 300s function and is **correct**: it is `.waitForTaskToken`, where the state timeout bounds a callback the function does not participate in. That now lives in `LambdaInvokeState.is_ordering_governed`, and a test pins that the exclusion selects that one state and no other — a semantic carve-out that cannot quietly widen.

## Root cause

The walk and the `FunctionName` normalizer existed **twice** in this repo. `check-lambda-existence.py`'s copy is correct: it matches the suffixed variants, normalizes all three `FunctionName` shapes, and covers all four definitions. The guard's copy had drifted. The defect was not in either copy but in there being two — so both now import `infrastructure/sf_definitions.py` and the second copy is deleted.

## Also closed here — the same shape, a check that could not run

- **`test_the_codified_function_timeouts_match_live` had never executed.** It is the one assertion proving the codified timeout table is not a stale claim about live AWS, and it is skipped unless `SF_TIMEOUT_LIVE_CHECK` is set — a variable set in no workflow in this repo. Run by hand today the table was accurate, which is luck, not enforcement. The table moves into `sf_definitions.py`, and a new sibling checker `infrastructure/step-functions/check-lambda-timeout-drift.py` grades it against live AWS on the daily credentialed drift workflow. **Verified live from this branch: 24/24 match.**
- **`_KNOWN_UNBOUND` gets a deadline (2026-10-01, `alpha-engine-config-I6897`).** Measured across the fleet today: 47 non-empty suppression collections hold 277 live entries, and not one fails when an entry ages; 13 of the 20 that cite an issue outlive an issue that is already CLOSED. This set is the best-behaved of them (21 → 11 in 19 days) and still had no expiry.
- **`sf-arn-drift-check.yml`'s remediation step was un-`id`'d and tolerated.** `automation_pause.py --enforce --alarms-only` is the only step in that workflow with no `id`, so the outcome aggregator covering its ten siblings could not see it, and it carried `continue-on-error: true` against the gate's own stated rule that "a remediation step failing is a real break, not a finding". It has been dying every run on `AccessDenied ... not authorized to perform: cloudwatch:DisableAlarmActions` — the self-healing loop has never once healed, and the pause check was the first failing step 42 times in the 14 days to 2026-08-31. It now carries an id and is no longer tolerated. **The missing IAM grant lands in a companion `nous-ergon-ops` PR; merge that one FIRST** or this workflow goes red on a break it is now correctly refusing to hide.

## Validation

- `tests/test_sf_lambda_timeout_ordering.py` + `tests/test_sf_lambda_existence_check.py`: 58 passed.
- Full repo selection `-k "sf_ or step_function or timeout or workflow or drift"`: 2860 passed. One local-only failure during development (`test_sf_definition_check_drift.py::test_main_fires_alert_on_drift`) was its staleness probe correctly refusing to page from a worktree with uncommitted definition edits; it is green in this PR's CI.
- Both live checkers run against real AWS from this branch: existence OK across all four definitions, timeout drift 24/24 clean.

## Out of scope, filed separately

- ~~`test_sf_definition_check_drift.py::test_main_fires_alert_on_drift` appears to fail on any branch touching a definition file~~ — **checked against this PR's own CI and withdrawn.** It fails only in a LOCAL worktree with uncommitted definition changes, where its staleness probe correctly refuses to page from a tree that differs from `origin/main`. CI is green on it. The guard is behaving as designed; no issue filed.
- The evaluator `ReportCard` root cause (an O(N-sessions) S3 read loop, not a timeout) is a companion PR in `crucible-evaluator`.

Rehearsal-path: tests/test_sf_lambda_timeout_ordering.py

Every corrected value is graded by that suite in CI without credentials, and the two live checkers (`infrastructure/step-functions/check-lambda-timeout-drift.py` and `check-lambda-existence.py`) were additionally run against real AWS from this branch before commit, plus `.github/workflows/sf-arn-drift-check.yml` carries `workflow_dispatch` so both can be exercised against live without waiting for a Saturday.

Refs `alpha-engine-config-I9702`, `alpha-engine-config-I6897`.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01492vLksdZuGXQbLr5Zabxu

