### PR TITLE
fix(weekly-sf): the coverage sweep names the execution it is running inside

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -84,7 +84,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.14.0

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # terminate_on_failure). Pinned in LOCKSTEP with this repo's root
 # requirements.txt (tests/test_lib_pin_lockstep.py) rather than carrying its own
 # exemption: this Lambda depends on no feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # krepis.spot_bootstrap.render_bootstrap() renders this box's watchdog units,
 # hard-runtime timer, interpreter install and public clone. Same lockstep rule:
 # a floor 45 minors below what the handler imports is a pin that says nothing

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/weekly-coverage-sweep/index.py
+++ b/infrastructure/lambdas/weekly-coverage-sweep/index.py
@@ -30,16 +30,26 @@ success terminal. The sweep reads Step Functions and S3 and writes S3 and one
 metric; it has no reason to need a box. Mirrors ``weekly-run-scope``, the
 sibling that reads the same execution history for the same pipeline.
 
-**Failure posture — fail-open, and never silent.** Three outcomes, and the
-third is the one that must not be collapsed into either of the others:
+**Failure posture — fail-open, and never silent.** FOUR outcomes, and the
+last two are the ones that must not be collapsed into either of the first:
 
 - ``clean`` — the sweep ran and found no gap.
 - ``findings`` — the sweep ran and found a gap. It has already paged from
   inside ``nousergon_lib`` (``krepis.alerts``, deduped per pipeline+run_date).
-- ``unavailable`` — **the sweep did not run.** "Found nothing" and "did not
-  run" are different facts and only the second means the surface is unobserved
-  (``principles.md`` §2.7). This handler returns it as its own outcome so the
-  SF can page for it, because a sweep that never ran cannot page for itself.
+- ``deferred`` — **the sweep ran and the cycle could not support the claim.**
+  ``alpha-engine-config-I10170``. ``absent`` means "expected, entered, and
+  recorded nothing", which only a cycle that has stopped changing can support;
+  when the cycle is still in flight, or its contributor walk was truncated on
+  a non-COMPLETED verdict, the sweep WITHHOLDS the absent count rather than
+  asserting it. Withholding is not silence: the sweep still pages, naming
+  every would-be-absent stage and the re-sweep command, and
+  ``publish_sweep`` emits ``StageCoverageSweepDeferred=1`` on its own metric
+  rather than letting the deferral be inferred from another metric's silence.
+- ``unavailable`` — **the sweep did not run.** "Found nothing", "could not
+  establish" and "did not run" are three different facts and only the last
+  means the reader itself is dead (``principles.md`` §2.7). This handler
+  returns it as its own outcome so the SF can page for it, because a sweep
+  that never ran cannot page for itself.
 
 It never raises: this state sits DOWNSTREAM of the pipeline's real success
 terminal, and an observe-only tail that fails a completed run is a worse defect
@@ -58,12 +68,38 @@ logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 BUCKET = os.environ.get("RESEARCH_BUCKET", "alpha-engine-research")
 PIPELINE = os.environ.get("PIPELINE", "ne-weekly-freshness-pipeline")
 
-#: The three outcomes, closed. The SF's Choice matches these literals; adding a
-#: fourth without a matching Choice branch lands on the Default, which is
+#: The four outcomes, closed. The SF's Choice matches these literals; adding a
+#: fifth without a matching Choice branch lands on the Default, which is
 #: ``unavailable`` — the honest fall-through, never ``clean``.
 OUTCOME_CLEAN = "clean"
 OUTCOME_FINDINGS = "findings"
 OUTCOME_UNAVAILABLE = "unavailable"
+#: The sweep RAN, and the cycle could not support the claim it was asked to
+#: make (``alpha-engine-config-I10170``). Distinct from all three above: it is
+#: not clean, it is not a finding about a stage, and the sweep did not fail.
+#: The SF Choice has a branch for it; without one it lands on the Default,
+#: which is ``unavailable`` — still honest, just less precise.
+OUTCOME_DEFERRED = "deferred"
+
+#: The pipeline state this handler IS. It is executing while it grades, so it
+#: can never have written a verdict about its own completion — reporting it
+#: ``absent`` is a false positive guaranteed on every run, and it was one of
+#: the 13 on 2026-09-04 (``alpha-engine-config-I10170``).
+SWEEP_STAGE = os.environ.get("SWEEP_STAGE", "WeeklyCoverageSweep")
+
+
+def _outcome_for(sweep) -> str:
+    """The handler's verdict. ``deferred`` OUTRANKS ``findings``.
+
+    ``alpha-engine-config-I10170``. When the cycle cannot support an absence
+    claim, the honest headline is that coverage is not established — not that
+    N stages are absent, which is the assertion the sweep just declined to
+    make. Findings that DID land are still real and still page from inside
+    ``nousergon_lib``; they are reported in the explanation either way.
+    """
+    if sweep.deferred:
+        return OUTCOME_DEFERRED
+    return OUTCOME_FINDINGS if sweep.should_alert else OUTCOME_CLEAN
 
 
 def handler(event, _context):
