### PR TITLE
fix(ci): alert-message-lint warn-only step must survive a crash (alpha-engine-config-I10147)

### DIFF
--- a/.github/workflows/alert-class-pr-guard.yml
+++ b/.github/workflows/alert-class-pr-guard.yml
@@ -193,6 +193,20 @@ jobs:
       # land in different repos, and a hard failure would redden eight repos'
       # main for the length of that merge window. The enforcement flip converts
       # BOTH halves — the miss and the findings — in one commit.
+      # alpha-engine-config-I10147. WARN-ONLY MEANS WARN-ONLY, INCLUDING ON A
+      # CRASH. Measured 2026-09-07: metron run 33718023593 hit
+      # `ModuleNotFoundError: No module named 'yaml'` in this exact step (the
+      # lint imports `alert_class_pr_guard` -> `alert_class_registry_drift`
+      # -> `yaml`) and the crash, under `set -euo pipefail`, failed the job --
+      # indistinguishable from an enforced finding, and it blocked seven
+      # metron PRs for four days. Separately, `alert_message_lint.py::main`
+      # itself returns 1 (not 0) on its own UNMEASURED paths (bad
+      # --repo-root, a GuardError while scanning) even under --warn-only --
+      # only the *findings* path honors the flag. Both are the same shape:
+      # a nonzero exit from the invocation must never propagate through
+      # `set -e` while warn-only is in force. The crash is RECORDED, never
+      # silenced -- via the same `::warning` GitHub Actions annotation a real
+      # finding uses, visible on the PR's Checks / Files-changed tab.
       - name: A PR-added alert message must be actionable (warn-only)
         run: |
           set -euo pipefail
@@ -205,4 +219,11 @@ jobs:
             echo "::warning title=alert-message-lint::$s is not on nousergon-data main yet, so the alert-message lint did not run. Warn-only by design while alpha-engine-config-I9460 lands across the fleet; alpha-engine-config-I9471 makes this a hard failure."
             exit 0
           fi
+          set +e
           python3 "$s" --repo "${{ github.event.repository.name }}" --repo-root "$GITHUB_WORKSPACE/graded" --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}" --warn-only
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning title=alert-message-lint::the lint exited $rc instead of 0 -- a CRASH or an internal UNMEASURED error, NOT a finding (findings exit 0 under --warn-only). This run recorded NOTHING about this PR's alert messages -- see the job log above this line for the traceback. Warn-only by design while the lint earns its enforcement (alpha-engine-config-I9471 carries the flip); alpha-engine-config-I10147 is this crash-safety fix."
+          fi
+          exit 0

--- a/tests/test_alert_message_lint_warn_only_survives_crash.py
+++ b/tests/test_alert_message_lint_warn_only_survives_crash.py
@@ -1,0 +1,63 @@
+"""alert-message-lint's warn-only step must survive a CRASH, not just a finding.
+
+alpha-engine-config-I10147. Measured 2026-09-07: metron run 33718023593
+crashed this step with `ModuleNotFoundError: No module named 'yaml'` under
+`set -euo pipefail`, and the crash failed the CI job -- indistinguishable from
+an enforced finding, and it blocked seven metron dependency PRs for four days.
+Separately, `alert_message_lint.py::main` (nousergon-data) returns 1 on its
+own UNMEASURED paths (bad --repo-root, a GuardError while scanning) even
+under --warn-only -- only the *findings* path honors the flag. Either way,
+warn-only must mean warn-only: the step must capture the lint invocation's
+exit code and turn ANY nonzero exit into a `::warning` annotation, then exit 0
+unconditionally -- recording the crash, never silencing it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "alert-class-pr-guard.yml"
+
+MARKER = "- name: A PR-added alert message must be actionable (warn-only)"
+
+
+def _lint_step_run_block() -> str:
+    text = WORKFLOW.read_text()
+    assert MARKER in text, f"{WORKFLOW} lost its alert-message-lint step"
+    return text[text.index(MARKER):]
+
+
+def test_the_workflow_still_carries_the_lint_step():
+    assert WORKFLOW.is_file(), f"{WORKFLOW} missing"
+    assert MARKER in WORKFLOW.read_text()
+
+
+def test_a_nonzero_lint_exit_cannot_propagate_through_set_e():
+    block = _lint_step_run_block()
+    assert "set +e" in block, (
+        f"{WORKFLOW.name}'s lint step invokes the script without disabling "
+        "`set -e` first -- a crash or an internal UNMEASURED exit(1) fails "
+        "the job, defeating warn-only (alpha-engine-config-I10147)"
+    )
+    assert "rc=$?" in block, (
+        f"{WORKFLOW.name}'s lint step does not capture the invocation's exit "
+        "code -- a nonzero exit cannot be reported without it"
+    )
+    assert block.rstrip().splitlines()[-1].strip() == "exit 0", (
+        f"{WORKFLOW.name}'s lint step does not end with an unconditional "
+        "`exit 0` -- warn-only must never fail the job"
+    )
+
+
+def test_a_crash_is_recorded_not_silenced():
+    block = _lint_step_run_block()
+    assert 'if [ "$rc" -ne 0 ]' in block, (
+        f"{WORKFLOW.name}'s lint step does not branch on a nonzero exit code"
+    )
+    after = block.split('if [ "$rc" -ne 0 ]', 1)[1]
+    assert "::warning" in after, (
+        f"{WORKFLOW.name}'s lint step swallows a nonzero exit silently -- a "
+        "crash must still emit a ::warning annotation naming it, per "
+        "alpha-engine-config-I10147"
+    )


### PR DESCRIPTION
## What

The `A PR-added alert message must be actionable (warn-only)` step is documented WARN-ONLY but was not: a nonzero exit from the lint invocation (a crash, or the script's own internal UNMEASURED error path, which returns 1 even under `--warn-only`) failed the whole CI job under `set -euo pipefail`, indistinguishable from an enforced finding. This PR captures the invocation's exit code and turns ANY nonzero exit into a `::warning` annotation instead of letting `set -e` kill the job, then exits 0 unconditionally.

**Surface that records a crash going forward:** the same `::warning` GitHub Actions annotation a real lint finding already uses -- visible on the PR's Checks / Files-changed tab, naming the exit code and pointing at the job log above it for the traceback.

Root cause and blast radius: `alpha-engine-config-I10147`. Measured on metron run 33718023593 (`ModuleNotFoundError: No module named 'yaml'`), which blocked metron dependency PRs #430-#436 for four days. This fix does NOT flip warn-only to enforcing -- that is `alpha-engine-config-I9471`, tracked separately and deliberately not pre-empted here.

Tests: `tests/test_alert_message_lint_warn_only_survives_crash.py` -- asserts the step disables `set -e` around the invocation, captures `$?`, records any nonzero exit via `::warning`, and always exits 0. Ran locally before pushing: new test file passes (3/3); no FAILED introduced by this diff in the repo's own suite (pre-existing failures, where present, reproduce identically on unmodified main and are unrelated to this change).

## Merge order

Independent PRs, no cross-repo dependency -- any order:
metron-PR437, crucible-executor-PR544, crucible-research-PR797, crucible-predictor-PR610, crucible-backtester-PR772, crucible-dashboard-PR833, crucible-evaluator-PR305, nousergon-data-PR1651, nousergon-lib-PR390, nous-ergon-ops-PR1104.

Closes-relevant: alpha-engine-config-I10147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWtkcnLaxyD8k7mZpzQMME
