### PR TITLE
sf-telegram-notifier: PollMorningArcticAppendSpot floor recalibrated 8m->20m + periodic floor re-derivation (alpha-engine-config-I10164)

### DIFF
--- a/.github/workflows/sf-arn-drift-check.yml
+++ b/.github/workflows/sf-arn-drift-check.yml
@@ -87,6 +87,7 @@ env:
     EventBridge Scheduler rule drift (fleet-wide, codified vs live)
     schedule-manifest.json drift (fleet-wide, vs live AWS)
     Playbook trigger surface drift (playbooks.yaml vs live AWS)
+    Duration-floor calibration drift (STATE_DURATION_FLOORS_SEC vs live SF history)
     Drift-check gate (fail the job on any failed check above)
   WORKFLOW_HEALTH_FINDING_ISSUE: alpha-engine-config-I3697
   WORKFLOW_HEALTH_FINDING_REASON: >-
@@ -312,6 +313,33 @@ jobs:
         if: github.event_name != 'push'
         run: python3 infrastructure/overseer/trigger_surface_drift.py
 
+      # alpha-engine-config-I10164 part 2. execution_digest.py's
+      # STATE_DURATION_FLOORS_SEC is a hand-typed table — the exact defect
+      # class this workflow's other ten checks already guard against, one
+      # level up: those compare codified infrastructure against live AWS;
+      # this compares a codified NUMBER against what live SF execution
+      # history says it should be. Two entries rotted silently in the same
+      # commit (config-I6857) before anyone measured either: one sat above
+      # the median of every healthy run (chronic false positive, caught only
+      # because it happened to fire), the other sat below every genuine run
+      # and missed a confirmed-broken execution (never caught at all). This
+      # step is the periodic re-derivation so a third entry cannot rot the
+      # same way without a daily, gated signal.
+      #
+      # boto3, not the `aws` CLI subprocess shape the other checks in this
+      # file use: floor_calibration.py shares its execution-history parsing
+      # (parse_task_state_durations, fetch_execution_history) with
+      # execution_digest.py itself — the Lambda's own runtime code — so the
+      # calibration math is checked against literally the same function the
+      # digest renders from, not a reimplementation that could drift from it.
+      - name: Install boto3 for the floor-calibration check
+        run: pip install --quiet boto3
+
+      - name: Duration-floor calibration drift (STATE_DURATION_FLOORS_SEC vs live SF history)
+        id: floor_calibration_drift
+        continue-on-error: true
+        run: python3 infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py --check
+
       # ── THE GATE ────────────────────────────────────────────────────────────
       # alpha-engine-config-I9121. Every check above is INDEPENDENT — a
       # different codified source against a different live AWS surface — but
@@ -358,6 +386,7 @@ jobs:
             scheduler_rule_drift=${{ steps.scheduler_rule_drift.outcome }}
             schedule_manifest_drift=${{ steps.schedule_manifest_drift.outcome }}
             trigger_surface_drift=${{ steps.trigger_surface_drift.outcome }}
+            floor_calibration_drift=${{ steps.floor_calibration_drift.outcome }}
         run: |
           failed=0
           echo "### Drift-check outcomes" >> "$GITHUB_STEP_SUMMARY"

--- a/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
@@ -64,7 +64,43 @@ STATE_DURATION_FLOORS_SEC: Mapping[str, int] = {
     # different state with its own distribution, out of scope for this
     # investigation and tracked separately in I10164.
     "PollMorningEnrichSpot": 90,
-    "PollMorningArcticAppendSpot": 8 * 60,
+    #
+    # PollMorningArcticAppendSpot RECALIBRATED 2026-09-08 (alpha-engine-config-
+    # I10164 part 1). The prior 8m (480s) floor was ALSO unmeasured (same
+    # config-I6857 commit, same reused ModelZooTrainMap literal) — but unlike
+    # PollMorningEnrichSpot it never produced a false positive, because it sat
+    # BELOW every genuine run rather than above the median. That is not
+    # evidence it was right: it means the floor was too LOW to catch a real
+    # failure, the mirror-image defect.
+    #
+    # Measured against all 34 SUCCEEDED ne-preopen-trading-pipeline executions
+    # in the account's full history that carried this state — but duration
+    # alone does not separate genuine from broken here the way it does for
+    # PollMorningEnrichSpot: this state's Task output carries a companion
+    # `arctic_append_poll.Status` field (the raw ssm:GetCommandInvocation
+    # result), which is ground truth for whether the spot command itself
+    # actually succeeded. Splitting on THAT (not just duration) found:
+    #   Success (n=29): min 1474.9s / p10 1535.4s / median 1919.4s /
+    #     p90 2403.1s / max 5595.5s.
+    #   Failed  (n=5): 121.3s, 260.3s, 929.7s, 3806.4s, 4808.3s.
+    # The three short Failed runs are a genuinely broken spot command (SSM
+    # StandardErrorContent: "WARNING: The directory '/home/ec2-user/.cache/
+    # pip' ... failed to run commands: exit status 1", and one "Undeliverable")
+    # that the SF execution still recorded as SUCCEEDED overall — an
+    # independent verification that a FAST run here is not a short-scope run,
+    # it is a broken one, exactly the class part 2's mechanism exists to keep
+    # catching. The old 480s floor caught two of the three (121.3s, 260.3s)
+    # but MISSED the third (929.7s > 480s) — a false negative on a confirmed-
+    # broken run, not a hypothetical.
+    # New floor: 1200s (20m), ~19% below the measured genuine minimum
+    # (1474.9s) — clears every one of the 29 genuine runs with margin, and now
+    # catches all three known-broken short runs (121.3s, 260.3s, 929.7s < 1200s
+    # all breach). The two long-duration Failed runs (3806.4s, 4808.3s) are
+    # NOT caught by any duration floor — a slow failure is a different
+    # detection problem (an attestation/output check, not a minimum-duration
+    # check) and is filed separately (alpha-engine-config-I10189), not folded
+    # into this recalibration.
+    "PollMorningArcticAppendSpot": 20 * 60,
     "Scanner": 60,
 }
 

