### PR TITLE
fix(collectors): the dated research.db backup has a writer again (alpha-engine-config-I10202)

### DIFF
--- a/collectors/research_db_upload.py
+++ b/collectors/research_db_upload.py
@@ -1,0 +1,66 @@
+"""The single writer of `research.db` and its dated backup.
+
+**Why this module exists.** Until 2026-07-12 both keys were written by ONE
+method — `crucible-research`'s `ArchiveManager.upload_db`, which uploaded
+`research.db` and `backups/research_<date>.db` in the same call. That method's
+only caller was deleted with the retired LangGraph pass
+(`alpha-engine-config-I7827`), and the pointer acquired a DIFFERENT writer here
+in `nousergon-data` while the dated backup acquired none.
+
+The result was invisible for 59 days (`alpha-engine-config-I10202`): the
+freshness row named `research_db_backup` watched `research.db`, whose new
+writer kept it fresh, so the row read healthy while the thing it is named for
+had stopped. The last dated object is `backups/research_20260710.db`.
+
+So the fix is not "add an upload back somewhere" — it is to make the two keys
+share a writer again, because a second writer for one of them is exactly how
+they diverged. Every caller goes through :func:`upload_research_db`; there is
+no supported path that writes the pointer alone.
+
+**Key format.** New backups are ISO-dated — `backups/research_2026-09-12.db` —
+so `ARTIFACT_REGISTRY.yaml` can express the key with its `{date}` placeholder
+and give the series a real freshness check. Objects written before 2026-07-11
+use the compressed `research_20260710.db` form; they are historical and are not
+renamed. A registry template that cannot render the key it watches is a row
+that reports UNMEASURED forever (`alpha-engine-config-I10200`), which is the
+same class of failure this issue is about.
+
+**Failure posture: RAISE.** Both uploads are producer writes, and the fleet
+rule forbids graceful-degrade on a producer (`~/Development/CLAUDE.md`, "Fail
+loud and fast"). The previous sites logged a WARNING and continued, so a failed
+upload left the caller reporting success — which is how a 407 MB database can
+stop being backed up without any run going red.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+#: The live pointer. Read by every consumer of the research database.
+DB_KEY = "research.db"
+
+#: The dated backup series. `{date}` is an ISO trading day (YYYY-MM-DD).
+BACKUP_KEY_TEMPLATE = "backups/research_{date}.db"
+
+
+def backup_key(run_date: str) -> str:
+    """Return the dated backup key for ``run_date`` (ISO ``YYYY-MM-DD``)."""
+    if not run_date:
+        raise ValueError("run_date is required to name the dated backup")
+    return BACKUP_KEY_TEMPLATE.format(date=run_date)
+
+
+def upload_research_db(s3, db_path: str, bucket: str, run_date: str) -> dict:
+    """Upload ``db_path`` to BOTH the live pointer and the dated backup.
+
+    Raises on either failure — see the module docstring. Returns the two keys
+    written so a caller can record them in its own result envelope.
+    """
+    key = backup_key(run_date)
+    s3.upload_file(db_path, bucket, DB_KEY)
+    log.info("Uploaded research.db to s3://%s/%s", bucket, DB_KEY)
+    s3.upload_file(db_path, bucket, key)
+    log.info("Uploaded dated backup to s3://%s/%s", bucket, key)
+    return {"pointer_key": DB_KEY, "backup_key": key}

--- a/collectors/signal_returns.py
+++ b/collectors/signal_returns.py
@@ -35,6 +35,9 @@ import pandas as pd
 from botocore.exceptions import ClientError
 from nousergon_lib.quant.horizons import DEFAULT_POLICY, HorizonPolicy
 
+from collectors.research_db_upload import upload_research_db
+from dates import default_run_date
+
 logger = logging.getLogger(__name__)
 
 # Default prediction horizon. Matches the predictor's canonical training
@@ -79,6 +82,7 @@ def collect(
     signals_prefix: str = "signals",
     dry_run: bool = False,
     forward_days: int = _DEFAULT_FORWARD_DAYS,
+    run_date: str | None = None,
 ) -> dict:
     """Seed and backfill signal performance tables in research.db.
 
@@ -186,14 +190,14 @@ def collect(
             db_path, forward_days=forward_days,
         )
 
