### PR TITLE
fix(eod): name the defect, tracked issue and clears-when in the daily DEGRADED alert (I10359)

### DIFF
--- a/.debug-swallow-allowlist.yaml
+++ b/.debug-swallow-allowlist.yaml
@@ -45,7 +45,7 @@ entries:
     expires: "2027-03-10"
     tracking: alpha-engine-config-I10226
   - path: weekly_collector.py
-    line: 1809
+    line: 1866
     reason: >-
       (a) failure mode swallowed: results["started_at"]/["completed_at"]
       missing or unparseable. (c) no recording surface — cosmetic duration
@@ -54,7 +54,7 @@ entries:
     expires: "2027-03-10"
     tracking: alpha-engine-config-I10226
   - path: weekly_collector.py
-    line: 3060
+    line: 3117
     reason: >-
       (a) failure mode swallowed: results["started_at"]/["completed_at"]
       missing or unparseable. (c) no recording surface — cosmetic duration
@@ -63,7 +63,7 @@ entries:
     expires: "2027-03-10"
     tracking: alpha-engine-config-I10226
   - path: weekly_collector.py
-    line: 3221
+    line: 3278
     reason: >-
       (a) failure mode swallowed: results["started_at"]/["completed_at"]
       missing or unparseable. (c) no recording surface — cosmetic duration

--- a/tests/test_degraded_alert_payload_names_defect_i10359.py
+++ b/tests/test_degraded_alert_payload_names_defect_i10359.py
@@ -1,0 +1,76 @@
+"""alpha-engine-config-I10359: the daily-collect DEGRADED alert must name the
+sub-component, the offending columns, the tracked issue and the clears-when
+condition — not a bare "features reported a known defect" every day.
+
+Measured live 2026-09-09: `weekly_collector.py`'s "Collection finished
+DEGRADED" log line was the sole content of flow-doctor's auto-filed GitHub
+issue (nousergon-data#1667, title "[DIAGNOSIS UNAVAILABLE]"), and it named
+nothing actionable — not which column, not alpha-engine-config-I7572 (the
+issue that has tracked this exact `factor_momentum_ratio` all-null defect
+since 2026-08-17), not what would clear it. The same message had already
+paged, identically, on at least 16 consecutive trading-day EOD runs
+(2026-08-18 through 2026-09-09, CloudWatch `/alpha-engine/data-spot`) with
+zero incremental information each time.
+
+`weekly_collector._describe_degraded_defects` is the fix: it turns a
+`degraded` collector's own reported `zero_variance_columns` /
+`all_null_columns` plus a small `_DEGRADED_DEFECT_REGISTRY` lookup into the
+`Defect detail: ...` clause folded into that same log line, so the string
+flow-doctor turns into an issue body carries the detail directly.
+"""
+from __future__ import annotations
+
+from weekly_collector import _DEGRADED_DEFECT_REGISTRY, _describe_degraded_defects
+
+
+def _results(all_null=None, zero_variance=None):
+    return {
+        "degraded_collectors": ["features"],
+        "collectors": {
+            "features": {
+                "status": "degraded",
+                "all_null_columns": all_null or [],
+                "zero_variance_columns": zero_variance or {},
+            },
+            "prices": {"status": "ok"},
+        },
+    }
+
+
+def test_known_defect_names_the_column_issue_and_clears_when():
+    detail = _describe_degraded_defects(
+        _results(all_null=["factor_momentum_ratio"])
+    )
+    assert "factor_momentum_ratio" in detail
+    assert _DEGRADED_DEFECT_REGISTRY["features"]["tracked_issue"] in detail
+    assert "clears_when" in detail
+    # The clears-when text itself, not just the label, must be present —
+    # a reader following this alert needs the condition, not a pointer to
+    # a key name.
+    assert _DEGRADED_DEFECT_REGISTRY["features"]["clears_when"] in detail
+
+
+def test_zero_variance_columns_are_named_too():
+    detail = _describe_degraded_defects(
+        _results(zero_variance={"earnings_surprise_pct": 902, "fcf_yield": 902})
+    )
+    assert "earnings_surprise_pct" in detail
+    assert "fcf_yield" in detail
+
+
+def test_an_unregistered_degraded_collector_reads_as_explicitly_untracked():
+    """A future collector reporting `degraded` with no registry entry must
+    not silently inherit the tracked shape — it must say UNTRACKED, loud."""
+    results = {
+        "degraded_collectors": ["some_new_collector"],
+        "collectors": {"some_new_collector": {"status": "degraded"}},
+    }
+    detail = _describe_degraded_defects(results)
+    assert "UNTRACKED" in detail
+    assert "some_new_collector" in detail
+
+
+def test_features_registry_entry_points_at_i7572():
+    """Pins the current live tracked issue so a rename/retarget is a visible
+    diff here, not a silent drift between the code and the tracker."""
+    assert _DEGRADED_DEFECT_REGISTRY["features"]["tracked_issue"] == "alpha-engine-config-I7572"

--- a/weekly_collector.py
+++ b/weekly_collector.py
@@ -136,6 +136,63 @@ def _load_chronic_polygon_gaps(config: dict) -> list[str]:
     return sorted(tickers.keys())
 
 
