### PR TITLE
ci(deploy-infrastructure): assume github-actions-cfn-sf-stack-deploy (I10112, stage 4 of I10109)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -41,10 +41,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # alpha-engine-config-I10112 (stage 4 of I10109, ruling I9788 option b).
+      # github-actions-cfn-sf-stack-deploy replaces the shared
+      # github-actions-lambda-deploy role for this workflow. Same statements,
+      # copied verbatim; the change is WHO may assume them. On the shared role
+      # cloudformation:CreateStack, states:CreateStateMachine and iam:PassRole
+      # on alpha-engine-* are reachable by 74 workflows in 21 repos. This role's
+      # trust pins repo + refs/heads/main + this workflow's job_workflow_ref, so
+      # adding a workflow to this repo — or opening a PR that adds one — is not
+      # a path to them.
+      #
+      # The role and its inline policy are codified in
+      # nous-ergon-ops/infrastructure/iam/github-actions-cfn-sf-stack-deploy/
+      # (nous-ergon-ops-PR1078) and MUST be live before this merges — the trust
+      # policy is a privilege-boundary document that repo deliberately does not
+      # auto-apply.
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
-          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-cfn-sf-stack-deploy
           aws-region: us-east-1
 
       - name: Deploy orchestration infrastructure

--- a/tests/test_cfn_sf_stack_deploy_role_consumers.py
+++ b/tests/test_cfn_sf_stack_deploy_role_consumers.py
@@ -1,0 +1,126 @@
+"""Exactly one workflow in this repo assumes `github-actions-cfn-sf-stack-deploy`.
+
+`alpha-engine-config-I10112`, stage 4 of `I10109` (ruling `I9788` option b).
+
+That role carries `cloudformation:CreateStack` on `alpha-engine-orchestration`,
+`states:Create/Update/DeleteStateMachine` on every orchestration pipeline, and
+`iam:PassRole` on `alpha-engine-*` to `states`/`scheduler`/`events`/`lambda`.
+The whole point of splitting it out of `github-actions-lambda-deploy` was to
+take those three grants from *74 workflows in 21 repos* down to one workflow —
+so the count of consumers **is** the deliverable, and it lives in this repo,
+because this is where a second consumer would be added.
+
+The role's trust policy pins `job_workflow_ref` to `deploy-infrastructure.yml`,
+so a second consumer here does not silently succeed — it fails at
+`sts:AssumeRoleWithWebIdentity` on a merged `main`, with nothing red until then.
+This test moves that failure to review time.
+
+The reverse direction matters too: `deploy-infrastructure.yml` must actually
+stop using the shared role. A flip that adds the new `role-to-assume` line
+without removing the old one is not a narrowing at all, and both lines are valid
+YAML in a `with:` block only until the duplicate-key check runs — which is not
+part of `actionlint`'s default rule set for composite `with` mappings.
+
+`deploy-scheduled-groom-dispatcher.yml` deliberately stays on the shared role;
+see the module-level constant below for why, and `I10112` for the ruling shape.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+ACCOUNT = "711398986525"
+NEW_ROLE = "github-actions-cfn-sf-stack-deploy"
+SHARED_ROLE = "github-actions-lambda-deploy"
+
+#: The single workflow this role exists for.
+INTENDED_CONSUMER = "deploy-infrastructure.yml"
+
+#: Named in `I10112`'s stage-4 row as a second consumer, and deliberately NOT
+#: flipped in that stage. Its two AWS steps both run
+#: `infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh`, one process
+#: whose flagless path spans stage 4 (`stepfunctions create/update/describe-
+#: state-machine`), stage 9 (`lambda create-function`, `update-function-code`,
+#: `update-function-configuration`, `get-function`) and stage 7 (log groups),
+#: and whose `--reconcile-schedules` path is stage 8 (`scheduler create/update/
+#: delete/get/list-schedule`). A GitHub Actions step takes exactly one set of
+#: credentials, so "split the job so only the CFN/SF steps assume the new role"
+#: would mean splitting `deploy.sh` itself — out of scope here, and it would
+#: decouple the schedule reconcile from the code deploy it must accompany
+#: (the `nousergon-data#1179` failure: a green deploy that created no schedule).
+DEFERRED_CONSUMER = "deploy-scheduled-groom-dispatcher.yml"
+
+_ROLE_TO_ASSUME = re.compile(
+    r"^\s*role-to-assume:\s*(?P<arn>arn:aws:iam::\d+:role/[A-Za-z0-9+=,.@_-]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def _workflows() -> list[Path]:
+    return sorted(
+        p
+        for p in WORKFLOW_DIR.iterdir()
+        if p.is_file() and p.suffix in {".yml", ".yaml"}
+    )
+
+
+def _assumed_roles(path: Path) -> list[str]:
+    """Role NAMES named in `role-to-assume:` lines. Executable references only —
+    a role named in a comment is documentation, not a consumer."""
+    return [
+        m.group("arn").rsplit("/", 1)[1]
+        for m in _ROLE_TO_ASSUME.finditer(path.read_text())
+    ]
+
+
+def test_exactly_one_workflow_assumes_the_new_role():
+    consumers = sorted(p.name for p in _workflows() if NEW_ROLE in _assumed_roles(p))
+    assert consumers == [INTENDED_CONSUMER], (
+        f"{NEW_ROLE} is scoped to one workflow by its trust policy's "
+        f"job_workflow_ref condition; found {consumers}. A second consumer must "
+        f"land together with the trust-policy edit in nous-ergon-ops, or it "
+        f"fails at AssumeRoleWithWebIdentity only after merge."
+    )
+
+
+def test_the_intended_consumer_no_longer_assumes_the_shared_role():
+    roles = _assumed_roles(WORKFLOW_DIR / INTENDED_CONSUMER)
+    assert roles == [NEW_ROLE], (
+        f"{INTENDED_CONSUMER} must assume exactly {NEW_ROLE}; found {roles}. "
+        f"Leaving the {SHARED_ROLE} line in place is not a narrowing."
+    )
+
+
+def test_the_deferred_consumer_still_assumes_the_shared_role():
+    """Not an aspiration — a guard. Flipping it before stages 7 and 8 land takes
+    away log-group and EventBridge/Scheduler authority the same job still uses,
+    and the first symptom is a half-applied production deploy."""
+    roles = _assumed_roles(WORKFLOW_DIR / DEFERRED_CONSUMER)
+    assert roles == [SHARED_ROLE], (
+        f"{DEFERRED_CONSUMER} still needs the stage-7 (log groups) and stage-8 "
+        f"(EventBridge/Scheduler) statements that stay on {SHARED_ROLE} until "
+        f"those stages of alpha-engine-config-I10109 land; found {roles}."
+    )
+
+
+@pytest.mark.parametrize("workflow", [p.name for p in _workflows()])
+def test_every_role_to_assume_names_this_account(workflow: str):
+    """Cheap backstop on the regex above: if a `role-to-assume` line ever stops
+    matching, the consumer count silently reads zero and every test here passes
+    for the wrong reason."""
+    text = (WORKFLOW_DIR / workflow).read_text()
+    declared = text.count("role-to-assume:")
+    matched = len(_ROLE_TO_ASSUME.findall(text))
+    assert declared == matched, (
+        f"{workflow}: {declared} role-to-assume line(s), {matched} parsed. "
+        f"An unparsed line makes this module's consumer count meaningless."
+    )
+    for role_arn_name in _assumed_roles(WORKFLOW_DIR / workflow):
+        assert role_arn_name, workflow
+    assert f"arn:aws:iam::{ACCOUNT}:role/" in text or declared == 0


### PR DESCRIPTION
## What this does

`deploy-infrastructure.yml` assumes `github-actions-cfn-sf-stack-deploy` instead of the shared `github-actions-lambda-deploy`. Consumer half of stage 4 of `alpha-engine-config-I10109` (Brian's ruling on `I9788`, option b: one identity per authority boundary).

Same statements, copied verbatim into the new role. The change is **who may assume them**. On the shared role, `cloudformation:CreateStack` on `alpha-engine-orchestration`, `states:Create/Update/DeleteStateMachine` on every orchestration pipeline, and `iam:PassRole` on `alpha-engine-*` to `states`/`scheduler`/`events`/`lambda` are reachable by **74 workflows in 21 repos** (measured 2026-09-06). The new role's trust pins `repo:nousergon/nousergon-data:ref:refs/heads/main` **and** this workflow's `job_workflow_ref`, so adding a workflow to this repo — or opening a PR that adds one — is not a path to them.

## Why `deploy-scheduled-groom-dispatcher.yml` is not flipped here — option (b)

`I10112`'s note offers **(a)** split that job so only its CFN/SF steps assume the new role, or **(b)** defer its flip until stages 7 and 8 land. **(b)**, because **(a) is not available**: both of its AWS steps run the same script, `infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh`, and one process cannot hold two credentials. Measured calls in that script:

| Stage of `I10109` | Calls in `deploy.sh` |
|---|---|
| 4 (this role) | `stepfunctions create-state-machine`, `update-state-machine`, `describe-state-machine` |
| 9 (`lambda-code-deploy`) | `lambda create-function`, `update-function-code`, `update-function-configuration`, `get-function`, `wait` |
| 7 (`log-metricfilter-lifecycle`) | log-group creation for the dispatcher |
| 8 (`eventbridge-alarm-apply`) | `scheduler create/update/delete/get/list-schedule`, in the `--reconcile-schedules` path |
| operator-only | `iam create-role`, `get-role`, `put-role-policy`, behind `--bootstrap-iam`; never run in CI |

"Only the CFN/SF steps assume the new role" would therefore mean splitting `deploy.sh` — out of scope for this stage, and it would decouple the schedule reconcile from the code deploy it must accompany. That coupling is the whole point of the workflow: `nousergon-data#1179` gave the PR sweep three daily schedules, the deploy ran green, and **none of them were created**. Every step's authority stays measured under (b): the dispatcher keeps a role that grants everything it calls, until stages 7 and 8 give it narrower ones.

Guarded, not just intended — `test_the_deferred_consumer_still_assumes_the_shared_role` fails if someone flips it early.

## Measured before flipping

Every AWS action `deploy-infrastructure.yml` reaches, across `infrastructure/deploy-infrastructure.sh`, `infrastructure/weekly_cadence_drift.py`, `infrastructure/step-functions/check-definition-drift.py`, the resource set of `infrastructure/cloudformation/alpha-engine-orchestration.yaml` (21 alarms, 6 EventBridge rules, 2 Scheduler schedules, 2 SNS topics + 1 subscription, 4 Lambda permissions, 4 metric filters, 2 log groups, the mutex table, 2 state machines), and the `nousergon-docs` `append-changelog` composite action. The full action → grant table is in `nous-ergon-ops-PR1078`.

Two results worth naming here:

- **The nine Sids named in `I10112` are not sufficient for this workflow.** It also calls `logs:CreateLogGroup`/`PutRetentionPolicy` directly (step 3, for `/aws/stepfunctions/ne-postclose-trading-pipeline` and `/aws/vendedlogs/states/alpha-engine-groom-dispatch`), `ssm:GetParameter`/`PutParameter` on `/alpha-engine/weekly-sf/exercise-cadence` (step 3a), `s3:PutObject` on `changelog/*`, the drift-alert transports, and — through CloudFormation — the alarm/rule/topic/schedule/permission/metric-filter set. All thirteen are carried on the new role, copied verbatim.
- **`SyncWeeklyExerciseCadenceParameter` is not a dead Sid.** `I10109` lists it under "Dead Sids (0 consumers) — delete at split time". Step 3a of `deploy-infrastructure.sh` calls it on every deploy, and `weekly_cadence_drift.py` raises on anything that is not `ParameterNotFound`. Deleting it would fail every orchestration deploy on `AccessDenied`.

Nothing this workflow calls is ungranted on the shared role today, so there is no true gap of the stage-5/9 kind here.

## Live sequencing — this PR merges second

`nous-ergon-ops-PR1078` codifies the role; its trust policy is a privilege-boundary document that repo deliberately does not auto-apply. Before this merges, all of the following must have happened (they are the operator steps of that PR, listed there in full): the role created with `aws iam create-role` from the codified trust document, `apply.sh --role github-actions-cfn-sf-stack-deploy`, `apply.sh --role github-actions-iam-apply-evaluator`, and `nous-ergon-ops-PR1078` merged with `iam-drift-check.yml` green.

Merging this before the role is live fails the first push to `main` at `sts:AssumeRoleWithWebIdentity`, which halts the orchestration deploy and — through the deploy-drift preflight — the next pipeline run. There is nothing to run **after** this merges: the workflow's own next run on `main` is the verification.

Once that run is green, a separate `nous-ergon-ops` PR removes the eight stage-4 Sids from the shared policy (the thirteen shared ones stay until their own stages).

## Cross-repo

- `nous-ergon-ops-PR1078` — codifies the role — **merges first**
- `nousergon-data-PR1649` (this) — the consumer flip — merges second

## Tests

`tests/test_cfn_sf_stack_deploy_role_consumers.py`: exactly one workflow in this repo assumes the new role (the count **is** the deliverable — a second consumer fails at `AssumeRoleWithWebIdentity` only after merge, because the trust pins `job_workflow_ref`) · the flipped workflow no longer names the shared role at all (a flip that adds a line without removing one is not a narrowing) · the deferred workflow still does · and a backstop asserting every `role-to-assume:` line is actually parsed, so the consumer count cannot silently read zero.

Full suite: **7,088 passed, 17 skipped, 0 failed** (`.venv/bin/python -m pytest tests/ -q`, 4m37s).

Tracker: alpha-engine-config-I10112

Prepared by: Claude Fable 5.1 via [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKxjHjBV5Urmw9Er1XkQCS
