### PR TITLE
fix(pause-reconcile): a Scheduler schedule is (group, name), not name (I10009)

### DIFF
--- a/infrastructure/pause_reconcile.py
+++ b/infrastructure/pause_reconcile.py
@@ -107,6 +107,13 @@ NON_SERVICE_LIFECYCLES = frozenset({"disabled", "deprecated", "retired"})
 #: carry no fleet row and never will.
 _AWS_MANAGED_PREFIX = "DO-NOT-DELETE-"
 
+#: EventBridge Scheduler puts every schedule in a group, and `get-schedule`
+#: resolves within ONE group — omitting `--group-name` searches only this one.
+#: `list-schedules` spans all of them, so an enumerate-then-describe pass that
+#: drops the group can list schedules it will then fail to describe
+#: (alpha-engine-config-I10009).
+DEFAULT_SCHEDULE_GROUP = "default"
+
 CHECK_ID = "automation-pause-reconcile"
 CHECK_LABEL = "automation pause: manifest vs registry vs live AWS"
 CADENCE_MINUTES = 1440  # the daily sf-arn-drift-check sweep
@@ -144,6 +151,19 @@ def live_triggers() -> list[dict]:
     APIs over disjoint resources, not aliases (alpha-engine-config-I6842: a
     Scheduler-triggered Lambda reads as untriggered when only the first is
     queried). Both are enumerated here or the sweep has a blind surface.
+
+    **A Scheduler schedule is identified by (group, name), not by name**
+    (alpha-engine-config-I10009). `list-schedules` spans every schedule group,
+    but `get-schedule` defaults to the `default` group and raises
+    `ResourceNotFoundException` for a schedule that exists in any other one. So
+    the group is carried on every scheduler row here and handed to every
+    per-schedule call below; dropping it makes this reconciler enumerate
+    schedules it can then never describe. Measured live 2026-09-04: the four
+    `crucible-v2`-group schedules landed on 2026-09-03 (I9994) and every run of
+    `pause-reconcile.yml` since has exited 2 on
+    `get-schedule --name alerts-sweep`, i.e. the pause reconciler — the daily
+    check over the manifest that governs which fleet automation may run — was
+    itself down for two days.
     """
     out: list[dict] = []
     for page in _paginate(["events", "list-rules"], "Rules"):
@@ -151,7 +171,8 @@ def live_triggers() -> list[dict]:
                     "state": page.get("State")})
     for page in _paginate(["scheduler", "list-schedules"], "Schedules"):
         out.append({"surface": "scheduler", "name": page["Name"],
-                    "state": page.get("State")})
+                    "state": page.get("State"),
+                    "group": page.get("GroupName") or DEFAULT_SCHEDULE_GROUP})
     return sorted(out, key=lambda t: (t["surface"], t["name"]))
 
 
@@ -261,7 +282,7 @@ def lambda_invocations(function_name: str, since=None) -> float:
     return sum(float(d.get("Sum") or 0) for d in got.get("Datapoints", []))
 
 
-def is_ephemeral_one_shot(name: str) -> bool:
+def is_ephemeral_one_shot(name: str, group: str = DEFAULT_SCHEDULE_GROUP) -> bool:
     """Does this Scheduler schedule delete itself the moment it fires?
 
     **The class this exists for (alpha-engine-config-I7547).** Two dispatchers
@@ -289,9 +310,18 @@ def is_ephemeral_one_shot(name: str) -> bool:
     proof rather than by assumption — self-deletion after firing is the only way
     that race resolves, and raising on it would make this check fail whenever a
     dispatcher happened to be deferring while it ran.
+
+    ``group`` is REQUIRED for correctness, not an optimisation
+    (alpha-engine-config-I10009). Without it `get-schedule` looks only in the
+    ``default`` group, so a schedule living in any other group raises
+    ``ResourceNotFoundException`` — which this function reads as "it deleted
+    itself" and returns ``True`` for. That is the quiet half of the same bug:
+    every non-default-group schedule would be silently classified an ephemeral
+    one-shot and excused from the register it is missing from.
     """
     try:
-        got = _aws_json(["scheduler", "get-schedule", "--name", name])
+        got = _aws_json(["scheduler", "get-schedule", "--name", name,
+                         "--group-name", group or DEFAULT_SCHEDULE_GROUP])
     except RuntimeError as exc:
         if "ResourceNotFoundException" in str(exc):
             return True
@@ -301,11 +331,15 @@ def is_ephemeral_one_shot(name: str) -> bool:
 
 def trigger_targets(trigger: dict) -> list[str]:
     """The ARNs a trigger invokes. Empty is a legitimate answer (a rule whose
-    targets were removed), and is reported as such rather than skipped."""
+    targets were removed), and is reported as such rather than skipped.
+
+    Scheduler rows carry their group (see `live_triggers`); it is passed
+    through because `get-schedule` resolves only within one group."""
     if trigger["surface"] == "events":
         got = _aws_json(["events", "list-targets-by-rule", "--rule", trigger["name"]])
         return [t["Arn"] for t in got.get("Targets", [])]