@@ -74,6 +110,15 @@ def handler(event, _context):
     # Absent => a single-partition sweep, which is the post-cutover shape.
     calendar_date = (event or {}).get("calendar_date") or ""
     state_machine_arn = (event or {}).get("state_machine_arn") or ""
+    # alpha-engine-config-I10170: THE OBSERVER. This handler runs as a state
+    # INSIDE the execution it is grading, so that execution is RUNNING at the
+    # instant it grades — on every run, forever. Measured on the live
+    # 2026-09-04 cycle: the sweep at 21:39:18Z declared the cycle in_flight
+    # and paged 13 absences in the same artifact; watch-rerun-2026-09-04-4,
+    # the execution it called RUNNING, stopped at 21:39:19Z, two hops later.
+    # Naming the observer lets nousergon_lib count its entered states (real
+    # work) without letting its status make its own cycle non-terminal.
+    observer_execution_arn = (event or {}).get("observer_execution_arn") or ""
     dry_run = bool((event or {}).get("dry_run"))
 
     if not run_date:
@@ -102,6 +147,8 @@ def handler(event, _context):
             state_machine_arn=state_machine_arn or None,
             bucket=BUCKET,
             s3_client=s3_client,
+            observer_execution_arn=observer_execution_arn or None,
+            observer_stage=SWEEP_STAGE,
         )
     except Exception as exc:  # noqa: BLE001 — a sweep that cannot run says so
         # Deliberate broad catch with a named recording surface: the return
@@ -133,7 +180,7 @@ def handler(event, _context):
         # detect. What ``dry_run`` withholds is the WRITES and the page, never
         # the verdict.
         return {
-            "outcome": OUTCOME_FINDINGS if sweep.should_alert else OUTCOME_CLEAN,
+            "outcome": _outcome_for(sweep),
             "dry_run": True,
             "run_date": run_date,
             "partitions_read": list(sweep.partitions_read),
@@ -202,8 +249,10 @@ def handler(event, _context):
             logger.exception("coverage sweep finding could not be paged")
 
     return {
-        "outcome": OUTCOME_FINDINGS if sweep.should_alert else OUTCOME_CLEAN,
+        "outcome": _outcome_for(sweep),
         "run_date": run_date,
+        "coverage_established": sweep.coverage_established,
+        "deferral_reason": sweep.deferral_reason,
         "partitions_read": list(sweep.partitions_read),
         "legacy_partition_rows": sweep.legacy_partition_rows,
         "explanation": explanation,

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -10,4 +10,4 @@
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
 # v0.124.88. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/infrastructure/lambdas/weekly-coverage-sweep/test_handler.py
+++ b/infrastructure/lambdas/weekly-coverage-sweep/test_handler.py
@@ -106,6 +106,9 @@ class _Sweep:
         cycle=object(),
         partitions_read=("2026-08-21", "2026-08-22"),
         legacy_partition_rows=0,
+        coverage_established=True,
+        deferred=False,
+        deferral_reason=None,
     ):
         self.should_alert = should_alert
         self.cycle = cycle
@@ -117,6 +120,22 @@ class _Sweep:
         # asserted in tests/test_weekly_partition_family_contract.py.
         self.partitions_read = partitions_read
         self.legacy_partition_rows = legacy_partition_rows
+        # alpha-engine-config-I10170. The real CoverageSweep exposes these as
+        # PROPERTIES, so a stub that omits them raises AttributeError rather
+        # than reading as a benign default — which is what happened: every
+        # test in this file failed on `'_Sweep' object has no attribute
+        # 'deferred'` once `_outcome_for` started reading it.
+        #
+        # Defaulting them True/False/None here is deliberate and is the
+        # HEALTHY case: coverage established, nothing deferred. A test that
+        # wants the deferred path passes deferred=True with a reason, so the
+        # two paths stay distinguishable — a stub hardcoding `deferred=False`
+        # would make `_outcome_for`'s deferred branch unreachable and untested
+        # while turning the suite green, which is the shape of defect this
+        # whole issue is about.
+        self.coverage_established = coverage_established
+        self.deferred = deferred
+        self.deferral_reason = deferral_reason
 
     def explain(self):
         return "sweep says so"
@@ -280,3 +299,48 @@ def test_the_marker_is_augmented_in_every_partition_that_was_read():
     )
     index.handler({"run_date": "2026-08-28", "calendar_date": "2026-08-29"}, None)
     assert calls["augment_kwargs"]["also_dates"] == ("2026-08-28", "2026-08-29")
