### PR TITLE
fix(backfill): macro truncation guard refused the price cache's designed rolling-window slide

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -294,6 +294,32 @@ def _existing_last_date(lib, symbol: str) -> "pd.Timestamp | None":
 # which upstream call answers short on a given run.
 _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS = 5
 
+# Rolling-window slide allowance for the first-date / row-count checks above.
+# The price cache is BY DESIGN a rolling 10-year, fully re-adjusted window
+# (``collectors/prices.py``: "full replace, not append" because yfinance
+# ``auto_adjust`` retroactively re-adjusts the whole series), and the FRED
+# history window is a trailing N years the same way. So a macro series' FIRST
+# date advances at every source refresh — ~5 NYSE sessions per weekly rebuild,
+# more after a missed Saturday or a freeze that released (``macro/HYOAS``
+# advanced ~85 sessions on 2026-09-05 once alpha-engine-config-I9287 unstuck
+# it). Between rebuilds ``daily_append`` extends the ArcticDB series at the
+# tail, so the rows a rebuild "loses" against ArcticDB equal exactly the
+# sessions the window's start slid. That is a slide, not truncation.
+#
+# Measured origin: the first live Saturday after the I9256 guard landed
+# (2026-09-05 10:48 UTC, weekly SF execution 49a1f4e0-…) it refused all 17
+# macro/sector symbols on ``planned_first > existing_first`` by ONE WEEK
+# (``macro.SPY: planned_first=2016-09-06 > existing_first=2016-08-29``) and
+# DataPhase1 failed the pipeline.
+#
+# Truncation (the I9256 class — VIX3M 2509 -> 16 rows) is a start that jumps
+# forward by more than any rebuild cadence can explain, or a row loss the
+# slide does not account for. Above WARN sessions the slide is logged as a
+# finding (a freeze released, or rebuilds were missed — history really was
+# lost); above MAX it is refused outright.
+_MACRO_WINDOW_SLIDE_WARN_TRADING_DAYS = 30
+_MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS = 252
+
 # Max-date staleness tolerance for the macro write boundary, in NYSE trading
 # days behind the reference date (alpha-engine-config-I9287). A shrink/
 # first-date check is blind to a series that keeps writing NEW versions
@@ -371,23 +397,52 @@ def _history_regression(
     existing_rows: int,
     existing_first: "pd.Timestamp | None",
 ) -> "str | None":
-    """Return a human-readable regression string, or None when the write is safe."""
+    """Return a human-readable regression string, or None when the write is safe.
+
+    A rolling-window source legitimately moves the series start forward at
+    every refresh (see ``_MACRO_WINDOW_SLIDE_*``). The slide, in NYSE
+    sessions, is credited against the row-count floor — a window that lost
+    N rows at the front because it advanced N sessions has not shrunk — and
+    is itself bounded: a start that jumps more than the MAX allowance is a
+    coverage change, not a slide, and is refused.
+    """
     planned_rows, planned_first = _series_row_span(planned)
     if existing_rows == 0:
         return None
-    if planned_rows < existing_rows - _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS:
-        return (
-            f"{label}: planned_rows={planned_rows} < existing_rows={existing_rows} "
-            f"(tolerance {_MACRO_HISTORY_SHRINK_TOLERANCE_ROWS})"
-        )
+    slide = 0
     if (
         planned_first is not None
         and existing_first is not None
         and planned_first > existing_first
     ):
+        from nousergon_lib.dates import trading_days_stale
+
+        slide = trading_days_stale(existing_first.date(), planned_first.date())
+    allowed_loss = _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS + min(
+        slide, _MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS
+    )
+    if planned_rows < existing_rows - allowed_loss:
+        return (
+            f"{label}: planned_rows={planned_rows} < existing_rows={existing_rows} "
+            f"(tolerance {_MACRO_HISTORY_SHRINK_TOLERANCE_ROWS} + window slide "
+            f"{min(slide, _MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS)} sessions)"
+        )
+    if slide > _MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS:
         return (
             f"{label}: planned_first={planned_first.date()} > "
-            f"existing_first={existing_first.date()} (history start moved forward)"
+            f"existing_first={existing_first.date()} by {slide} trading days "
+            f"(history start moved forward past the "
+            f"{_MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS}-session rolling-window "
+            f"allowance — a coverage change, not a slide)"
+        )
+    if slide > _MACRO_WINDOW_SLIDE_WARN_TRADING_DAYS:
+        log.warning(
+            "MACRO_WINDOW_SLIDE %s: history start advanced %d trading days "
+            "(%s -> %s) in one rebuild — more than a weekly cadence explains "
+            "(a frozen source released, or rebuilds were missed); %d rows of "
+            "history before %s are gone from ArcticDB's head version.",
+            label, slide, existing_first.date(), planned_first.date(),
+            max(existing_rows - planned_rows, 0), planned_first.date(),
         )
     return None
 
