### PR TITLE
feat(ci): live-ArcticDB smoke assumes its own read role, not the deploy identity (I10110)

### DIFF
--- a/.github/workflows/live-arcticdb-smoke.yml
+++ b/.github/workflows/live-arcticdb-smoke.yml
@@ -9,11 +9,20 @@ name: Live ArcticDB Smoke
 #
 # Cost: one tail-row S3 read per triggered run (~$0.0001).
 #
-# Auth gate: assumes the existing github-actions-lambda-deploy OIDC
-# role. That role grants S3 read on alpha-engine-research/arcticdb/*
-# (verified via `aws iam get-role-policy` 2026-05-27). Forks without
-# the OIDC trust get a clean skip rather than a failing CI status —
-# the script exits 0 when no AWS creds are in the env.
+# Auth gate: assumes github-actions-arcticdb-smoke-read, an OIDC role
+# whose entire grant is s3:GetObject on alpha-engine-research/arcticdb/*
+# plus the prefix-scoped s3:ListBucket ArcticDB needs to resolve a
+# symbol version. Forks without the OIDC trust get a clean skip rather
+# than a failing CI status — the script exits 0 when no AWS creds are
+# in the env.
+#
+# It used to assume github-actions-lambda-deploy, and that was the only
+# reason the fleet's widest CI identity — ECR push, UpdateFunctionCode,
+# CloudFormation stack update, iam:PassRole, ssm:SendCommand onto the
+# dashboard box — trusted a `pull_request` sub at all. Every other entry
+# in that role's trust is `ref:refs/heads/main`; this one was assumable
+# from a branch nobody had reviewed. alpha-engine-config-I10110 (stage 2
+# of I10109, ruling I9788 option b) split it out.
 
 on:
   pull_request:
@@ -44,7 +53,7 @@ jobs:
         continue-on-error: true
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
-          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-arcticdb-smoke-read
           aws-region: us-east-1
 
       - name: Set up Python 3.12

--- a/tests/test_arcticdb_smoke_assumes_its_own_role.py
+++ b/tests/test_arcticdb_smoke_assumes_its_own_role.py
@@ -1,0 +1,84 @@
+"""The live-ArcticDB smoke assumes its own read role, never the deploy role.
+
+alpha-engine-config-I10110 (stage 2 of I10109, ruling I9788 option b).
+
+WHAT THIS EXISTS TO STOP COMING BACK
+------------------------------------
+`live-arcticdb-smoke.yml` triggers on `pull_request` and assumed
+`github-actions-lambda-deploy` — the fleet's widest CI identity (ECR push,
+`lambda:UpdateFunctionCode`, CloudFormation stack update, `iam:PassRole`,
+`ssm:SendCommand` onto the dashboard box). That single consumer is the ONLY
+reason `repo:nousergon/nousergon-data:pull_request` appeared in that role's
+trust; every other entry there is `ref:refs/heads/main`, i.e. code a human
+merged. So a workflow edit on any unreviewed branch in this repo could reach
+the deploy identity's whole authority, and the smoke needed two S3 statements.
+
+The replacement is `github-actions-arcticdb-smoke-read`, codified in
+`nous-ergon-ops/infrastructure/iam/github-actions-arcticdb-smoke-read/`.
+
+The same split was made for the SF-definition validator
+(`ne-github-sf-validate`, alpha-engine-config-I7798) and
+`tests/test_sf_definition_validated_preflight.py` guards it the same way — an
+assertion on the assumed role plus a negative on the deploy role, because the
+regression shape is a copy-paste of `role-to-assume` from another workflow,
+which reads as correct in a diff and is invisible at runtime (the run goes
+green either way; only the blast radius changes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "live-arcticdb-smoke.yml"
+
+SMOKE_ROLE_ARN = (
+    "arn:aws:iam::711398986525:role/github-actions-arcticdb-smoke-read"
+)
+DEPLOY_ROLE = "github-actions-lambda-deploy"
+
+
+def test_the_workflow_exists() -> None:
+    """A rename would make every assertion below pass by vacuum."""
+    assert WORKFLOW.is_file(), f"missing {WORKFLOW}"
+
+
+def test_the_smoke_assumes_the_dedicated_read_role() -> None:
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    assert f"role-to-assume: {SMOKE_ROLE_ARN}" in wf, (
+        f"live-arcticdb-smoke.yml must assume {SMOKE_ROLE_ARN} — the role whose "
+        f"whole grant is a read of s3://alpha-engine-research/arcticdb/*. "
+        f"alpha-engine-config-I10110."
+    )
+
+
+def test_the_smoke_never_assumes_the_deploy_role() -> None:
+    """Not implied by the assertion above: a workflow can name two roles, and a
+    second `configure-aws-credentials` step added later would overwrite the
+    first job's credentials without changing the line the test above reads."""
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    executable = [
+        line
+        for line in wf.splitlines()
+        if DEPLOY_ROLE in line and not line.lstrip().startswith("#")
+    ]
+    assert not executable, (
+        f"live-arcticdb-smoke.yml names {DEPLOY_ROLE} outside a comment: "
+        f"{executable}. This PR-triggered workflow must never reach the deploy "
+        f"identity — that trust is being removed from it (I10110 stage 3), so "
+        f"the run would fail as well as being wrong."
+    )
+
+
+def test_the_workflow_stays_pull_request_triggered() -> None:
+    """The role's trust is `repo:nousergon/nousergon-data:pull_request` and
+    nothing else, so moving this workflow onto `push` or `schedule` makes it
+    unassumable. That failure would read as an IAM outage rather than as the
+    trigger change that caused it — assert the coupling where it is legible."""
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request:" in wf, (
+        "live-arcticdb-smoke.yml no longer triggers on pull_request, but "
+        "github-actions-arcticdb-smoke-read trusts only "
+        "`repo:nousergon/nousergon-data:pull_request`. Change the role's trust "
+        "in nous-ergon-ops in the same arc, or the smoke cannot authenticate."
+    )


