### PR TITLE
fix(pause-reconcile): declare finding-surface semantics, fix Scheduler group join-key bug

### DIFF
--- a/.github/workflows/pause-reconcile.yml
+++ b/.github/workflows/pause-reconcile.yml
@@ -83,6 +83,31 @@ permissions:
   id-token: write   # required for OIDC
   contents: read
 
+# WORKFLOW HEALTH SEMANTICS (alpha-engine-config-I9169, I9553, I9681).
+# Read by alpha-engine-config's scripts/check_scheduled_workflow_health.py out
+# of THIS file, so the declaration cannot outlive the steps it describes. This
+# workflow's own header comment above already states the contract at length
+# ("TWO JOBS, AND THAT IS THE POINT") — the exit code is deliberately
+# unchanged on real drift, only the rendering. `scheduled-workflow-health`
+# graded that design on plain execution health and filed
+# alpha-engine-config-I9681 (0/12 clean over 12 runs): every one of those runs
+# either failed in the `reconcile` job itself (exit 2, the real defect closed
+# below) or in the single declared step here (exit 1, findings). Renaming that
+# step without updating this list is caught by `--validate-declarations`.
+env:
+  WORKFLOW_HEALTH_SEMANTICS: finding-surface
+  WORKFLOW_HEALTH_FINDING_STEPS: |
+    Fail on drift, pass when every trigger is declared
+  WORKFLOW_HEALTH_FINDING_ISSUE: alpha-engine-config-I7118
+  WORKFLOW_HEALTH_FINDING_REASON: >-
+    The `verdict` job's one step fails whenever the reconciler script run by
+    the `reconcile` job above reports drift between automation_pause.json,
+    the observability registry and live AWS - the non-zero exit IS the
+    drift finding, by design (see this file's header comment). The
+    `reconcile` job failing on its OWN step is a different thing - the
+    reconciler could not run at all (AWS denied, a register unreadable) -
+    and is graded on execution health as before, un-muted.
+
 jobs:
   reconcile:
     name: compare the three registers

--- a/infrastructure/pause_reconcile.py
+++ b/infrastructure/pause_reconcile.py
@@ -499,12 +499,33 @@ def reconcile(
         name, state = t["name"], t["state"]
         if name.startswith(_AWS_MANAGED_PREFIX):
             continue
-        row = reg.get(name)
-        declared_off = name in paused or _declares_off(row)
+        # `automation_pause.py::_live_triggers()` reports (and `not_paused`/
+        # `paused`/`pending` therefore declare) a non-default-group Scheduler
+        # schedule as ``"<group>/<name>"`` — see `_split_scheduler_name`'s
+        # docstring and the `crucible-v2/heartbeat` et al. entries in
+        # automation_pause.json (alpha-engine-config-I9994). This module's own
+        # `live_triggers()` above carries the group as a separate field rather
+        # than folding it into `name`, so matching bare `name` against
+        # `paused`/`kept`/the registry silently fails for every schedule
+        # outside the default group — reported `undeclared-enabled` on every
+        # run regardless of what the manifest says (alpha-engine-config-I9681:
+        # measured 2026-09-08, all four `crucible-v2`-group schedules flagged
+        # despite being declared `not_paused` since 2026-09-04/I9994). The join
+        # key below reconstructs the same qualified form so this direction
+        # agrees with automation_pause.py about what a declaration names; the
+        # bare `name` (plus `t["group"]`) is still what is handed to every
+        # AWS-calling helper (`targets_of`, `is_ephemeral`), which need the
+        # unqualified name and the group as separate arguments.
+        group = t.get("group") if t["surface"] == "scheduler" else None
+        declared_name = (
+            f"{group}/{name}" if group and group != DEFAULT_SCHEDULE_GROUP else name
+        )
+        row = reg.get(declared_name) or reg.get(name)
+        declared_off = declared_name in paused or _declares_off(row)
         if state != "ENABLED":
             if not declared_off:
                 findings.append({
-                    "kind": "undeclared-dark", "trigger": name, "surface": t["surface"],
+                    "kind": "undeclared-dark", "trigger": declared_name, "surface": t["surface"],
                     "detail": (
                         f"live State={state}, but no register declares it off: it is not "
                         f"named in automation_pause.json and its observability row says "
@@ -523,7 +544,7 @@ def reconcile(
             # asserting the component is deliberately off while it runs.
             if _declares_off(row):
                 findings.append({
-                    "kind": "running-while-declared-off", "trigger": name,
+                    "kind": "running-while-declared-off", "trigger": declared_name,
                     "surface": t["surface"],
                     "detail": (
                         f"live State=ENABLED while its observability row declares "
@@ -535,7 +556,7 @@ def reconcile(
                         "in-service, or it was not and the trigger goes back off."
                     ),
                 })
-            elif name not in kept and row is None:
+            elif declared_name not in kept and row is None:
                 # A self-deleting one-shot is an in-flight continuation of an
                 # already-registered dispatcher, not standing scheduled work —
                 # see `is_ephemeral_one_shot`. Probed only here, so a clean run
@@ -556,7 +577,8 @@ def reconcile(
                     })
                     continue
                 findings.append({
-                    "kind": "undeclared-enabled", "trigger": name, "surface": t["surface"],
+                    "kind": "undeclared-enabled", "trigger": declared_name,
+                    "surface": t["surface"],
                     "detail": (
                         "live State=ENABLED, named in neither automation_pause.json nor "
                         "the observability registry. Scheduled work is running that no "

--- a/tests/test_pause_reconcile.py
+++ b/tests/test_pause_reconcile.py
@@ -632,6 +632,48 @@ def test_a_scheduler_row_with_no_group_falls_back_to_default(mod, monkeypatch):
     assert seen[0][-2:] == ["--group-name", mod.DEFAULT_SCHEDULE_GROUP]
 
 
+# ── the join key must be group-qualified too (alpha-engine-config-I9681) ────
+# `live_triggers()` carries a non-default Scheduler group as a separate field
+# (the two tests above), but `check()`'s direction A matched the BARE name
+# against `paused`/`kept`/the registry — a different join key than
+# `automation_pause.py::_live_triggers()` uses to populate those very sets
+# (`"<group>/<name>"`, per `_split_scheduler_name`'s docstring). Measured
+# live 2026-09-08: all four `crucible-v2`-group schedules (`heartbeat`,
+# `weekly`, `alerts-sweep`, `data-daily`) — declared `not_paused` under keys
+# `crucible-v2/heartbeat` etc. since 2026-09-04 (I9994) — were reported
+# `undeclared-enabled` on every run because bare `"heartbeat"` is not in a
+# `kept` set that only contains `"crucible-v2/heartbeat"`.
+
+def test_a_kept_non_default_group_schedule_is_not_undeclared_enabled(mod):
+    """The exact I9681 defect, induced: a `crucible-v2`-group schedule
+    declared `not_paused` under its group-qualified key must not be flagged
+    just because its live AWS name is bare."""
+    findings = _reconcile(
+        mod,
+        manifest=_manifest(kept={"crucible-v2/heartbeat": "crucible v2 build, KEPT"}),
+        rows={},
+        triggers=[{"surface": "scheduler", "name": "heartbeat", "state": "ENABLED",
+                   "group": "crucible-v2"}],
+    )
+    assert findings == []
+
+
+def test_an_undeclared_non_default_group_schedule_still_fires_qualified(mod):
+    """The other direction: a real gap in a non-default group must still be
+    caught, and reported under the SAME qualified key automation_pause.json
+    would need to declare — not the bare name, which nobody could add there."""
+    findings = mod.reconcile(
+        manifest=_manifest(), rows={},
+        triggers=[{"surface": "scheduler", "name": "stowaway", "state": "ENABLED",
+                   "group": "crucible-v2"}],
+        targets_of=lambda t: [], sf_invoked=set(), invocations_of=lambda cid: 0,
+        alarm_breaching_of=lambda name: True,
+        is_ephemeral=lambda name, group=None: False,
+    )
+    assert [(f["kind"], f["trigger"]) for f in findings] == \
+        [("undeclared-enabled", "crucible-v2/stowaway")]
+
+
 def test_the_headline_distinguishes_drift_from_a_broken_detector(mod):
     """I7547 deliverable 3. GitHub renders both as `failure`; these do not.
 


### PR DESCRIPTION
## alpha-engine-config-I9681

`pause-reconcile.yml` failed 0/12 clean runs. Two things, done separately:

### 1. Declaration
Confirmed this workflow is a genuine finding surface — its own header comment states the design at length ("TWO JOBS, AND THAT IS THE POINT"): the `verdict` job's single step is deliberately built to exit non-zero on real drift, with the exit code unchanged and only the rendering improved. Declared `WORKFLOW_HEALTH_SEMANTICS: finding-surface` on the workflow per the `alpha-engine-config-I9169`/`I9553` mechanism (`workflow_health_semantics.py --workflow-dir .github/workflows` validates clean), naming the one declared step and `alpha-engine-config-I7118` (this workflow's own genesis issue) as the findings' destination.

### 2. The finding itself — NOT real drift, a code defect
The reported findings (`scheduler:alerts-sweep`, `scheduler:data-daily`, `scheduler:heartbeat`, `scheduler:weekly`, all `undeclared-enabled`) were a false positive, not real drift needing a ruling.

`automation_pause.py::_live_triggers()` reports (and `not_paused`/`paused`/`pending` therefore declare) a non-default-Scheduler-group schedule as `"<group>/<name>"` (`alpha-engine-config-I9994`) — `automation_pause.json` already declares all four crucible-v2 schedules under `crucible-v2/heartbeat` etc. since 2026-09-04. `pause_reconcile.py`'s own `live_triggers()` carries the group as a separate field but never folded it back into the join key used to check `paused`/`kept`/the registry in `reconcile()`'s direction A — so the bare live name (`"heartbeat"`) never matched the qualified declaration (`"crucible-v2/heartbeat"`), and it was flagged undeclared on every run.

Fixed by reconstructing the same qualified key before every membership check and finding label in direction A, keeping the bare name + separate group for every AWS-calling helper that still needs them (`targets_of`, `is_ephemeral`). Two regression tests induce the exact defect: `test_a_kept_non_default_group_schedule_is_not_undeclared_enabled` and `test_an_undeclared_non_default_group_schedule_still_fires_qualified`.

This residual join-key gap sat underneath `alpha-engine-config-I10003`/`I10009`, whose already-landed fixes covered `live_triggers()`/`is_ephemeral_one_shot()`/`trigger_targets()` but not this one call site — worth a look by whoever grooms those two issues once this PR's effect is verified live (the run history also shows the 12 failures split across two causes: earlier runs failed in the `reconcile` job itself, exit 2, the defect I10009 already fixed; later runs failed only on this join-key bug).

No ruling needed — all four triggers are already correctly declared `not_paused`/kept in `automation_pause.json`; the checker was wrong, not the manifest.

## Test plan
```
python3 -m pytest tests/test_pause_reconcile.py tests/test_automation_pause.py tests/test_systemd_unit_drift_check.py tests/test_artifact_registry_coverage.py -q
183 passed, 1 skipped
```
`workflow_health_semantics.py --workflow-dir .github/workflows` — 3 declared finding surfaces, 0 declared operator-gated detectors: all valid.

## Not a fourth form
This does not depend on any post-merge step. The next scheduled run of `pause-reconcile.yml` re-evaluates the manifest against live AWS with the fixed join key; nothing needs to run manually after merge.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)