-    got = _aws_json(["scheduler", "get-schedule", "--name", trigger["name"]])
+    got = _aws_json(["scheduler", "get-schedule", "--name", trigger["name"],
+                     "--group-name", trigger.get("group") or DEFAULT_SCHEDULE_GROUP])
     arn = (got.get("Target") or {}).get("Arn")
     return [arn] if arn else []
 
@@ -506,7 +540,7 @@ def reconcile(
                 # already-registered dispatcher, not standing scheduled work —
                 # see `is_ephemeral_one_shot`. Probed only here, so a clean run
                 # pays nothing for it.
-                if t["surface"] == "scheduler" and is_ephemeral(name):
+                if t["surface"] == "scheduler" and is_ephemeral(name, t.get("group")):
                     noted.append({
                         "id": name, "kind": "ephemeral-one-shot",
                         "detail": (

--- a/tests/test_pause_reconcile.py
+++ b/tests/test_pause_reconcile.py
@@ -518,7 +518,7 @@ def test_a_self_deleting_one_shot_is_not_undeclared_scheduled_work(mod):
                    "state": "ENABLED"}],
         targets_of=lambda t: [], sf_invoked=set(), invocations_of=lambda cid: 0,
         alarm_actions_of=lambda n: None,
-        is_ephemeral=lambda name: True, noted=noted,
+        is_ephemeral=lambda name, group=None: True, noted=noted,
     )
     assert findings == []
     assert [(n["kind"], n["id"]) for n in noted] == [
@@ -536,7 +536,7 @@ def test_a_standing_schedule_is_still_a_finding(mod):
         triggers=[{"surface": "scheduler", "name": "some-daily-job", "state": "ENABLED"}],
         targets_of=lambda t: [], sf_invoked=set(), invocations_of=lambda cid: 0,
         alarm_actions_of=lambda n: None,
-        is_ephemeral=lambda name: False,
+        is_ephemeral=lambda name, group=None: False,
     )
     assert [(f["kind"], f["trigger"]) for f in findings] == [
         ("undeclared-enabled", "some-daily-job")]
@@ -550,7 +550,7 @@ def test_the_ephemeral_probe_is_not_called_on_a_clean_run(mod):
         triggers=[{"surface": "scheduler", "name": "kept-job", "state": "ENABLED"}],
         targets_of=lambda t: [], sf_invoked=set(), invocations_of=lambda cid: 0,
         alarm_actions_of=lambda n: None,
-        is_ephemeral=lambda name: calls.append(name) or True,
+        is_ephemeral=lambda name, group=None: calls.append(name) or True,
     )
     assert calls == []
 
@@ -575,6 +575,61 @@ def test_a_real_scheduler_failure_still_raises(mod, monkeypatch):
     monkeypatch.setattr(mod, "_aws_json", _boom)
     with pytest.raises(RuntimeError, match="AccessDenied"):
         mod.is_ephemeral_one_shot("sf-watch-defer-abc-g1")
+
+
+# ── (group, name) is a Scheduler schedule's identity ─────────────────────────
+# alpha-engine-config-I10009. `list-schedules` spans every schedule group;
+# `get-schedule` resolves within ONE, defaulting to `default`. An
+# enumerate-then-describe pass that drops the group lists schedules it can then
+# never describe — measured live 2026-09-04, where the four `crucible-v2`-group
+# schedules landed on 09-03 and every `pause-reconcile.yml` run since exited 2
+# on `get-schedule --name alerts-sweep`.
+
+
+def test_live_triggers_carries_each_schedules_group(mod, monkeypatch):
+    """Without the group on the row there is nothing to pass downstream, and
+    the bug reappears the next time someone makes a non-default group."""
+    def _fake(cmd, key):
+        if cmd[0] == "events":
+            return iter([])
+        return iter([
+            {"Name": "alerts-sweep", "State": "ENABLED", "GroupName": "crucible-v2"},
+            {"Name": "alpha-engine-weekday", "State": "ENABLED", "GroupName": "default"},
+        ])
+    monkeypatch.setattr(mod, "_paginate", _fake)
+    by_name = {t["name"]: t for t in mod.live_triggers()}
+    assert by_name["alerts-sweep"]["group"] == "crucible-v2"
+    assert by_name["alpha-engine-weekday"]["group"] == "default"
+
+
+def test_the_ephemeral_probe_passes_the_group_through(mod, monkeypatch):
+    """The quiet half of the bug: `get-schedule` without `--group-name` raises
+    ResourceNotFoundException for a non-default-group schedule, which this
+    function reads as 'it deleted itself' and returns True for. So the bug
+    does not only break the run — it silently excuses every non-default-group
+    schedule from the register it is missing from."""
+    seen: list[list[str]] = []
+    monkeypatch.setattr(mod, "_aws_json", lambda args: seen.append(args) or {})
+    mod.is_ephemeral_one_shot("alerts-sweep", "crucible-v2")
+    assert seen[0] == ["scheduler", "get-schedule", "--name", "alerts-sweep",
+                       "--group-name", "crucible-v2"]
+
+
+def test_trigger_targets_passes_the_group_through(mod, monkeypatch):
+    seen: list[list[str]] = []
+    monkeypatch.setattr(mod, "_aws_json", lambda args: seen.append(args) or {})
+    mod.trigger_targets({"surface": "scheduler", "name": "alerts-sweep",
+                         "group": "crucible-v2"})
+    assert "--group-name" in seen[0] and "crucible-v2" in seen[0]
+
+
+def test_a_scheduler_row_with_no_group_falls_back_to_default(mod, monkeypatch):
+    """Rows built before this change, and any hand-built row in a caller,
+    must keep resolving rather than crash on a missing key."""
+    seen: list[list[str]] = []
+    monkeypatch.setattr(mod, "_aws_json", lambda args: seen.append(args) or {})
+    mod.trigger_targets({"surface": "scheduler", "name": "alpha-engine-weekday"})
+    assert seen[0][-2:] == ["--group-name", mod.DEFAULT_SCHEDULE_GROUP]
 
 
 def test_the_headline_distinguishes_drift_from_a_broken_detector(mod):