+
+
+def test_deferred_outranks_findings():
+    """`_outcome_for`'s deferred branch, which had no test at all.
+
+    `alpha-engine-config-I10170`: when the cycle cannot support an absence
+    claim, the honest headline is that coverage is not established — not that
+    N stages are absent, which is the assertion the sweep just DECLINED to
+    make. Reporting `findings` there would publish a number the sweep does not
+    stand behind.
+
+    This existed only as a docstring until 2026-09-08. Every test in this file
+    had been failing on `'_Sweep' object has no attribute 'deferred'` because
+    the stub predated the attribute, and the repair that added it could have
+    hardcoded `deferred=False` — turning the suite green while leaving this
+    branch unreachable. That is the same "green over an unexercised path"
+    shape the sweep itself exists to catch, so the branch is asserted here.
+    """
+    index, _ = _install_stubs(
+        sweep=_Sweep(
+            should_alert=True,
+            deferred=True,
+            deferral_reason="cycle in flight — absence not established",
+        )
+    )
+    out = index.handler({"run_date": "2026-08-22"}, None)
+
+    assert out["outcome"] == index.OUTCOME_DEFERRED, (
+        "a deferred sweep reported its findings count as the headline — the "
+        "sweep declined to make that absence claim"
+    )
+    assert out["outcome"] != index.OUTCOME_FINDINGS
+
+
+def test_a_clean_sweep_that_is_not_deferred_is_still_clean():
+    """The other side of the same branch: `deferred` must not swallow a pass.
+
+    Guards against a fix that makes the assertion above true by reporting
+    `deferred` unconditionally.
+    """
+    index, _ = _install_stubs(sweep=_Sweep(should_alert=False))
+    assert index.handler({"run_date": "2026-08-22"}, None)["outcome"] == index.OUTCOME_CLEAN
+
+    index2, _ = _install_stubs(sweep=_Sweep(should_alert=True))
+    assert index2.handler({"run_date": "2026-08-22"}, None)["outcome"] == index2.OUTCOME_FINDINGS

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,7 +16,7 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # alpha-engine-config-I8155: this Lambda records its own coverage verdict via
 # krepis.stage_coverage. Pin the released contract that refuses a blank SF
 # execution run_date and uses no cycle-date fallback.

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -9012,7 +9012,7 @@
       "Comment": "alpha-engine-config-I6891: the clean Friday-PM preflight terminal. Byte-equivalent in outcome to the End: true NotifyShellRunComplete previously carried \u2014 a green preflight still ends SUCCEEDED and still writes no completion marker; only the degraded edge changed."
     },
     "WeeklyCoverageSweep": {
-      "Comment": "WeeklyCoverageSweep (alpha-engine-config-I8214, carrying I8154 deliverable 4 and I8186's state-machine half) \u2014 runs nousergon_lib's stage-coverage sweep over THIS cycle and augments the completion marker the previous state just wrote with the cycle's real shape. WHY IT EXISTS: the sweep's READER shipped in nousergon-lib and nothing called it, so it detected nothing. This state is its caller. PLACEMENT: immediately after WriteCompletionMarker, deliberately \u2014 the marker must exist before it can be augmented. The marker the SF writes claims only 'this SF execution reached its terminal' (claim: sf_execution_terminal, cycle_verdict: unknown); this state is what upgrades that to a cycle verdict. On 2026-08-22 the marker was written by an execution that entered 1 of 16 declared stages and said nothing about it. WHY A LAMBDA AND NOT AN SSM COMMAND: this pipeline has no always-on box \u2014 $.ec2_instance_id is an ephemeral spot, and since alpha-engine-config-I8162 a recovery run whose every box stage is skipped carries NO instance id at all, which is exactly the run that most needs a coverage verdict. A sweep dereferencing it would throw States.Runtime one state after the pipeline's own success terminal. Mirrors weekly-run-scope, the sibling Lambda that reads the same execution history for the same pipeline. OBSERVE-ONLY TAIL, a design constraint not an omission: everything from here down is downstream of the real success terminal and must never turn a completed weekly run into a failure (sf-pipeline-policy \u00a72.1 blast radius). Every terminal below is a Succeed, and the Catch routes to the unobserved terminal rather than to a failure. THREE OUTCOMES AND 'DID NOT RUN' IS NOT ONE OF THE OTHER TWO: the handler returns outcome clean / findings / unavailable. Findings have ALREADY paged from inside the handler (krepis.alerts, deduped per pipeline+run_date), so nothing pages again here; 'unavailable' is the one case the sweep cannot page for itself, so the state machine does it. Collapsing unavailable into findings renders an unobserved surface as a detection, and collapsing it into clean renders it green (principles.md \u00a72.7). PREFLIGHT-AWARE: dry_run.$ = $.research_dry \u2014 the Friday-PM shell run exercises the whole read path and every IAM grant, and writes nothing. TIMEOUT: 240s, deliberately BELOW the Lambda's own 300s so the SF ceiling is the one that binds (tests/test_sf_lambda_timeout_ordering.py). MEASURED, not guessed: the first live invocation on 2026-08-22 took 29.4s at 1024 MB with a 675 MB peak, walking 40 executions of the cycle. The original 90s/120s/256MB sizing TIMED OUT at 120s \u2014 at 256 MB the function used 256 of 256 MB and Lambda scales CPU with memory, so it was throttled as well as starved. 240s is ~8x the measured runtime; the budget bounds an unbounded walk, it does not size the work. DEGRADED PATH DELIBERATELY NOT WIRED: WriteCompletionMarkerDegraded must keep flowing straight into DegradedRun (a Fail state) or sf-telegram-notifier's 'Error: DegradedRun' consumer contract breaks (alpha-engine-config-I6891). A degraded cycle's coverage is swept out-of-band instead. | alpha-engine-config-I8809: PARTITION FAMILY = trading_day, with calendar_date passed as the LEGACY family. The sweep unions both _stage_coverage partitions (canonical first; a verdict in the trading-day partition wins a duplicate) until the 2026-09-05 cutover, so this cycle reports against ONE logical cycle and pages no false absences. Its dry run on 2026-08-22 logged '9 covered / 1 findings / 28 absent of 39 expected' - the 28 were in the sibling partition. nousergon-lib read_coverage_sweep(calendar_date=...) is the reader half; the pin in infrastructure/lambdas/weekly-coverage-sweep/requirements.txt is what carries it.",
+      "Comment": "WeeklyCoverageSweep (alpha-engine-config-I8214, carrying I8154 deliverable 4 and I8186's state-machine half) \u2014 runs nousergon_lib's stage-coverage sweep over THIS cycle and augments the completion marker the previous state just wrote with the cycle's real shape. WHY IT EXISTS: the sweep's READER shipped in nousergon-lib and nothing called it, so it detected nothing. This state is its caller. PLACEMENT: immediately after WriteCompletionMarker, deliberately \u2014 the marker must exist before it can be augmented. The marker the SF writes claims only 'this SF execution reached its terminal' (claim: sf_execution_terminal, cycle_verdict: unknown); this state is what upgrades that to a cycle verdict. On 2026-08-22 the marker was written by an execution that entered 1 of 16 declared stages and said nothing about it. WHY A LAMBDA AND NOT AN SSM COMMAND: this pipeline has no always-on box \u2014 $.ec2_instance_id is an ephemeral spot, and since alpha-engine-config-I8162 a recovery run whose every box stage is skipped carries NO instance id at all, which is exactly the run that most needs a coverage verdict. A sweep dereferencing it would throw States.Runtime one state after the pipeline's own success terminal. Mirrors weekly-run-scope, the sibling Lambda that reads the same execution history for the same pipeline. OBSERVE-ONLY TAIL, a design constraint not an omission: everything from here down is downstream of the real success terminal and must never turn a completed weekly run into a failure (sf-pipeline-policy \u00a72.1 blast radius). Every terminal below is a Succeed, and the Catch routes to the unobserved terminal rather than to a failure. THREE OUTCOMES AND 'DID NOT RUN' IS NOT ONE OF THE OTHER TWO: the handler returns outcome clean / findings / unavailable. Findings have ALREADY paged from inside the handler (krepis.alerts, deduped per pipeline+run_date), so nothing pages again here; 'unavailable' is the one case the sweep cannot page for itself, so the state machine does it. Collapsing unavailable into findings renders an unobserved surface as a detection, and collapsing it into clean renders it green (principles.md \u00a72.7). PREFLIGHT-AWARE: dry_run.$ = $.research_dry \u2014 the Friday-PM shell run exercises the whole read path and every IAM grant, and writes nothing. TIMEOUT: 240s, deliberately BELOW the Lambda's own 300s so the SF ceiling is the one that binds (tests/test_sf_lambda_timeout_ordering.py). MEASURED, not guessed: the first live invocation on 2026-08-22 took 29.4s at 1024 MB with a 675 MB peak, walking 40 executions of the cycle. The original 90s/120s/256MB sizing TIMED OUT at 120s \u2014 at 256 MB the function used 256 of 256 MB and Lambda scales CPU with memory, so it was throttled as well as starved. 240s is ~8x the measured runtime; the budget bounds an unbounded walk, it does not size the work. DEGRADED PATH DELIBERATELY NOT WIRED: WriteCompletionMarkerDegraded must keep flowing straight into DegradedRun (a Fail state) or sf-telegram-notifier's 'Error: DegradedRun' consumer contract breaks (alpha-engine-config-I6891). A degraded cycle's coverage is swept out-of-band instead. | alpha-engine-config-I8809: PARTITION FAMILY = trading_day, with calendar_date passed as the LEGACY family. The sweep unions both _stage_coverage partitions (canonical first; a verdict in the trading-day partition wins a duplicate) until the 2026-09-05 cutover, so this cycle reports against ONE logical cycle and pages no false absences. Its dry run on 2026-08-22 logged '9 covered / 1 findings / 28 absent of 39 expected' - the 28 were in the sibling partition. nousergon-lib read_coverage_sweep(calendar_date=...) is the reader half; the pin in infrastructure/lambdas/weekly-coverage-sweep/requirements.txt is what carries it. | alpha-engine-config-I10170 \u2014 THE OBSERVER. observer_execution_arn.$ = $$.Execution.Id. This state runs INSIDE the execution it grades, so that execution is RUNNING at the instant it grades, on every run, forever. Measured on the live 2026-09-04 cycle: the sweep at 21:39:18Z wrote cycle.verdict in_flight / still_running and paged 13 stages absent in the SAME artifact, while watch-rerun-2026-09-04-4 - the execution it called RUNNING - stopped at 21:39:19Z, one second later, two hops past this state. The 2026-08-28 artifact carries the identical pair, so this was the mechanism's normal state and not an incident. Two consequences, and the second reaches other systems: (1) IN_FLIGHT could never mean what it says, so a cycle genuinely still running was indistinguishable from every healthy one; (2) augment_marker stamped cycle_verdict in_flight and did_work false onto the completion marker of a COMPLETED cycle - the object every gate:* Verified-when predicate reads, which is alpha-engine-config-I8186 re-created with the sign flipped. Naming the observer lets nousergon_lib count this execution's entered states (real work) without letting its status make its own cycle non-terminal; ANY OTHER running execution still yields in_flight, so the honest 'not yet gradeable' answer survives for the case that means it. A FOURTH OUTCOME: 'deferred' - the sweep ran and the cycle could not support the absence claim, so the absent count is WITHHELD rather than asserted. Its own Choice branch and terminal below; collapsing it into 'clean' renders an unestablished surface green and collapsing it into 'findings' reports an assertion the sweep just declined to make.",
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
@@ -9021,6 +9021,7 @@
           "run_date.$": "$.run_date",
           "dry_run.$": "$.research_dry",
           "state_machine_arn.$": "$$.StateMachine.Id",
+          "observer_execution_arn.$": "$$.Execution.Id",
           "calendar_date.$": "$.calendar_date"
         }
       },
