### PR TITLE
fix(workflow-health): declare the Lambda-timeout-drift step as a finding step (alpha-engine-config-I9702)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -82,6 +82,7 @@ env:
     EventBridge SF-ARN drift (codified vs live)
     SF LoggingConfiguration drift (codified vs live)
     SF lambda:invoke Lambda-existence check (codified vs live)
+    Lambda timeout drift (codified table vs live)
     SF definition drift (codified vs live vs S3-staged)
     EventBridge Scheduler rule drift (fleet-wide, codified vs live)
     schedule-manifest.json drift (fleet-wide, vs live AWS)
@@ -97,6 +98,8 @@ env:
     2026-08-31 over the 14-day window, the FIRST failing step was
     'Scheduled-automation pause still holds (live)' 42 times, the gate 15,
     'SF definition drift' 3 and the lambda-existence check once.
+    'Lambda timeout drift' joined the surface on 2026-09-01 and is declared
+    with them.
     'Configure AWS credentials via OIDC', 'Publish the arming record'
     and 'Paused-component alarm actions reconciled with the manifest'
     are deliberately NOT declared: the last is REMEDIATION, and a


### PR DESCRIPTION
## What & why

`nousergon-data-PR1619` added `Lambda timeout drift (codified table vs live)` to `sf-arn-drift-check.yml` with an `id`, `continue-on-error: true`, and a row in the terminal outcome gate — but did not add it to `WORKFLOW_HEALTH_FINDING_STEPS`.

Consequence: its red would be graded as a **broken check** rather than as the **finding** it is, so the workflow reads as unhealthy instead of as reporting, and `check_scheduled_workflow_health.py` could file a "this control has never once succeeded" issue against a control working exactly as designed.

Every check on PR1619 was green, because `--validate-declarations` asserted only *declared → exists* (catching a rename) and never *exists → declared* (catching an addition). The reverse direction lands in `alpha-engine-config-PR9736`; this is the instance it found here.

One line added to the declaration, and the `WORKFLOW_HEALTH_FINDING_REASON` prose updated to say when the step joined the surface — the reason block enumerates the measured first-failing-step counts and would otherwise read as if the list were still ten.

## Noted while in this file, not fixed here

The comment block above the declaration says *"Renaming a step below without updating this list is caught by `--validate-declarations`."* It is not: that guard runs in exactly one repo, over `alpha-engine-config/.github/workflows` only (`pr-validators.yml:251`). Nothing validates this file. Filed as `alpha-engine-config-I9735`, which owns both the coverage fix and the comment correction — doing it here would land half of it.

## Cross-repo

`alpha-engine-config-PR9736` adds the reverse-direction check and sweeps that repo's own 20 instances. **Merge order: this PR first**, then PR9736.

## Test plan

Run before opening: `pytest tests/test_scheduled_workflow_reachability.py tests/test_sf_drift_gate_families.py` → **26 passed**.

Validated directly by running the guard from `alpha-engine-config` against this directory: `2 declared finding surface(s) in .github/workflows: all valid`, with the new step present in the enumerated list. Before the change, the same invocation reported it as undeclared.

Rehearsal-path: `tests/test_scheduled_workflow_reachability.py`

Refs `alpha-engine-config-I9702`, `alpha-engine-config-I9735`.

Prepared by: claude-opus-5[1m] via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01492vLksdZuGXQbLr5Zabxu