### PR TITLE
automation_pause.py: add trigger-undeclared / trigger-out-of-scope findings

### DIFF
--- a/infrastructure/automation_pause.py
+++ b/infrastructure/automation_pause.py
@@ -109,12 +109,19 @@ Usage:
                                                     # run by pause-check-alert.yml on its own
                                                     # 4-hourly schedule, needs krepis installed
 
-``--check`` needs ``events:DescribeRule`` + ``scheduler:GetSchedule`` +
+``--check`` needs ``events:DescribeRule`` + ``events:ListRules`` +
+``scheduler:GetSchedule`` + ``scheduler:ListSchedules`` +
 ``cloudwatch:DescribeAlarms``; ``--enforce`` additionally needs
 ``events:DisableRule`` + ``scheduler:UpdateSchedule`` +
-``cloudwatch:EnableAlarmActions`` + ``cloudwatch:DisableAlarmActions``. CI runs
-``--check`` (read-only) and ``--enforce --alarms-only`` (alarm actions only)
-under the ``github-actions-iam-drift-check`` role, daily in
+``cloudwatch:EnableAlarmActions`` + ``cloudwatch:DisableAlarmActions``. The
+``ListRules``/``ListSchedules`` pair is alpha-engine-config-I9959's
+``trigger-undeclared``/``trigger-out-of-scope`` completeness scan — the
+account-wide enumeration ``_live_triggers()`` needs, on top of the per-name
+``DescribeRule``/``GetSchedule`` the rest of ``--check`` already used; both
+are already granted to ``github-actions-iam-drift-check``
+(``pause_reconcile.py`` has called them from the same role since
+alpha-engine-config-I7118). CI runs ``--check`` (read-only) and ``--enforce
+--alarms-only`` (alarm actions only) under that role, daily in
 ``sf-arn-drift-check.yml``; ``pause-check-alert.yml`` runs ONLY
 ``--check --alert-on-fail`` (same role, same read-only permission set) on its
 own schedule so a finding pages even while the groom that would otherwise
@@ -133,6 +140,17 @@ from pathlib import Path
 
 MANIFEST = Path(__file__).parent.resolve() / "automation_pause.json"
 REGION = "us-east-1"
+
+#: SCOPE, made explicit (alpha-engine-config-I9959). The 2026-08-07 ruling's own
+#: text — "shut down all automatic AWS processes ... everything else has its
+#: schedule removed" — covers every EventBridge rule (default bus) and every
+#: EventBridge Scheduler schedule in the account, region us-east-1. The ONE
+#: carve-out is a rule AWS itself creates and manages (e.g. Inspector's ECR
+#: scan rule, ``DO-NOT-DELETE-AmazonInspectorEcrManagedRule``): the fleet owns
+#: none of its lifecycle, so it is not "scheduled automation" this manifest can
+#: classify. This MUST match ``pause_reconcile.py``'s ``_AWS_MANAGED_PREFIX`` —
+#: two literals for one exclusion is a silent-drift risk the test file pins.
+AWS_MANAGED_TRIGGER_PREFIX = "DO-NOT-DELETE-"
 
 #: Every ``paused_alarms`` entry must name the OPEN tracker issue whose closure
 #: ends the pause, in the fleet's own reference grammar. A free-text owner is