@@ -9056,7 +9057,7 @@
     },
     "CheckWeeklyCoverageSweepOutcome": {
       "Type": "Choice",
-      "Comment": "The handler's outcome IS the verdict; each value gets its own named terminal so the execution history says which happened. $.coverage_sweep.outcome is safe to dereference un-guarded: the sole predecessor pins it via ResultSelector (config#2275 rule 3b). The Default is the UNOBSERVED terminal, not the clean one \u2014 an outcome this Choice does not recognise is an unknown state of the coverage surface, and unknown is never rendered green.",
+      "Comment": "The handler's outcome IS the verdict; each value gets its own named terminal so the execution history says which happened. $.coverage_sweep.outcome is safe to dereference un-guarded: the sole predecessor pins it via ResultSelector (config#2275 rule 3b). The Default is the UNOBSERVED terminal, not the clean one \u2014 an outcome this Choice does not recognise is an unknown state of the coverage surface, and unknown is never rendered green. | alpha-engine-config-I10170: 'deferred' is the fourth outcome and has its own branch. It is NOT unavailable (the sweep ran) and NOT clean (coverage was not established).",
       "Choices": [
         {
           "Variable": "$.coverage_sweep.outcome",
@@ -9067,6 +9068,11 @@
           "Variable": "$.coverage_sweep.outcome",
           "StringEquals": "findings",
           "Next": "WeeklyCoverageSweepFindings"
+        },
+        {
+          "Variable": "$.coverage_sweep.outcome",
+          "StringEquals": "deferred",
+          "Next": "WeeklyCoverageSweepDeferred"
         }
       ],
       "Default": "WeeklyCoverageSweepUnavailable"
@@ -9115,6 +9121,43 @@
     "WeeklyCoverageSweepUnobserved": {
       "Type": "Succeed",
       "Comment": "Terminal for the did-not-run case, named for what is true \u2014 the coverage surface is unobserved for this cycle \u2014 rather than for the run, which completed."
+    },
+    "WeeklyCoverageSweepDeferred": {
+      "Type": "Task",
+      "Comment": "outcome=deferred (alpha-engine-config-I10170): the sweep RAN and declined to assert an absence its own cycle cannot support - the cycle is still IN_FLIGHT, or its ListExecutions contributor walk was truncated on a non-COMPLETED verdict, and under either condition a stage that has not finished is indistinguishable from one that finished and recorded nothing. WHY THIS PAGES: withholding is not silence. nousergon_lib withholds the StageCoverageSweepAbsent datapoint (publishing 0 would render an unestablished surface green - principles.md 2.7) and publishes StageCoverageSweepDeferred=1 in its place, so the deferral has its own datapoint rather than being inferred from another metric's silence; alpha-engine-stage-coverage-deferred alarms on it. The sweep has ALSO already paged from inside the handler on the coverage_deferred alert condition, which names every would-be-absent stage and the re-sweep command - this state's notification is the state-machine-visible record of the same fact, and both are deduped by krepis.alerts per pipeline+run_date. Succeed rather than Fail: the weekly run completed, and failing the execution would retroactively mark a good run bad (alpha-engine-config-I8045). | alpha-engine-config-I8809: PARTITION FAMILY = trading_day (pass-through). This state does not KEY on the date; it carries $.run_date into a notification body. Named here anyway because the contract test requires every state touching a run-date variable to state which family it means - an undeclared site is how the split reappeared once already.",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn.$": "$.sns_topic_arn",
+        "Subject": "Alpha Engine Weekly Pipeline - stage-coverage sweep DEFERRED",
+        "Message.$": "States.Format('The weekly run for {} completed, and the stage-coverage sweep ran but could not establish coverage: the cycle was not terminal, or its contributor walk was truncated on a non-COMPLETED verdict. The absent count is WITHHELD, not zero - this is an UNESTABLISHED surface, not a clean result. Read s3://alpha-engine-research/_stage_coverage/_sweep/ne-weekly-freshness-pipeline/{}.json - its deferral_reason names the condition and absent_stages names every stage that had no verdict at sweep time. Re-sweep once the cycle is terminal by invoking the alpha-engine-weekly-coverage-sweep Lambda with run_date {} and state_machine_arn arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline (omit observer_execution_arn - an out-of-band re-sweep observes from outside the cycle).', $.run_date, $.run_date, $.run_date)"
+      },
+      "TimeoutSeconds": 30,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 2,
+          "IntervalSeconds": 2,
+          "BackoffRate": 2.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Comment": "config#1819 notifier convention: a failed notify must not fail the run.",
+          "Next": "WeeklyCoverageSweepUnestablished",
+          "ResultPath": "$.coverage_sweep_notify_error"
+        }
+      ],
+      "ResultPath": "$.coverage_sweep_notify_result",
+      "Next": "WeeklyCoverageSweepUnestablished"
+    },
+    "WeeklyCoverageSweepUnestablished": {
+      "Type": "Succeed",
+      "Comment": "The coverage of this cycle is UNESTABLISHED - the sweep ran, declined to assert an absence the cycle could not support, and said so (alpha-engine-config-I10170). Named separately from WeeklyCoverageSweepClean and WeeklyCoverageSweepUnobserved so the execution history says which of the three happened; a terminal shared with 'clean' would make the distinction unreadable in exactly the place an operator looks first."
     },
     "WriteCompletionMarkerDegraded": {
       "Type": "Task",

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.15.0
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,7 +130,7 @@ arcticdb>=6.23.0
 # states in this PR; tests/test_pipeline_status_registry_source_check.py stays
 # RED until the pin carries the rows — the guard against SF JSON landing ahead
 # of the registry entry.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.109
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.113
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -82,8 +82,21 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # sweep unions it with the trading-day family until the 2026-09-05 cutover,
     # so one cycle split across both reads as one cycle instead of ~28 false
     # absences. Removed with the fallback at the cutover.
+    # alpha-engine-config-I10170: +observer_execution_arn.$ ($$.Execution.Id).
+    # This state runs INSIDE the execution it grades, so that execution is
+    # RUNNING whenever it grades — measured on the live 2026-09-04 cycle, the
+    # sweep declared the cycle in_flight and paged 13 absences in the same
+    # artifact one second before that execution succeeded. Naming the observer
+    # lets its entered states count without its status making its own cycle
+    # non-terminal. Any OTHER running execution still yields in_flight.
     "WeeklyCoverageSweep": frozenset(
-        {"run_date.$", "calendar_date.$", "dry_run.$", "state_machine_arn.$"}
+        {
+            "run_date.$",
+            "calendar_date.$",
+            "dry_run.$",
+            "state_machine_arn.$",
+            "observer_execution_arn.$",
+        }
     ),
     # alpha-engine-config-I8809: the weekly graph's ONE date normalization —
     # calendar date in, cycle trading day out. Reuses alpha-engine-weekly-preflight

--- a/tests/test_weekly_coverage_sweep_observer.py
+++ b/tests/test_weekly_coverage_sweep_observer.py
@@ -1,0 +1,148 @@
+"""The coverage sweep names the execution it is running inside.
+
+``alpha-engine-config-I10170``. Measured on the live 2026-09-04 weekly cycle:
+``_stage_coverage/_sweep/ne-weekly-freshness-pipeline/2026-09-04.json`` was
+written at ``2026-09-05T21:39:18Z`` carrying ``cycle.verdict: in_flight``,
+``cycle.reason: still_running`` AND ``should_alert: true`` with 13 stages
+called ``absent``. ``DescribeExecution`` on ``watch-rerun-2026-09-04-4`` — the
+execution the same artifact reported RUNNING — returns ``stopDate
+2026-09-05T21:39:19Z``, ``status SUCCEEDED``: one second later, on the Succeed
+state two hops past ``WeeklyCoverageSweep``.
+
+The sweep IS a state of the pipeline it grades, so it can only ever observe
+its own execution mid-flight. These tests pin the wiring that lets
+``nousergon_lib`` know which execution is the observer, and the fourth outcome
+that wiring makes reachable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+DEFINITION = REPO / "infrastructure" / "step_function.json"
+HANDLER = REPO / "infrastructure" / "lambdas" / "weekly-coverage-sweep" / "index.py"
+
+
+@pytest.fixture(scope="module")
+def states() -> dict:
+    return json.loads(DEFINITION.read_text())["States"]
+
+
+@pytest.fixture(scope="module")
+def handler_module():
+    spec = importlib.util.spec_from_file_location("weekly_coverage_sweep_index", HANDLER)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_sweep_state_passes_its_own_execution_id(states: dict) -> None:
+    """``$$.Execution.Id``, not the state machine ARN.
+
+    ``state_machine_arn.$`` is ``$$.StateMachine.Id`` and identifies the
+    pipeline; the observer question is *which execution am I inside*, which
+    only the execution context object answers.
+    """
+    payload = states["WeeklyCoverageSweep"]["Parameters"]["Payload"]
+    assert payload["observer_execution_arn.$"] == "$$.Execution.Id"
+    assert payload["state_machine_arn.$"] == "$$.StateMachine.Id"
+
+
+def test_every_handler_outcome_literal_has_a_choice_branch(states: dict, handler_module) -> None:
+    """A fifth outcome added without a branch lands on the Default, which is
+    ``unavailable`` — honest, but it would report a sweep that RAN as one that
+    did not. The literals and the branches are two declarations of one
+    contract, so they are compared rather than trusted."""
+    literals = {
+        value
+        for name, value in vars(handler_module).items()
+        if name.startswith("OUTCOME_") and isinstance(value, str)
+    }
+    assert literals == {"clean", "findings", "deferred", "unavailable"}
+
+    choice = states["CheckWeeklyCoverageSweepOutcome"]
+    branched = {c["StringEquals"] for c in choice["Choices"]}
+    # ``unavailable`` is deliberately the Default rather than a branch: an
+    # outcome the Choice does not recognise is an unknown state of the
+    # coverage surface, and unknown is never rendered green.
+    assert branched == literals - {"unavailable"}
+    assert choice["Default"] == "WeeklyCoverageSweepUnavailable"
+
+
+def test_the_deferred_branch_reaches_its_own_terminal(states: dict) -> None:
+    """Not shared with ``clean``. A terminal shared with the clean one makes
+    "the sweep ran and could not establish coverage" unreadable in the
+    execution history, which is the first place an operator looks."""
+    choice = states["CheckWeeklyCoverageSweepOutcome"]
+    target = next(c["Next"] for c in choice["Choices"] if c["StringEquals"] == "deferred")
+    assert target == "WeeklyCoverageSweepDeferred"
+
+    deferred = states[target]
+    assert deferred["Resource"] == "arn:aws:states:::sns:publish"
+    assert deferred["Next"] == "WeeklyCoverageSweepUnestablished"
+    assert states["WeeklyCoverageSweepUnestablished"]["Type"] == "Succeed"
+    # Observe-only tail: everything from WriteCompletionMarker down is
+    # downstream of the pipeline's real success terminal and must never turn a
+    # completed weekly run into a failure (sf-pipeline-policy 2.1).
+    for name in ("WeeklyCoverageSweepDeferred", "WeeklyCoverageSweepUnestablished"):
+        assert states[name]["Type"] in ("Task", "Succeed")
+
+
+def test_the_deferred_notification_says_withheld_not_zero(states: dict) -> None:
+    """The whole point of the outcome. A message that reads like a clean
+    result would re-create the defect in prose."""
+    message = states["WeeklyCoverageSweepDeferred"]["Parameters"]["Message.$"]
+    assert "WITHHELD" in message
+    assert "not zero" in message
+    assert "_stage_coverage/_sweep" in message
+    assert "alpha-engine-weekly-coverage-sweep" in message
+
+
+def test_the_handler_declares_its_own_stage_name(handler_module) -> None:
+    """``WeeklyCoverageSweep`` was 1 of the 13 absences on 2026-09-04. The
+    handler must tell the library which stage it IS, or the library cannot
+    know that stage's absence is guaranteed by construction."""
+    assert handler_module.SWEEP_STAGE == "WeeklyCoverageSweep"
+
+
+def test_the_handler_passes_both_observer_fields_to_the_reader() -> None:
+    """Signature-level, because the Lambda's real import is not available in
+    this test environment: the call must carry BOTH halves of the observer —
+    the execution (for the cycle verdict) and the stage (for its own row)."""
+    source = HANDLER.read_text()
+    call = re.search(r"read_coverage_sweep\((.*?)\n        \)", source, re.S)
+    assert call, "read_coverage_sweep call not found"
+    body = call.group(1)
+    assert "observer_execution_arn=observer_execution_arn or None" in body
+    assert "observer_stage=SWEEP_STAGE" in body
+
+
+def test_deferred_outranks_findings(handler_module) -> None:
+    """When the cycle cannot support an absence claim, the honest headline is
+    that coverage is not established — not that N stages are absent, which is
+    the assertion the sweep just declined to make."""
+
+    class _Sweep:
+        deferred = True
+        should_alert = True
+
+    assert handler_module._outcome_for(_Sweep()) == "deferred"
+
+    class _Findings:
+        deferred = False
+        should_alert = True
+
+    assert handler_module._outcome_for(_Findings()) == "findings"
+
+    class _Clean:
+        deferred = False
+        should_alert = False
+
+    assert handler_module._outcome_for(_Clean()) == "clean"


### PR DESCRIPTION
## The defect

`WeeklyCoverageSweep` is a state of `ne-weekly-freshness-pipeline`, placed immediately after `WriteCompletionMarker`. Its own execution is therefore RUNNING at the instant it grades — on every run, forever.

Measured on the live 2026-09-04 cycle: `_stage_coverage/_sweep/ne-weekly-freshness-pipeline/2026-09-04.json` was written at `2026-09-05T21:39:18Z` carrying `cycle.verdict: in_flight`, `cycle.reason: still_running` **and** `should_alert: true` with 13 stages called `absent`. `DescribeExecution watch-rerun-2026-09-04-4` — the execution the same artifact reported RUNNING — returns `stopDate 2026-09-05T21:39:19Z`, `status SUCCEEDED`. One second later, two hops past this state. The 2026-08-28 artifact carries the identical pair, so this was the mechanism's normal state.

## Changes

- **`observer_execution_arn.$` = `$$.Execution.Id`** in the sweep's Payload. Not `$$.StateMachine.Id`, which identifies the pipeline; the observer question is *which execution am I inside*, and only the execution context object answers it. `nousergon_lib` then counts this execution's entered states (real work) without letting its RUNNING status make its own cycle non-terminal. Any **other** running execution still yields `in_flight`.
- **`SWEEP_STAGE = "WeeklyCoverageSweep"`** in the handler. Its own stage was 1 of the 13; it cannot have written a verdict about its own completion, and now reports `self`, outside the denominator.
- **A fourth outcome, `deferred`** — the sweep RAN and declined to assert an absence its cycle could not support. It outranks `findings`: the honest headline is that coverage is not established, not that N stages are absent, which is the assertion the sweep just declined to make. Its own Choice branch and its own terminals (`WeeklyCoverageSweepDeferred` → `WeeklyCoverageSweepUnestablished`), never shared with the clean one — a shared terminal makes the distinction unreadable in the execution history, which is the first place an operator looks.

Withholding is not silence: the library withholds `StageCoverageSweepAbsent` rather than publishing a 0, publishes `StageCoverageSweepDeferred` in its place, and both the handler and this state page. Still an observe-only tail — every terminal below `WriteCompletionMarker` is a Succeed, and failing the execution would retroactively mark a good run bad (`alpha-engine-config-I8045`, `sf-pipeline-policy` 2.1).

## Test plan (run before opening)

- New: `tests/test_weekly_coverage_sweep_observer.py` — 7 tests pinning the `$$.Execution.Id` wiring, that every handler outcome literal has a Choice branch (or is the deliberate Default), that `deferred` reaches its own terminal, that the notification says WITHHELD rather than zero, and that `deferred` outranks `findings`.
- `tests/test_sf_payload_uniqueness.py` updated for the new payload key, with the reason inline.
- `WeeklyCoverageSweepDeferred` declares its partition family in its `Comment`, per `tests/test_weekly_partition_family_contract.py`.
- With the paired lib branch on `PYTHONPATH`: **83 passed** across `test_pipeline_status_registry_source_check`, `test_weekly_partition_family_contract`, `test_sf_payload_uniqueness`, `test_weekly_coverage_sweep_observer`.
- Full suite against the STALE installed lib (v0.124.21 vs pin v0.124.109 — the environment drift tracked as `alpha-engine-config-I9070`): 7097 passed, 4 failed. Three are the Weekday `CorrectnessVerdictGate` / `WaitForCorrectnessVerdict` registry assertions that fail on `main` too for the same stale-install reason; the fourth was the new state's registry entry, now added in the lib PR and green with it on the path.

## Merge order — this PR is BLOCKED

1. `nousergon-lib-PR391` — must merge first. `WeeklyCoverageSweepDeferred` must exist in `nousergon_lib.pipeline_status.registry.STATE_TO_ARCHIVE_PAGE`, and `read_coverage_sweep` must accept `observer_execution_arn` / `observer_stage`, or this handler raises on every invocation and returns `outcome: unavailable`.
2. **this PR** — after bumping `infrastructure/lambdas/weekly-coverage-sweep/requirements.txt` (currently `v0.124.109`) to the version `auto-version-bump.yml` writes on that merge. That bump belongs in this PR, before merge — not after it.
3. `nous-ergon-ops-PR1112` — the alarms.

Tracker is `alpha-engine-config`; a closing keyword does not work across repositories, so `alpha-engine-config-I10170` is closed by hand.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVE67NRyV6Ss3DvnnyVEnj


Rehearsal-path: tests/test_weekly_coverage_sweep_observer.py