### PR DESCRIPTION
Stage 2 of `alpha-engine-config-I10109` (ruling I9788 option b), consumer half.

**Tracker: alpha-engine-config-I10110**

## What & why

`live-arcticdb-smoke.yml` triggers on `pull_request` and assumed
`github-actions-lambda-deploy` — the fleet's widest CI identity (ECR push,
`lambda:UpdateFunctionCode`, CloudFormation stack update, `iam:PassRole`,
`ssm:SendCommand` onto the dashboard box, deploy identity for ~20 repos).

This workflow is the **only** reason `repo:nousergon/nousergon-data:pull_request`
appears in that role's trust. Every other entry there is `ref:refs/heads/main`
— code a human merged. A `pull_request` sub is assumable from a branch nobody
has reviewed, so any PR in this repo editing a workflow could reach that whole
authority, for the sake of two S3 read statements.

It now assumes `github-actions-arcticdb-smoke-read`, whose entire grant is
`s3:GetObject` on `alpha-engine-research/arcticdb/*` plus the prefix-scoped
`s3:ListBucket` ArcticDB needs to resolve a symbol version.

## The guard

`tests/test_arcticdb_smoke_assumes_its_own_role.py` mirrors what
`test_sf_definition_validated_preflight.py` already carries for the identical
split at `ne-github-sf-validate` (I7798): assert the new role, negate the
deploy role outside comments, and assert the `pull_request` trigger the role's
trust is coupled to (its trust admits nothing else, so moving this workflow to
`push`/`schedule` would make it unassumable — a failure that reads as an IAM
outage rather than as the trigger change that caused it).

The regression shape is a copy-pasted `role-to-assume` from a neighbouring
workflow. It reads as correct in a diff and the run goes green either way —
only the blast radius changes.

## Merge order

`nous-ergon-ops-PR1077` first (codifies the role), then the operator creates it
live per that PR's sequencing, **then** this PR. Merged before the role exists,
this workflow's next PR run fails `configure-aws-credentials` against a
non-existent role.

## Test plan

`.venv/bin/python -m pytest tests/ -q` — **7035 passed, 17 skipped, 0 failed**
(4 new), run before opening.

CI's own `Live ArcticDB Smoke` check on this PR is the real end-to-end
verification, and it can only pass once the role exists live — that is the
sequencing above, not a gap in this change.

Prepared by: Claude Fable 5.1 via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKxjHjBV5Urmw9Er1XkQCS