+# A recurring `status=degraded` collector must page with the SAME actionable
+# detail every day: which sub-defect, the issue tracking it, and the
+# condition that clears it — without these a human cannot tell today's page
+# from yesterday's (alpha-engine-config-I10359). Keyed by collector name;
+# extend when a new producer starts reporting `degraded`. Do NOT downgrade
+# severity or de-dupe this away while an entry's issue stays open — I7572's
+# own non-inferable gotcha forbids weakening the zero-variance guard's
+# visibility, and a recurring page for a genuinely still-broken producer
+# defect is the correct behavior until the tracked issue actually closes.
+_DEGRADED_DEFECT_REGISTRY: dict[str, dict[str, str]] = {
+    "features": {
+        "tracked_issue": "alpha-engine-config-I7572",
+        "clears_when": (
+            "every named column shows non-zero cross-sectional std on a live "
+            "s3://alpha-engine-research/features/<date>/*.parquet snapshot, "
+            "or is removed from features/registry.py::CATALOG + SCHEMA.md §3"
+        ),
+    },
+}
+
+
+def _describe_degraded_defects(results: dict) -> str:
+    """Build the `Defect detail: ...` clause of the DEGRADED alert.
+
+    Pulled out of ``main()`` so it can be unit-tested without driving the
+    whole daily-collect entrypoint (alpha-engine-config-I10359): a recurring
+    ``degraded`` page must name, per degraded collector, the offending
+    columns, the tracked issue, and the condition that clears it — a human
+    (or the flow-doctor notifier that turns this exact string into a GitHub
+    issue body) must not have to re-derive that from source on the day it
+    pages. A collector missing from ``_DEGRADED_DEFECT_REGISTRY`` reads as
+    explicitly ``UNTRACKED``, never silently blended into the tracked shape.
+    """
+    degraded_names = results.get("degraded_collectors", [])
+    lines = []
+    for name in degraded_names:
+        info = results.get("collectors", {}).get(name, {}) or {}
+        cols = sorted({
+            *(info.get("zero_variance_columns") or {}).keys(),
+            *(info.get("all_null_columns") or []),
+        })
+        reg = _DEGRADED_DEFECT_REGISTRY.get(name)
+        if reg:
+            lines.append(
+                f"{name}: columns={cols or '?'} "
+                f"tracked={reg['tracked_issue']} "
+                f"clears_when={reg['clears_when']}"
+            )
+        else:
+            lines.append(
+                f"{name}: columns={cols or '?'} tracked=UNTRACKED — file an "
+                "alpha-engine-config issue and add a "
+                "_DEGRADED_DEFECT_REGISTRY entry for this collector"
+            )
+    return " | ".join(lines) or "no detail available"
+
+
 class _CollectorError(RuntimeError):
     """Raised inside a phase block when a collector returns ``status=error`` so the
     phase writes an ``error`` marker (→ a recovery RE-RUNS it) instead of a lying
@@ -3617,9 +3674,10 @@ def main() -> None:
         logger.error(
             "Collection finished DEGRADED — the artifact was produced and the "
             "pipeline continues, but %s reported a known defect. Exiting 0 so "
-            "the EOD SF still runs the ArcticDB append and EODReconcile; the "
-            "defect is tracked, not swallowed. Per-collector statuses: %s",
+            "the EOD SF still runs the ArcticDB append and EODReconcile. "
+            "Defect detail: %s. Per-collector statuses: %s",
             ", ".join(results.get("degraded_collectors", [])) or "a collector",
+            _describe_degraded_defects(results),
             {k: v.get("status", "?") for k, v in results.get("collectors", {}).items()},
         )
     if results["status"] not in ("ok", "skipped", "degraded"):


### PR DESCRIPTION
## What

The daily `[ERROR] data-collector` page ends `features: 'degraded'` and asserts *"the defect is tracked, not swallowed"* — while naming **no defect, no issue, and no clearing condition**. It has read identically for 16+ consecutive days. A recurring page a human cannot distinguish from yesterday's, and cannot act on, is alert fatigue by construction.

This adds the missing detail to the alert payload. `_describe_degraded_defects()` names, per degraded collector: the offending columns, the tracked issue, and the condition that clears it.

## The underlying defect this page is about

`factor_momentum_ratio` is still **0/901 non-null on the EOD daily path** despite `alpha-engine-config-I7572`'s #1422/#1452 fixes — filed as **alpha-engine-config-I10359** (P1, `complexity:high`). This PR does not fix that; it makes the page say so.

## Why a registry rather than derivation

`_DEGRADED_DEFECT_REGISTRY` maps collector name to `{tracked_issue, clears_when}`. That mapping is not derivable from the collector's own output — a producer knows a column is dead, not which issue tracks it. A collector missing from the registry renders explicitly as `tracked=UNTRACKED` with the instruction to file one; it is never silently blended into the tracked shape. Fail-loud, per fleet standing rules.

## Deliberately NOT done

**No severity downgrade and no de-duplication.** I7572's own non-inferable gotcha forbids weakening the zero-variance guard's visibility, and a recurring page for a genuinely still-broken producer is correct behaviour until the tracked issue actually closes. The right place to decide that this class should stop paging is the routing tier, not the producer — see `alpha-engine-config-I6751`.

## Tests

- `tests/test_degraded_alert_payload_names_defect_i10359.py` — 4 passed.
- `tests/test_alert_message_lint.py`, `test_alert_class_pr_guard.py`, `test_alert_class_registry_drift.py`, all `test_weekly_collector_*.py` — 219 passed.
- `tests/test_no_debug_only_swallows.py` could not be collected **locally only**: it imports `nousergon_lib.testing.debug_swallow_guard`, which this repo pins at `v0.124.116` (requirements.txt:134,140) while this laptop's global interpreter carries `0.124.103`. Environmental, verified against the repo's own pin per `alpha-engine-config-I9070`. CI runs the pin and covers it.

Tracker: `alpha-engine-config-I10359` (cross-repo, so no closing keyword — it stays open; this PR is the payload fix, not the `factor_momentum_ratio` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz1Xdg5AgKAH1CkVxWDe3
