### PR TITLE
feat(backfill): cumulative ArcticDB history for un-adjusted macro series (I10054 option (a))

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -341,6 +341,56 @@ _MACRO_STALENESS_TOLERANCE_TRADING_DAYS = 10
 # line a health sweep can grep for, rather than a month later.
 _MACRO_FIRST_WRITE_SIBLING_FRACTION = 0.5
 
+# ── Cumulative-retention registry (alpha-engine-config-I10054, option (a)) ────
+#
+# Every macro source is a ROLLING window: ``collectors/prices.py`` refreshes
+# the price cache as a 10-year yfinance ``auto_adjust=True`` FULL REPLACE, and
+# ``collectors/fred_history.py`` fetches a trailing ``period_years`` window the
+# same way. ``builders/backfill.py`` then writes each ArcticDB symbol wholesale
+# (``lib.write``), so the head version loses its oldest week every Saturday.
+# ArcticDB keeps prior versions, so nothing is destroyed — but no reader sees
+# anything older than the window, which silently contradicts the standing
+# "retain all archives, data is an asset" preference for exactly the series a
+# regime model trains on.
+#
+# The reason this cannot simply be fixed for every symbol is the ADJUSTMENT
+# BASIS. ``auto_adjust=True`` retroactively re-adjusts an ETF/equity series'
+# whole history on every split and dividend, so rows written last year are on a
+# different scale from rows written today; splicing them would create a silent
+# seam mid-series. That is why ``collectors/prices.py`` full-replaces rather
+# than appends in the first place, and it is the contract data#1298 established.
+#
+# FRED-sourced INDICES carry no split/dividend adjustment at all — a VIX close
+# from 2016 means today exactly what it meant in 2016 — so for those, and ONLY
+# those, prepending the rows we already hold is EXACT and seamless. This set is
+# therefore the declared cumulative-retention registry: a symbol is cumulative
+# because it is DECLARED here, never because of anything inferable from its
+# name at write time.
+#
+# It is asserted equal to ``collectors/fred_history.FRED_HISTORY_MAP``'s keys
+# by ``tests/test_macro_cumulative_history.py`` — the single declared FRED
+# source map since alpha-engine-config-I9286 — so adding a FRED series without
+# ruling on its retention fails CI rather than silently landing on the rolling
+# default. Do NOT derive this set from that map at import time: a derived set
+# can never fail that test, and the ruling that FRED == un-adjusted is a
+# JUDGEMENT about the data, not a fact about the map.
+#
+# Ruling: alpha-engine-config-I10054 option (a). Option (b) — cumulative for
+# everything, re-stating old rows onto the current basis from the corporate-
+# actions registry — is correct in principle and is the Crucible v2 data-plane
+# shape (raw series + a factor table, adjustment applied at READ time), but it
+# needs dividend factors the registry does not currently carry. Adjusted
+# ETF/equity series stay rolling until v2 owns the data plane.
+CUMULATIVE_MACRO_SYMBOLS: frozenset[str] = frozenset({
+    "VIX",     # VIXCLS      — CBOE volatility index level
+    "VIX3M",   # VXVCLS      — CBOE 3-month volatility index level
+    "TNX",     # DGS10       — 10y Treasury constant-maturity yield, percent
+    "IRX",     # DTB3        — 3-month T-bill rate, percent
+    "TWO",     # DGS2        — 2y Treasury constant-maturity yield, percent
+    "HYOAS",   # BAMLH0A0HYM2 — ICE BofA US HY index OAS, percent
+    "BAA10Y",  # BAA10Y      — Moody's BAA yield less 10y Treasury, percent
+})
+
 
 def _series_row_span(series_or_df) -> "tuple[int, pd.Timestamp | None]":
     """``(n_rows, first_date)`` for a planned Series/DataFrame."""
@@ -355,24 +405,41 @@ def _series_row_span(series_or_df) -> "tuple[int, pd.Timestamp | None]":
     return len(idx), first.normalize()
 
 
-def _existing_row_span(lib, symbol: str) -> "tuple[int, pd.Timestamp | None]":
-    """``(n_rows, first_date)`` for an existing ArcticDB symbol.
+def _read_existing_macro(lib, symbol: str):
+    """The existing ArcticDB frame for ``symbol``, or None when it has none.
 