--- a/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
@@ -1,0 +1,399 @@
+"""Periodic re-derivation for STATE_DURATION_FLOORS_SEC (alpha-engine-config-I10164 part 2).
+
+WHY THIS EXISTS. Every entry in ``execution_digest.STATE_DURATION_FLOORS_SEC``
+is a hand-typed constant, and nothing checked it against reality after it was
+written. Two of them rotted the same way: ``PollMorningEnrichSpot``'s 8m floor
+sat ABOVE the median of every healthy run (a chronic false positive, caught
+only because it happened to fire on 2026-09-08); ``PollMorningArcticAppendSpot``'s
+own 8m floor sat BELOW every genuine run and MISSED a confirmed-broken 929.7s
+execution (a false negative, never caught at all — it took an unrelated
+investigation to find it). Both floors were introduced in the same commit,
+reusing an unrelated weekly floor's literal, with no measurement basis
+recorded. A hand-kept table is the defect this module targets: it recomputes
+what each floor SHOULD be from live Step Functions history, on a schedule, and
+reports drift on a durable, alerting surface — never only a log line.
+
+WHAT THIS DOES NOT DO. It does not rewrite ``execution_digest.py`` and it does
+not merge anything: floor changes go into that file's git history, and merge
+authority is Brian's per ``pull-request-policy.md``. The loop this module
+closes is DETECT (pull live durations) -> DIAGNOSE (compare against the
+codified floor with a stated formula) -> ACT (fail a gated CI step naming the
+exact numbers, the SOTA-available action short of an unattended source edit)
+-> VERIFY (the next scheduled run re-checks after a fix lands) -> CLOSE (the
+check goes green). ``--check`` is wired into ``sf-arn-drift-check.yml``
+(daily) alongside this repo's other codified-vs-live drift detectors, so a
+newly-rotted floor cannot go undetected for longer than one day, the same
+guarantee every other entry in that workflow already carries.
+
+WHY LOCAL TO THIS LAMBDA, NOT nousergon-lib (policy-shared-code). One
+consumer today (this module, called from this one CI step). The policy's own
+rule is explicit: lift on the SECOND adoption, not pre-generalize for one that
+may never arrive. If another fleet detector needs the same
+derive-a-threshold-from-live-history shape, THAT is the trigger to extract a
+shared library function — not before.
+
+STATUS-AWARE SAMPLING (the lesson this module exists to encode). A SUCCEEDED
+Step Functions execution does not mean every Task inside it did real work —
+``PollMorningArcticAppendSpot``'s own output carries a companion
+``arctic_append_poll.Status`` field (the raw ``ssm:GetCommandInvocation``
+result) that can read ``Failed`` even while the execution completes
+SUCCEEDED. Where a state has a KNOWN companion poll-status field
+(``KNOWN_POLL_STATUS_KEYS`` below), only ``Status == "Success"`` samples count
+as GENUINE for the floor formula; a duration alone would silently launder a
+broken run into the distribution. Where no companion key is declared, this
+module computes on raw duration and says so — DECLARED rather than inferred,
+same discipline ``execution_digest.py`` already applies to
+``TERMINAL_ERROR_HANDLING_STATES`` / ``WORK_STATES_ON_TERMINAL_PATHS``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import statistics
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from execution_digest import STATE_DURATION_FLOORS_SEC, parse_task_state_durations
+
+logger = logging.getLogger(__name__)
+
+REGION = "us-east-1"
+ACCOUNT_ID = "711398986525"
+
+#: Which Step Functions state machine carries each floored state. Declared,
+#: not inferred: DIGEST_STATE_ORDER interleaves weekly and weekday state
+#: names in one list with no machine-readable split, so this module names the
+#: split explicitly rather than re-deriving it from comment boundaries.
+STATE_TO_STATE_MACHINE: Mapping[str, str] = {
+    "MorningEnrich": "ne-weekly-freshness-pipeline",
+    "DataPhase1": "ne-weekly-freshness-pipeline",
+    "RAGIngestion": "ne-weekly-freshness-pipeline",
+    "PredictorTraining": "ne-weekly-freshness-pipeline",
+    "Backtester": "ne-weekly-freshness-pipeline",
+    "ModelZooTrainMap": "ne-weekly-freshness-pipeline",
+    "PollMorningEnrichSpot": "ne-preopen-trading-pipeline",
+    "PollMorningArcticAppendSpot": "ne-preopen-trading-pipeline",
+    "Scanner": "ne-preopen-trading-pipeline",
+}
+
+#: States whose Task output carries a companion SSM-poll-result dict (the raw
+#: ssm:GetCommandInvocation shape: Status/ResponseCode/StatusDetails/
+#: StandardErrorContent) that is ground truth for whether the underlying spot
+#: command actually succeeded, independent of the state's own Task exit and
+#: independent of the SF execution's overall terminal status. A state absent
+#: here is calibrated from raw duration alone — see the module docstring.
+#: A newly poll-backed state gets an entry here in the same PR that adds it.
+KNOWN_POLL_STATUS_KEYS: Mapping[str, str] = {
+    "PollMorningEnrichSpot": "morning_enrich_poll",
+    "PollMorningArcticAppendSpot": "arctic_append_poll",
+}
+
+#: Below this many GENUINE samples, a floor is UNMEASURABLE — never defaulted
+#: to 0, never dropped from the reported set, always recorded as its own
+#: status so a state new to production doesn't masquerade as either "fine" or
+#: "gone missing".
+MIN_SAMPLES = 10
+
+#: Recommended floor = measured genuine minimum * (1 - MARGIN). Matches the
+#: ~15-19% margin both I10164 recalibrations used by hand; codified here so
+#: future recalibrations are consistent rather than picked per incident.
+MARGIN = 0.15
+
+#: A live floor is reported as drifted only outside this relative band around
+#: the recommended value, so ordinary week-to-week sample noise (a handful of
+#: new executions shifting the min by a few seconds) doesn't flap the check.
+DRIFT_TOLERANCE = 0.20
+
+#: A distribution this tight is treated as DEGENERATE rather than trusted
+#: blindly — e.g. every sample coming from one synthetic backfill, or a
+#: state that always completes in lockstep with a fixed-length Wait. Flagged
+#: for human review; no recommendation is computed from it.
+DEGENERATE_SPREAD_RATIO = 1.02
+
+
+@dataclass(frozen=True)
+class FloorRecommendation:
+    state_name: str
+    status: str  # "ok" | "drift_tighten" | "drift_loosen" | "unmeasurable" | "degenerate"
+    current_floor_sec: int
+    n_genuine: int
+    n_excluded: int
+    min_sec: Optional[float] = None
+    p10_sec: Optional[float] = None
+    median_sec: Optional[float] = None
+    p90_sec: Optional[float] = None
+    max_sec: Optional[float] = None
+    recommended_floor_sec: Optional[int] = None
+    basis: str = ""
+
+    @property
+    def is_drift(self) -> bool:
+        return self.status in ("drift_tighten", "drift_loosen")
+
+
+def _percentile(sorted_values: Sequence[float], p: float) -> float:
+    n = len(sorted_values)
+    idx = min(n - 1, max(0, int(round(p * (n - 1)))))
+    return sorted_values[idx]
+
+
+def collect_state_duration_samples(
+    sf_client: Any,
+    state_machine_arn: str,
+    state_names: Sequence[str],
+    *,
+    fetch_history: Any,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Per-state list of ``{"duration_sec": float, "poll_status": Optional[str]}``
+    samples across every SUCCEEDED execution of ``state_machine_arn``.
+
+    ``fetch_history(sf_client, execution_arn) -> List[dict]`` is injected
+    (rather than calling ``execution_digest.fetch_execution_history``
+    directly) so tests can supply canned event lists without a live SF
+    execution to point at — the same shape ``build_execution_digest`` already
+    takes ``sf_client``/``s3_client`` as parameters for.
+    """
+    samples: Dict[str, List[Dict[str, Any]]] = {name: [] for name in state_names}
+    paginator = sf_client.get_paginator("list_executions")
+    executions: List[dict] = []
+    for page in paginator.paginate(stateMachineArn=state_machine_arn, statusFilter="SUCCEEDED"):
+        executions.extend(page.get("executions", []))
+
+    for execution in executions:
+        events = fetch_history(sf_client, execution["executionArn"])
+        durations = parse_task_state_durations(events)
+        last_outputs = _last_task_outputs(events, state_names)
+        for name in state_names:
+            if name not in durations:
+                continue
+            poll_status = None
+            poll_key = KNOWN_POLL_STATUS_KEYS.get(name)
+            if poll_key:
+                output = last_outputs.get(name)
+                if isinstance(output, dict):
+                    poll_status = (output.get(poll_key) or {}).get("Status")
+            samples[name].append(
+                {"duration_sec": durations[name], "poll_status": poll_status}
+            )
+    return samples
+
+
+def _last_task_outputs(events: Sequence[dict], state_names: Sequence[str]) -> Dict[str, dict]:
+    import json as _json
+
+    wanted = set(state_names)
+    last: Dict[str, dict] = {}
+    for event in events:
+        if event.get("type") != "TaskStateExited":
+            continue
+        detail = event.get("stateExitedEventDetails") or {}
+        name = detail.get("name")
+        if name not in wanted:
+            continue
+        raw = detail.get("output")
+        if not raw:
+            continue
+        try:
+            last[name] = _json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+    return last
+
+
+def compute_recommendation(
+    state_name: str,
+    samples: Sequence[Mapping[str, Any]],
+    current_floor_sec: int,
+) -> FloorRecommendation:
+    """One state's recommendation, from its collected samples.
+
+    ``samples`` items carry ``duration_sec`` and (when the state has a
+    ``KNOWN_POLL_STATUS_KEYS`` entry) ``poll_status``. GENUINE samples are
+    those with no companion key declared (raw duration is all there is) OR
+    ``poll_status == "Success"``. A companion key present with a non-Success
+    status is EXCLUDED from the genuine set, never averaged in.
+    """
+    has_poll_key = state_name in KNOWN_POLL_STATUS_KEYS
+    if has_poll_key:
+        genuine = [s["duration_sec"] for s in samples if s.get("poll_status") == "Success"]
+        excluded = [s for s in samples if s.get("poll_status") != "Success"]
+    else:
+        genuine = [s["duration_sec"] for s in samples]
+        excluded = []
+
+    n_genuine = len(genuine)
+    n_excluded = len(excluded)
+
+    if n_genuine < MIN_SAMPLES:
+        return FloorRecommendation(
+            state_name=state_name,
+            status="unmeasurable",
+            current_floor_sec=current_floor_sec,
+            n_genuine=n_genuine,
+            n_excluded=n_excluded,
+            basis=(
+                f"only {n_genuine} genuine sample(s), below MIN_SAMPLES={MIN_SAMPLES} — "
+                "no recommendation computed; floor left as-is and recorded unmeasurable, "
+                "never defaulted to 0 and never dropped from the report"
+            ),
+        )
+
+    genuine_sorted = sorted(genuine)
+    min_sec = genuine_sorted[0]
+    p10_sec = _percentile(genuine_sorted, 0.10)
+    median_sec = statistics.median(genuine_sorted)
+    p90_sec = _percentile(genuine_sorted, 0.90)
+    max_sec = genuine_sorted[-1]
+
+    if min_sec > 0 and (max_sec / min_sec) < DEGENERATE_SPREAD_RATIO:
+        return FloorRecommendation(
+            state_name=state_name,
+            status="degenerate",
+            current_floor_sec=current_floor_sec,
+            n_genuine=n_genuine,
+            n_excluded=n_excluded,
+            min_sec=min_sec,
+            p10_sec=p10_sec,
+            median_sec=median_sec,
+            p90_sec=p90_sec,
+            max_sec=max_sec,
+            basis=(
+                f"spread max/min = {max_sec / min_sec:.4f} < {DEGENERATE_SPREAD_RATIO} — "
+                "distribution implausibly tight (a synthetic/backfill-only sample set, or a "
+                "state gated by a fixed Wait); flagged for human review, no floor recommended"
+            ),
+        )
+
+    recommended = max(0, int(round(min_sec * (1 - MARGIN))))
+    lower = recommended * (1 - DRIFT_TOLERANCE)
+    upper = recommended * (1 + DRIFT_TOLERANCE)
+    if lower <= current_floor_sec <= upper:
+        status = "ok"
+    elif current_floor_sec < lower:
+        status = "drift_tighten"  # current floor too loose to catch a real hollow run
+    else:
+        status = "drift_loosen"  # current floor sits at/above genuine runs — false positives
+
+    return FloorRecommendation(
+        state_name=state_name,
+        status=status,
+        current_floor_sec=current_floor_sec,
+        n_genuine=n_genuine,
+        n_excluded=n_excluded,
+        min_sec=min_sec,
+        p10_sec=p10_sec,
+        median_sec=median_sec,
+        p90_sec=p90_sec,
+        max_sec=max_sec,
+        recommended_floor_sec=recommended,
+        basis=(
+            f"recommended = round(min_genuine * (1-{MARGIN})) = "
+            f"round({min_sec:.1f} * {1 - MARGIN}) = {recommended}s; "
+            f"current {current_floor_sec}s is "
+            f"{'within' if status == 'ok' else 'outside'} the "
+            f"+/-{int(DRIFT_TOLERANCE * 100)}% tolerance band "
+            f"[{lower:.0f}s, {upper:.0f}s]"
+        ),
+    )
+
+
+def compute_all_recommendations(
+    samples_by_state: Mapping[str, Sequence[Mapping[str, Any]]],
+) -> List[FloorRecommendation]:
+    """One recommendation per entry in STATE_DURATION_FLOORS_SEC — the DERIVED
+    set, not a hand-kept subset. A state present in the codified floors table
+    but missing from ``samples_by_state`` (no live samples reachable, e.g. an
+    unrecognized state machine) is still reported, as unmeasurable with
+    n=0 — never silently dropped.
+    """
+    recs = []
+    for state_name, floor_sec in STATE_DURATION_FLOORS_SEC.items():
+        recs.append(
+            compute_recommendation(
+                state_name, samples_by_state.get(state_name, []), floor_sec
+            )
+        )
+    return recs
+
+
+def render_report(recommendations: Sequence[FloorRecommendation]) -> str:
+    lines = ["state,status,current_floor_sec,n_genuine,n_excluded,recommended_floor_sec,basis"]
+    for rec in recommendations:
+        lines.append(
+            ",".join(
+                [
+                    rec.state_name,
+                    rec.status,
+                    str(rec.current_floor_sec),
+                    str(rec.n_genuine),
+                    str(rec.n_excluded),
+                    "" if rec.recommended_floor_sec is None else str(rec.recommended_floor_sec),
+                    f'"{rec.basis}"',
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def _default_fetch_history(sf_client: Any, execution_arn: str) -> List[dict]:
+    from execution_digest import fetch_execution_history
+
+    return fetch_execution_history(sf_client, execution_arn)
+
+
+def run_check(sf_client: Any) -> List[FloorRecommendation]:
+    """Pull live samples for every state machine referenced in
+    STATE_TO_STATE_MACHINE and return the full recommendation set."""
+    states_by_machine: Dict[str, List[str]] = {}
+    for state_name, machine in STATE_TO_STATE_MACHINE.items():
+        states_by_machine.setdefault(machine, []).append(state_name)
+
+    samples_by_state: Dict[str, List[Dict[str, Any]]] = {}
+    for machine, state_names in states_by_machine.items():
+        arn = f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{machine}"
+        collected = collect_state_duration_samples(
+            sf_client, arn, state_names, fetch_history=_default_fetch_history
+        )
+        samples_by_state.update(collected)
+
+    return compute_all_recommendations(samples_by_state)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any floor has drifted or gone degenerate.",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Print the full recommendation table (CSV) and exit 0.",
+    )
+    args = parser.parse_args(argv)
+
+    import boto3
+
+    sf_client = boto3.client("stepfunctions", region_name=REGION)
+    recommendations = run_check(sf_client)
+    report = render_report(recommendations)
+    print(report)
+
+    if args.report and not args.check:
+        return 0
+
+    findings = [r for r in recommendations if r.is_drift or r.status == "degenerate"]
+    if findings:
+        print("\nFINDINGS:", file=sys.stderr)
+        for rec in findings:
+            print(f"  {rec.state_name}: {rec.status} — {rec.basis}", file=sys.stderr)
+        return 1
+    print("\nevery floor is within tolerance or unmeasurable", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
@@ -106,6 +106,48 @@ def test_poll_morning_enrich_spot_floor_still_catches_a_genuinely_hollow_run():
     assert rows[0].anomaly is True
 
 
+def test_poll_morning_arctic_append_spot_floor_is_the_recalibrated_value():
+    # alpha-engine-config-I10164 part 1: the prior 8m (480s) floor was also
+    # unmeasured (config-I6857) and sat BELOW every genuine run (min 1474.9s
+    # across n=29 Success-status executions), so it never false-positived —
+    # but it also missed a confirmed-broken 929.7s run, the mirror-image
+    # defect. Recalibrated to 1200s, ~19% below the measured genuine minimum.
+    assert STATE_DURATION_FLOORS_SEC["PollMorningArcticAppendSpot"] == 1200
+
+
+def test_poll_morning_arctic_append_spot_floor_clears_the_measured_minimum_genuine_run():
+    # The fastest genuine (arctic_append_poll.Status == "Success") run
+    # measured (500c7956-..., 1474.9s) must NOT breach the new floor.
+    start = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
+    rows = build_state_durations(
+        {"PollMorningArcticAppendSpot": 1475},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-07-04",
+        s3_client=None,
+    )
+    assert rows[0].floor_breach is False
+
+
+def test_poll_morning_arctic_append_spot_floor_still_catches_a_confirmed_broken_run():
+    # 929.7s (b9d76d5c-..., 2026-07-14) is a CONFIRMED broken run — its
+    # arctic_append_poll.Status read "Failed" (SSM StandardErrorContent:
+    # a pip-cache-permission failure, "failed to run commands: exit status
+    # 1") even though the overall SF execution completed SUCCEEDED. The old
+    # 480s floor MISSED this one (929.7s > 480s); the recalibrated 1200s
+    # floor must catch it.
+    start = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
+    rows = build_state_durations(
+        {"PollMorningArcticAppendSpot": 930},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-07-04",
+        s3_client=None,
+    )
+    assert rows[0].floor_breach is True
+    assert rows[0].anomaly is True
+
+
 def test_format_digest_sorts_anomalies_visually():
     rows = [
         StateDuration("Backtester", 600, 600, False, False),

--- a/infrastructure/lambdas/sf-telegram-notifier/test_floor_calibration.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_floor_calibration.py
@@ -1,0 +1,254 @@
+"""Unit tests for floor_calibration.py (alpha-engine-config-I10164 part 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from floor_calibration import (
+    DEGENERATE_SPREAD_RATIO,
+    MARGIN,
+    MIN_SAMPLES,
+    STATE_TO_STATE_MACHINE,
+    FloorRecommendation,
+    collect_state_duration_samples,
+    compute_all_recommendations,
+    compute_recommendation,
+    render_report,
+    run_check,
+)
+
+
+def _samples(durations, poll_statuses=None):
+    if poll_statuses is None:
+        return [{"duration_sec": d, "poll_status": None} for d in durations]
+    return [
+        {"duration_sec": d, "poll_status": s} for d, s in zip(durations, poll_statuses)
+    ]
+
+
+# ── compute_recommendation: core statuses ────────────────────────────────
+
+
+def test_unmeasurable_below_min_samples():
+    samples = _samples([100.0] * (MIN_SAMPLES - 1))
+    rec = compute_recommendation("SomeState", samples, current_floor_sec=90)
+    assert rec.status == "unmeasurable"
+    assert rec.recommended_floor_sec is None
+    assert rec.n_genuine == MIN_SAMPLES - 1
+
+
+def test_unmeasurable_is_never_zero_and_never_dropped():
+    """A too-small sample never defaults to a floor of 0 — it stays a
+    reported row with its own status, not a silently omitted one."""
+    samples = _samples([50.0, 60.0])
+    rec = compute_recommendation("RareState", samples, current_floor_sec=30)
+    assert rec.status == "unmeasurable"
+    assert rec.current_floor_sec == 30  # untouched, not zeroed
+    assert rec.recommended_floor_sec is None
+    # See test_every_codified_floor_state_is_reported for the invariant that
+    # every STATE_DURATION_FLOORS_SEC entry (not just states with samples) is
+    # always present in the full report.
+
+
+def test_degenerate_distribution_flagged_not_recommended():
+    # Every sample within DEGENERATE_SPREAD_RATIO of each other.
+    tight = [1000.0 + i * 0.01 for i in range(MIN_SAMPLES + 5)]
+    assert (max(tight) / min(tight)) < DEGENERATE_SPREAD_RATIO
+    rec = compute_recommendation("TooTight", _samples(tight), current_floor_sec=800)
+    assert rec.status == "degenerate"
+    assert rec.recommended_floor_sec is None
+
+
+def test_ok_when_current_floor_within_tolerance_of_recommendation():
+    durations = [100.0 + i for i in range(MIN_SAMPLES + 10)]  # min=100
+    recommended = round(100.0 * (1 - MARGIN))  # 85
+    rec = compute_recommendation("Steady", _samples(durations), current_floor_sec=recommended)
+    assert rec.status == "ok"
+    assert rec.recommended_floor_sec == recommended
+
+
+def test_drift_tighten_when_current_floor_too_low():
+    # Mirrors PollMorningArcticAppendSpot: current floor sits far BELOW the
+    # measured genuine minimum, catching nothing — a false negative.
+    durations = [1474.9 + i * 40 for i in range(MIN_SAMPLES + 10)]
+    rec = compute_recommendation("TooLoose", _samples(durations), current_floor_sec=480)
+    assert rec.status == "drift_tighten"
+    assert rec.recommended_floor_sec is not None
+    assert rec.recommended_floor_sec > 480
+
+
+def test_drift_loosen_when_current_floor_too_high():
+    # Mirrors PollMorningEnrichSpot pre-recalibration: current floor sits
+    # ABOVE the measured genuine minimum, false-positiving on healthy runs.
+    durations = [106.8 + i for i in range(MIN_SAMPLES + 10)]
+    rec = compute_recommendation("TooTightFloor", _samples(durations), current_floor_sec=480)
+    assert rec.status == "drift_loosen"
+    assert rec.recommended_floor_sec is not None
+    assert rec.recommended_floor_sec < 480
+
+
+def test_never_silently_widens_a_correctly_tight_floor():
+    """A floor that already sits BELOW the recommendation (correctly tight,
+    catching more than the bare minimum would) is not reported OK just
+    because it's conservative — it is drift_loosen only when it exceeds the
+    band, otherwise the mechanism must not push it wider for no reason."""
+    durations = [1000.0 + i * 40 for i in range(MIN_SAMPLES + 10)]
+    recommended = round(1000.0 * (1 - MARGIN))
+    # current floor already well below recommended (tighter than necessary,
+    # but not by so much it is a false negative) — inside tolerance band.
+    tight_but_in_band = int(recommended * 0.85)
+    rec = compute_recommendation("Conservative", _samples(durations), current_floor_sec=tight_but_in_band)
+    assert rec.status in ("ok", "drift_tighten")
+    # Whichever it is, the formula-driven recommendation is symmetric — this
+    # test exists to pin that "ok" is reachable from BELOW recommended too,
+    # not only from above (i.e. the check is not loosen-only).
+    if rec.status == "drift_tighten":
+        assert rec.recommended_floor_sec > tight_but_in_band
+
+
+# ── poll-status exclusion (the ArcticAppend lesson) ──────────────────────
+
+
+def test_poll_status_failed_samples_excluded_from_genuine_distribution():
+    """A state with a KNOWN_POLL_STATUS_KEYS entry must exclude Failed
+    samples from the genuine min/percentile computation — the exact defect
+    this module exists to prevent (a broken-but-SUCCEEDED Task laundering a
+    short duration into the 'genuine' distribution)."""
+    genuine_durations = [1474.9 + i * 40 for i in range(MIN_SAMPLES + 5)]
+    broken_durations = [121.3, 260.3, 929.7]
+    samples = _samples(
+        broken_durations + genuine_durations,
+        poll_statuses=["Failed"] * len(broken_durations)
+        + ["Success"] * len(genuine_durations),
+    )
+    rec = compute_recommendation(
+        "PollMorningArcticAppendSpot", samples, current_floor_sec=480
+    )
+    assert rec.n_excluded == 3
+    assert rec.min_sec == pytest.approx(1474.9, abs=0.5)
+    assert rec.status == "drift_tighten"
+
+
+def test_state_without_poll_key_uses_raw_duration():
+    """A state absent from KNOWN_POLL_STATUS_KEYS has no ground-truth signal
+    beyond duration — this is a declared, documented limitation, not a bug:
+    every sample counts as genuine regardless of a (nonexistent) poll_status."""
+    durations = [500.0 + i for i in range(MIN_SAMPLES + 5)]
+    rec = compute_recommendation("Scanner", _samples(durations), current_floor_sec=60)
+    assert rec.n_excluded == 0
+    assert rec.n_genuine == len(durations)
+
+
+# ── compute_all_recommendations: derived set, not hand-kept ──────────────
+
+
+def test_every_codified_floor_state_is_reported():
+    """The report covers every entry in STATE_DURATION_FLOORS_SEC, derived
+    from that module, never a separately hand-kept list here."""
+    recs = compute_all_recommendations({})
+    from execution_digest import STATE_DURATION_FLOORS_SEC
+
+    reported_names = {r.state_name for r in recs}
+    assert reported_names == set(STATE_DURATION_FLOORS_SEC)
+    # With zero samples supplied, every one is unmeasurable — recorded, not
+    # dropped.
+    assert all(r.status == "unmeasurable" for r in recs)
+    assert all(r.n_genuine == 0 for r in recs)
+
+
+def test_state_to_state_machine_covers_every_codified_floor():
+    from execution_digest import STATE_DURATION_FLOORS_SEC
+
+    assert set(STATE_DURATION_FLOORS_SEC) == set(STATE_TO_STATE_MACHINE)
+
+
+# ── render_report ──────────────────────────────────────────────────────
+
+
+def test_render_report_includes_every_recommendation():
+    recs = [
+        FloorRecommendation(
+            state_name="A", status="ok", current_floor_sec=90, n_genuine=20, n_excluded=0,
+            min_sec=100.0, recommended_floor_sec=85, basis="x",
+        ),
+        FloorRecommendation(
+            state_name="B", status="unmeasurable", current_floor_sec=480, n_genuine=2,
+            n_excluded=0, basis="y",
+        ),
+    ]
+    report = render_report(recs)
+    assert "A" in report and "B" in report
+    assert "ok" in report and "unmeasurable" in report
+
+
+# ── collect_state_duration_samples: status extraction from Task output ───
+
+
+def _entered(name, ts):
+    return {"type": "TaskStateEntered", "timestamp": ts, "stateEnteredEventDetails": {"name": name}}
+
+
+def _exited(name, ts, output):
+    import json
+
+    return {
+        "type": "TaskStateExited",
+        "timestamp": ts,
+        "stateExitedEventDetails": {"name": name, "output": json.dumps(output)},
+    }
+
+
+def test_collect_state_duration_samples_extracts_poll_status():
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
+    events = [
+        _entered("PollMorningArcticAppendSpot", base),
+        _exited(
+            "PollMorningArcticAppendSpot",
+            base + timedelta(seconds=930),
+            {"arctic_append_poll": {"Status": "Failed"}},
+        ),
+    ]
+
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {"executions": [{"executionArn": "arn:exec:1", "name": "exec-1"}]}
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        ["PollMorningArcticAppendSpot"],
+        fetch_history=fake_fetch,
+    )
+    assert len(samples["PollMorningArcticAppendSpot"]) == 1
+    sample = samples["PollMorningArcticAppendSpot"][0]
+    assert sample["duration_sec"] == pytest.approx(930.0)
+    assert sample["poll_status"] == "Failed"
+
+
+def test_run_check_wires_every_state_machine():
+    """run_check must reach every state machine named in
+    STATE_TO_STATE_MACHINE, not only the one under active investigation —
+    the whole point of a periodic mechanism is it does not need a human to
+    remember which pipeline to point it at."""
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [{"executions": []}]
+
+    recs = run_check(sf_client)
+    names = {r.state_name for r in recs}
+    assert names == set(STATE_TO_STATE_MACHINE)
+
+    called_arns = {
+        call.kwargs.get("stateMachineArn")
+        for call in sf_client.get_paginator.return_value.paginate.call_args_list
+    }
+    expected_machines = set(STATE_TO_STATE_MACHINE.values())
+    called_machines = {arn.rsplit(":", 1)[-1] for arn in called_arns}
+    assert called_machines == expected_machines

--- a/tests/test_scheduled_workflow_reachability.py
+++ b/tests/test_scheduled_workflow_reachability.py
@@ -60,6 +60,12 @@ NON_CHECK_STEPS = {
     "Paused-component alarm actions reconciled with the manifest (live)",
     # A report, not an assertion. `if: always()` already makes it reachable.
     "Publish the arming record",
+    # Setup, not a check: installs a dependency the next step needs. Its own
+    # failure already fails the job outright (no continue-on-error) rather
+    # than being read as a finding, which is correct — a broken pip install
+    # is an infrastructure break, not a drift finding (alpha-engine-config-
+    # I10164 part 2).
+    "Install boto3 for the floor-calibration check",
 }
 
 


### PR DESCRIPTION
## Summary
Closes `alpha-engine-config-I10164`, both parts. **Stacked on nousergon-data-PR1652** (base branch `fix/pollmorningenrichspot-floor-recalibration-i10163`) — merge order: **PR1652 first, then this PR**; this PR will auto-retarget to `main` once 1652 merges.

## Part 1 — PollMorningArcticAppendSpot floor
The prior 8m (480s) floor was also unmeasured (config-I6857, same commit that gave `PollMorningEnrichSpot` its unmeasured 8m floor). Unlike enrich, it never produced a false positive — it sat BELOW every genuine run — but that's not evidence it was right: it MISSED a confirmed-broken 929.7s execution, the mirror-image defect.

Measured all 34 SUCCEEDED `ne-preopen-trading-pipeline` executions carrying this state, split by the state's own `arctic_append_poll.Status` field (the raw `ssm:GetCommandInvocation` result embedded in Task output — ground truth for whether the spot command itself succeeded, independent of the SF execution's overall terminal status):
- **Success (n=29):** min 1474.9s / p10 1535.4s / median 1919.4s / p90 2403.1s / max 5595.5s.
- **Failed (n=5):** 121.3s, 260.3s, 929.7s, 3806.4s, 4808.3s.

Independently verified the three short "fast" runs are NOT full artifacts completed quickly — they are confirmed-broken SSM commands (`StandardErrorContent`: a pip-cache-permission failure, "failed to run commands: exit status 1"; one `Undeliverable`) that the overall SF execution still recorded as SUCCEEDED. Duration does not launder a broken run into looking genuine here, but only because the companion status field was checked — this is the exact defect part 2 exists to keep catching generally.

**New floor: 1200s (20m)**, ~19% below the measured genuine minimum (1474.9s). Clears every one of the 29 genuine runs with margin. Now catches all three known-broken short runs (121.3s, 260.3s, 929.7s — all < 1200s). The old 480s floor caught only two of three (missed 929.7s). The two long-duration Failed runs (3806.4s, 4808.3s) are NOT catchable by any duration floor — filed separately as `alpha-engine-config-I10189` (an output/attestation check, not a duration check).

## Part 2 — periodic re-derivation mechanism
`floor_calibration.py` (new, local to `sf-telegram-notifier`):
- Derives a recommendation per `STATE_DURATION_FLOORS_SEC` entry from live SF execution history — never a hand-kept second list.
- Where a state has a known companion SSM-poll-status field (`KNOWN_POLL_STATUS_KEYS`), excludes non-Success samples from the genuine distribution before computing floor/percentiles — the ArcticAppend lesson, generalized.
- Flags drift in **either** direction (`drift_tighten` when the current floor is too loose to catch a real hollow run, `drift_loosen` when it sits at/above genuine runs) — not loosen-only.
- States with fewer than `MIN_SAMPLES=10` genuine observations are reported `unmeasurable` — never defaulted to a floor of 0, never dropped from the report.
- Implausibly tight distributions (`max/min < 1.02`) are flagged `degenerate` for human review rather than trusted blindly.
- Wired as a new `continue-on-error` + gated step in the EXISTING `sf-arn-drift-check.yml` (daily cron), matching that workflow's own pattern for its other ten live-vs-codified checks — deliberately NOT a new scheduled workflow file, since a new one reddens `nous-ergon-ops`' authority-surface check with no way to land the ops-side row from this repo. `WORKFLOW_HEALTH_FINDING_STEPS` and `tests/test_scheduled_workflow_reachability.py`'s `NON_CHECK_STEPS` updated accordingly.

**Loop closed:** detect (pull live durations) -> diagnose (compare against codified floor, stated formula) -> act (fail a gated, alerting CI step naming the exact numbers — the SOTA-available action short of an unattended source edit, since merge authority is Brian's) -> verify (next scheduled run re-checks) -> close (check goes green once a fix lands).

**SOTA / delta:** the robust target state is exactly this — derived thresholds checked on a cadence against live reality, same shape as this repo's other ten drift detectors. Delta: it does not auto-open a remediation PR (that would require the mechanism to pick a new floor value and commit it unattended); given merge authority is reserved to Brian, the detection+alert loop is the correct stopping point. No further deviation.

**Shared-code:** kept local to this Lambda (not lifted to `nousergon-lib`) — one consumer today; policy-shared-code's own rule is lift on the SECOND adoption, not before.

## Follow-up filed
`alpha-engine-config-I10189` — the two long-duration Failed ArcticAppend runs (3806.4s/4808.3s) that no duration floor can ever catch; needs an output/attestation-based check instead.

## Cross-repo note
Closing keywords don't work across repos for this tracker — `alpha-engine-config-I10164` and `alpha-engine-config-I10189` are closed by hand once this merges (after PR1652) and is verified live, per fleet convention.

## Test plan
- [x] `test_floor_calibration.py` (14 tests, new): unmeasurable/degenerate/ok/drift_tighten/drift_loosen statuses, poll-status exclusion (the ArcticAppend lesson), every codified floor state reported, `run_check` reaches every state machine.
- [x] `test_execution_digest.py`: 3 new tests pin the recalibrated 1200s value, confirm the measured genuine minimum (1475s) clears it, confirm the confirmed-broken 930s run still breaches.
- [x] `tests/test_scheduled_workflow_reachability.py`: passes against the new gated step (id + continue-on-error + gate-read + `NON_CHECK_STEPS` entry for the boto3-install setup step).
- [x] Ran every `sf-telegram-notifier/test_*.py` via `run_handler_tests` (one process per file, matching the documented `sys.modules` invariant): all pass (test_handler.py 39, test_eod_artifact_verification.py 14, test_execution_digest.py 37, test_floor_calibration.py 14, test_flow_doctor_fleet_wiring.py 1, test_terminal_delivery_guarantee.py 16).
- [x] Ran the three repo-wide tests referencing `PollMorningArcticAppendSpot` by state name (unaffected by the floor value change): `test_sf_data_spot_relocation_wiring.py` (65), `test_sf_payload_uniqueness.py` (48), `test_sf_liveness_watchdog_wiring.py` (5) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVE67NRyV6Ss3DvnnyVEnj