### PR DESCRIPTION
## What

Threads the EventBridge Scheduler **schedule group** through `infrastructure/pause_reconcile.py` as part of a schedule's identity, restoring a detector that has been dead for two days.

## Why

`pause-reconcile.yml` has exited **2 — "the reconciler could NOT run"** on every run since 2026-09-02. It is the only detector over `automation_pause.json`, the manifest that decides which fleet automation is allowed to run at all.

`gh run list --repo nousergon/nousergon-data --workflow pause-reconcile.yml --limit 6` → `failure` ×6 (2026-09-02T13:53Z → 2026-09-04T20:15Z). `gh run view 33915334786 --log-failed`:

```
ERROR: aws scheduler get-schedule --name alerts-sweep: An error occurred
(ResourceNotFoundException) when calling the GetSchedule operation:
Schedule alerts-sweep does not exist.
reconciler exit code: 2
The reconciler could NOT run. This is a broken detector, not a clean fleet.
```

The schedule exists. **`list-schedules` spans every schedule group; `get-schedule` resolves within one and defaults to `default`.** This module enumerated with the first, discarded `GroupName`, then described with the second — so it enumerated schedules it could never describe.

Latent until `nousergon-data-PR1639` (`alpha-engine-config-I9994`) taught the reconciler about the four crucible-v2 triggers. Measured 2026-09-04, `aws scheduler list-schedules --query "Schedules[].{n:Name,g:GroupName,s:State}"`: `heartbeat`, `weekly`, `alerts-sweep`, `data-daily` carry `GroupName: crucible-v2`; every other schedule in the account carries `default`.

## The quiet half — same cause, no error

`is_ephemeral_one_shot()` catches `ResourceNotFoundException` and returns `True`, because a runtime-minted `sf-watch-defer-*` one-shot legitimately deletes itself after firing. With the group dropped, **every non-default-group schedule would have been silently classified an ephemeral one-shot and excused from the register it is missing from.** Only call ordering decided which half of the bug surfaced. Fixing the loud half alone would have left the silent one live.

## How

The group is threaded through **as identity**, not special-cased for the group that exposed it:

- `DEFAULT_SCHEDULE_GROUP = "default"`, with the reason
- `live_triggers()` carries `"group": page.get("GroupName") or DEFAULT_SCHEDULE_GROUP` on every scheduler row
- `is_ephemeral_one_shot(name, group=...)` and `trigger_targets()` both pass `--group-name`
- a row without a group falls back to `default`, so a hand-built row in any caller keeps resolving

No literal `"crucible-v2"` anywhere — the next schedule group anyone creates needs no edit here.

## Testing

`.venv/bin/python3 -m pytest tests/ -q --ignore=tests/integration` → **6973 passed, 12 skipped**.

Four new regressions in `tests/test_pause_reconcile.py`: the group survives `live_triggers`, both `get-schedule` call sites emit `--group-name`, and a group-less row falls back. Three existing `is_ephemeral=` injections updated for the new arity.

## Deployment

Nothing to run after merging. `pause-reconcile.yml` runs the script from the checkout on its own schedule; the next run picks up the fix.

## Out of scope, recorded

Nothing pages when this workflow stops producing a verdict. It was down for two days and the only signal was the GitHub Actions list. That is the same class as `alpha-engine-config-I10007` (`nous-ergon-ops-PR1037`) and is recorded there rather than widened into this diff.

## SOTA + delta

**SOTA:** a resource is addressed by its full identity, read off the enumeration that found it, so a new partition of the namespace needs no code change. **Delta:** none — the alternative (a group allowlist, or defaulting to `crucible-v2` on failure) would be the hand-maintained list this module's own §2.2 reasoning exists to forbid.

Tracker: `alpha-engine-config-I10009`

Prepared by: Claude Fable 5.1 via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGbmACnphu8Lxy6HNk513n
