### PR TITLE
fix(iam): grant weekly-preflight-role stage-coverage write access

### DIFF
--- a/infrastructure/lambdas/weekly-preflight/iam-policy.json
+++ b/infrastructure/lambdas/weekly-preflight/iam-policy.json
@@ -53,6 +53,26 @@
                 "logs:PutLogEvents"
             ],
             "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-weekly-preflight:*"
+        },
+        {
+            "Sid": "WriteStageCoverageVerdicts",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/*"
+        },
+        {
+            "Sid": "PutAlphaEngineMetrics",
+            "Effect": "Allow",
+            "Action": "cloudwatch:PutMetricData",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "cloudwatch:namespace": [
+                        "AlphaEngine",
+                        "AlphaEngine/*"
+                    ]
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
## Summary
- `alpha-engine-weekly-preflight-role`'s inline policy grants no `s3:PutObject` on `_stage_coverage/*` and no `cloudwatch:PutMetricData` at all. `krepis.stage_coverage.record_verdict` now runs on every weekly-preflight invocation (the earlier ImportError from I8228 is already fixed) and AccessDenied's on write — every run reports `WeeklyPreflight` `ABSENT`, one of the 13 absent stages feeding `alpha-engine-stage-coverage-absent` (latched in ALARM since 2026-08-30, re-notifying daily per I9332).
- Third instance of the `alpha-engine-config-I8152`/`I9048` class (a role gained a `krepis.stage_coverage` call site with no matching IAM grant). Mirrors `nous-ergon-ops/infrastructure/iam/alpha-engine-evaluator-role/alpha-engine-evaluator-policy.json`'s `WriteStageCoverageVerdicts`/`PutAlphaEngineMetrics` statements from I8152. `s3:GetObject` on the prefix is already covered by this role's existing blanket `ReadS3Config` statement.

## Operator step required after merge (security-boundary IAM gate, per pull-request-policy §4.2 form 3)
This role's IAM is applied via an operator-gated path, not merge-button IaC: the CI OIDC identity (`github-actions-lambda-deploy`) deliberately lacks `iam:PutRolePolicy` (single-writer rule, `_shared/apply_iam_policy.sh`). **Merging this PR does not apply the grant.**

**Brian, after merge, run:**
```
AWS_PROFILE=ne-admin bash infrastructure/lambdas/weekly-preflight/deploy.sh --apply-iam
```
Expected output ends `✓ IAM applied. Nothing else was touched — no code, no env, no alarms.`

**Detector that stays red until this runs:** `alpha-engine-stage-coverage-absent` (CloudWatch) stays in ALARM, and the WeeklyPreflight row in `s3://alpha-engine-research/_stage_coverage/_sweep/ne-weekly-freshness-pipeline/<run_date>.json` keeps reporting `absent`, until the next Saturday run after the grant is applied.

## Test plan
- [x] `python3 -c "import json; json.load(open('infrastructure/lambdas/weekly-preflight/iam-policy.json'))"` — valid JSON
- [x] `python3 -m pytest tests/test_apply_iam_is_iam_only.py tests/test_freshness_deploy_apply_iam_narrows.py tests/test_stage_coverage_assertions.py tests/test_sf_weekly_preflight_wiring.py tests/test_sf_preflight.py -q` — 273 passed, 2 skipped
- [ ] CI green (pending)
- [ ] Operator applies IAM (above), next Saturday's sweep confirms `WeeklyPreflight` covered

Closes: alpha-engine-config-I10144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWtkcnLaxyD8k7mZpzQMME