### PR TITLE
fix(backfill): macro slide computation must not crash on pre-2016 dates (alpha-engine-config-I10267)

### DIFF
--- a/builders/backfill.py
+++ b/builders/backfill.py
@@ -496,7 +496,47 @@ def _history_regression(
     ):
         from nousergon_lib.dates import trading_days_stale
 
-        slide = trading_days_stale(existing_first.date(), planned_first.date())
+        try:
+            from krepis.trading_calendar import (
+                TradingCalendarRangeError as _CalendarRangeError,
+            )
+        except ImportError:
+            # Pinned krepis predates the I10127 coverage guard entirely (it
+            # never raises this) — nothing to catch, and the except below is
+            # unreachable, matching today's (pre-fix) behaviour exactly.
+            _CalendarRangeError = ()
+
+        try:
+            slide = trading_days_stale(existing_first.date(), planned_first.date())
+        except _CalendarRangeError as exc:
+            # alpha-engine-config-I10267: krepis>=0.59.52 (I10127) correctly
+            # refuses a trading-day-precise answer for any date before
+            # NYSE_CALENDAR_COVERS_FROM (2016-01-01) — the holiday table has
+            # no data at all that far back. A declared-CUMULATIVE FRED symbol
+            # (CUMULATIVE_MACRO_SYMBOLS) can legitimately span dates that old
+            # (BAA10Y/TWO/VIX etc. go back to the 1980s), so this is not an
+            # error condition, just a range the live calendar cannot resolve.
+            # Catching the specific krepis range-error class (not bare
+            # Exception) keeps an unrelated bug in `trading_days_stale` fail
+            # loud as before. Fall back to a business-day count — an
+            # always-available, calendar-independent, slightly conservative
+            # (holiday-blind, so marginally over-generous) estimate — logged
+            # loudly so the approximation is greppable. This does not weaken
+            # the integrity check for the case that can actually reach it: a
+            # declared-cumulative symbol's WRITTEN result is independently
+            # verified by `_cumulative_invariant_violation` after
+            # `_cumulative_prepend`, using plain date/row comparisons with no
+            # calendar dependency, so a wrong slide credit here cannot mask a
+            # real loss. A non-cumulative (rolling yfinance) symbol never
+            # reaches this branch in practice — its window is always within
+            # the last ~10 years.
+            slide = int(np.busday_count(existing_first.date(), planned_first.date()))
+            log.info(
+                "MACRO_SLIDE_PRECALENDAR_FALLBACK %s existing_first=%s "
+                "planned_first=%s busday_slide=%d reason=%s — see "
+                "alpha-engine-config-I10267.",
+                label, existing_first.date(), planned_first.date(), slide, exc,
+            )
     allowed_loss = _MACRO_HISTORY_SHRINK_TOLERANCE_ROWS + min(
         slide, _MACRO_WINDOW_SLIDE_MAX_TRADING_DAYS
     )


### PR DESCRIPTION
## What and why

`alpha-engine-config-I10267`: `tests/test_macro_cumulative_history.py::test_prepend_emits_a_reconstructible_log_record` was filed as failing pre-existing on `main`, blocking `nousergon-data-PR1664` (the debug-swallow sweep, `alpha-engine-config-I10226`), which is green on everything else (7182 passed, 18 skipped).

## Test or code — and the evidence

**CODE, not the test — option (b) from the issue.** Re-measured before touching anything:

- Fresh venv installed strictly from this repo's own pinned `requirements.txt` (`krepis==0.59.46`): `tests/test_macro_cumulative_history.py` — **15 passed**. The issue's "confirmed failing identically on clean origin/main" does not hold against the repo's own pin; it must have been measured against a stale/unpinned local `krepis`.
- Traced the actual call chain from `_write_macro_series_no_shrink` → `_history_regression` → `nousergon_lib.dates.trading_days_stale(existing_first, planned_first)` → `krepis.dates.expected_last_close(planned_first)` → `krepis.trading_calendar.is_trading_day`. `trading_calendar.is_trading_day` gained a `TradingCalendarPrecedesCoverageError` guard in krepis `0.59.52` (`alpha-engine-config-I10127`, merged 2026-09-07) for any date before `NYSE_CALENDAR_COVERS_FROM` (2016-01-01).
- Force-installed `krepis==0.59.54` (current PyPI tip) over the pinned requirements set (all else unchanged) and reran: **RED**, exact traceback from the issue, reproduced.
- `nousergon-data-PR1664` bumps `requirements.txt`'s `krepis` pin `0.59.46 -> 0.59.53` as part of its own pin-lockstep fix — so this test genuinely fails on *that* PR's head SHA, even though it's green on unmodified `main` today. This is a real, dormant production defect: `_history_regression`'s slide-credit computation calls a "freshness relative to now" primitive (`trading_days_stale`) on an arbitrary historical `planned_first`, and any declared-**CUMULATIVE** FRED macro symbol (`CUMULATIVE_MACRO_SYMBOLS` — `BAA10Y`, `TWO`, `VIX`, etc., which genuinely span back to the 1980s) can legitimately produce a pre-2016 `planned_first` during a full-history collector run. Not visible today only because main's pin predates the guard.

## Fix

`_history_regression` (`builders/backfill.py`) now catches the specific `krepis.trading_calendar.TradingCalendarRangeError` (not bare `Exception`, so an unrelated bug in `trading_days_stale` still fails loud) and falls back to a business-day count — calendar-independent, holiday-blind so marginally over-generous, logged loudly as `MACRO_SLIDE_PRECALENDAR_FALLBACK` for reconstructibility from durable logs alone. The import itself is guarded (`try/except ImportError`) so this is a no-op against the currently pinned older `krepis` — the except branch is provably unreachable there.

Safe because the fallback only feeds a *tolerance credit*, and the actual WRITTEN result for a declared-cumulative symbol is independently re-verified by `_cumulative_invariant_violation` after `_cumulative_prepend`, using plain date/row comparisons with **no** calendar dependency — a wrong slide credit here cannot mask a real truncation for the case that can realistically reach this branch. A non-cumulative (rolling yfinance, `auto_adjust=True`) symbol never reaches this branch in practice — its window is always within the last ~10 years, well after 2016.

## Test plan

- `krepis==0.59.46` (repo's own pin, unchanged): `tests/test_macro_cumulative_history.py` — 15 passed (unchanged before/after).
- `krepis==0.59.54` (force-installed over the pin, reproduces PR1664's bump): **RED before this change** (`TradingCalendarPrecedesCoverageError`, matching the issue exactly), **GREEN after** (15 passed) — confirmed the fallback log line fires with the expected reconstructible content (`MACRO_SLIDE_PRECALENDAR_FALLBACK macro.BAA10Y existing_first=1986-01-02 planned_first=1986-06-02 busday_slide=107 ...`).
- Broader regression check (repo's own pin): `tests/test_macro_cumulative_history.py` + all `tests/test_backfill_*.py` + `tests/test_daily_append_backfill_safe.py` — 76 passed.

Unblocks `nousergon-data-PR1664` — once rebased onto this fix, its bumped `krepis==0.59.53` pin will hit the guarded fallback path instead of crashing.

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)