-    # Upload updated research.db back to S3
+    # Upload updated research.db back to S3 — pointer AND dated backup through
+    # the single owning writer (alpha-engine-config-I10202). See
+    # collectors/research_db_upload.py for why they may not be written apart.
+    #
+    # No try/except: a producer write that fails must fail the run.
     total_written = sum(r.get("rows_written", 0) for r in results.values())
     if not dry_run and total_written > 0:
-        try:
-            s3.upload_file(db_path, bucket, "research.db")
-            logger.info("Uploaded research.db to s3://%s/research.db", bucket)
-        except Exception as e:
-            logger.warning("Failed to upload research.db: %s", e)
+        upload_research_db(s3, db_path, bucket, run_date or default_run_date())
 
     has_errors = any(r.get("status") == "error" for r in results.values())
     return {

--- a/collectors/universe_returns.py
+++ b/collectors/universe_returns.py
@@ -63,6 +63,9 @@ import pandas as pd
 from nousergon_lib.trading_calendar import add_trading_days as _add_trading_days
 from polygon_client import PolygonForbiddenError
 
+from collectors.research_db_upload import upload_research_db
+from dates import default_run_date
+
 logger = logging.getLogger(__name__)
 
 # -- Sector ETF mapping ------------------------------------------------------
@@ -208,6 +211,7 @@ def collect(
     sector_map_key: str = "data/sector_map.json",
     max_lookback_trading_days: int = 90,
     dry_run: bool = False,
+    run_date: str | None = None,
 ) -> dict:
     """
     Populate universe_returns table with forward returns for every trading day.
@@ -296,13 +300,15 @@ def collect(
             logger.warning("universe_returns: failed for %s: %s", eval_date, e)
             errors.append({"date": eval_date, "error": str(e)})
 
-    # Upload updated research.db back to S3
+    # Upload updated research.db back to S3 — BOTH the live pointer and the
+    # dated backup, through the one writer that owns them (alpha-engine-config-
+    # I10202). Writing the pointer alone here is what let the dated series die
+    # unnoticed for 59 days while its freshness row read healthy.
+    #
+    # No try/except: a failed producer write must fail the run. The previous
+    # WARNING-and-continue is why nothing went red.
     if not dry_run and total_inserted > 0:
-        try:
-            s3.upload_file(db_path, bucket, "research.db")
-            logger.info("Uploaded research.db to s3://%s/research.db", bucket)
-        except Exception as e:
-            logger.warning("Failed to upload research.db: %s", e)
+        upload_research_db(s3, db_path, bucket, run_date or default_run_date())
 
     # Any real error (exception or "no rows computed" after pre-filter) is a
     # hard failure under the no-silent-fails rule. The old `partial` path was

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -273,8 +273,16 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     "collectors/prices.py": 1,
     "collectors/short_interest.py": 1,
     "collectors/universe_classification.py": 1,  # market_data/universe_classification/{date,latest}.json — sector/country/industry for the ~900 universe board
-    "collectors/signal_returns.py": 1,
-    "collectors/universe_returns.py": 1,
+    # alpha-engine-config-I10202: the research.db PUT sites MOVED out of these
+    # two collectors into collectors/research_db_upload.py, which writes the
+    # pointer AND the dated backup in one call. They are pinned at 0 by absence
+    # — the entries are gone rather than set to zero — and the guard test
+    # `test_no_collector_writes_the_pointer_without_the_backup` in
+    # tests/test_research_db_dated_backup.py is what keeps them from coming
+    # back: a direct `upload_file(db_path, bucket, "research.db")` in either
+    # file would write the pointer while leaving the dated series unwritten,
+    # which is the 59-day outage this arc fixed.
+    "collectors/research_db_upload.py": 2,  # research.db + backups/research_{date}.db — the pointer is registered as research_db_backup and the dated series as research_db_dated_backup in ARTIFACT_REGISTRY.yaml (alpha-engine-config-I10202)
     # corporate_actions/actions/{action_id}.json + applied/{store}/{action_id}.json —
     # EVENT-DRIVEN corporate-action provenance records (config#1431), written only
     # when a split is detected/applied. NOT a periodic freshness-SLA artifact: there

--- a/tests/test_research_db_dated_backup.py
+++ b/tests/test_research_db_dated_backup.py
@@ -1,0 +1,113 @@
+"""The dated `research.db` backup has a writer again, and it cannot be lost.
+
+`alpha-engine-config-I10202`: until 2026-07-12 one method wrote both
+`research.db` and `backups/research_<date>.db`. Its caller was deleted, the
+pointer acquired a new writer here and the dated backup acquired none, and the
+freshness row named `research_db_backup` kept reading healthy because it
+watched the pointer. 59 days, 407 MB, no surface reported it.
+
+These tests pin the property that made the loss possible: the two keys must be
+written by the SAME call. A test that only asserted "a dated backup is
+uploaded" would pass again the day someone adds a second pointer-only writer.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from collectors.research_db_upload import (
+    BACKUP_KEY_TEMPLATE,
+    DB_KEY,
+    backup_key,
+    upload_research_db,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+COLLECTORS = REPO / "collectors"
+
+
+class _RecordingS3:
+    def __init__(self, fail_on: str | None = None):
+        self.calls: list[tuple[str, str, str]] = []
+        self._fail_on = fail_on
+
+    def upload_file(self, path, bucket, key):
+        if self._fail_on is not None and key == self._fail_on:
+            raise RuntimeError(f"simulated S3 failure on {key}")
+        self.calls.append((path, bucket, key))
+
+
+def test_both_keys_are_written_by_one_call():
+    s3 = _RecordingS3()
+    out = upload_research_db(s3, "/tmp/research.db", "alpha-engine-research", "2026-09-12")
+    assert [c[2] for c in s3.calls] == [DB_KEY, "backups/research_2026-09-12.db"]
+    assert out == {
+        "pointer_key": DB_KEY,
+        "backup_key": "backups/research_2026-09-12.db",
+    }
+
+
+def test_a_failed_backup_upload_raises_rather_than_warning():
+    """The pointer landing while the backup silently did not is the exact
+    shape of the 59-day outage. A producer write that fails must fail the run
+    (fleet rule: fail loud and fast, no graceful-degrade on a writer)."""
+    s3 = _RecordingS3(fail_on="backups/research_2026-09-12.db")
+    with pytest.raises(RuntimeError):
+        upload_research_db(s3, "/tmp/research.db", "alpha-engine-research", "2026-09-12")
+
+
+def test_a_failed_pointer_upload_raises_too():
+    s3 = _RecordingS3(fail_on=DB_KEY)
+    with pytest.raises(RuntimeError):
+        upload_research_db(s3, "/tmp/research.db", "alpha-engine-research", "2026-09-12")
+
+
+def test_backup_key_is_iso_dated():
+    """ISO, not the pre-2026-07-11 compressed form: ARTIFACT_REGISTRY.yaml can
+    only render `{date}` as YYYY-MM-DD, and a template that cannot render the
+    key it watches reports UNMEASURED forever (alpha-engine-config-I10200)."""
+    assert backup_key("2026-09-12") == "backups/research_2026-09-12.db"
+    assert "{date}" in BACKUP_KEY_TEMPLATE
+
+
+def test_backup_key_refuses_an_empty_run_date():
+    with pytest.raises(ValueError):
+        backup_key("")
+
+
+def _uploads_research_db_directly(path: Path) -> list[int]:
+    """Line numbers of `*.upload_file(..., "research.db")` calls in `path`."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "upload_file"):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and arg.value == DB_KEY:
+                hits.append(node.lineno)
+    return hits
+
+
+def test_no_collector_writes_the_pointer_without_the_backup():
+    """The regression guard. `research.db` may only be uploaded through
+    `upload_research_db`; a direct `upload_file(db_path, bucket, "research.db")`
+    anywhere in `collectors/` re-creates the divergence, because that call
+    keeps the freshness row green while writing no dated object."""
+    offenders: list[str] = []
+    for path in sorted(COLLECTORS.rglob("*.py")):
+        if path.name == "research_db_upload.py":
+            continue  # the one owning writer
+        for line in _uploads_research_db_directly(path):
+            offenders.append(f"{path.relative_to(REPO)}:{line}")
+    assert not offenders, (
+        "these sites upload the research.db pointer directly, leaving the dated "
+        "backup unwritten — route them through "
+        "collectors.research_db_upload.upload_research_db "
+        f"(alpha-engine-config-I10202): {offenders}"
+    )

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -587,8 +587,11 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                 db_path = None
 
         if db_path:
-            # supports_auto_skip=False: writes the shared mutable research.db (no
-            # dated artifact to validate) → markers + watchdog only.
+            # supports_auto_skip=False: writes the shared mutable research.db.
+            # It ALSO writes backups/research_{run_date}.db since
+            # alpha-engine-config-I10202, but that dated object is a backup of
+            # the shared database rather than this phase's own product, so the
+            # auto-skip validator still has nothing phase-specific to check.
             results["collectors"]["universe_returns"] = _phase_collect(
                 reg, "universe_returns",
                 lambda: universe_returns.collect(
@@ -599,6 +602,7 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                         "sector_map_key", "reference/price_cache/sector_map.json"
                     ),
                     dry_run=dry_run,
+                    run_date=run_date,
                 ),
                 supports_auto_skip=False,
             )
@@ -621,6 +625,7 @@ def _run_phase1(config: dict, args: argparse.Namespace) -> dict:
                     signals_prefix=ur_cfg.get("signals_prefix", "signals"),
                     dry_run=dry_run,
                     forward_days=int(sr_cfg.get("forward_days", 21)),
+                    run_date=run_date,
                 ),
                 supports_auto_skip=False,
             )


### PR DESCRIPTION
## What & why

The dated `research.db` backups stopped on **2026-07-11** and nothing reported it for **59 days** — a 407 MB database with no backup series and no red surface anywhere.

**Why it was invisible.** Until 2026-07-12 one method wrote both keys: `crucible-research`'s `ArchiveManager.upload_db` uploaded `research.db` and `backups/research_<date>.db` in the same call. Its only caller went away with the retired LangGraph pass (`alpha-engine-config-I7827`). The POINTER then acquired a new writer here in `nousergon-data`; the dated backup acquired none. The freshness row named `research_db_backup` is a `last_modified` check on the pointer, so it kept reading fresh while the thing it is named for was dead.

Measured, `s3://alpha-engine-research/backups/`:

```
2026-07-03 02:51:44  244989952  research_20260702.db
2026-07-11 12:23:44  263008256  research_20260710.db   <- last one
```

## The fix is the shared writer, not a restored upload

`collectors/research_db_upload.py` owns both keys and writes them in ONE call. Both collectors go through it. `tests/test_research_db_dated_backup.py::test_no_collector_writes_the_pointer_without_the_backup` walks the AST of everything under `collectors/` and fails on any direct `upload_file(..., "research.db")`.

Adding an upload back at one site would have rebuilt the exact fragility that caused this — a second writer for one of the two keys is how they diverged in the first place.

**Fail loud.** Both sites previously logged a WARNING and continued, so a failed upload left the caller reporting success. That swallow is the second reason nothing went red; the fleet rule forbids graceful-degrade on a producer write. `upload_research_db` raises.

**Key format.** New objects are ISO-dated (`backups/research_2026-09-12.db`) so `ARTIFACT_REGISTRY.yaml` can render the key with its `{date}` placeholder and give the series a real freshness check — a template that cannot render its own key reports UNMEASURED forever (`alpha-engine-config-I10200`). Pre-2026-07-11 objects keep the compressed form and are NOT renamed: they are the only record of when the series stopped.

## Cross-repo

- `alpha-engine-config-PR10176` — registers `research_db_dated_backup` in its own right and corrects the `grandfathered_paths` reason that claimed this prefix was "covered by `research_db_backup` pointer". That claim was false and is why the outage was invisible.
- Merge order: either order. This PR restores the writer; the config PR gives the series its detector. Neither breaks without the other, but the detector is only meaningful once objects appear.

## Test plan — run BEFORE opening

`python3 -m pytest tests/ -q` → **7176 passed, 18 skipped, 5 failed**.

All 5 failures are `tests/test_pipeline_status_registry_source_check.py` and are ENVIRONMENTAL, not caused by this diff. The test prints its own provenance note: it reads the SF JSONs from the working tree but the registry from the INSTALLED lib, and this laptop has `nousergon-lib` **v0.124.21** against this repo's pin of **v0.124.113**. Verified that the pin is correct: `WeeklyCoverageSweepDeferred` IS in `nousergon_lib/pipeline_status/registry.py` on `nousergon-lib` `origin/main` (commit `bb7c6e3`, PR#391), and `git merge-base --is-ancestor bb7c6e3 v0.124.113` returns true. CI installs the pin, so these cannot fail there. Tracked as `alpha-engine-config-I9070`.

New tests: `tests/test_research_db_dated_backup.py`, 6 passing — both keys from one call, a failed backup upload raises, a failed pointer upload raises, ISO key format, empty run_date refused, and the no-direct-pointer-write guard.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVE67NRyV6Ss3DvnnyVEnj