-    Returns ``(0, None)`` when the symbol does not exist yet — a first write
-    is never a regression. Any OTHER read failure RAISES: silently treating an
-    unreadable symbol as absent is exactly how a truncating write gets waved
-    through (fail-loud rule, AGENTS.md "no silent degrade on a producer").
+    Returns None when the symbol does not exist yet, or exists but is empty —
+    a first write is never a regression. Any OTHER read failure RAISES:
+    silently treating an unreadable symbol as absent is exactly how a
+    truncating write gets waved through (fail-loud rule, AGENTS.md "no silent
+    degrade on a producer").
     """
     try:
         df = lib.read(symbol).data
     except Exception as exc:
         if _symbol_absent(lib, symbol):
-            return 0, None
+            return None
         raise RuntimeError(
             f"Macro history guard: could not read existing ArcticDB symbol "
             f"{symbol!r} to check for truncation: {exc}"
         ) from exc
     if df is None or df.empty:
+        return None
+    return df
+
+
+def _existing_row_span(lib, symbol: str) -> "tuple[int, pd.Timestamp | None]":
+    """``(n_rows, first_date)`` for an existing ArcticDB symbol.
+
+    Returns ``(0, None)`` when the symbol does not exist yet — see
+    ``_read_existing_macro`` for the fail-loud read contract.
+    """
+    return _existing_span_of(_read_existing_macro(lib, symbol))
+
+
+def _existing_span_of(df) -> "tuple[int, pd.Timestamp | None]":
+    """``(n_rows, first_date)`` for an already-read existing frame."""
+    if df is None or len(df) == 0:
         return 0, None
     first = pd.Timestamp(df.index[0])
     if first.tzinfo is not None:
@@ -396,6 +463,7 @@ def _history_regression(
     planned,
     existing_rows: int,
     existing_first: "pd.Timestamp | None",
+    cumulative: bool = False,
 ) -> "str | None":
     """Return a human-readable regression string, or None when the write is safe.
 
@@ -405,6 +473,17 @@ def _history_regression(
     N rows at the front because it advanced N sessions has not shrunk — and
     is itself bounded: a start that jumps more than the MAX allowance is a
     coverage change, not a slide, and is refused.
+
+    This judges the PLANNED frame — what the SOURCE produced — and it does so
+    identically for cumulative and rolling symbols. ``cumulative`` only
+    corrects the *wording* of the slide finding: for a declared-cumulative
+    symbol (``CUMULATIVE_MACRO_SYMBOLS``) the rows the window slid past are
+    restored by ``_cumulative_prepend`` before the write, so they are NOT
+    gone from ArcticDB's head version. Keeping the detector itself blind to
+    that distinction is deliberate: the prepend closes the LOSS, and a source
+    that answers 16 rows where it answered 2509 last week is still a producer
+    defect that must page (alpha-engine-config-I9256), not a defect the repair
+    is allowed to hide.
     """
     planned_rows, planned_first = _series_row_span(planned)
     if existing_rows == 0:
@@ -440,9 +519,15 @@ def _history_regression(
             "MACRO_WINDOW_SLIDE %s: history start advanced %d trading days "
             "(%s -> %s) in one rebuild — more than a weekly cadence explains "
             "(a frozen source released, or rebuilds were missed); %d rows of "
-            "history before %s are gone from ArcticDB's head version.",
+            "history before %s %s.",
             label, slide, existing_first.date(), planned_first.date(),
             max(existing_rows - planned_rows, 0), planned_first.date(),
+            (
+                "are retained by the cumulative prepend "
+                "(alpha-engine-config-I10054)"
+                if cumulative
+                else "are gone from ArcticDB's head version"
+            ),
         )
     return None
 
@@ -510,6 +595,137 @@ def _warn_if_short_first_write(lib, symbol: str, df: "pd.DataFrame") -> None:
         )
 
 
+def _naive_normalized_index(idx) -> "pd.DatetimeIndex":
+    """``idx`` as a tz-naive, midnight-normalized DatetimeIndex."""
+    out = pd.DatetimeIndex(idx)
+    if out.tz is not None:
+        out = out.tz_convert("UTC").tz_localize(None)
+    return out.normalize()
+
+
+def _cumulative_prepend(symbol: str, existing, planned):
+    """Prepend the existing rows strictly older than ``planned``'s first date.
+
+    alpha-engine-config-I10054 option (a). For a symbol declared in
+    ``CUMULATIVE_MACRO_SYMBOLS`` — un-adjusted, FRED-sourced indices, where
+    splicing is EXACT because no split/dividend re-adjustment ever moves an
+    old row's scale — the wholesale ``lib.write`` becomes the union
+    ``(existing rows older than planned_first) ∪ planned`` instead of the
+    rolling source window alone. Overlapping dates always take the PLANNED
+    (fresh) value: only strictly-older rows are taken from ArcticDB, and the
+    de-duplication below keeps the last occurrence as a second line of
+    defence. The result is idempotent — a second run over the same source
+    finds the same union already at the head and reproduces it exactly.
+
+    Everything not declared cumulative (SPY, GLD, USO, XL*, the sub-sector
+    ETFs) is returned untouched and stays rolling: ``auto_adjust=True``
+    retroactively re-adjusts those series, so old rows are on a different
+    scale and splicing them would create a silent mid-series seam.
+
+    Returns ``(frame_to_write, n_prepended, first_prepended_date)``.
+    """
+    if symbol not in CUMULATIVE_MACRO_SYMBOLS or existing is None or len(existing) == 0:
+        return planned, 0, None
+
+    _, planned_first = _series_row_span(planned)
+    if planned_first is None:
+        return planned, 0, None
+
+    existing_idx = _naive_normalized_index(existing.index)
+    older_mask = existing_idx < planned_first
+    if not bool(older_mask.any()):
+        return planned, 0, None
+
+    older = existing.loc[older_mask]
+    older = older.set_axis(existing_idx[older_mask], axis=0)
+
+    # Shape alignment. A column set that no longer matches means the macro
+    # write schema changed under an existing symbol; splicing across that
+    # would fabricate NaN columns, so the prepend is SKIPPED and said so
+    # loudly. Skipping is safe rather than a silent degrade because the
+    # cumulative invariant asserted by the caller then refuses the write
+    # outright — the loss cannot pass unnoticed either way.
+    if isinstance(planned, pd.DataFrame):
+        if not isinstance(older, pd.DataFrame) or set(older.columns) != set(planned.columns):
+            log.warning(
+                "MACRO_HISTORY_PREPEND_SKIPPED symbol=%s reason=column_mismatch "
+                "existing=%s planned=%s — see alpha-engine-config-I10054.",
+                symbol,
+                sorted(getattr(older, "columns", [])),
+                sorted(planned.columns),
+            )
+            return planned, 0, None
+        older = older[list(planned.columns)]
+    else:
+        # A planned Series (the preflight's shape). Take the matching column
+        # from the stored frame, or the frame's single column.
+        if isinstance(older, pd.DataFrame):
+            candidates = [c for c in (planned.name, "Close") if c in older.columns]
+            if candidates:
+                older = older[candidates[0]]
+            elif older.shape[1] == 1:
+                older = older.iloc[:, 0]
+            else:
+                log.warning(
+                    "MACRO_HISTORY_PREPEND_SKIPPED symbol=%s reason=ambiguous_column "
+                    "existing=%s — see alpha-engine-config-I10054.",
+                    symbol, sorted(older.columns),
+                )
+                return planned, 0, None
+        older = older.rename(planned.name)
+
+    planned_normalized = planned.set_axis(_naive_normalized_index(planned.index), axis=0)
+    merged = pd.concat([older, planned_normalized])
+    merged = merged[~merged.index.duplicated(keep="last")].sort_index()
+    merged.index.name = planned.index.name or "date"
+
+    n_prepended = len(older)
+    first_prepended = pd.Timestamp(older.index[0]).date()
+    log.info(
+        "MACRO_HISTORY_PREPENDED symbol=%s rows=%d first=%s planned_first=%s total=%s",
+        symbol, n_prepended, first_prepended, planned_first.date(), len(merged),
+    )
+    return merged, n_prepended, first_prepended
+
+
+def _cumulative_invariant_violation(
+    symbol: str,
+    to_write,
+    existing_rows: int,
+    existing_first: "pd.Timestamp | None",
+) -> "str | None":
+    """Refuse a declared-cumulative symbol whose WRITTEN series still slides.
+
+    The whole point of ``CUMULATIVE_MACRO_SYMBOLS`` is that the head version
+    of these symbols never loses a row it once held, so any forward movement
+    of the written first date — or any net row loss beyond the restatement
+    tolerance — means the prepend did not do its job (a skipped prepend, an
+    unreadable existing frame, a future call site that bypassed it). That is
+    a refusal, not a warning: publishing a truncated head under a cumulative
+    contract is exactly the silent loss this closes.
+    """
+    if symbol not in CUMULATIVE_MACRO_SYMBOLS or existing_rows == 0:
+        return None
+    written_rows, written_first = _series_row_span(to_write)
+    if (
+        written_first is not None
+        and existing_first is not None
+        and written_first > existing_first
+    ):
+        return (
+            f"macro.{symbol}: written_first={written_first.date()} > "
+            f"existing_first={existing_first.date()} on a symbol declared "
+            f"CUMULATIVE — a cumulative series never slides"
+        )
+    if written_rows < existing_rows - _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS:
+        return (
+            f"macro.{symbol}: written_rows={written_rows} < "
+            f"existing_rows={existing_rows} on a symbol declared CUMULATIVE "
+            f"(tolerance {_MACRO_HISTORY_SHRINK_TOLERANCE_ROWS})"
+        )
+    return None
+
+
 def _write_macro_series_no_shrink(
     lib, symbol: str, df: "pd.DataFrame", reference_date: "str | None" = None,
 ) -> None:
@@ -529,8 +745,12 @@ def _write_macro_series_no_shrink(
     publish. ``reference_date=None`` skips the staleness half of the check
     (no run_date known to the caller) but still enforces no-shrink.
     """
-    existing_rows, existing_first = _existing_row_span(lib, symbol)
-    regression = _history_regression(f"macro.{symbol}", df, existing_rows, existing_first)
+    existing = _read_existing_macro(lib, symbol)
+    existing_rows, existing_first = _existing_span_of(existing)
+    cumulative = symbol in CUMULATIVE_MACRO_SYMBOLS
+    regression = _history_regression(
+        f"macro.{symbol}", df, existing_rows, existing_first, cumulative=cumulative,
+    )
     if regression is not None:
         raise RuntimeError(
             "Macro write refused — it would TRUNCATE an existing series. "
@@ -556,7 +776,22 @@ def _write_macro_series_no_shrink(
         )
     if existing_rows == 0:
         _warn_if_short_first_write(lib, symbol, df)
-    lib.write(symbol, df)
+    # alpha-engine-config-I10054 option (a): un-adjusted (FRED-sourced) series
+    # are cumulative — union the rows we already hold that predate the source
+    # window with the fresh window, so the head version never loses history.
+    # Adjusted ETF/equity series fall through untouched and stay rolling.
+    to_write, _, _ = _cumulative_prepend(symbol, existing, df)
+    violation = _cumulative_invariant_violation(
+        symbol, to_write, existing_rows, existing_first,
+    )
+    if violation is not None:
+        raise RuntimeError(
+            "Macro write refused — it would truncate a series declared "
+            f"CUMULATIVE. {violation}. The rows should have been restored by "
+            "``_cumulative_prepend``; check the MACRO_HISTORY_PREPEND_SKIPPED "
+            "log line for why they were not. See alpha-engine-config-I10054."
+        )
+    lib.write(symbol, to_write)
 
 
 def _assert_no_arctic_regression(
@@ -617,7 +852,10 @@ def _assert_no_arctic_regression(
         # every row before last month — which is exactly how VIX3M went from
         # 2509 rows to 16 while passing this preflight clean twice.
         existing_rows, existing_first = _existing_row_span(macro_lib, key)
-        hist = _history_regression(f"macro.{key}", series, existing_rows, existing_first)
+        hist = _history_regression(
+            f"macro.{key}", series, existing_rows, existing_first,
+            cumulative=key in CUMULATIVE_MACRO_SYMBOLS,
+        )
         if hist is not None:
             regressions.append(hist)
         # STALENESS regression (alpha-engine-config-I9287). Neither check

--- a/features/SCHEMA.md
+++ b/features/SCHEMA.md
@@ -91,6 +91,55 @@ and return-basis columns sit adjacent.
 
 ---
 
+## 2b. ArcticDB macro-library retention, per symbol family (I10054)
+
+Every macro source is a **rolling window**: `collectors/prices.py` refreshes
+the price cache as a 10-year yfinance `auto_adjust=True` **full replace**, and
+`collectors/fred_history.py` fetches a trailing `period_years` window the same
+way. `builders/backfill.py` then writes each ArcticDB symbol wholesale
+(`lib.write`), so without intervention the head version loses its oldest week
+every Saturday. ArcticDB keeps prior versions, so nothing is destroyed — but no
+reader sees anything older than the window.
+
+Retention is therefore declared **per symbol family**, and the deciding
+property is the **adjustment basis**, not the data source:
+
+| Family | Symbols | Retention | Why |
+|---|---|---|---|
+| **Un-adjusted indices (cumulative)** | `VIX`, `VIX3M`, `TNX`, `IRX`, `TWO`, `HYOAS`, `BAA10Y` | **Cumulative** — the head version never loses a row it once held | FRED-sourced index levels and yields carry no split/dividend adjustment, so rows already held are on the same scale as fresh rows. Prepending them is exact and seamless. |
+| **Adjusted ETFs / equities** | `SPY`, `GLD`, `USO`, `XL*` sector ETFs, the sub-sector benchmark ETFs, the whole `universe` library | **Rolling** — 10-year window, oldest rows leave the head each rebuild | `auto_adjust=True` retroactively re-adjusts the entire series on every split and dividend, so a row written last year is on a different scale from today's. Splicing would create a silent mid-series seam. This is why `collectors/prices.py` full-replaces rather than appends (`data#1298`). |
+| **`macro/features`** | the derived macro feature frame | **Rolling** — derived from the above | Recomputed wholesale from the macro series each rebuild. |
+
+The cumulative set is **declared, not inferred**:
+`builders/backfill.py::CUMULATIVE_MACRO_SYMBOLS`. It is asserted equal to
+`collectors/fred_history.FRED_HISTORY_MAP`'s keys by
+`tests/test_macro_cumulative_history.py`, so **adding a FRED series without
+ruling on its retention fails CI** rather than silently landing on the rolling
+default. Adding one means: the map entry, the `CUMULATIVE_MACRO_SYMBOLS` entry
+(or a written rationale for leaving it rolling), and a row in the table above.
+
+Mechanism: `builders/backfill.py::_cumulative_prepend` unions the existing rows
+strictly older than the source window's first date with the fresh window before
+the wholesale write; overlapping dates always take the fresh value, and the
+operation is idempotent. Each prepend emits
+`MACRO_HISTORY_PREPENDED symbol=… rows=… first=…`. A declared-cumulative symbol
+whose *written* first date still moved forward is a **refusal**
+(`_cumulative_invariant_violation`) — a cumulative series never slides.
+
+The source-side detectors are unchanged and still judge the **planned** frame:
+a rolling-window slide is still reported (`MACRO_WINDOW_SLIDE`, I9256/PR1642)
+and a source truncation still refuses the write even on a cumulative symbol.
+The prepend closes the loss; it does not hide the defect.
+
+**Target state (not this):** a point-in-time store keeps every raw series
+cumulatively and applies adjustment at *read* time from a factor table, so the
+adjusted view is derived rather than stored. That is the Crucible v2 data-plane
+shape; it needs dividend factors the corporate-actions registry does not yet
+carry. Adjusted series stay rolling until v2 owns the data plane
+(`alpha-engine-config-I10054` option (a), `I9751`).
+
+---
+
 ## 3. Field catalog — units, compute, consumers
 
 Sorted by group, matching `features/registry.py::CATALOG`. Every entry

--- a/tests/test_arctic_write_contract.py
+++ b/tests/test_arctic_write_contract.py
@@ -245,9 +245,17 @@ def test_backfill_wraps_macro_writes():
         "reference_date=today_str,\n"
         "                    )"
     ) in _BACKFILL_SRC
-    assert "lib.write(symbol, df)" in _BACKFILL_SRC, (
+    # alpha-engine-config-I10054: the payload the wrapper writes is
+    # ``to_write`` — ``df`` for a rolling (adjusted) symbol, and the union of
+    # the retained older rows with ``df`` for a symbol declared in
+    # ``CUMULATIVE_MACRO_SYMBOLS``. Still exactly one terminating write.
+    assert "lib.write(symbol, to_write)" in _BACKFILL_SRC, (
         "the no-shrink wrapper must still terminate in a single lib.write "
         "boundary — no second, unguarded macro write path."
+    )
+    assert _BACKFILL_SRC.count("lib.write(symbol, ") == 1, (
+        "exactly one macro raw-series write boundary — a second one would "
+        "bypass the truncation guard and the cumulative-retention prepend."
     )
 
 

--- a/tests/test_macro_cumulative_history.py
+++ b/tests/test_macro_cumulative_history.py
@@ -1,0 +1,302 @@
+"""alpha-engine-config-I10054 option (a) — cumulative ArcticDB history for the
+un-adjusted (FRED-sourced) macro series only.
+
+Measured origin (issue body, 2026-09-05):
+
+  * ``collectors/prices.py`` refreshes the price cache as a rolling 10-year
+    yfinance ``auto_adjust=True`` FULL REPLACE (append is unsafe for an
+    adjusted series — the whole history is re-scaled on every corporate
+    action).
+  * ``collectors/fred_history.py`` fetches a trailing ``period_years`` window
+    the same way.
+  * ``builders/backfill.py`` writes each ArcticDB symbol wholesale
+    (``lib.write``), so the head version loses its oldest week every Saturday.
+    ``macro/HYOAS``'s 2023-05-09..2023-09-04 rows left the head version on
+    2026-09-05 once I9287 unstuck its 3-year window.
+
+FRED-sourced indices carry no split/dividend adjustment, so prepending the
+rows we already hold is exact and seamless. Adjusted ETF/equity series stay
+rolling until Crucible v2 owns the data plane.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import builders.backfill as _bf
+from collectors.fred_history import FRED_HISTORY_MAP
+
+
+def _series(first: str, n: int, start: float = 10.0, stop: float = 20.0) -> pd.Series:
+    idx = pd.bdate_range(first, periods=n)
+    s = pd.Series(np.linspace(start, stop, n), index=idx)
+    s.index.name = "date"
+    return s
+
+
+def _frame(first: str, n: int, start: float = 10.0, stop: float = 20.0) -> pd.DataFrame:
+    s = _series(first, n, start, stop)
+    df = pd.DataFrame({"Close": s.values}, index=s.index)
+    df.index.name = "date"
+    return df
+
+
+class _FakeLib:
+    """Minimal ArcticDB library stand-in (mirrors the I9256 guard tests)."""
+
+    def __init__(self, data: dict[str, pd.DataFrame] | None = None):
+        self.data = dict(data or {})
+        self.writes: list[tuple[str, int]] = []
+
+    def has_symbol(self, symbol):
+        return symbol in self.data
+
+    def list_symbols(self):
+        return list(self.data)
+
+    def read(self, symbol, **kwargs):
+        if symbol not in self.data:
+            raise KeyError(symbol)
+        return type("R", (), {"data": self.data[symbol]})()
+
+    def tail(self, symbol, n=1, **kwargs):
+        if symbol not in self.data:
+            raise KeyError(symbol)
+        return type("R", (), {"data": self.data[symbol].tail(n)})()
+
+    def write(self, symbol, df, **kwargs):
+        self.data[symbol] = df
+        self.writes.append((symbol, len(df)))
+
+
+# ── the declared registry ────────────────────────────────────────────────────
+
+
+def test_cumulative_registry_is_exactly_the_fred_sourced_set():
+    """The retention ruling is a DECLARED set, and it must stay identical to
+    the single declared FRED source map (``FRED_HISTORY_MAP``, merged as the
+    one source by alpha-engine-config-I9286).
+
+    This is the guard that makes the registry maintainable: adding a FRED
+    series to the collector without ruling on its ArcticDB retention fails
+    here rather than silently landing on the rolling default. It is asserted,
+    never derived — a set derived from the map at import time could never
+    fail, and 'FRED-sourced implies un-adjusted' is a judgement about the
+    data, not a property of the dict.
+    """
+    assert _bf.CUMULATIVE_MACRO_SYMBOLS == frozenset(FRED_HISTORY_MAP), (
+        "CUMULATIVE_MACRO_SYMBOLS and FRED_HISTORY_MAP have drifted. A new "
+        "FRED series needs an explicit retention ruling in "
+        "builders/backfill.py::CUMULATIVE_MACRO_SYMBOLS (and a row in "
+        "features/SCHEMA.md §2b) — see alpha-engine-config-I10054."
+    )
+
+
+def test_the_adjusted_macro_symbols_are_not_declared_cumulative():
+    """The yfinance ``auto_adjust`` families must stay rolling: splicing an
+    old row onto a re-adjusted series is a silent mid-series seam."""
+    for symbol in ("SPY", "GLD", "USO", "XLK", "XLF", "SMH", "IGV"):
+        assert symbol not in _bf.CUMULATIVE_MACRO_SYMBOLS
+
+
+def test_registry_membership_is_not_inferable_from_the_symbol_name():
+    """Guards against a future 'looks like an index' heuristic replacing the
+    declaration: SPY and VIX are indistinguishable by shape, and TWO/BAA10Y
+    look nothing alike."""
+    assert "VIX" in _bf.CUMULATIVE_MACRO_SYMBOLS
+    assert "VIX3M" in _bf.CUMULATIVE_MACRO_SYMBOLS
+    assert "TWO" in _bf.CUMULATIVE_MACRO_SYMBOLS
+    assert "BAA10Y" in _bf.CUMULATIVE_MACRO_SYMBOLS
+
+
+# ── the prepend at the write boundary ────────────────────────────────────────
+
+
+def test_prepend_happens_for_a_declared_symbol():
+    """The measured HYOAS shape: a 3y FRED window that slid ~85 sessions.
+    The written head is the union, starting where ArcticDB already started."""
+    lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    planned = _frame("2023-09-05", 783)
+
+    _bf._write_macro_series_no_shrink(lib, "HYOAS", planned)
+
+    written = lib.data["HYOAS"]
+    assert written.index[0] == pd.Timestamp("2023-05-09")
+    assert written.index[-1] == planned.index[-1]
+    assert written.index.is_monotonic_increasing
+    assert not written.index.has_duplicates
+    # Union: every existing date older than the planned window, plus all of it.
+    older = _frame("2023-05-09", 786).loc[lambda d: d.index < planned.index[0]]
+    assert len(written) == len(older) + len(planned)
+
+
+def test_prepend_does_not_happen_for_an_adjusted_symbol():
+    """SPY is not declared cumulative — the rolling window is written as-is,
+    because ``auto_adjust`` re-scales its whole history on every action."""
+    lib = _FakeLib({"SPY": _frame("2016-08-29", 2514)})
+    planned = _frame("2016-09-06", 2514)
+
+    _bf._write_macro_series_no_shrink(lib, "SPY", planned)
+
+    assert lib.writes == [("SPY", 2514)]
+    assert lib.data["SPY"].index[0] == planned.index[0]
+
+
+def test_overlapping_dates_take_the_planned_value():
+    """The fresh window is authoritative wherever the two overlap — a FRED
+    restatement of a recent print must not be shadowed by the stored copy."""
+    existing = _frame("2024-01-01", 200, start=1.0, stop=1.0)
+    planned = _frame("2024-04-01", 160, start=9.0, stop=9.0)
+    lib = _FakeLib({"VIX": existing})
+
+    _bf._write_macro_series_no_shrink(lib, "VIX", planned)
+
+    written = lib.data["VIX"]
+    overlap = written.index.intersection(planned.index)
+    assert len(overlap) == len(planned)
+    assert (written.loc[overlap, "Close"] == 9.0).all()
+    # And the pre-window rows are the stored ones, untouched.
+    assert (written.loc[written.index < planned.index[0], "Close"] == 1.0).all()
+
+
+def test_prepend_is_idempotent_on_a_second_run():
+    """A second rebuild from the same source window reproduces the same head
+    exactly — the union of (union, planned) is the union."""
+    lib = _FakeLib({"TNX": _frame("2016-01-04", 2500)})
+    planned = _frame("2016-03-01", 2600)
+
+    _bf._write_macro_series_no_shrink(lib, "TNX", planned)
+    first_write = lib.data["TNX"].copy()
+
+    _bf._write_macro_series_no_shrink(lib, "TNX", planned)
+    second_write = lib.data["TNX"]
+
+    pd.testing.assert_frame_equal(first_write, second_write)
+    assert len(lib.writes) == 2
+
+
+def test_prepend_is_a_noop_when_the_window_did_not_slide(caplog):
+    """No older rows to restore → nothing prepended, nothing logged."""
+    lib = _FakeLib({"IRX": _frame("2016-08-19", 2513)})
+    planned = _frame("2016-08-19", 2514)
+
+    with caplog.at_level("INFO"):
+        _bf._write_macro_series_no_shrink(lib, "IRX", planned)
+
+    assert lib.writes == [("IRX", 2514)]
+    assert not any("MACRO_HISTORY_PREPENDED" in r.getMessage() for r in caplog.records)
+
+
+def test_prepend_emits_a_reconstructible_log_record(caplog):
+    """``MACRO_HISTORY_PREPENDED symbol=… rows=… first=…`` — the prepend must
+    be reconstructible from durable logs alone."""
+    lib = _FakeLib({"BAA10Y": _frame("1986-01-02", 500)})
+    planned = _frame("1986-06-02", 500)
+
+    with caplog.at_level("INFO"):
+        _bf._write_macro_series_no_shrink(lib, "BAA10Y", planned)
+
+    prepends = [r for r in caplog.records if "MACRO_HISTORY_PREPENDED" in r.getMessage()]
+    assert len(prepends) == 1
+    message = prepends[0].getMessage()
+    assert "symbol=BAA10Y" in message
+    assert "rows=" in message
+    assert "first=1986-01-02" in message
+
+
+def test_prepend_handles_a_tz_aware_stored_index():
+    """A stored index carrying a timezone must not defeat the date comparison
+    or produce a mixed-tz written index."""
+    existing = _frame("2024-01-01", 200)
+    existing.index = existing.index.tz_localize("UTC")
+    lib = _FakeLib({"VIX3M": existing})
+    planned = _frame("2024-04-01", 160)
+
+    _bf._write_macro_series_no_shrink(lib, "VIX3M", planned)
+
+    written = lib.data["VIX3M"]
+    assert written.index.tz is None
+    assert written.index.is_monotonic_increasing
+    assert written.index[0] == pd.Timestamp("2024-01-01")
+
+
+# ── the guard, made consistent with the new behaviour ────────────────────────
+
+
+def test_a_slide_on_a_declared_cumulative_symbol_is_refused_when_unprepended(monkeypatch):
+    """A cumulative series never slides. If the prepend is bypassed or skipped
+    for any reason, the written frame still carries the slide — and that is a
+    REFUSAL, not a warning: publishing a truncated head under a cumulative
+    contract is the exact loss I10054 closes."""
+    monkeypatch.setattr(
+        _bf, "_cumulative_prepend", lambda symbol, existing, planned: (planned, 0, None)
+    )
+    lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
+    planned = _frame("2023-09-05", 783)
+
+    with pytest.raises(RuntimeError, match="declared\\s+CUMULATIVE"):
+        _bf._write_macro_series_no_shrink(lib, "HYOAS", planned)
+
+    assert lib.writes == [], "a refused write must not reach the library"
+
+
+def test_a_column_mismatch_skips_the_prepend_loudly_and_then_refuses(caplog):
+    """A macro schema change under an existing symbol must not fabricate NaN
+    columns. The prepend is skipped with a greppable finding, and the
+    cumulative invariant then refuses the (now truncating) write."""
+    existing = _frame("2023-05-09", 786).rename(columns={"Close": "value"})
+    lib = _FakeLib({"HYOAS": existing})
+    planned = _frame("2023-09-05", 783)
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError, match="declared\\s+CUMULATIVE"):
+            _bf._write_macro_series_no_shrink(lib, "HYOAS", planned)
+
+    assert any(
+        "MACRO_HISTORY_PREPEND_SKIPPED" in r.getMessage() and "column_mismatch" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_the_source_truncation_detector_still_fires_on_a_cumulative_symbol():
+    """Detection blindness outranks the defect it hides: the prepend closes
+    the LOSS, but a source answering 16 rows where it answered 2509 last week
+    is still a producer defect that must page (I9256) — it must not be
+    silently repaired into looking healthy."""
+    lib = _FakeLib({"VIX3M": _frame("2016-08-19", 2509)})
+    planned = _frame("2016-08-19", 2509).tail(16)
+
+    with pytest.raises(RuntimeError, match="would TRUNCATE"):
+        _bf._write_macro_series_no_shrink(lib, "VIX3M", planned)
+
+    assert lib.writes == []
+
+
+def test_a_first_write_of_a_cumulative_symbol_is_not_a_violation():
+    """Nothing established to be cumulative against."""
+    lib = _FakeLib({})
+    _bf._write_macro_series_no_shrink(lib, "TWO", _frame("2016-08-19", 2514))
+    assert lib.writes == [("TWO", 2514)]
+
+
+# ── the preflight's wording stays honest ─────────────────────────────────────
+
+
+def test_history_regression_slide_wording_differs_by_retention(caplog):
+    existing_rows, existing_first = 786, pd.Timestamp("2023-05-09")
+    planned = _frame("2023-09-05", 783)
+
+    with caplog.at_level("WARNING"):
+        assert _bf._history_regression(
+            "macro.HYOAS", planned, existing_rows, existing_first, cumulative=True,
+        ) is None
+    assert any("retained by the cumulative prepend" in r.getMessage() for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        assert _bf._history_regression(
+            "macro.GLD", planned, existing_rows, existing_first, cumulative=False,
+        ) is None
+    assert any("gone from ArcticDB's head version" in r.getMessage() for r in caplog.records)

--- a/tests/test_macro_history_truncation_guard.py
+++ b/tests/test_macro_history_truncation_guard.py
@@ -103,13 +103,37 @@ def test_write_boundary_allows_a_slide_after_a_source_freeze(caplog):
     """The measured 2026-09-05 HYOAS shape: a 3y FRED window that had been
     frozen for four months (I9287) and then advanced ~85 sessions at once.
     Allowed, but LOUD — a start moving more than a few weeks means a freeze
-    released or rebuilds were missed, and the row loss is real."""
+    released or rebuilds were missed.
+
+    HYOAS is a DECLARED-CUMULATIVE symbol (alpha-engine-config-I10054), so the
+    rows the window slid past are restored by the prepend rather than lost:
+    the SOURCE still slid (the detector must still say so — that is the I9287
+    signal) but ArcticDB's head keeps its 2023-05-09 start."""
     lib = _FakeLib({"HYOAS": _frame("2023-05-09", 786)})
     planned = _frame("2023-09-05", 783)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("INFO"):
         _bf._write_macro_series_no_shrink(lib, "HYOAS", planned)
-    assert lib.writes == [("HYOAS", 783)]
     assert any("MACRO_WINDOW_SLIDE" in r.message for r in caplog.records)
+    # The written frame is the union, not the source window.
+    (written_symbol, written_rows), = lib.writes
+    assert written_symbol == "HYOAS"
+    assert written_rows > 783
+    assert lib.data["HYOAS"].index[0] == pd.Timestamp("2023-05-09")
+
+
+def test_write_boundary_slide_after_a_freeze_is_lossy_on_an_adjusted_symbol(caplog):
+    """The same shape on an ADJUSTED symbol (auto_adjust ETF) stays rolling:
+    written as-is, and the finding says the history really is gone."""
+    lib = _FakeLib({"GLD": _frame("2023-05-09", 786)})
+    planned = _frame("2023-09-05", 783)
+    with caplog.at_level("WARNING"):
+        _bf._write_macro_series_no_shrink(lib, "GLD", planned)
+    assert lib.writes == [("GLD", 783)]
+    assert any(
+        "MACRO_WINDOW_SLIDE" in r.message
+        and "gone from ArcticDB's head version" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_write_boundary_allows_a_missed_rebuild_week():


### PR DESCRIPTION
## What

Implements **option (a)** of `alpha-engine-config-I10054`: ArcticDB macro history becomes **cumulative for un-adjusted (FRED-sourced) series only**. Adjusted ETF/equity series stay rolling and are untouched.

## Why

Every macro source is a rolling window — `collectors/prices.py` refreshes the price cache as a 10y yfinance `auto_adjust=True` **full replace**, `collectors/fred_history.py` fetches a trailing `period_years` window the same way — and `builders/backfill.py` writes each ArcticDB symbol wholesale (`lib.write`). So the head version lost its oldest week every Saturday. ArcticDB keeps prior versions, so nothing was destroyed, but **no reader saw anything older than the window**, which silently contradicts the standing "retain all archives, data is an asset" preference for exactly the series a regime model trains on. Measured instance: `macro/HYOAS`'s 2023-05-09..2023-09-04 rows left the head version on 2026-09-05 once `I9287` unstuck its 3-year window.

The reason this cannot simply be fixed for every symbol is the **adjustment basis**. `auto_adjust=True` retroactively re-adjusts an ETF/equity series' whole history on every corporate action, so rows written last year sit on a different scale from rows written today; splicing them would create a silent mid-series seam. That is why `collectors/prices.py` full-replaces rather than appends, and it is the one-continuous-scale contract `data#1298` established. FRED-sourced indices carry no split/dividend adjustment at all, so for those — and only those — prepending the rows we already hold is **exact**.

## The rule implemented

For a symbol declared in `builders/backfill.py::CUMULATIVE_MACRO_SYMBOLS`, before the wholesale write, prepend the **existing head-version rows strictly older than the planned first date**, so the written series is `(existing-older ∪ planned)`. Overlapping dates always take the **planned (fresh)** value; the result has no duplicate index, no seam, and is idempotent on a second run. Everything else is written unchanged.

- **`CUMULATIVE_MACRO_SYMBOLS`** = `{VIX, VIX3M, TNX, IRX, TWO, HYOAS, BAA10Y}` — an explicit declared registry, never inferred from the symbol name at write time. `tests/test_macro_cumulative_history.py` asserts it is **exactly** `collectors/fred_history.FRED_HISTORY_MAP`'s keys (the single declared FRED source map since `I9286`), so adding a FRED series without ruling on its retention **fails CI** rather than silently landing on the rolling default. Asserted, not derived — a set derived from the map at import time could never fail that test, and "FRED-sourced implies un-adjusted" is a judgement about the data, not a property of the dict.
- **`MACRO_HISTORY_PREPENDED symbol=… rows=… first=…`** is logged for each prepend, so the operation is reconstructible from durable logs alone.

## Guard consistency with `nousergon-data-PR1642`

- The PR1642 rolling-window slide allowance and the `I9256` truncation refusal **still judge the PLANNED frame, unchanged**, on cumulative and rolling symbols alike. A source answering 16 rows where it answered 2509 last week still refuses the write on `VIX3M`. **The prepend closes the loss; it must not hide the defect.** Only the `MACRO_WINDOW_SLIDE` warning's wording is now retention-aware (rows "retained by the cumulative prepend" vs "gone from ArcticDB's head version").
- New refusal: **a declared-cumulative series never slides.** `_cumulative_invariant_violation` raises if the *written* frame's first date still moved forward, or if it still lost rows beyond the restatement tolerance — i.e. if the prepend was bypassed or skipped for any reason. A column-set mismatch between the stored frame and the planned frame skips the prepend with a loud `MACRO_HISTORY_PREPEND_SKIPPED reason=column_mismatch` rather than fabricating NaN columns, and that refusal is what then stops the write, so the loss cannot pass unnoticed either way.
- `_existing_row_span`'s fail-loud read contract is preserved (an unreadable existing symbol still raises, never treated as absent); the read is now done once per write and reused rather than twice.

## Test plan

All verification is unit tests — nothing in this PR was run against ArcticDB or production S3.

`tests/test_macro_cumulative_history.py` (new, 15 tests):
- registry is exactly the FRED-sourced set; adjusted families are not in it; membership is not name-inferable
- prepend happens for a declared symbol (the measured HYOAS shape) and does **not** for an adjusted one (the measured SPY one-week slide)
- overlapping dates take the planned value; the pre-window rows are the stored ones
- idempotent on a second run (`assert_frame_equal` across two writes)
- no-op, and no log line, when the window did not slide
- `MACRO_HISTORY_PREPENDED` carries symbol/rows/first
- a tz-aware stored index does not defeat the comparison or leak into the written index
- an unprepended slide on a cumulative symbol is **refused**; a column mismatch skips loudly then refuses
- the `I9256` source-truncation detector still fires on a cumulative symbol
- a first write of a cumulative symbol is not a violation
- slide wording differs by retention

`tests/test_macro_history_truncation_guard.py`: the PR1642 HYOAS freeze-release case now asserts the union is written *and* that `MACRO_WINDOW_SLIDE` still fires; a sibling case pins the lossy rolling behaviour on an adjusted symbol.

`tests/test_arctic_write_contract.py`: the single-terminating-`lib.write` contract updated for the new payload name, plus a count assertion that there is still exactly one macro raw-series write boundary.

Full suite: **6998 passed, 12 skipped** (`tests/`, integration excluded).

## Out of scope, noted

`TWO` and `BAA10Y` are declared cumulative but are not currently in `backfill.py`'s raw-series write loop or `_extract_macro_series`'s `macro_keys` — they reach ArcticDB only via `daily_append`. Declaring them costs nothing and is correct for when they are added; wiring them into the backfill loop is a separate change and is not made here — filed as `alpha-engine-config-I10068`, which also carries the class fix (a test that every `FRED_HISTORY_MAP` key appears in backfill's raw-series write loop).

Deploy-mechanism: no post-merge step. The trading/data box pulls `main` on boot and the next canonical Saturday `DataPhase1` exercises the new path; the first cumulative write is observable as `MACRO_HISTORY_PREPENDED` lines in that run's logs.

Refs `alpha-engine-config-I10054` (option (a)), `nousergon-data-PR1642`, `alpha-engine-config-I9256`, `I9287`, `I9286`, `I9751`.

Prepared by: claude-fable-5-1 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmRUNQXVdhT6nbghhUpgEJ
