### PR TITLE
fix(sf): pin the weekday definitions' whole-execution ceilings (I10008)

### DIFF
--- a/infrastructure/step_function_daily.json
+++ b/infrastructure/step_function_daily.json
@@ -1,7 +1,7 @@
 {
   "Comment": "Alpha Engine Weekday Pipeline — morning polygon enrichment, predictor inference, executor start. Runs Mon-Fri 5:15 AM PT (America/Los_Angeles, DST-aware); schedule is CFN-canonical in cloudformation/alpha-engine-orchestration.yaml — do not hand-edit here. MorningEnrich (added 2026-04-24) overwrites the prior trading day's ArcticDB row with polygon's authoritative OHLCV+VWAP before predictor inference reads it — fixes the 2026-04-17→2026-04-23 silent VWAP outage where the EOD yfinance pass was the only source. EOD yfinance collection runs via the post-close EOD SF on ae-trading. Policy: all SSM steps run on ae-trading (trading_instance_id); ae-dashboard is reserved for Streamlit + nginx + spot-launcher only. alpha-engine-config-I2717/I2722 (2026-07-16): the universe-gap + chronic-polygon-gap self-heal (formerly ChronicGapSelfHeal) and the PredictorHealthCheck/PredictorDriftCheck observability producers were REMOVED from this SF entirely — the heal now runs standalone (weekly_collector.py --daily-heal, EventBridge 09:00 UTC weekdays) and the two health checks now fire on their own direct EventBridge triggers (13:40 UTC weekdays), both off this critical path. See infrastructure/cloudformation/alpha-engine-orchestration.yaml. alpha-engine-config-I6494: after MorningArcticAppend, CheckSkipScanner → Scanner invokes alpha-engine-research-scanner:live (same entrypoint as the Saturday weekly SF) before PredictorInference so weekday universe_membership/{date} + factor profiles stay fresh without running the full Saturday pipeline (distinct from I5489 weekday weekly-SF exercise).",
   "StartAt": "InitializeInput",
-  "TimeoutSeconds": 39600,
+  "TimeoutSeconds": 7200,
   "States": {
     "InitializeInput": {
       "Type": "Pass",

--- a/infrastructure/step_function_eod.json
+++ b/infrastructure/step_function_eod.json
@@ -1,7 +1,7 @@
 {
   "Comment": "Alpha Engine EOD Pipeline \u2014 post-market data capture, snapshot capture, reconciliation, daily substrate health check, instance shutdown. Triggered by daemon shutdown on trading EC2.",
   "StartAt": "MarketHoursGate",
-  "TimeoutSeconds": 64800,
+  "TimeoutSeconds": 14400,
   "States": {
     "MarketHoursGate": {
       "Type": "Task",

--- a/tests/test_sf_structural_contract.py
+++ b/tests/test_sf_structural_contract.py
@@ -1297,16 +1297,48 @@ def test_sf_file_set_matches_exemption_registry():
     )
 
 
+# alpha-engine-config#10008. The per-definition whole-execution ceiling, in
+# seconds. PRESENCE was already asserted below; the VALUE was not, and the two
+# weekday definitions had drifted to numbers nothing derived and nothing
+# checked — daily=39600 (11h) against a policy ceiling of 7200, eod=64800
+# (18h) against a ≤75-minute wall-clock budget. A ceiling that no test pins is
+# a ceiling that only ever grows, because every individual bump looks safe.
+#
+#   weekly  43200  sf-pipeline-policy.md §4, stated ceiling (12h)
+#   daily    7200  sf-pipeline-policy.md §4, stated ceiling (2h). The window to
+#                  the 06:30 PT market open is 75 min from the 05:15 PT
+#                  trigger; p95 of the 17 successful scheduled runs over
+#                  2026-07-28→09-04 is ~52 min and the longest recovery rerun
+#                  in that span was 102 min, so 2h bounds every real run while
+#                  releasing the SF mutex the same morning. That last part is
+#                  the point: sf-pipeline-policy.md §1.2 makes same-day
+#                  recovery a standing rule, and an 11h ceiling let one hung
+#                  execution hold the mutex past the close and take the
+#                  recovery with it.
+#   eod     14400  sf-pipeline-policy.md §4 gives the eod pipeline a ≤75-min
+#                  wall-clock target and no numeric ceiling (it must "include
+#                  the bounded heal loop"). Derived: 4h is 2.1× the longest
+#                  execution observed over 2026-07-31→09-04 (115 min, a failed
+#                  run on 08-17) and still clears the 22:00 PT
+#                  alpha-engine-stop-trading cost guard by six hours.
+#   groom   15000  unchanged; not a pipeline sf-pipeline-policy.md governs.
+_TOP_LEVEL_TIMEOUT_CEILING = {
+    "step_function.json": 43200,
+    "step_function_daily.json": 7200,
+    "step_function_eod.json": 14400,
+    "step_function_groom.json": 15000,
+}
+
+
 @pytest.mark.parametrize("sf_file", _SF_FILE_NAMES)
 def test_definition_declares_top_level_timeout(sf_file: str):
     """alpha-engine-config#6693: a hung execution with no top-level
     TimeoutSeconds can run to the Step Functions 1-year service maximum,
     invisible to any status-keyed watcher. Covers every file in the
-    exemption registry above (weekly, daily, eod, groom) — all four
-    currently declare one (weekly=43200, daily=39600, eod=64800,
-    groom=15000); a new step_function_*.json landing without one fails
-    here rather than silently inheriting the 1-year default. (Formerly
-    its own module, tests/test_sf_timeout_coverage.py; folded in here on
+    exemption registry above (weekly, daily, eod, groom); a new
+    step_function_*.json landing without one fails here rather than
+    silently inheriting the 1-year default. (Formerly its own module,
+    tests/test_sf_timeout_coverage.py; folded in here on
     #1256/config#6693 to avoid two parallel checkers over the same files
     as config#6684's structural-contract suite.)"""
     definition = _load(sf_file)
@@ -1315,6 +1347,33 @@ def test_definition_declares_top_level_timeout(sf_file: str):
         "to the Step Functions 1-year service maximum invisibly"
     )
     assert isinstance(definition["TimeoutSeconds"], int) and definition["TimeoutSeconds"] > 0
+
+
+def test_every_definition_has_a_codified_ceiling():
+    """A new step_function_*.json must state its ceiling here, with the
+    derivation, rather than inherit whatever number was typed into it."""
+    assert sorted(_TOP_LEVEL_TIMEOUT_CEILING) == _SF_FILE_NAMES, (
+        f"_TOP_LEVEL_TIMEOUT_CEILING covers {sorted(_TOP_LEVEL_TIMEOUT_CEILING)} "
+        f"but the definition registry is {_SF_FILE_NAMES} — add the new file's "
+        f"ceiling and the one-line derivation that justifies it"
+    )
+
+
+@pytest.mark.parametrize("sf_file", _SF_FILE_NAMES)
+def test_top_level_timeout_matches_its_codified_ceiling(sf_file: str):
+    """alpha-engine-config#10008. Presence is not enough: a whole-execution
+    ceiling nothing pins drifts upward one 'safe' bump at a time, and every
+    bump is invisible because no reader knows what the number was derived
+    from. Changing a value here is a deliberate edit to the comment block
+    above it, which is where the derivation lives."""
+    expected = _TOP_LEVEL_TIMEOUT_CEILING[sf_file]
+    actual = _load(sf_file)["TimeoutSeconds"]
+    assert actual == expected, (
+        f"{sf_file}: top-level TimeoutSeconds is {actual}, expected {expected}. "
+        f"See _TOP_LEVEL_TIMEOUT_CEILING in this file for the derivation. If "
+        f"the pipeline genuinely needs a different ceiling, change the map AND "
+        f"its derivation comment in the same diff — sf-pipeline-policy.md §4."
+    )
 
 
 @pytest.mark.parametrize("sf_file", _SF_FILE_NAMES)


### PR DESCRIPTION
## What

Brings the two weekday trading definitions' whole-execution `TimeoutSeconds` to their policy ceilings, and pins the values so they cannot drift again.

- `infrastructure/step_function_daily.json` (preopen): **39600 → 7200**
- `infrastructure/step_function_eod.json` (postclose): **64800 → 14400**
- `tests/test_sf_structural_contract.py`: new `_TOP_LEVEL_TIMEOUT_CEILING` map carrying every definition's ceiling **with its derivation**, plus two tests

## Why

`sf-pipeline-policy.md` §4 states the preopen hard ceiling as **7200 (2h)** in a table. Live and in the repo it was **39600 (11h)**. `test_definition_declares_top_level_timeout` asserted only `"TimeoutSeconds" in definition` and `> 0` — presence was pinned, the **value** was not. A ceiling nothing pins only ever grows, because every individual bump looks safe in isolation and no reader knows what the number was derived from.

**The preopen number is not cosmetic.** The definition acquires an SF mutex (`AcquireMutex` → `MutexConflict` Fail). A **hung** execution — as distinct from a failed one — holds that mutex for the whole definition ceiling. At 39600s a hang starting at the 05:15 PT trigger holds it until **16:15 PT, past the close**, and every same-day recovery attempt fails `MutexConflict`. `sf-pipeline-policy.md` §1.2 makes same-day recovery a **standing rule** — "the scheduled trigger is the *first* attempt at the session, never the only one". The ceiling was quietly making that rule unexecutable on exactly the mornings it exists for. At 7200s the hang self-clears by 07:15 PT.

## Measured

`AWS_PROFILE=ne-admin aws stepfunctions list-executions --max-results 40`, 2026-07-28 → 09-04:

| | |
|---|---|
| successful scheduled preopen runs | 17; p95 ≈ **52 min**, max **54.1 min** (2026-09-03) |
| longest preopen recovery rerun in span | **102 min** (2026-08-13, 08:44 → 10:26 PT) |
| longest postclose execution 07-31 → 09-04 | **115 min** (2026-08-17, a failed run) |

So 7200s bounds every real preopen run observed with 18 minutes of headroom over the worst, while cutting the mutex-hold blast radius by 5.5×.

`sf-pipeline-policy.md` §4 gives the postclose pipeline a ≤75-min wall-clock target and **no numeric ceiling** ("sized to include the bounded heal loop"). 14400 is derived: **2.1× the longest execution observed**, and still six hours clear of the 22:00 PT `alpha-engine-stop-trading` cost guard.

Verified this is not repo-vs-live drift — `describe-state-machine --query definition` for both pipelines matched the repo files exactly on the top-level value and state count before this change.

## The class fix, not just the instance

`_TOP_LEVEL_TIMEOUT_CEILING` carries every definition's ceiling **and the derivation for each value as a comment block**. Two tests:

- `test_every_definition_has_a_codified_ceiling` — the map must cover every file in `_SF_FILE_NAMES`, so a new `step_function_*.json` has to state and justify a ceiling rather than inherit whatever number was typed into it.
- `test_top_level_timeout_matches_its_codified_ceiling` — each definition's value must equal its codified ceiling.

Changing a ceiling is now a deliberate edit to the derivation that justifies it, in the same diff.

## Merge window — this is a trading change

`step_function_daily.json` and `step_function_eod.json` deploy through the `alpha-engine-orchestration` CloudFormation stack. Per `crucible_v2_rebuild_plan_260901.md` §3.1's standing rule, a change to that stack is a change to trading: **merge outside 05:00–16:30 ET on NYSE trading days.** This is a constraint on *when* the merge button is pressed, not a step to run after pressing it — `deploy-infrastructure.yml` redeploys the stack on push to `main` with no operator action.

Blast radius: two integer literals in state-machine metadata. No state, transition, retry, catch or IAM surface changes. A run that would have exceeded the new ceiling would have been long past useless — the preopen's external deadline is 75 minutes from its trigger.

## Testing

`.venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration` → **6974 passed, 12 skipped**, including `test_sf_structural_contract.py` (76 passed with `test_sf_drift_gate_families.py`) and the new ceiling tests.

## SOTA + delta

**SOTA:** every whole-execution ceiling is derived from the pipeline's measured p95 and its external deadline, and pinned by a test that carries the derivation — so the number is auditable and cannot creep. **Delta:** the derivation is pinned in a test module rather than in the single declared-cadence parameter `sf-pipeline-policy.md` §2.6 wants (`alpha-engine-config-I6689`); when that declaration lands, this map is what it absorbs.

Tracker: `alpha-engine-config-I10008`

Prepared by: Claude Fable 5.1 via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGbmACnphu8Lxy6HNk513n

Rehearsal-path: tests/test_sf_structural_contract.py — the change is two integer literals in state-machine metadata, and its entire effect is asserted by test_top_level_timeout_matches_its_codified_ceiling plus sf-definition-validate, which round-trips both definitions through the Step Functions validator. Nothing here needs a live trading morning to exercise: no state, transition, retry, catch or IAM surface changes, and the ceiling only binds on an execution that has already blown past its external deadline.