@@ -266,6 +284,108 @@ def _aws(args: list[str]) -> tuple[int, str, str]:
         ["aws"] + args + ["--region", REGION], capture_output=True, text=True, check=False
     )
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _live_triggers() -> list[dict]:
+    """Every EventBridge rule (default bus) and Scheduler schedule live in the
+    account — the enumeration ``trigger_coverage_findings()`` grades for
+    completeness, as opposed to ``_live_state()``'s per-name lookup for the
+    entries the manifest already names.
+
+    Paginated EXPLICITLY, never via ``aws --no-paginate``: ``list-rules`` and
+    ``list-schedules`` each cap at 100 per page, and a truncated first page
+    read as "every trigger" would let an undeclared trigger on page two hide
+    behind a clean run — the exact shape ``aws --no-paginate`` produces
+    (measured elsewhere in the fleet: it returns the first page and no marker,
+    silently). This loops on ``NextToken`` until AWS itself says there is none
+    left, and RAISES on any non-zero AWS exit rather than returning a partial
+    list — a permissions error or a truncated read must never be indistinguishable
+    from "the account holds exactly this many triggers".
+    """
+    out: list[dict] = []
+    for surface, cmd, key in (
+        ("events", ["events", "list-rules"], "Rules"),
+        ("scheduler", ["scheduler", "list-schedules"], "Schedules"),
+    ):
+        token: str | None = None
+        while True:
+            args = list(cmd) + ["--output", "json"]
+            if token:
+                args += ["--next-token", token]
+            rc, out_text, err = _aws(args)
+            if rc != 0:
+                raise RuntimeError(f"aws {' '.join(cmd)}: {err}")
+            page = json.loads(out_text or "{}")
+            for row in page.get(key, []):
+                out.append({"surface": surface, "name": row["Name"], "state": row.get("State")})
+            token = page.get("NextToken")
+            if not token:
+                break
+    return out
+
+
+def trigger_coverage_findings(manifest: dict | None = None,
+                               triggers: list[dict] | None = None) -> list[dict]:
+    """Is every live ENABLED trigger CLASSIFIED — not merely every declared one?
+
+    The trigger-side mirror of ``alarm_coverage_findings()``. ``check()``'s
+    other findings all iterate ``paused_entries()``/``kept_names()`` — the
+    manifest's OWN hand-listed names — so a live, ENABLED trigger named in
+    NEITHER ``paused`` nor ``not_paused`` was invisible to every one of them:
+    the check ran daily, reported, and could not see the one case it most
+    needed to. Found by hand on 2026-09-03 for exactly two triggers
+    (``alpha-engine-preflight-sweep-daily``,
+    ``alpha-engine-preopen-deploy-readiness-probe``; alpha-engine-config-I9937,
+    classified by nousergon-data-PR1635) — nothing would have found a third.
+    This closes that: the population is derived from live AWS
+    (``_live_triggers()``), never from either block, so a name nobody listed
+    is a finding by construction instead of an omission nobody sees.
+
+    SCOPE (alpha-engine-config-I9959, made explicit — see
+    ``AWS_MANAGED_TRIGGER_PREFIX``): every live EventBridge rule and Scheduler
+    schedule in the account, except an AWS-managed rule, which is reported as
+    ``trigger-out-of-scope`` rather than silently filtered — an excluded
+    population that renders nowhere is indistinguishable from one nobody
+    thought to exclude.
+    """
+    m = manifest if manifest is not None else load_manifest()
+    trigs = triggers if triggers is not None else _live_triggers()
+    declared = paused_names(m) | kept_names(m)
+    out: list[dict] = []
+    for t in trigs:
+        name, state, surface = t["name"], t["state"], t["surface"]
+        if name.startswith(AWS_MANAGED_TRIGGER_PREFIX):
+            out.append({
+                "trigger": name, "surface": surface, "kind": "trigger-out-of-scope",
+                "detail": (
+                    "AWS-managed rule — the 2026-08-07 ruling covers the fleet's "
+                    "own scheduled automation, not a rule AWS itself creates and "
+                    "manages (e.g. an Inspector ECR-scan rule); the fleet owns "
+                    "none of its lifecycle. Declared here so the exclusion is "
+                    "visible rather than a silent filter. Needs no paused/"
+                    "not_paused entry."
+                ),
+            })
+            continue
+        if state != "ENABLED":
+            continue
+        if name in declared:
+            continue
+        out.append({
+            "trigger": name, "surface": surface, "kind": "trigger-undeclared",
+            "detail": (
+                "live State=ENABLED, named in neither `paused` nor `not_paused` "
+                "in automation_pause.json — this check has no register saying "
+                "whether it should be running. Classify it: add it to "
+                "`not_paused` with a one-line reason if it is deliberately "
+                "kept, or move it under `paused` if it should be off. An "
+                "unclassified enabled trigger is exactly what "
+                "alpha-engine-preflight-sweep-daily and "
+                "alpha-engine-preopen-deploy-readiness-probe were until "
+                "alpha-engine-config-I9959."
+            ),
+        })
+    return out
 
 
 def _live_state(surface: str, name: str) -> str | None:
@@ -474,6 +594,10 @@ def check() -> list[dict]:
     # starts no scheduled work, so it carries none of the risk that keeps
     # `enforce()` from ever re-enabling a kept-but-disabled TRIGGER.
     findings.extend(alarm_findings())
+
+    # ── completeness: every live trigger CLASSIFIED, not merely every
+    # declared one (alpha-engine-config-I9959) ─────────────────────────────
+    findings.extend(trigger_coverage_findings())
     return findings
 
 
@@ -843,6 +967,8 @@ def main() -> int:
             print("  ✓ every declared alarm's ActionsEnabled matches its current justification")
             print("  ✓ every breaching alarm live in CloudWatch is declared in one block "
                   "or the other")
+            print("  ✓ every live ENABLED trigger in the account is declared paused or "
+                  "kept, or is out of scope")
         for f in findings:
             print(f"  ✗ [{f['kind']}] {f['surface']}:{f['trigger']}")
             print(f"      {f['detail']}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 testpaths = ["tests"]
 markers = [
   "real_alarm_scan: opt out of the autouse CloudWatch stub in tests/test_automation_pause.py — for the one test whose subject IS the live-alarm scan",
+  "real_trigger_scan: opt out of the autouse live-trigger-enumeration stub in tests/test_automation_pause.py — for tests whose subject IS _live_triggers() itself",
 ]
 
 [tool.coverage.run]

--- a/tests/test_automation_pause.py
+++ b/tests/test_automation_pause.py
@@ -71,6 +71,31 @@ def module():
     return _load_module()
 
 
+@pytest.fixture(autouse=True)
+def clean_trigger_world(module, manifest, monkeypatch, request):
+    """A live-trigger enumeration that exactly matches the manifest's own
+    declarations (alpha-engine-config-I9959).
+
+    ``check()`` now calls ``trigger_coverage_findings()``, which calls
+    ``_live_triggers()`` — a real ``aws events list-rules`` / ``aws scheduler
+    list-schedules`` account-wide enumeration. Every test written before this
+    existed calls ``module.check()`` with no idea that call exists, so without
+    this stub every one of them would reach the network (and fail with
+    NoCredentialsError in CI, which has none by design — the same problem
+    ``classified_world`` solves one level up for the alarm scan it added).
+    Autouse, so the NEXT live read added to ``check()`` cannot reintroduce this
+    either.
+    """
+    if request.node.get_closest_marker("real_trigger_scan") is not None:
+        return
+    live: list[dict] = []
+    for surface, name, _ in module.paused_entries(manifest):
+        live.append({"surface": surface, "name": name, "state": "DISABLED"})
+    for name in module.kept_names(manifest):
+        live.append({"surface": "events", "name": name, "state": "ENABLED"})
+    monkeypatch.setattr(module, "_live_triggers", lambda: live)
+
+
 def test_manifest_parses_and_every_entry_has_a_reason(manifest):
     for surface in ("events_rules", "scheduler_schedules"):
         entries = manifest["paused"][surface]
@@ -1234,3 +1259,175 @@ def test_an_armed_alarm_is_never_reported_as_an_undeclared_silence(module, monke
     findings = module.alarm_coverage_findings()
     assert not [f for f in findings if f["kind"] == "alarm-undeclared-silence"]
     assert {f["kind"] for f in findings} == {"armed-but-silenced"}
+
+
+# ── Completeness: every live trigger CLASSIFIED, not merely every declared
+# one (alpha-engine-config-I9959) ────────────────────────────────────────────
+#
+# `check()`'s other findings all iterate the manifest's OWN hand-listed names
+# (`paused_entries()`, `kept_names()`), so a live, ENABLED trigger named in
+# NEITHER block was invisible to every one of them — the check ran daily,
+# reported, and could not see the case it most needed to. Found by hand on
+# 2026-09-03 for exactly two triggers (alpha-engine-preflight-sweep-daily,
+# alpha-engine-preopen-deploy-readiness-probe; alpha-engine-config-I9937) —
+# nothing would have found a third.
+
+
+def test_trigger_coverage_is_silent_when_live_matches_the_manifest_exactly(
+        module, manifest):
+    """The GREEN direction: the live world `clean_trigger_world` builds from
+    the manifest itself must produce no trigger-side finding."""
+    findings = module.trigger_coverage_findings(manifest)
+    assert not [f for f in findings
+                if f["kind"] in ("trigger-undeclared", "trigger-out-of-scope")]
+
+
+def test_an_undeclared_enabled_trigger_is_a_finding(module, manifest):
+    """The defect this check exists for: a new trigger nobody classified."""
+    live = [{"surface": "events", "name": "alpha-engine-saturday", "state": "ENABLED"},
+            {"surface": "events", "name": "alpha-engine-brand-new-undeclared-rule",
+             "state": "ENABLED"}]
+    findings = module.trigger_coverage_findings(manifest, triggers=live)
+    kinds = {(f["trigger"], f["kind"]) for f in findings}
+    assert ("alpha-engine-brand-new-undeclared-rule", "trigger-undeclared") in kinds
+    assert not any(f["trigger"] == "alpha-engine-saturday" for f in findings)
+
+
+def test_an_undeclared_disabled_trigger_is_not_a_finding(module, manifest):
+    """Only ENABLED is graded here — a disabled, undeclared trigger is dormant
+    and carries no scheduled-work risk; `missing-in-aws`/`kept-but-missing`
+    already cover the declared half of this axis."""
+    live = [{"surface": "scheduler", "name": "some-random-disabled-thing",
+             "state": "DISABLED"}]
+    assert module.trigger_coverage_findings(manifest, triggers=live) == []
+
+
+def test_an_aws_managed_rule_is_reported_out_of_scope_not_silently_dropped(
+        module, manifest):
+    live = [{"surface": "events",
+             "name": "DO-NOT-DELETE-AmazonInspectorEcrManagedRule",
+             "state": "ENABLED"}]
+    findings = module.trigger_coverage_findings(manifest, triggers=live)
+    kinds = {(f["trigger"], f["kind"]) for f in findings}
+    assert ("DO-NOT-DELETE-AmazonInspectorEcrManagedRule", "trigger-out-of-scope") in kinds
+    assert not any(f["kind"] == "trigger-undeclared" for f in findings), (
+        "an AWS-managed rule must never ALSO read as undeclared — one "
+        "condition, one finding"
+    )
+
+
+def test_check_surfaces_trigger_coverage_findings(module, monkeypatch, manifest):
+    """The wiring: `check()` must actually call the new completeness scan,
+    not just have it exist as a dead function."""
+    monkeypatch.setattr(
+        module, "_live_state",
+        lambda surface, name: "DISABLED" if name in module.paused_names(manifest) else "ENABLED")
+    monkeypatch.setattr(module, "_alarm_actions_enabled", lambda name: False)
+    monkeypatch.setattr(module, "_live_triggers", lambda: [
+        {"surface": "events", "name": "alpha-engine-mystery-rule", "state": "ENABLED"},
+    ])
+    kinds = {(f["trigger"], f["kind"]) for f in module.check()}
+    assert ("alpha-engine-mystery-rule", "trigger-undeclared") in kinds
+
+
+# ── §7.4 RED proof: the finding must fail without the fix, and clear when the
+# manifest is restored (alpha-engine-config-I9959) ───────────────────────────
+
+
+def test_removing_a_kept_entrys_declaration_from_a_fixture_manifest_is_caught(
+        module, manifest):
+    """Mutates a FIXTURE COPY only — never MANIFEST_PATH / the real file."""
+    import copy
+
+    fixture = copy.deepcopy(manifest)
+    victim = "alpha-engine-preflight-sweep-daily"
+    assert victim in fixture["not_paused"], (
+        "fixture setup is wrong: the victim must be a real, currently-declared "
+        "kept trigger for this to be a meaningful RED proof"
+    )
+    del fixture["not_paused"][victim]
+    assert victim not in fixture["not_paused"], (
+        "the deletion did not change the fixture — a demonstration that "
+        "mutated nothing would prove nothing"
+    )
+    # The rest of the manifest is untouched — same object graph, one key gone.
+    assert fixture["paused"] == manifest["paused"]
+
+    live = [{"surface": "events", "name": victim, "state": "ENABLED"}]
+
+    # RED: with the entry gone, the live-enabled trigger must be reported.
+    red = module.trigger_coverage_findings(fixture, triggers=live)
+    red_kinds = {(f["trigger"], f["kind"]) for f in red}
+    assert (victim, "trigger-undeclared") in red_kinds, (
+        f"removing {victim!r}'s declaration did not surface it as undeclared: {red}"
+    )
+
+    # GREEN: the ORIGINAL (unmutated) manifest still declares it — restoring
+    # the entry (i.e. going back to `manifest` instead of `fixture`) must
+    # clear the finding for the same live state.
+    green = module.trigger_coverage_findings(manifest, triggers=live)
+    assert not [f for f in green if f["trigger"] == victim], (
+        f"the unmutated manifest still declares {victim!r}, but it was still "
+        f"reported: {green}"
+    )
+
+
+# ── the enumeration itself: pagination and fail-loud (alpha-engine-config-I9959) ─
+
+
+@pytest.mark.real_trigger_scan
+def test_live_triggers_pagination_is_followed(module, monkeypatch):
+    """A truncated first page would silently shrink the population an
+    undeclared trigger could hide behind — the `aws --no-paginate` failure
+    mode (first page only, no marker) this loop must never reproduce."""
+    pages = {
+        ("events", None): '{"Rules": [{"Name": "r1", "State": "ENABLED"}], "NextToken": "tok1"}',
+        ("events", "tok1"): '{"Rules": [{"Name": "r2", "State": "DISABLED"}], "NextToken": null}',
+        ("scheduler", None): '{"Schedules": [{"Name": "s1", "State": "ENABLED"}], "NextToken": null}',
+    }
+    seen: list[tuple[str, str | None]] = []
+
+    def fake_aws(args):
+        surface = "events" if "list-rules" in args else "scheduler"
+        token = args[args.index("--next-token") + 1] if "--next-token" in args else None
+        seen.append((surface, token))
+        return 0, pages[(surface, token)], ""
+
+    monkeypatch.setattr(module, "_aws", fake_aws)
+    triggers = module._live_triggers()
+    got = {(t["surface"], t["name"], t["state"]) for t in triggers}
+    assert got == {
+        ("events", "r1", "ENABLED"),
+        ("events", "r2", "DISABLED"),
+        ("scheduler", "s1", "ENABLED"),
+    }
+    assert ("events", "tok1") in seen, "the second page of events:list-rules was never requested"
+
+
+@pytest.mark.real_trigger_scan
+def test_live_triggers_raises_loud_on_an_aws_failure(module, monkeypatch):
+    """A partial listing must never be reported as 'every trigger checked' —
+    RAISE, don't return whatever page came back."""
+    monkeypatch.setattr(module, "_aws", lambda args: (255, "", "AccessDeniedException"))
+    with pytest.raises(RuntimeError, match="AccessDeniedException"):
+        module._live_triggers()
+
+
+def test_scope_carve_out_matches_pause_reconcile(module):
+    """One exclusion, declared once each in two files that must not drift.
+
+    `pause_reconcile.py`'s own account-wide enumeration excludes AWS-managed
+    rules under `_AWS_MANAGED_PREFIX`; this module's `_live_triggers()`-based
+    completeness scan excludes the same population under
+    `AWS_MANAGED_TRIGGER_PREFIX`. Two literals for one exclusion is exactly
+    how the `_reactive-notifier-rules` class of defect (a value no checker
+    reads) reappears one level up — pinned here so the two cannot diverge
+    silently.
+    """
+    pytest.importorskip("boto3")
+    pytest.importorskip("yaml")
+    spec = importlib.util.spec_from_file_location("pause_reconcile", INFRA / "pause_reconcile.py")
+    pause_reconcile = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("pause_reconcile", pause_reconcile)
+    spec.loader.exec_module(pause_reconcile)
+    assert module.AWS_MANAGED_TRIGGER_PREFIX == pause_reconcile._AWS_MANAGED_PREFIX


### PR DESCRIPTION
## Summary

`automation_pause.py --check` graded live AWS only against the manifest's own hand-listed names (`paused`/`not_paused`), so a live, ENABLED EventBridge rule or Scheduler schedule named in neither block was invisible to it — the check ran daily, reported, and could not see the one case it most needed to. Two such triggers were found by hand on 2026-09-03 (`alpha-engine-preflight-sweep-daily`, `alpha-engine-preopen-deploy-readiness-probe`; alpha-engine-config-I9937, classified by nousergon-data-PR1635). Nothing would have found a third.

- Adds `_live_triggers()`: an account-wide enumeration of every EventBridge rule and Scheduler schedule, explicitly paginated (loops on `NextToken`, never `aws --no-paginate`) and RAISES on any AWS failure rather than trusting a partial page.
- Adds `trigger_coverage_findings()`, mirroring the existing `alarm_coverage_findings()` completeness scan: a live ENABLED trigger named in neither `paused` nor `not_paused` is reported as `trigger-undeclared`, by name, in the same finding shape every other `--check` finding already uses (no parallel reporting channel).
- Makes scope explicit: `AWS_MANAGED_TRIGGER_PREFIX` (`DO-NOT-DELETE-`) carves out AWS-managed rules (e.g. Inspector's ECR-scan rule) — the fleet owns none of their lifecycle — and reports them as `trigger-out-of-scope` rather than silently filtering them. Matches `pause_reconcile.py`'s own `_AWS_MANAGED_PREFIX` carve-out; a test pins the two constants equal so they cannot drift apart.
- Wired into `check()`. CI's `github-actions-iam-drift-check` role already holds `events:ListRules`/`scheduler:ListSchedules` (`pause_reconcile.py` has used them from the same role since alpha-engine-config-I7118) — no IAM change needed.

## §7.4 RED proof

`tests/test_automation_pause.py::test_removing_a_kept_entrys_declaration_from_a_fixture_manifest_is_caught` deletes `alpha-engine-preflight-sweep-daily`'s entry from a **deep-copied fixture** of the manifest (never the real file), asserts the deletion actually took effect, then asserts `trigger_coverage_findings()` reports it as `trigger-undeclared`; a second assertion against the unmutated manifest confirms the finding clears.

Manually verified the wiring itself fails without the fix: temporarily commented out `findings.extend(trigger_coverage_findings())` in `check()` and re-ran `-k trigger` — `test_check_surfaces_trigger_coverage_findings` failed (`AssertionError: assert (...) in set()`); restored the line and the full suite passed again.

## Test plan

- [x] `tests/test_automation_pause.py` (94 tests incl. 18 new) — full pass
- [x] Full repo suite (`pytest tests/ --ignore=tests/integration`) — 6963 passed, 12 skipped, 0 failed
- [x] RED/GREEN demonstration of the new finding (above)
- [ ] CI green on this PR

alpha-engine-config-I9959 (tracker: `alpha-engine-config`; code lands here per the cross-repo convention — no closing keyword used, cited in prose only).

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)