### PR TITLE
fix(weekly): the offcycle runner still routed the v1 weekly to the PAGING topic (I9756 d3)

### DIFF
--- a/infrastructure/run_weekly_offcycle.sh
+++ b/infrastructure/run_weekly_offcycle.sh
@@ -73,7 +73,20 @@ SATURDAY_RULE_ARN="arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/${SATURDAY_RULE}"
 # execution — an off-cycle run reproducing the live contracts byte-for-byte
 # now means reproducing THEIR omission of ec2_instance_id too, so this
 # script's launches go through the same dispatch path as the real cron.
-SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts"
+# alpha-engine-config-I9756 deliverable 3 (crucible v2 phase 0, Brian ruling
+# I9751 item 3a): the v1 weekly's alerts are MUTED for the v2 build window.
+# `SaturdayTrigger` in infrastructure/cloudformation/alpha-engine-orchestration.yaml
+# routes to AlertsMutedTopic; this script is the OTHER way the same state
+# machine gets started, and it still named the paging topic. A recovery run
+# launched here during the graded week therefore filed an execution routed to
+# `alpha-engine-alerts`, and `crucible/gate.py::_clause_old_alerts_muted`
+# grades EVERY execution in the week, not only the scheduled ones — so one
+# shell run was enough to hold phase 0 UNMET on a week that was otherwise
+# clean. Measured 2026-09-04: `friday-shell-2026-08-28-eod-*` and
+# `offcycle-shell-20260828-*` are in the store carrying the paging topic.
+# Re-exam 2026-09-14, with the CFN switch above: revert BOTH to AlertsTopic
+# once phase 0 exits or the v1 pipeline is retired, whichever comes first.
+SNS_TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:alpha-engine-alerts-muted"
 
 # Auto re-enable infra (one-time EventBridge Scheduler job + its execution role)
 REENABLE_ROLE_NAME="alpha-engine-offcycle-cron-role"

--- a/tests/test_run_weekly_offcycle.py
+++ b/tests/test_run_weekly_offcycle.py
@@ -82,7 +82,7 @@ def test_shell_input_contract() -> None:
     # it from a fresh ephemeral spot; this script no longer hardcodes the
     # always-on dashboard box id.
     assert "ec2_instance_id" not in obj
-    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts")
+    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts-muted")
 
 
 def test_full_input_contract() -> None:
@@ -90,7 +90,7 @@ def test_full_input_contract() -> None:
     assert obj["pipeline_role"] == "weekly"
     assert "shell_run" not in obj, "full weekly run must NOT set shell_run"
     assert "ec2_instance_id" not in obj  # config#2248 — see test_shell_input_contract
-    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts")
+    assert obj["sns_topic_arn"].endswith(":alpha-engine-alerts-muted")
 
 
 def test_full_input_matches_live_cron_target() -> None:
@@ -112,6 +112,31 @@ def test_full_input_matches_live_cron_target() -> None:
     # through the dispatch path together.
     assert "ec2_instance_id" not in input_block
     assert _dry_run_input("full")["pipeline_role"] == "weekly"
+
+    # alpha-engine-config-I9756 deliverable 3. This test's docstring has
+    # always said the builder "must reproduce the CFN SaturdayTrigger Input",
+    # and until 2026-09-04 it checked three keys and never `sns_topic_arn` —
+    # so when the CFN target was repointed to AlertsMutedTopic and this
+    # script was not, the test stayed green across the drift it names.
+    # (The very next helper's docstring warns about hand-checking NAMED keys;
+    # this assertion is that warning applied to the test above it.)
+    #
+    # Compared by SNS logical resource id rather than by ARN: the CFN side is
+    # a `!Sub` reference (`${AlertsMutedTopic}`) and the script side is an
+    # interpolated literal, so the only thing both sides spell the same way
+    # is the topic NAME.
+    cfn_topic = re.search(r'"sns_topic_arn":\s*"\$\{(\w+)\}"', input_block)
+    assert cfn_topic, "SaturdayTrigger Input declares no sns_topic_arn"
+    expected_name = {
+        "AlertsTopic": "alpha-engine-alerts",
+        "AlertsMutedTopic": "alpha-engine-alerts-muted",
+    }[cfn_topic.group(1)]
+    assert _dry_run_input("full")["sns_topic_arn"].endswith(":" + expected_name), (
+        "the offcycle runner routes the weekly SF somewhere the live cron "
+        "target does not; every execution it starts is graded for routing by "
+        "crucible/gate.py::_clause_old_alerts_muted"
+    )
+    assert _dry_run_input("shell")["sns_topic_arn"].endswith(":" + expected_name)
 
 
 def _lambda_shell_input() -> dict:


