### PR TITLE
fix(expenses): raise the stale DeepSeek budget from $10 to $35

### DIFF
--- a/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
+++ b/infrastructure/lambdas/expense-collector/expense_budgets.seed.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "_doc": "Budgets/quotas SSoT for the expense-collector Lambda + console Expenses page. Live copy: s3://alpha-engine-research/config/expense_budgets.json (operator-edited: aws s3 cp expense_budgets.seed.json s3://alpha-engine-research/config/expense_budgets.json — or edit the live object directly). monthly_budget_usd null = no budget line (row shows spend without over/under pacing). fixed_monthly_usd on a key with no live adapter renders a flat-subscription row, so future subscriptions are config-only additions.",
-  "updated": "2026-07-19",
+  "updated": "2026-09-08",
   "providers": {
     "aws": {
       "label": "AWS",
@@ -23,7 +23,8 @@
     },
     "deepseek": {
       "label": "DeepSeek",
-      "monthly_budget_usd": 10.0
+      "monthly_budget_usd": 35.0,
+      "note": "Raised from $10 (set 2026-07-17, b9f287e9) — stale: that number predates three material widenings of DeepSeek's real routing footprint that were never revisited against it. (1) 2026-08-14 (config-I6562/-I7326): director/retro.py's retro judge was silently broken for 24 days (OpenRouter 400 on every call) and incurred ~$0 real DeepSeek spend; the fix routes it through krepis.router's `high` group, whose primary resolves to deepseek-v4-pro. (2) 2026-08-25 (config-I8350): reconcile-llm-model-registry had been red since 08-22 with DeepSeek pricing understated ~3x (in 0.435->1.32, out 0.87->3.96 per-unit) — corrected, but confirms DeepSeek is high's primary and one of ultra's arms. (3) 2026-09-04 (config-I9975, crucible v2 phase-0 router arc): `med` now serves from DeepSeek alone; `low`/`high`/`ultra` are deepseek+zhipu. None of that is misrouting — llm-provider-model-policy.md LPM-1 already prices the PRC/DeepSeek jurisdiction acceptance at ~$2K/mo at full volume, so a $10 placeholder was never meant to be the ceiling. 2026-09 MTD $2.71 -> projected $10.16 is the FIRST full month reflecting (3), 4 days in; $35 gives ~3.4x headroom over that projection while the new steady-state settles. Re-exam tracked as alpha-engine-config-I10279 (2026-10-08) against a full month of post-I9975 data."
     },
     "neon": {
       "label": "Neon Postgres",


### PR DESCRIPTION
## Two signals dispatched to this repo — both addressed

**Signal 1 (CI red — `automation_pause.py --check`: `alarm-undeclared` on `alpha-engine-eval-control-bands-no-datapoint`) was ALREADY FIXED on `main` before this branch was cut.** `nousergon-data#1653` ("chore(alarms): declare alpha-engine-eval-control-bands-no-datapoint as armed (alpha-engine-config-I10166)") merged 2026-09-08T23:09:06Z, classifying it in `armed_alarms` — verified live and correct: the emitter (`crucible-research/evals/control_bands.py`, weekly `EvalRollingMean` stage of `ne-weekly-freshness-pipeline`, a KEPT pipeline) publishes on every run including the healthy zero, and the weekly pipeline is running (largest observed gap 6 days). This branch is cut from `main` at `55ee0dba`, which already includes that fix — no further change needed here. Current `main` CI (CI, Deploy Infrastructure, Gitleaks) is green.

Also checked the standing "is a new alarm classified at birth" question: `nous-ergon-ops` already ships a birth-time gate (`config-I10086`, `infrastructure/cloudwatch/apply.py` + `alarm_declarations.py`, merged well before this incident) that fetches this repo's `automation_pause.json` and **refuses to create** an undeclared breaching alarm. The eval-control-bands alarm's brief unclassified window matches the known, accepted residual the gate's own docstring documents: the alarm-creating PR (`nous-ergon-ops-PR1111`) and its classification PR (`nousergon-data#1653`) are necessarily two separate cross-repo PRs, and the 4-hourly `pause-check-alert.yml` backstop is what closes that race — which it did, same day. Not a new detection gap; no new issue filed for it.

## Signal 2 — DeepSeek budget pacing (this PR's change)

`infrastructure/lambdas/expense-collector/expense_budgets.seed.json`: `providers.deepseek.monthly_budget_usd` $10 -> **$35**, with a `note` recording the rationale (mirrors the existing `anthropic_api` convention).

**Root cause: a stale budget number, not misrouting or a new/misplaced consumer.** The $10 figure was set 2026-07-17 (`b9f287e9`) and never revisited against three later, legitimate widenings of DeepSeek's real routing footprint:

1. **2026-08-14** (`config-I6562`/`-I7326`): `director/retro.py`'s retro judge was silently broken for 24 days (hand-built OpenRouter client passed a registry group handle as a literal model id -> 400 on every call) — near-zero real DeepSeek spend during the outage. Fixed to resolve through `krepis.router`'s `high` group, whose primary is `deepseek-v4-pro`.
2. **2026-08-25** (`config-I8350`): `reconcile-llm-model-registry` had been red since 08-22 with DeepSeek pricing understated ~3x (in $0.435->$1.32, out $0.87->$3.96 per-unit) — corrected, and confirms DeepSeek backs `high`'s primary and one of `ultra`'s arms.
3. **2026-09-04** (`config-I9975`, crucible v2 phase-0 router arc): `med` now serves from DeepSeek alone; `low`/`high`/`ultra` are deepseek+zhipu.

None of this is a routing defect to fix — `llm-provider-model-policy.md` LPM-1 already prices the PRC/DeepSeek jurisdiction acceptance at ~$2K/mo at full volume, so $10 was a placeholder, never the ceiling. 2026-09 MTD $2.71 -> projected $10.16 is the *first* full month reflecting (3), only 4 days in. $35 gives ~3.4x headroom over the current projection while the post-I9975 steady-state settles.

**Follow-up filed:** `alpha-engine-config-I10279` (`complexity:low`) — re-examine the $35 figure on 2026-10-08 against a full calendar month of post-I9975 spend; raise, lower, or confirm with the measured pace.

## Branching

Cut from `main` (`55ee0dba`), **not** from the open draft `nousergon-data#1664` (`nd-i10226-swallows`, except-Exception swallow sweep) — read its diff first; it touches `builders/daily_append.py`, `collectors/alternative.py`, `collectors/macro.py`, `emailer.py`, `features/compute.py`, `weekly_collector.py`, lambda `requirements.txt` pins, `.debug-swallow-allowlist.yaml` and its own new test file. This PR touches only `expense_budgets.seed.json`. No overlap either way.

## Test plan

- `.venv/bin/python3 -m pytest tests/ -q`: **7180 passed, 18 skipped, 1 failed** — the failure is `tests/test_macro_cumulative_history.py::test_prepend_emits_a_reconstructible_log_record`, the pre-existing, unrelated defect tracked as `alpha-engine-config-I10267` (also reproduces identically on unmodified `main`). Not fixed here, per dispatch instructions.
- `python3 -c "import json; json.load(open(...))"` — valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gZLcpKjEsuNK5EbTkkxA4