@@ -610,7 +665,9 @@ def _assert_no_arctic_regression(
     if regressions:
         raise RuntimeError(
             f"Backfill regression preflight failed: {len(regressions)} symbols would regress "
-            f"if backfill proceeded. Source data (predictor/price_cache + daily_closes delta) "
+            f"if backfill proceeded (each entry names its own check: last-date regression, "
+            f"history-length truncation, or frozen-source staleness). For a LAST-DATE "
+            f"regression the source (predictor/price_cache + daily_closes delta) "
             f"ends earlier than what ArcticDB already has. Most common cause: the price cache "
             f"mtime 'current' check skipped the weekly refresh, so the cache lags "
             f"MorningEnrich/daily_append writes — and ``_apply_daily_delta`` failed to bridge "

--- a/tests/test_macro_history_truncation_guard.py
+++ b/tests/test_macro_history_truncation_guard.py
@@ -77,13 +77,67 @@ def test_write_boundary_refuses_the_measured_vix3m_truncation():
     assert len(lib.data["VIX3M"]) == 2509
 
 
-def test_write_boundary_refuses_a_forward_moving_history_start():
-    """Same row count, but the series start slid forward a week — still a loss."""
-    lib = _FakeLib({"VIX3M": _frame("2026-07-31", 16)})
-    planned = _frame("2026-08-07", 16)
+# ── rolling-window slide vs truncation (2026-09-05 weekly SF failure) ─────────
+#
+# The price cache is BY DESIGN a rolling 10-year, fully re-adjusted window
+# (collectors/prices.py: "full replace, not append", yfinance auto_adjust), so
+# its FIRST date advances at every refresh. The first live Saturday after the
+# I9256 guard landed (2026-09-05 10:48 UTC) it refused all 17 macro symbols:
+#
+#     macro.SPY: planned_first=2016-09-06 > existing_first=2016-08-29
+#     macro.HYOAS: planned_first=2023-09-05 > existing_first=2023-05-09
+#
+# A window that slides forward at both ends is not truncation. Truncation is a
+# start that jumps forward by more than any rebuild cadence can explain, or a
+# row loss the slide does not account for.
 
+def test_write_boundary_allows_a_one_week_rolling_window_slide():
+    """The measured 2026-09-05 SPY shape: same length, start one week later."""
+    lib = _FakeLib({"SPY": _frame("2016-08-29", 2514)})
+    planned = _frame("2016-09-06", 2514)
+    _bf._write_macro_series_no_shrink(lib, "SPY", planned)
+    assert lib.writes == [("SPY", 2514)]
+
+
+def test_write_boundary_allows_a_slide_after_a_source_freeze(caplog):
+    """The measured 2026-09-05 HYOAS shape: a 3y FRED window that had been
+    frozen for four months (I9287) and then advanced ~85 sessions at once.
+    Allowed, but LOUD — a start moving more than a few weeks means a freeze
+    released or rebuilds were missed, and the row loss is real."""
+    lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    planned = _frame("2023-09-05", 783)
+    with caplog.at_level("WARNING"):
+        _bf._write_macro_series_no_shrink(lib, "HYOAS", planned)
+    assert lib.writes == [("HYOAS", 783)]
+    assert any("MACRO_WINDOW_SLIDE" in r.message for r in caplog.records)
+
+
+def test_write_boundary_allows_a_missed_rebuild_week():
+    """Two weeks of daily_append rows on top of the last rebuild, then a
+    rebuild from a window that slid two weeks: net loss of ~10 rows is the
+    slide, not a truncation."""
+    lib = _FakeLib({"GLD": _frame("2016-08-15", 2524)})
+    planned = _frame("2016-08-29", 2514)
+    _bf._write_macro_series_no_shrink(lib, "GLD", planned)
+    assert lib.writes == [("GLD", 2514)]
+
+
+def test_write_boundary_refuses_a_start_that_jumps_past_the_slide_allowance():
+    """Same row count, start two years later: a frequency/coverage change,
+    not a rolling window — refused."""
+    lib = _FakeLib({"VIX3M": _frame("2016-08-19", 2514)})
+    planned = _frame("2018-08-20", 2514)
     with pytest.raises(RuntimeError, match="history start moved forward"):
         _bf._write_macro_series_no_shrink(lib, "VIX3M", planned)
+    assert lib.writes == []
+
+
+def test_write_boundary_refuses_a_row_loss_the_slide_does_not_explain():
+    """Start unchanged, 30 rows gone from the body/tail — truncation."""
+    lib = _FakeLib({"USO": _frame("2016-08-19", 2514)})
+    planned = _frame("2016-08-19", 2484)
+    with pytest.raises(RuntimeError, match="planned_rows=2484 < existing_rows=2514"):
+        _bf._write_macro_series_no_shrink(lib, "USO", planned)
 
 
 def test_write_boundary_allows_a_normal_append():


### PR DESCRIPTION
## What & why

Weekly SF incident 2026-09-05 (execution `49a1f4e0-…`), first of two causes — DataPhase1 failed at the ArcticDB rebuild:

```
Backfill regression preflight failed: 17 symbols would regress …
macro.SPY: planned_first=2016-09-06 > existing_first=2016-08-29 (history start moved forward)
macro.HYOAS: planned_first=2023-09-05 > existing_first=2023-05-09 (history start moved forward)
```

The I9256 guard (`#1583`, merged 2026-08-29 12:06 PT, after that Saturday's 10:48 UTC backfill — so today was its first live Saturday) refuses ANY forward move of a macro series' first date. But the price cache is by design a rolling 10-year, fully re-adjusted window (`collectors/prices.py`: full replace because yfinance `auto_adjust` retroactively re-adjusts), and the FRED window is a trailing N years the same way. The start advances every refresh; `daily_append` extends ArcticDB at the tail in between; the rows a rebuild "loses" equal the sessions the start slid. A window that slides at both ends is not truncation.

`_history_regression` now measures the slide in NYSE sessions (`nousergon_lib.dates.trading_days_stale`) and:
- credits it against the row-count floor;
- refuses a start that jumps more than 252 sessions (coverage change, not a slide); the measured 2509→16 VIX3M class still fails on the row floor;
- logs `MACRO_WINDOW_SLIDE` above 30 sessions — HYOAS advanced ~85 sessions today once I9287 unstuck it; that history loss is real and must be visible.

Also corrects the preflight's summary message, which attributed every regression to the last-date cause.

Sibling PR (second cause, HandleFailure 403): `nous-ergon-ops-PR1048`. Independent; either order. Both must be on `main` before the SF rerun (the DataPhase1 spot clones `main`).

## Verification

- `tests/test_macro_history_truncation_guard.py`: 5 new cases — the measured SPY and HYOAS shapes pass, a missed-rebuild week passes, a two-year start jump and an unexplained 30-row loss are refused. 3 were red before the fix. All 13 pre-existing I9256/I9287 cases unchanged and green.
- `tests/test_arctic_write_contract.py` green.
- Full `tests/` suite: run locally before ready (result recorded in the PR before `gh pr ready`).
- Post-merge behavioral gate: weekly SF rerun from DataPhase1 via `scripts/weekly_sf_rerun.py --start`.

**Deploy-mechanism:** N/A (no deploy-triggering path; the DataPhase1 spot box clones `main` at bootstrap, so merge == live for the next run).

Merge lane: auto-merge-policy §3 lane 6 (Overseer incident-fix, one named SF incident), under Brian's 2026-09-05 instruction to fix and rerun the weekly SF until it succeeds.

**Prepared by:** claude-fable-5-1 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRUNQXVdhT6nbghhUpgEJ