### PR TITLE
fix(stage-coverage): instrument 5 never-wired stages, fix DispatchWeeklyFreshnessSpot misattribution, exclude declared-skip stages from the cycle spine (I10172, I10175)

### DIFF
--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/iam-policy.json
@@ -97,6 +97,19 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
     },
     {
+      "Sid": "ReadStageCoverageRegistryList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "_freshness_monitor/*"
+          ]
+        }
+      }
+    },
+    {
       "Sid": "WriteStageCoverageVerdicts",
       "Effect": "Allow",
       "Action": "s3:PutObject",

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/iam-policy.json
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/iam-policy.json
@@ -89,6 +89,32 @@
           "ec2:ResourceTag/Name": "alpha-engine-eval-judge-spot"
         }
       }
+    },
+    {
+      "Sid": "ReadStageCoverageRegistry",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
+    },
+    {
+      "Sid": "WriteStageCoverageVerdicts",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/*"
+    },
+    {
+      "Sid": "PutAlphaEngineMetrics",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "cloudwatch:namespace": [
+            "AlphaEngine",
+            "AlphaEngine/*"
+          ]
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/index.py
@@ -401,6 +401,10 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
     """
     event = event or {}
     force_on_demand = bool(event.get("force_on_demand", False))
+    # Captured at handler ENTRY, before any write this invocation makes
+    # (alpha-engine-config-I7214).
+    started = datetime.datetime.now(datetime.timezone.utc)
+    run_date = str(event.get("run_date", "")).strip() or None
 
     if not DISPATCH_ENABLED:
         raise RuntimeError(
@@ -482,4 +486,34 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "market": market,
         "command_id": command_id,
         "run_token": run_token,
+        "stage_coverage": _assert_stage_coverage("DispatchEvalJudgeSpot", started, run_date),
     }
+
+
+def _assert_stage_coverage(stage: str, started: datetime.datetime, run_date: str | None) -> dict:
+    """Record this stage's own output verdict (alpha-engine-config-I10172).
+
+    `DispatchEvalJudgeSpot` is an INFRASTRUCTURE stage declaring
+    `output: variable_cardinality` in `ARTIFACT_REGISTRY.yaml`'s
+    `pipeline_stages:` — the Lambda writes nothing itself (EC2 + SSM API
+    calls only; the async bootstrap command it fires writes its own log at a
+    variable-cardinality key), so the verdict is `COVERED_NO_OUTPUT`.
+    Measured 2026-09-08: this stage had never once written a
+    `_stage_coverage` verdict — the I8228 "never wired" class.
+
+    Never alters the handler's outcome. Mirrors
+    `weekly-freshness-spot-dispatcher/index.py::_assert_stage_coverage`
+    (`policy-shared-code`).
+    """
+    if not run_date:
+        logger.error(
+            "stage-coverage assertion has no run_date for %s — event carried none",
+            stage,
+        )
+        return {"stage": stage, "status": "UNMEASURED", "reason": "no run_date on state input"}
+    try:
+        from krepis.stage_coverage import assert_stage_coverage
+    except ImportError as exc:
+        logger.error("stage-coverage assertion unavailable for %s: %s", stage, exc)
+        return {"stage": stage, "status": "UNMEASURED", "reason": str(exc)}
+    return assert_stage_coverage(stage, window_start=started, run_date=run_date)

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py
@@ -72,13 +72,15 @@ class TestDispatch:
     def test_returns_the_four_fields_the_step_function_threads(self, index_mod):
         index, sd = index_mod
         out = index.handler({"run_date": "2026-08-29"}, None)
-        assert out == {
-            "instance_id": "i-evaljudge",
-            "market": "spot",
-            "command_id": "cmd-eval-judge-1",
-            "run_token": out["run_token"],
-        }
+        assert out["instance_id"] == "i-evaljudge"
+        assert out["market"] == "spot"
+        assert out["command_id"] == "cmd-eval-judge-1"
         assert out["run_token"]
+        # alpha-engine-config-I10172: the stage-coverage self-assertion —
+        # never raises even without live AWS credentials in this unit test
+        # (record_verdict is fail-soft), and never alters the SF-threaded
+        # fields above.
+        assert out["stage_coverage"]["stage"] == "DispatchEvalJudgeSpot"
 
     def test_box_carries_the_tag_the_sf_send_command_grant_is_scoped_to(self, index_mod):
         """`alpha-engine-step-functions-role`'s SendCommandEvalJudgeSpot

--- a/infrastructure/lambdas/substrate-health-gate/iam-policy.json
+++ b/infrastructure/lambdas/substrate-health-gate/iam-policy.json
@@ -38,6 +38,32 @@
         "logs:PutLogEvents"
       ],
       "Resource": "arn:aws:logs:us-east-1:711398986525:log-group:/aws/lambda/alpha-engine-substrate-health-gate*"
+    },
+    {
+      "Sid": "ReadStageCoverageRegistry",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
+    },
+    {
+      "Sid": "WriteStageCoverageVerdicts",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/*"
+    },
+    {
+      "Sid": "PutAlphaEngineMetrics",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "cloudwatch:namespace": [
+            "AlphaEngine",
+            "AlphaEngine/*"
+          ]
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/substrate-health-gate/iam-policy.json
+++ b/infrastructure/lambdas/substrate-health-gate/iam-policy.json
@@ -46,6 +46,19 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
     },
     {
+      "Sid": "ReadStageCoverageRegistryList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "_freshness_monitor/*"
+          ]
+        }
+      }
+    },
+    {
       "Sid": "WriteStageCoverageVerdicts",
       "Effect": "Allow",
       "Action": "s3:PutObject",

--- a/infrastructure/lambdas/substrate-health-gate/index.py
+++ b/infrastructure/lambdas/substrate-health-gate/index.py
@@ -53,6 +53,7 @@ import logging
 import os
 import re
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 import boto3
@@ -165,8 +166,47 @@ def _parse_disk_used_percent(stdout: str) -> int | None:
     return int(match.group(1))
 
 
+def _assert_stage_coverage(stage: str, started: datetime, run_date: str | None) -> dict:
+    """Record this stage's own output verdict (alpha-engine-config-I10172).
+
+    `SubstrateHealthGate` is an INFRASTRUCTURE/GATE stage: it positively
+    declares in `ARTIFACT_REGISTRY.yaml`'s `pipeline_stages:` that it writes
+    no durable artifact (`output: none`), so the verdict is
+    `COVERED_NO_OUTPUT` regardless of the gate's own HEALTHY /
+    SUBSTRATE_UNHEALTHY finding — the coverage question ("did this stage run
+    and declare itself") is orthogonal to the health question it answers.
+    Measured 2026-09-08: this stage had never once written a
+    `_stage_coverage` verdict — it is the I8228 "never wired" class, not a
+    partition-family or IAM defect.
+
+    Never alters the handler's outcome: an observer that can change the
+    stage it observes is a new failure mode bolted onto the one it reports.
+    Mirrors `weekly-preflight/index.py::_assert_stage_coverage` and
+    `weekly-freshness-spot-dispatcher/index.py::_assert_stage_coverage`
+    (`policy-shared-code` — third adoption of the same shape in this repo).
+    """
+    if not run_date:
+        logger.error(
+            "stage-coverage assertion has no run_date for %s — event carried none",
+            stage,
+        )
+        return {"stage": stage, "status": "UNMEASURED", "reason": "no run_date on state input"}
+    try:
+        from krepis.stage_coverage import assert_stage_coverage
+    except ImportError as exc:
+        logger.error("stage-coverage assertion unavailable for %s: %s", stage, exc)
+        return {"stage": stage, "status": "UNMEASURED", "reason": str(exc)}
+    return assert_stage_coverage(stage, window_start=started, run_date=run_date)
+
+
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG001
     instance_id = event["instance_id"]
+    # Captured at handler ENTRY, before any write this invocation makes
+    # (alpha-engine-config-I7214) — this gate writes no artifact, but the
+    # window is still the contract every other coverage-asserting stage
+    # follows.
+    started = datetime.now(timezone.utc)
+    run_date = str(event.get("run_date", "")).strip() or None
 
     command_id = _send_probe(instance_id)
     outcome = _poll_to_terminal(command_id, instance_id)
@@ -189,6 +229,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
             f"agent process is dead."
         )
         logger.warning(result["message"])
+        result["stage_coverage"] = _assert_stage_coverage("SubstrateHealthGate", started, run_date)
         return result
 
     if outcome["status"] != "Success":
@@ -204,6 +245,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
             f"or under severe resource pressure."
         )
         logger.warning(result["message"])
+        result["stage_coverage"] = _assert_stage_coverage("SubstrateHealthGate", started, run_date)
         return result
 
     used_percent = _parse_disk_used_percent(outcome["stdout"])
@@ -222,6 +264,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
             f"substrate signal failure rather than assuming healthy."
         )
         logger.warning(result["message"])
+        result["stage_coverage"] = _assert_stage_coverage("SubstrateHealthGate", started, run_date)
         return result
 
     if used_percent >= DISK_WARN_PERCENT:
@@ -234,6 +277,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
             f"partial output."
         )
         logger.warning(result["message"])
+        result["stage_coverage"] = _assert_stage_coverage("SubstrateHealthGate", started, run_date)
         return result
 
     result["verdict"] = "HEALTHY"
@@ -242,4 +286,5 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         f"agent responsive."
     )
     logger.info(result["message"])
+    result["stage_coverage"] = _assert_stage_coverage("SubstrateHealthGate", started, run_date)
     return result

--- a/infrastructure/lambdas/substrate-health-gate/requirements.txt
+++ b/infrastructure/lambdas/substrate-health-gate/requirements.txt
@@ -1,2 +1,12 @@
-# boto3 is provided by the Lambda python3.12 runtime; no external deps.
-# (File kept so deploy.sh's uniform pip-install packaging step works.)
+# boto3 is provided by the Lambda python3.12 runtime; no external deps beyond
+# krepis. (File kept so deploy.sh's uniform pip-install packaging step works.)
+#
+# alpha-engine-config-I10172: krepis.stage_coverage.assert_stage_coverage is
+# the fleet's ONE stage-coverage assertion implementation (policy-shared-code
+# — this is at least the third adoption in this repo alone). Pinned, not
+# floored (alpha-engine-config-I7635), mirroring the identical pin already
+# carried by weekly-preflight/requirements.txt, weekly-run-scope/
+# requirements.txt and eval-judge-spot-dispatcher/requirements.txt in this
+# same directory — a fourth, different pin here would drift the lockstep
+# these siblings already hold.
+krepis==0.59.41

--- a/infrastructure/lambdas/substrate-health-gate/test_handler.py
+++ b/infrastructure/lambdas/substrate-health-gate/test_handler.py
@@ -70,6 +70,45 @@ def test_healthy_low_disk_usage():
     assert out["disk_used_percent"] == 42
 
 
+# ── alpha-engine-config-I10172: the stage-coverage self-assertion ───────────
+
+
+def test_stage_coverage_is_unmeasured_without_a_run_date():
+    """No run_date on the event (an operator off-cycle invocation, or a test
+    fixture predating I8155) must report UNMEASURED, never fabricate a date
+    (alpha-engine-config-I8155) and never attempt the krepis import/AWS call."""
+    ssm = _ssm_stub(invocation_sequence=[_df_success(42)])
+    with mock.patch.object(index, "_ssm", ssm), mock.patch.object(time, "sleep"):
+        out = index.handler(_event(), None)
+    assert out["stage_coverage"] == {
+        "stage": "SubstrateHealthGate",
+        "status": "UNMEASURED",
+        "reason": "no run_date on state input",
+    }
+
+
+def test_stage_coverage_is_asserted_on_every_verdict_path():
+    """The coverage question ('did this stage run and declare itself') is
+    orthogonal to the health question — asserted whether the gate finds
+    HEALTHY or SUBSTRATE_UNHEALTHY, so a real miss is never masked by a
+    non-terminal early return."""
+    ssm = _ssm_stub(invocation_sequence=[_df_success(100)])
+    with mock.patch.object(index, "_ssm", ssm), mock.patch.object(time, "sleep"):
+        out = index.handler(_event(run_date="2026-09-04"), None)
+    assert out["verdict"] == "SUBSTRATE_UNHEALTHY"
+    assert out["stage_coverage"]["stage"] == "SubstrateHealthGate"
+
+
+def test_stage_coverage_assertion_is_import_guarded_and_loud():
+    """The nousergon-lib/krepis pin may predate the module; an inert
+    assertion must stay distinguishable from a covered stage and must not
+    change the gate's own verdict."""
+    body = (Path(__file__).parent / "index.py").read_text()
+    assert "from krepis.stage_coverage import assert_stage_coverage" in body
+    assert "except ImportError as exc:" in body
+    assert "UNMEASURED" in body
+
+
 def test_disk_full_verdict_is_named_substrate_unhealthy():
     """The issue's headline scenario: disk 100% full must produce a NAMED
     SubstrateUnhealthy verdict (not a generic failure)."""

--- a/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
+++ b/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
@@ -44,6 +44,12 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/_sweep/*"
     },
     {
+      "Sid": "ReadRunScopeForDeclaredSkipExclusion",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/backtest/*/run_scope.json"
+    },
+    {
       "Sid": "AugmentTheCompletionMarker",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
+++ b/infrastructure/lambdas/weekly-coverage-sweep/iam-policy.json
@@ -50,6 +50,19 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/backtest/*/run_scope.json"
     },
     {
+      "Sid": "ReadRunScopeForDeclaredSkipExclusionList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "backtest/*"
+          ]
+        }
+      }
+    },
+    {
       "Sid": "AugmentTheCompletionMarker",
       "Effect": "Allow",
       "Action": [

--- a/infrastructure/lambdas/weekly-coverage-sweep/index.py
+++ b/infrastructure/lambdas/weekly-coverage-sweep/index.py
@@ -88,6 +88,75 @@ OUTCOME_DEFERRED = "deferred"
 SWEEP_STAGE = os.environ.get("SWEEP_STAGE", "WeeklyCoverageSweep")
 
 
+#: `RunScope`'s own artifact key template (mirrors
+#: `weekly-run-scope/index.py::KEY_TEMPLATE`) — the ONE place a cycle records
+#: which declared stages it deliberately did not intend to run this week
+#: (`disposition: DISABLED`, e.g. `skip_parity: true`), versus which it
+#: simply never reached.
+RUN_SCOPE_KEY_TEMPLATE = "backtest/{run_date}/run_scope.json"
+
+
+def _declared_skip_stage_spine(
+    *, pipeline: str, run_date: str, bucket: str, s3_client
+) -> tuple[tuple[str, ...] | None, tuple[str, ...]]:
+    """The declared spine for THIS cycle, minus any stage RunScope recorded
+    as ``DISABLED`` — and which stages were excluded, for the caller to log.
+
+    ``alpha-engine-config-I10175``. ``nousergon_lib.pipeline_status.registry
+    .PIPELINE_STAGE_ORDER`` declares ``ParityParallel`` / ``PitParityCompare``
+    unconditionally for every weekly cycle. A cycle with ``skip_parity: true``
+    (a recorded operator flag on the Saturday EventBridge target since
+    2026-08-13, not a defect) never intends to enter them — and without this
+    exclusion the cycle's completion verdict reads ``INCOMPLETE`` forever,
+    every week, for as long as the flag holds. Measured live on the
+    2026-09-04 cycle after ``alpha-engine-config-I10170``'s observer fix:
+    ``stages 14/16, missing ParityParallel, PitParityCompare``,
+    ``walk_exhausted: false`` — not a truncation artifact.
+
+    Returns ``(None, ())`` — the full declared spine, no caller-side
+    exclusion — on ANY failure to read or parse ``run_scope.json``: this is
+    advisory, best-effort, and NEVER fabricates a claim that a stage was
+    disabled. A missing/unreadable ``run_scope.json`` degrades to today's
+    behaviour (the cycle reads INCOMPLETE if it genuinely is), never to a
+    false COMPLETED.
+    """
+    try:
+        from nousergon_lib.pipeline_status.registry import stage_order_for
+
+        full_spine = stage_order_for(pipeline)
+        if not full_spine:
+            return None, ()
+
+        key = RUN_SCOPE_KEY_TEMPLATE.format(run_date=run_date)
+        body = s3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+        import json as _json
+
+        scope = _json.loads(body)
+        stages = scope.get("stages") or {}
+        excluded = tuple(
+            sorted(
+                {
+                    str(row.get("entry_state") or name)
+                    for name, row in stages.items()
+                    if isinstance(row, dict) and row.get("disposition") == "DISABLED"
+                }
+                & set(full_spine)
+            )
+        )
+        if not excluded:
+            return None, ()
+        adjusted = tuple(s for s in full_spine if s not in excluded)
+        return adjusted, excluded
+    except Exception as exc:  # noqa: BLE001 — advisory, never blocks the sweep
+        logger.warning(
+            "coverage sweep: could not derive a declared-skip exclusion for "
+            "%s %s from run_scope.json — using the full declared spine "
+            "(%s: %s)",
+            pipeline, run_date, type(exc).__name__, exc,
+        )
+        return None, ()
+
+
 def _outcome_for(sweep) -> str:
     """The handler's verdict. ``deferred`` OUTRANKS ``findings``.
 
@@ -140,6 +209,21 @@ def handler(event, _context):
 
         region = resolve_region()
         s3_client = boto3.client("s3", region_name=region)
+
+        # alpha-engine-config-I10175: a cycle-local exclusion for stages
+        # RunScope recorded as deliberately DISABLED this run (skip_parity
+        # and its kind) — advisory, never fabricated; see the function
+        # docstring for the fail-open contract.
+        stage_spine, excluded_stages = _declared_skip_stage_spine(
+            pipeline=PIPELINE, run_date=run_date, bucket=BUCKET, s3_client=s3_client,
+        )
+        if excluded_stages:
+            logger.info(
+                "coverage sweep %s %s: excluding declared-skip stage(s) from "
+                "the cycle spine (RunScope disposition=DISABLED): %s",
+                PIPELINE, run_date, ", ".join(excluded_stages),
+            )
+
         sweep = read_coverage_sweep(
             pipeline=PIPELINE,
             run_date=run_date,
@@ -149,6 +233,7 @@ def handler(event, _context):
             s3_client=s3_client,
             observer_execution_arn=observer_execution_arn or None,
             observer_stage=SWEEP_STAGE,
+            stage_spine=stage_spine,
         )
     except Exception as exc:  # noqa: BLE001 — a sweep that cannot run says so
         # Deliberate broad catch with a named recording surface: the return

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/index.py
@@ -574,13 +574,25 @@ def handler(event: dict, context) -> dict:  # noqa: ARG001 — Lambda contract
         "market": market,
         "command_id": command_id,
         "run_token": run_token,
-        # The stage name is DERIVED, never hardcoded: this one Lambda backs two
-        # SF states — DispatchWeeklyFreshnessSpot and, with force_on_demand,
-        # RelaunchWeeklyFreshnessSpot. A file-level constant would file the
-        # relaunch's verdict under the dispatch's name, so a real miss would be
-        # attributed to a stage that was working (alpha-engine-config-I7214).
+        # The stage name is EXPLICIT, never derived (alpha-engine-config-
+        # I10172): this one Lambda backs two SF states, DispatchWeeklyFresh-
+        # nessSpot and RelaunchWeeklyFreshnessSpot, and both callers pass
+        # `force_on_demand: true` (config-I7119 / config-I7120 — spot-first
+        # would re-enter the pool that just reclaimed the box, and this ONE
+        # box is the shared substrate every stage-liveness gate addresses).
+        # With force_on_demand no longer distinguishing the two callers, the
+        # OLD derivation `"RelaunchWeeklyFreshnessSpot" if force_on_demand
+        # else "DispatchWeeklyFreshnessSpot"` always resolved to the first
+        # branch — DispatchWeeklyFreshnessSpot's own invocations wrote their
+        # verdict under RelaunchWeeklyFreshnessSpot's name, and
+        # DispatchWeeklyFreshnessSpot had ZERO verdicts in any partition,
+        # ever (measured 2026-09-08). Each SF Task now stamps its own
+        # identity as a Payload literal (`sf_stage`); the force_on_demand
+        # heuristic survives only as the fallback for an operator off-cycle
+        # invocation that predates this field.
         "stage_coverage": _assert_stage_coverage(
-            "RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot",
+            str(event.get("sf_stage", "")).strip()
+            or ("RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot"),
             started,
             str(event.get("run_date", "")).strip() or None,
         ),

--- a/infrastructure/lambdas/weekly-run-scope/iam-policy.json
+++ b/infrastructure/lambdas/weekly-run-scope/iam-policy.json
@@ -46,6 +46,32 @@
           ]
         }
       }
+    },
+    {
+      "Sid": "ReadStageCoverageRegistry",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
+    },
+    {
+      "Sid": "WriteStageCoverageVerdicts",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::alpha-engine-research/_stage_coverage/*"
+    },
+    {
+      "Sid": "PutAlphaEngineMetrics",
+      "Effect": "Allow",
+      "Action": "cloudwatch:PutMetricData",
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "cloudwatch:namespace": [
+            "AlphaEngine",
+            "AlphaEngine/*"
+          ]
+        }
+      }
     }
   ]
 }

--- a/infrastructure/lambdas/weekly-run-scope/iam-policy.json
+++ b/infrastructure/lambdas/weekly-run-scope/iam-policy.json
@@ -54,6 +54,19 @@
       "Resource": "arn:aws:s3:::alpha-engine-research/_freshness_monitor/*"
     },
     {
+      "Sid": "ReadStageCoverageRegistryList",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::alpha-engine-research",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "_freshness_monitor/*"
+          ]
+        }
+      }
+    },
+    {
       "Sid": "WriteStageCoverageVerdicts",
       "Effect": "Allow",
       "Action": "s3:PutObject",

--- a/infrastructure/lambdas/weekly-run-scope/index.py
+++ b/infrastructure/lambdas/weekly-run-scope/index.py
@@ -275,7 +275,43 @@ def _persist(scope: dict, key: str) -> dict:
     )
 
 
+def _assert_stage_coverage(stage: str, started: datetime, run_date: str | None) -> dict:
+    """Record this stage's own output verdict (alpha-engine-config-I10172).
+
+    `RunScope` declares `output: registered` / `artifacts: [weekly_run_scope]`
+    in `ARTIFACT_REGISTRY.yaml` — this is a real producer, not a gate, so the
+    verdict depends on whether `backtest/{run_date}/run_scope.json` actually
+    landed in-window. Measured 2026-09-08: this stage had never once written
+    a `_stage_coverage` verdict — the I8228 "never wired" class.
+
+    ``run_date`` here is `event["run_date"]` — by the time `RunScope` runs,
+    downstream of `NormalizeRunDates` (alpha-engine-config-I8809), that is
+    already the cycle's TRADING day, the same value `_persist` above keys the
+    artifact by. Never fabricated: a missing/blank run_date reports
+    UNMEASURED rather than defaulting to any derived date
+    (alpha-engine-config-I8155). Never alters the handler's outcome — an
+    observer that can change the stage it observes is a new failure mode
+    bolted onto the one it reports. Mirrors
+    `weekly-preflight/index.py::_assert_stage_coverage` (`policy-shared-code`).
+    """
+    if not run_date:
+        logger.error(
+            "stage-coverage assertion has no run_date for %s — event carried none",
+            stage,
+        )
+        return {"stage": stage, "status": "UNMEASURED", "reason": "no run_date on state input"}
+    try:
+        from krepis.stage_coverage import assert_stage_coverage
+    except ImportError as exc:
+        logger.error("stage-coverage assertion unavailable for %s: %s", stage, exc)
+        return {"stage": stage, "status": "UNMEASURED", "reason": str(exc)}
+    return assert_stage_coverage(stage, window_start=started, run_date=run_date)
+
+
 def handler(event, _context):
+    # Captured at handler ENTRY, before any write this invocation makes
+    # (alpha-engine-config-I7214).
+    _stage_coverage_started = datetime.now(timezone.utc)
     calendar_run_date = event.get("run_date") or ""
     execution_arn = event.get("execution_arn") or ""
     state_machine_arn = event.get("state_machine_arn") or ""
@@ -376,6 +412,13 @@ def handler(event, _context):
             "run_date never resolved — not writing an artifact for this "
             "execution (calendar_run_date=%r)", calendar_run_date,
         )
+        scope["stage_coverage"] = _assert_stage_coverage(
+            "RunScope", _stage_coverage_started, None
+        )
         return scope
 
-    return _persist(scope, KEY_TEMPLATE.format(run_date=run_date))
+    written = _persist(scope, KEY_TEMPLATE.format(run_date=run_date))
+    written["stage_coverage"] = _assert_stage_coverage(
+        "RunScope", _stage_coverage_started, run_date
+    )
+    return written

--- a/infrastructure/lambdas/weekly-run-scope/test_handler.py
+++ b/infrastructure/lambdas/weekly-run-scope/test_handler.py
@@ -412,6 +412,33 @@ def test_the_handler_writes_the_artifact_for_the_run_date(
     assert result["run_date"] == "2026-08-14"
     assert result["calendar_run_date"] == "2026-08-15"
     assert result["stages"]["Parity"]["disabled_by"] == "skip_parity"
+    # alpha-engine-config-I10172: the stage-coverage self-assertion — never
+    # raises without live AWS credentials (record_verdict is fail-soft) and
+    # keyed on the same normalized TRADING day the artifact itself landed on.
+    assert result["stage_coverage"]["stage"] == "RunScope"
+
+
+def test_stage_coverage_assertion_is_import_guarded_and_loud(monkeypatch, definition, real_run_history):
+    """The nousergon-lib/krepis pin may predate the module; an inert
+    assertion must stay distinguishable from a covered stage."""
+    index, _written = _index(monkeypatch, definition=definition, history=real_run_history)
+    body = pathlib.Path(index.__file__).read_text()
+    assert "from krepis.stage_coverage import assert_stage_coverage" in body
+    assert "except ImportError as exc:" in body
+    assert '"status": "UNMEASURED"' in body
+
+
+def test_stage_coverage_is_unmeasured_without_a_run_date(monkeypatch, definition, real_run_history):
+    """`EmptyRunDateError` (or any total derivation failure) must never
+    fabricate a run_date for the coverage assertion — UNMEASURED, not a
+    guessed date (alpha-engine-config-I8155)."""
+    index, _written = _index(monkeypatch, definition=definition, history=real_run_history)
+    result = index.handler({"run_date": "", "execution_arn": "arn:x", "state_machine_arn": "arn:y"}, None)
+    assert result["stage_coverage"] == {
+        "stage": "RunScope",
+        "status": "UNMEASURED",
+        "reason": "no run_date on state input",
+    }
 
 
 def test_a_saturday_run_date_normalizes_to_the_preceding_nyse_session(

--- a/infrastructure/step_function.json
+++ b/infrastructure/step_function.json
@@ -7866,12 +7866,13 @@
     },
     "SubstrateHealthGate": {
       "Type": "Task",
-      "Comment": "config#2249: fast pre-dispatch substrate health gate, immediately before MorningEnrich (the first state to actually dispatch work to the Saturday box). A dead/unhealthy dispatch box (disk full, or the SSM agent wedged/unresponsive so a command silently never registers) used to be discovered only after MorningEnrich burned its full 'gold 4+2' retry ladder (config#2279, up to ~15 min) before falling into the generic PipelineFailure path. This ONE Lambda invocation issues its own tiny SSM `df` probe command and polls it to a terminal status internally (bounded well under this Task's own TimeoutSeconds), returning verdict=HEALTHY or verdict=SUBSTRATE_UNHEALTHY with a distinct reason (disk_full / ssm_unresponsive / ssm_command_never_registered) \u2014 see infrastructure/lambdas/substrate-health-gate/index.py. Deliberately a SEPARATE fast pre-check, not a replacement for MorningEnrich's own resilience: MorningEnrich keeps its full retry ladder for real transient issues once dispatch is confirmed healthy. Adds ~10-20s to every Saturday run (accepted \u2014 the Saturday run has slack, unlike the tight weekday pre-open buffer; NOT wired into the weekday SF). ResultSelector captures the WHOLE Lambda payload under .gate (verdict/message/reason/disk_used_percent/...) rather than cherry-picking $.Payload.<key>: the Lambda's documented contract emits `reason` ONLY on the SUBSTRATE_UNHEALTHY verdicts, so a prior per-key select of `reason.$: $.Payload.reason` crashed EVERY healthy run with States.Runtime '$.Payload.reason could not be found' (the gate could never pass on a healthy box \u2014 surfaced by the 2026-07-17 Friday preflight shell run). Passthrough lets each consumer read only fields the producer guarantees for its branch (Choice reads .gate.verdict; the non-HEALTHY Extract reads .gate.reason). Contract regression-guarded by tests/test_sf_substrate_gate_contract_wiring.py.",
+      "Comment": "config#2249: fast pre-dispatch substrate health gate, immediately before MorningEnrich (the first state to actually dispatch work to the Saturday box). A dead/unhealthy dispatch box (disk full, or the SSM agent wedged/unresponsive so a command silently never registers) used to be discovered only after MorningEnrich burned its full 'gold 4+2' retry ladder (config#2279, up to ~15 min) before falling into the generic PipelineFailure path. This ONE Lambda invocation issues its own tiny SSM `df` probe command and polls it to a terminal status internally (bounded well under this Task's own TimeoutSeconds), returning verdict=HEALTHY or verdict=SUBSTRATE_UNHEALTHY with a distinct reason (disk_full / ssm_unresponsive / ssm_command_never_registered) \u2014 see infrastructure/lambdas/substrate-health-gate/index.py. Deliberately a SEPARATE fast pre-check, not a replacement for MorningEnrich's own resilience: MorningEnrich keeps its full retry ladder for real transient issues once dispatch is confirmed healthy. Adds ~10-20s to every Saturday run (accepted \u2014 the Saturday run has slack, unlike the tight weekday pre-open buffer; NOT wired into the weekday SF). ResultSelector captures the WHOLE Lambda payload under .gate (verdict/message/reason/disk_used_percent/...) rather than cherry-picking $.Payload.<key>: the Lambda's documented contract emits `reason` ONLY on the SUBSTRATE_UNHEALTHY verdicts, so a prior per-key select of `reason.$: $.Payload.reason` crashed EVERY healthy run with States.Runtime '$.Payload.reason could not be found' (the gate could never pass on a healthy box \u2014 surfaced by the 2026-07-17 Friday preflight shell run). Passthrough lets each consumer read only fields the producer guarantees for its branch (Choice reads .gate.verdict; the non-HEALTHY Extract reads .gate.reason). Contract regression-guarded by tests/test_sf_substrate_gate_contract_wiring.py. | alpha-engine-config-I8809: PARTITION FAMILY = trading_day - $.run_date is the cycle's trading day from NormalizeRunDates. It keys no artifact here (this gate declares output: none) \u2014 its only use is the stage-coverage assertion's grouping key (alpha-engine-config-I10172), and it must be the trading day because that is what every other Lambda-backed coverage-asserting state in this graph keys its verdict by.",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "FunctionName": "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-substrate-health-gate",
         "Payload": {
-          "instance_id.$": "$.ec2_instance_id[0]"
+          "instance_id.$": "$.ec2_instance_id[0]",
+          "run_date.$": "$.run_date"
         }
       },
       "TimeoutSeconds": 30,
@@ -8087,7 +8088,8 @@
         "Payload": {
           "execution_id.$": "$$.Execution.Id",
           "run_date.$": "$.run_date",
-          "force_on_demand": true
+          "force_on_demand": true,
+          "sf_stage": "DispatchWeeklyFreshnessSpot"
         }
       },
       "TimeoutSeconds": 600,
@@ -9241,7 +9243,8 @@
         "Payload": {
           "execution_id.$": "$$.Execution.Id",
           "run_date.$": "$.run_date",
-          "force_on_demand": true
+          "force_on_demand": true,
+          "sf_stage": "RelaunchWeeklyFreshnessSpot"
         }
       },
       "TimeoutSeconds": 540,

--- a/tests/test_sf_payload_uniqueness.py
+++ b/tests/test_sf_payload_uniqueness.py
@@ -72,7 +72,10 @@ def _flatten_states(sf_doc: dict) -> dict:
 _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # config#2249: fast pre-dispatch substrate health gate, immediately
     # before MorningEnrich (alpha-engine-substrate-health-gate Lambda).
-    "SubstrateHealthGate": frozenset({"instance_id.$"}),
+    # alpha-engine-config-I10172: run_date.$ added — this stage had never
+    # once written a _stage_coverage verdict (the I8228 "never wired" class);
+    # its Payload carried no execution identity at all to key one by.
+    "SubstrateHealthGate": frozenset({"instance_id.$", "run_date.$"}),
     # alpha-engine-config-I8214: the stage-coverage sweep at the tail of the
     # run. Deliberately NOT threading execution_arn: the sweep reads the whole
     # CYCLE (every contributing execution for this run_date), not this one
@@ -230,8 +233,17 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # coverage verdict (DispatchWeeklyFreshnessSpot / RelaunchWeeklyFreshnessSpot,
     # both INFRASTRUCTURE/GATE stages) had been writing under an empty
     # run_date since I7214 shipped, because neither Payload carried one.
+    # alpha-engine-config-I10172: sf_stage added — a Payload literal naming
+    # each Task's OWN identity. Both callers pass force_on_demand: true (see
+    # comments above and on RelaunchWeeklyFreshnessSpot below), so the
+    # boolean no longer distinguishes them: the handler's old
+    # force_on_demand-derived stage name always resolved to
+    # RelaunchWeeklyFreshnessSpot, and this state's own invocations wrote
+    # their coverage verdict under the OTHER state's name —
+    # DispatchWeeklyFreshnessSpot had zero verdicts in any partition, ever
+    # (measured 2026-09-08).
     "DispatchWeeklyFreshnessSpot": frozenset(
-        {"execution_id.$", "run_date.$", "force_on_demand"}
+        {"execution_id.$", "run_date.$", "force_on_demand", "sf_stage"}
     ),
     # config-I7119: the SAME dispatcher, invoked to replace a launcher box that
     # was reclaimed mid-run. force_on_demand was added to the dispatcher in
@@ -241,7 +253,7 @@ _SATURDAY_PAYLOAD_KEYS: dict[str, frozenset[str]] = {
     # two payloads are now identical. A literal `true`, not a `.$` path: the
     # decision is structural, never execution input.
     "RelaunchWeeklyFreshnessSpot": frozenset(
-        {"execution_id.$", "run_date.$", "force_on_demand"}
+        {"execution_id.$", "run_date.$", "force_on_demand", "sf_stage"}
     ),
 }
 

--- a/tests/test_stage_coverage_assertions.py
+++ b/tests/test_stage_coverage_assertions.py
@@ -250,13 +250,36 @@ def test_weekly_preflight_records_its_no_output_declaration() -> None:
     assert '"stage_coverage"' in body
 
 
-def test_the_spot_dispatcher_derives_which_of_its_two_stages_ran() -> None:
-    """One Lambda, two SF states. Hardcoding either name would file the
-    relaunch's verdict under the dispatch's."""
+def test_the_spot_dispatcher_prefers_the_explicit_sf_stage_identity() -> None:
+    """One Lambda, two SF states, and (alpha-engine-config-I10172) BOTH
+    callers pass `force_on_demand: true` — the boolean no longer
+    distinguishes them, so the old `"RelaunchWeeklyFreshnessSpot" if
+    force_on_demand else "DispatchWeeklyFreshnessSpot"` derivation always
+    took the first branch. DispatchWeeklyFreshnessSpot's own invocations
+    wrote their verdict under RelaunchWeeklyFreshnessSpot's name, and
+    DispatchWeeklyFreshnessSpot had zero verdicts in any partition, ever.
+    Each SF Task now stamps its own name via a Payload literal (`sf_stage`)
+    and the handler must read it FIRST."""
     body = (
         INFRA / "lambdas" / "weekly-freshness-spot-dispatcher" / "index.py"
     ).read_text()
+    assert 'str(event.get("sf_stage", "")).strip()' in body
+    # The force_on_demand derivation survives only as the fallback for an
+    # operator off-cycle invocation that predates the sf_stage field.
     assert '"RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot"' in body
+
+
+def test_both_spot_dispatcher_sf_states_stamp_their_own_identity() -> None:
+    """Guards the SF side of I10172: a Payload literal, not derived, so a
+    future third caller cannot silently fall back to the ambiguous
+    force_on_demand heuristic without a reviewer noticing a missing field."""
+    definition = json.loads(SF_DEFINITION.read_text())
+    states = _states(definition)
+    for name in ("DispatchWeeklyFreshnessSpot", "RelaunchWeeklyFreshnessSpot"):
+        payload = states[name]["Parameters"]["Payload"]
+        assert payload.get("sf_stage") == name, (
+            f"{name}: Payload does not stamp its own sf_stage identity"
+        )
 
 
 # ── alpha-engine-config-I8155: the two Lambdas pass a real run_date ──────────

--- a/tests/test_weekly_coverage_sweep_observer.py
+++ b/tests/test_weekly_coverage_sweep_observer.py
@@ -146,3 +146,82 @@ def test_deferred_outranks_findings(handler_module) -> None:
         should_alert = False
 
     assert handler_module._outcome_for(_Clean()) == "clean"
+
+
+# ── alpha-engine-config-I10175: declared-skip stage exclusion ───────────────
+
+
+class _FakeBody:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeS3RunScope:
+    """Returns a fixed run_scope.json body, or raises 404, on get_object."""
+
+    def __init__(self, stages: dict | None) -> None:
+        self._stages = stages
+
+    def get_object(self, *, Bucket: str, Key: str):  # noqa: N803 — boto3 shape
+        if self._stages is None:
+            raise RuntimeError("NoSuchKey")
+        return {"Body": _FakeBody(json.dumps({"stages": self._stages}).encode())}
+
+
+def test_declared_skip_excludes_the_disabled_stage(handler_module) -> None:
+    """`Parity`'s row names `entry_state: ParityParallel` — the spine excludes
+    THAT name, not the `Parity` row key, because the spine is keyed by SF
+    Task-state name."""
+    s3 = _FakeS3RunScope(
+        {
+            "Parity": {"disposition": "DISABLED", "entry_state": "ParityParallel"},
+            "MorningEnrich": {"disposition": "ENABLED_COMPLETED"},
+        }
+    )
+    spine, excluded = handler_module._declared_skip_stage_spine(
+        pipeline="ne-weekly-freshness-pipeline",
+        run_date="2026-09-04",
+        bucket="alpha-engine-research",
+        s3_client=s3,
+    )
+    assert excluded == ("ParityParallel",)
+    assert spine is not None
+    assert "ParityParallel" in _default_spine()
+    assert "ParityParallel" not in spine
+    assert "MorningEnrich" in spine  # every other declared stage survives
+
+
+def test_declared_skip_is_a_noop_when_nothing_is_disabled(handler_module) -> None:
+    s3 = _FakeS3RunScope({"MorningEnrich": {"disposition": "ENABLED_COMPLETED"}})
+    spine, excluded = handler_module._declared_skip_stage_spine(
+        pipeline="ne-weekly-freshness-pipeline",
+        run_date="2026-09-04",
+        bucket="alpha-engine-research",
+        s3_client=s3,
+    )
+    assert spine is None
+    assert excluded == ()
+
+
+def test_declared_skip_degrades_to_the_full_spine_on_any_read_failure(handler_module) -> None:
+    """Advisory, best-effort: a missing/unreadable run_scope.json must NEVER
+    fabricate a claim that a stage was disabled — it degrades to today's
+    behaviour (the full declared spine), never to a false COMPLETED."""
+    s3 = _FakeS3RunScope(None)  # raises on get_object
+    spine, excluded = handler_module._declared_skip_stage_spine(
+        pipeline="ne-weekly-freshness-pipeline",
+        run_date="2026-09-04",
+        bucket="alpha-engine-research",
+        s3_client=s3,
+    )
+    assert spine is None
+    assert excluded == ()
+
+
+def _default_spine() -> tuple[str, ...]:
+    from nousergon_lib.pipeline_status.registry import stage_order_for
+
+    return stage_order_for("ne-weekly-freshness-pipeline")


### PR DESCRIPTION
## Summary

Closes real stage-coverage gaps behind `alpha-engine-stage-coverage-absent` / `-findings` — the detector-side fixes (`nousergon-lib-PR391`, `nousergon-data-PR1654`, `nous-ergon-ops-PR1112`) are already in flight; this fixes what they correctly detect.

### `alpha-engine-config-I10172` — 5 of 7 never-instrumented stages
`DispatchEvalJudgeSpot`, `SubstrateHealthGate`, `RunScope` had never once written a `_stage_coverage` verdict (the I8228 "never wired" class — no `krepis.stage_coverage` call site existed anywhere). Added, mirroring `weekly-preflight/index.py`'s existing shape (`policy-shared-code`): a never-raising `_assert_stage_coverage` helper, `UNMEASURED` on a missing `run_date` (I8155), `COVERED_NO_OUTPUT` for the two gate stages and a real producer verdict for `RunScope`. IAM grants (registry read, verdict write, CW metric) added to each Lambda's `iam-policy.json`; `krepis` pinned in `substrate-health-gate`'s previously-empty `requirements.txt`.

`DispatchWeeklyFreshnessSpot` had **zero** verdicts in any partition, ever — not IAM, not partition family. Root cause: both SF callers pass `force_on_demand: true` (I7119/I7120), so the handler's `"RelaunchWeeklyFreshnessSpot" if force_on_demand else "DispatchWeeklyFreshnessSpot"` derivation always took the first branch — `DispatchWeeklyFreshnessSpot`'s own invocations wrote their verdict under `RelaunchWeeklyFreshnessSpot`'s name. Fixed at the SF layer: each Task's Payload now stamps its own identity as a literal (`sf_stage`); the handler prefers it, falling back to the old heuristic only for a pre-existing operator invocation.

**Not fixed here — out of scope, explicit constraint:** `ResearchSelfTest` (the 7th stage) and all five `I10171` partition-split writers (`Counterfactual`, `RationaleClustering`, `ReplayConcordance`, `EvalRollingMean`, `EvalJudgeSubmitFirstSaturday`) are `crucible-research` Lambda handlers, and `crucible-research` was named DO-NOT-TOUCH for this track (a live sibling-agent track). Both are root-caused precisely in the closing report of this arc, not touched in code here.

### `alpha-engine-config-I10175` — the parity branch never entered
`weekly-coverage-sweep`'s handler now reads `RunScope`'s own `run_scope.json` for the cycle and excludes any stage it recorded `disposition: DISABLED` (e.g. `Parity`/`ParityParallel` under the recorded `skip_parity: true` operator flag) from the spine `read_coverage_sweep` grades the cycle against, via the `stage_spine` override `nousergon-lib-PR392` adds. Advisory and fail-open: any read/parse failure of `run_scope.json` degrades silently to the FULL declared spine — never fabricates an exclusion, never turns a genuinely incomplete cycle into a false COMPLETED.

Without this, a cycle with parity deliberately gated off reads `INCOMPLETE` forever, on every run, for as long as the flag holds — measured live on the 2026-09-04 cycle: `stages 14/16, missing ParityParallel + PitParityCompare`, `walk_exhausted: false` (not a truncation artifact), and `run_scope.json` itself already recorded `Parity: DISABLED (skip_parity)` for that exact cycle.

## Base branch / merge order
Branched from `nousergon-data-PR1654`'s head (`fix/coverage-sweep-observer-i10170`) — both touch `infrastructure/step_function.json` and `infrastructure/lambdas/weekly-coverage-sweep/index.py`. **Merge order: `nousergon-data-PR1654` → `nousergon-lib-PR392` → this PR.** `nousergon-lib-PR392` itself sits on `nousergon-lib-PR391`'s head.

## Post-merge (NOT part of this PR's diff — named here per policy)
- `infrastructure/lambdas/weekly-coverage-sweep/requirements.txt`'s `nousergon-lib` pin needs bumping to the version created by `nousergon-lib-PR392`'s merge-time autobump (the `read_coverage_sweep(stage_spine=...)` param this PR calls does not exist in the currently-pinned `v0.124.109`) — **the main session owns this**, already flagged for `PR1654`'s own pin dependency; do not do this from this PR.
- IAM policy changes to `substrate-health-gate`, `eval-judge-spot-dispatcher`, `weekly-run-scope` and `weekly-coverage-sweep` are operator-applied by design (each Lambda's `deploy.sh --apply-iam`, narrow OIDC blast radius — not automated by any GHA workflow in this repo, matching `weekly-preflight`'s own documented pattern). Exact commands, run once each after this PR merges:
  1. `bash infrastructure/lambdas/substrate-health-gate/deploy.sh --apply-iam`
  2. `bash infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh --apply-iam`
  3. `bash infrastructure/lambdas/weekly-run-scope/deploy.sh --apply-iam`
  4. `bash infrastructure/lambdas/weekly-coverage-sweep/deploy.sh --apply-iam`
  `substrate-health-gate` additionally has **no GHA code-deploy workflow at all** (deliberate — "operator-deployed only, narrow OIDC blast radius" per its own `deploy.sh` header, matching `ssm-liveness-poller`/`pipeline-watchdog`/`eod-backstop`) — its code change also needs a plain `bash infrastructure/lambdas/substrate-health-gate/deploy.sh` run.

## Test plan
- [x] `python3 -m pytest tests/test_stage_coverage_assertions.py tests/test_weekly_coverage_sweep_observer.py tests/test_sf_payload_uniqueness.py tests/test_sf_research_predictor_parallel_wiring.py tests/test_run_scope_wiring.py tests/test_sf_eval_judge_wiring.py tests/test_weekly_partition_family_contract.py -q` — 391 passed
- [x] `python3 -m pytest infrastructure/lambdas/substrate-health-gate/test_handler.py infrastructure/lambdas/eval-judge-spot-dispatcher/test_handler.py infrastructure/lambdas/weekly-run-scope/test_handler.py -q` — 80 passed
- [x] Full suite: `python3 -m pytest tests/ -q` — 7101 passed, 4 failed, 17 skipped. All 4 failures are the PRE-EXISTING `alpha-engine-config-I9070` local-lib-mismatch class (`installed: v0.124.21` vs `pinned: v0.124.109`), on state names this PR never touches (`WeeklyCoverageSweepDeferred`, `CorrectnessVerdictGate`, `WaitForCorrectnessVerdict`) — each failure's own assertion message identifies and names this exact cause.

## Related
- `alpha-engine-config-I10170` (tracker), `-I10171`, `-I10172`, `-I10173`, `-I10175`
- `nousergon-data-PR1654` (base — merges first)
- `nousergon-lib-PR391` (merges before PR392)
- `nousergon-lib-PR392` (merges before this PR)
- `nous-ergon-ops-PR1112` (sibling detector fix, independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVE67NRyV6Ss3DvnnyVEnj

Rehearsal-path: tests/test_stage_coverage_assertions.py