### PR DESCRIPTION
## What

`alpha-engine-config-I9756` deliverable 3 — the v1 weekly's alerts are muted for the crucible v2 build window (Brian ruling `I9751` item 3a).

`SaturdayTrigger` in `infrastructure/cloudformation/alpha-engine-orchestration.yaml` routes to `AlertsMutedTopic`. `infrastructure/run_weekly_offcycle.sh` is the **other** way the same state machine gets started, and it still hardcoded `alpha-engine-alerts`.

`crucible/gate.py::_clause_old_alerts_muted` grades **every** execution in the week, not only the scheduled ones. So one recovery run launched from this script was enough to hold phase 0's third clause UNMET on a week that was otherwise clean — and a recovery run is exactly what a failed Saturday provokes.

Measured 2026-09-04 in the live store, anchor `2026-08-28`: `friday-shell-2026-08-28-eod-*` and `offcycle-shell-20260828-*` both carry the paging topic.

## The half that matters

`test_full_input_matches_live_cron_target` has always said, in its own docstring, that the builder *"must reproduce the CFN SaturdayTrigger Input"*. It asserted `pipeline_role`, the absence of `shell_run`, and the absence of `ec2_instance_id` — and never `sns_topic_arn`. So when the CFN target was repointed to `AlertsMutedTopic` and this script was not, the test stayed green across the drift it exists to catch.

The helper immediately below it carries a docstring warning about precisely this: *"the previous version of the lockstep test hand-checked two NAMED keys, so a field added to one side and not the other was invisible to it."* This change applies that warning to the test above it.

It now reads the topic's logical resource id out of the CFN Input's own `!Sub` reference and asserts **both** builders against it. Compared by topic NAME rather than ARN, because the CFN side is a `!Sub` reference and the script side an interpolated literal — the name is the only spelling both sides share.

That also protects the scheduled revert. The re-exam on 2026-09-14 says to point both back at `AlertsTopic` once phase 0 exits; with this assertion, reverting one side and not the other fails CI.

## Verified by mutation, both directions

| mutation | result |
|---|---|
| baseline | 10 passed |
| script literal back to `alpha-engine-alerts` | 3 failed |
| CFN Input to `${AlertsTopic}` | `test_full_input_matches_live_cron_target` failed |
| restored | 10 passed |

## Test plan

`python3 -m pytest tests/ -q -p no:randomly` → **6983 passed, 17 skipped, 2 failed**. Both failures are `test_pipeline_status_registry_source_check.py::*[Weekday-json_path1]`, reproduce identically on unmodified `main`, and the assertion's own first line reads `READ THIS FIRST — your installed nousergon-lib does NOT match the pin` — the laptop carries 0.124.21 against this repo's 0.124.104 pin (`alpha-engine-config-I9070`, on the Decision Queue). Environmental, untouched by this diff.

## Related

- `nous-ergon-ops-PR1034` — the anchor-window correction for the same phase-0 gate. Independent; no merge order between them.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWAr3hS6MYUhmsTBQQc9e1

Rehearsal-path: tests/test_run_weekly_offcycle.py

The rehearsal mechanism is `run_weekly_offcycle.sh --dry-run` itself (weekly-sf-policy §7.1): that test drives the script's own dry-run builders and reads back the JSON input it would hand `StartExecution`, so both changed builders are exercised end to end without starting the state machine. The mutation table above is that rehearsal run four times over.
