### PR TITLE
test(contract): build the PIPELINE_STAGE_ORDER guard its docstring already claims (alpha-engine-config-I10201)

### DIFF
--- a/tests/test_pipeline_stage_order_contract.py
+++ b/tests/test_pipeline_stage_order_contract.py
@@ -1,0 +1,160 @@
+"""`PIPELINE_STAGE_ORDER` names states this repo's Step Functions actually have.
+
+`nousergon_lib.pipeline_status.registry.PIPELINE_STAGE_ORDER`'s own docstring
+says:
+
+    Kept in sync with the live SF JSONs by a producer-side contract test in
+    ``nousergon-data`` — a stage rename that is not mirrored here blinds every
+    reader matching on the old name, and that blindness reports as the benign
+    "that stage did not run" (the I6857 defect).
+
+**That test did not exist.** Verified 2026-09-08 by grepping this entire
+repository for ``PIPELINE_STAGE_ORDER`` and ``stage_order_for``: no hits. The docstring named the failure mode, named the guard that prevents
+it, and the guard was never built — so the constant has been unguarded against
+a rename in the one repository that owns the definitions, which is the only
+place a rename can happen (`alpha-engine-config-I10201`).
+
+WHY THE DIRECTION OF THE ASSERTION IS THE WHOLE TEST
+----------------------------------------------------
+The spine is a **judgment**: a small ordered subset of substantive stages that
+`cycles._depth_of` reads as progress. It is deliberately NOT the state list —
+`ne-weekly-freshness-pipeline` declares 465 states and a 16-stage spine.
+
+So this asserts one direction only: **every spine stage must exist as a state.**
+The converse — every state appearing in the spine — would be false by design and
+would make the constant unmaintainable.
+
+That single direction is exactly the I6857 protection. A rename in
+`step_function.json` that is not mirrored in the library leaves a reader
+matching on a name nothing will ever emit, and the resulting silence is
+indistinguishable from "that stage did not run this week".
+
+STATES NEST, AND A SHALLOW READ IS A FALSE PASS
+-----------------------------------------------
+Seven of the sixteen weekly spine stages are not top-level `States` keys — they
+live inside `Parallel.Branches[].States` and `Map` iterators. A first cut of
+this file read only the top level and reported all seven as missing, which
+would have been a guard reporting a defect that did not exist. `_state_names`
+therefore recurses through `Branches`, `Iterator` and `ItemProcessor`; the
+depth is asserted below so a future shallow regression fails here rather than
+becoming a silent false pass.
+
+The library version this runs against is the PINNED one in CI, which is the
+version whose constant is actually shipped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nousergon_lib.pipeline_status.registry import PIPELINE_STAGE_ORDER
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: pipeline -> the definition this repo owns. Mirrors the map
+#: `tests/test_sf_definition_s3_consumer_contract.py::_CONSUMER_PATHS` already
+#: uses for the two trading pipelines, extended with the weekly one.
+DEFINITIONS = {
+    "ne-weekly-freshness-pipeline": "infrastructure/step_function.json",
+    "ne-preopen-trading-pipeline": "infrastructure/step_function_daily.json",
+    "ne-postclose-trading-pipeline": "infrastructure/step_function_eod.json",
+}
+
+
+def _state_names(states: dict | None, out: set[str]) -> None:
+    """Every state name at any depth: Parallel branches and Map iterators too."""
+    for name, body in (states or {}).items():
+        out.add(name)
+        if not isinstance(body, dict):
+            continue
+        for branch in body.get("Branches") or []:
+            _state_names(branch.get("States"), out)
+        for key in ("Iterator", "ItemProcessor"):
+            nested = body.get(key)
+            if isinstance(nested, dict):
+                _state_names(nested.get("States"), out)
+
+
+def _names_for(pipeline: str) -> set[str]:
+    doc = json.loads((REPO / DEFINITIONS[pipeline]).read_text(encoding="utf-8"))
+    names: set[str] = set()
+    _state_names(doc.get("States"), names)
+    return names
+
+
+def test_every_pipeline_in_the_spine_has_a_definition_here():
+    """A pipeline the library declares and this repo cannot show is unguarded.
+
+    Derived from the library, not from `DEFINITIONS`: adding a fourth pipeline
+    to `PIPELINE_STAGE_ORDER` must fail here until its definition is mapped,
+    rather than silently going unchecked.
+    """
+    missing = sorted(set(PIPELINE_STAGE_ORDER) - set(DEFINITIONS))
+    assert not missing, (
+        f"PIPELINE_STAGE_ORDER declares {missing} and this test maps no "
+        f"definition for it, so that pipeline's spine is unguarded against a "
+        f"rename. Add it to DEFINITIONS."
+    )
+
+
+@pytest.mark.parametrize("pipeline", sorted(PIPELINE_STAGE_ORDER))
+def test_every_spine_stage_exists_in_the_live_definition(pipeline):
+    names = _names_for(pipeline)
+    missing = [s for s in PIPELINE_STAGE_ORDER[pipeline] if s not in names]
+    assert not missing, (
+        f"{pipeline}: nousergon-lib's PIPELINE_STAGE_ORDER names {missing}, "
+        f"which {DEFINITIONS[pipeline]} does not contain at any depth. Either "
+        f"a state was renamed here without mirroring it in the library — which "
+        f"leaves every reader matching a name nothing will emit, reported as "
+        f"the benign 'that stage did not run' (the I6857 defect) — or the "
+        f"library declares a stage this pipeline never had."
+    )
+
+
+@pytest.mark.parametrize("pipeline", sorted(PIPELINE_STAGE_ORDER))
+def test_the_spine_is_a_subset_and_not_the_state_list(pipeline):
+    """Guards the assertion's DIRECTION, which is the point of the test.
+
+    If someone later 'tightens' this file into an equality check, the spine
+    becomes unmaintainable and the pressure will be to delete the guard. The
+    asymmetry is deliberate and is asserted so it survives.
+    """
+    names = _names_for(pipeline)
+    spine = set(PIPELINE_STAGE_ORDER[pipeline])
+    assert spine < names, (
+        f"{pipeline}: the spine is not a PROPER subset of the definition's "
+        f"states ({len(spine)} vs {len(names)}). The spine is a judgment about "
+        f"which stages represent progress, never the full state list."
+    )
+
+
+def test_the_reader_descends_into_parallel_branches_and_maps():
+    """A shallow read is a FALSE PASS, and it was the first cut of this file.
+
+    Seven of the sixteen weekly spine stages live inside `Parallel` branches or
+    `Map` iterators. A top-level-only `States` read reported all seven as
+    missing. Asserting the depth keeps a future regression to the shallow form
+    failing here instead of silently passing over nested states.
+    """
+    doc = json.loads(
+        (REPO / DEFINITIONS["ne-weekly-freshness-pipeline"]).read_text(encoding="utf-8")
+    )
+    top_level = set(doc.get("States") or {})
+    all_names = _names_for("ne-weekly-freshness-pipeline")
+
+    assert len(all_names) > len(top_level), (
+        "the weekly definition has no nested states, which contradicts its "
+        "Parallel/Map structure — _state_names has stopped descending"
+    )
+    nested_spine = [
+        s for s in PIPELINE_STAGE_ORDER["ne-weekly-freshness-pipeline"]
+        if s in all_names and s not in top_level
+    ]
+    assert nested_spine, (
+        "no weekly spine stage is nested any more. If that is a real "
+        "restructuring, this assertion should be updated deliberately; if it "
+        "is a reader regression, the guard above has become a false pass."
+    )


### PR DESCRIPTION
## What

`nousergon_lib.pipeline_status.registry.PIPELINE_STAGE_ORDER` says of itself:

> Kept in sync with the live SF JSONs by a producer-side contract test in `nousergon-data` — a stage rename that is not mirrored here blinds every reader matching on the old name, and that blindness reports as the benign "that stage did not run" (the I6857 defect).

**That test did not exist.** Verified 2026-09-08 by grepping this whole repository for `PIPELINE_STAGE_ORDER` and `stage_order_for`: no hits. This is the repository that *owns* the Step Functions definitions — the only place a rename can originate — so the constant has been unguarded for its entire life against exactly the defect its own comment describes.

Worse than a missing guard: a reader who checked whether the constant was protected would have found a sentence saying yes.

Found while adding `EvalRollingMean` to the weekly spine under `alpha-engine-config-I10199` (`nousergon-lib-PR393`) — the spine was being extended on the strength of a sync guarantee that was never built.

## One direction, and the direction is the test

Every stage in the spine must exist as a state. **Not** every state must appear in the spine — `ne-weekly-freshness-pipeline` has **465 states and a 16-stage spine**, because the spine is a judgment about which stages represent progress, read by `cycles._depth_of`.

An equality check would make the constant unmaintainable and the pressure would then be to delete the guard, so the asymmetry is itself asserted by its own test rather than left as a convention someone later "tightens" away.

## A shallow read is a false pass — and it was my first cut

Seven of the sixteen weekly spine stages are **not** top-level `States` keys; they live inside `Parallel.Branches[].States` and `Map` iterators. Reading only the top level reported all seven as missing — a guard reporting a defect that did not exist, which is the same class this session has been unwinding all day.

`_state_names` recurses through `Branches` / `Iterator` / `ItemProcessor`, and a fourth test pins that depth so a regression to the shallow form fails loudly instead of passing silently over nested states.

## Demonstrated, not just asserted

Renaming `Scanner` → `ScannerV2` in `infrastructure/step_function.json` fails the guard:

```
FAILED test_every_spine_stage_exists_in_the_live_definition[ne-weekly-freshness-pipeline]
FAILED test_the_spine_is_a_subset_and_not_the_state_list[ne-weekly-freshness-pipeline]
```

The definition was restored byte-identical afterwards and the suite is green.

A fifth test derives the pipeline set from the library, so a fourth pipeline added to `PIPELINE_STAGE_ORDER` fails here until its definition is mapped rather than going silently unchecked.

## Scope

Test-only. No production code, no IAM, no `iam-policy-change-guard` interaction, no post-merge step — deployable by the merge button alone. Base `main`, no stacking: it touches no file any open PR owns.

## Tests

8 new, all passing. Full suite ran locally before pushing: **7098 passed, 17 skipped**. The two `test_pipeline_status_registry_source_check[Weekday-json_path1]` failures are environment-only and reproduce identically on the unmodified tree — the local `nousergon-lib` install is 0.124.21 against this repo's `v0.124.109` pin (`alpha-engine-config-I9070`); CI installs the pinned version.

Refs `alpha-engine-config-I10201`. A closing keyword does not work across repositories, so that issue is closed by hand after merge.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVE67NRyV6Ss3DvnnyVEnj
