### PR TITLE
Tier every alert class, and publish the routing registry (I6751 Phase 1)

### DIFF
--- a/.github/workflows/sync-alert-tier-registry.yml
+++ b/.github/workflows/sync-alert-tier-registry.yml
@@ -1,0 +1,104 @@
+name: Sync alert tier registry to S3
+
+# Publishes the DELIVERY-TIER routing document distilled from
+# infrastructure/overseer/playbooks.yaml::alert_classes to the S3 object that
+# `krepis.alert_tiers` reads on every fleet alert.
+#
+# WHY THIS EXISTS
+#
+# alpha-engine-config-I6751 Phase 1. `krepis.alerts.publish` now resolves
+# delivery (page / notify-silent / tracked-only) from the alert CLASS keyed on
+# `source`, not from the severity string a call site picked. krepis is a PyPI
+# library imported by Lambdas, spot boxes and the laptop; none of them check
+# this repository out, and vendoring a copy of the tier table into krepis is
+# alpha-engine-config-I10121's bug class (iam-drift-check needed a hand-kept
+# twin of a source it could have read, and reddened `main` four times in three
+# days). So the table stays here and is PUBLISHED.
+#
+# TWO ARMS, ON PURPOSE — deliberately mirroring sync-llm-model-registry.yml and
+# sync-artifact-registry.yml in alpha-engine-config (shared-code-policy: third
+# adoption; all three remain thin wrappers over a validator plus a put, so
+# there is nothing yet worth lifting into a shared action).
+#
+#   push      publish on merge, then READ THE OBJECT BACK and compare the
+#             source digest. A put that exits 0 is an event; the read-back is
+#             the effect (principles.md 2.3 — a loop that does not verify its
+#             own action is not closed).
+#   schedule  assert repo == S3 with nothing to publish. This is the arm that
+#             survives what the push arm cannot see: a path filter that stops
+#             matching, a disabled workflow, a hand-edit straight to the
+#             bucket. Without it, "the publish never fired" and "the publish
+#             fired and worked" are the same shape on every surface
+#             (principles.md 2.7).
+#
+# WHAT FAILURE LOOKS LIKE, AND WHY IT IS SAFE
+#
+# A stale or absent object does not silence anything: `krepis.alert_tiers`
+# fails UPWARD, routing every source to `page` and marking each emission
+# `registry_drift`. That is today's behaviour (37 emails a day), which is loud
+# and recoverable — the opposite direction would be silent.
+#
+# IAM: `github-actions-lambda-deploy` already carries s3:PutObject/GetObject on
+# arn:aws:s3:::alpha-engine-research/* (the same grant the artifact-registry
+# and model-registry syncs use). No IAM change accompanies this workflow.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infrastructure/overseer/playbooks.yaml'
+      - 'infrastructure/overseer/playbooks.schema.json'
+      - 'infrastructure/overseer/publish_alert_tier_registry.py'
+      - '.github/workflows/sync-alert-tier-registry.yml'
+  schedule:
+    # Daily 13:20 UTC. The registry gates every fleet notification, so the
+    # drift arm runs daily rather than weekly: a day of undetected drift is a
+    # day of alerts routed by a table nobody is looking at.
+    - cron: '20 13 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-alert-tier-registry-main
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync:
+    name: Publish + verify the alert tier registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout data repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          aws-region: us-east-1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install validator dependencies
+        run: python -m pip install --quiet 'pyyaml==6.0.2' 'jsonschema==4.23.0' 'boto3==1.35.99'
+
+      - name: Publish and verify (merge / manual)
+        if: github.event_name != 'schedule'
+        run: python infrastructure/overseer/publish_alert_tier_registry.py
+
+      - name: Assert the published registry still matches the repo (drift arm)
+        if: github.event_name == 'schedule'
+        run: python infrastructure/overseer/publish_alert_tier_registry.py --assert-in-sync
+
+  notify-main-failure:
+    needs: [sync]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@5a434a599a4fba3e6201db43d6453c3ecffbba29 # main
+    secrets: inherit

--- a/infrastructure/overseer/alert_class_pr_guard.py
+++ b/infrastructure/overseer/alert_class_pr_guard.py
@@ -319,13 +319,36 @@ def class_name_for(source: str) -> str:
     return slug[:60].strip("_")
 
 
+#: Suggested tier for a newly-detected source, by the emitted severity. This
+#: is a STARTING POINT the author must justify, not a verdict: the tier is a
+#: statement about ACTIONABILITY (is something broken?), and severity is only
+#: the best evidence available before a human has read the call site
+#: (alpha-engine-config-I6751; observability-policy.md 7.1 — derived where
+#: derivable, declared where not). `dynamic` is suggested where the emitter
+#: picks its severity at runtime, which is exactly when it is not derivable
+#: here.
+_SUGGESTED_TIER: dict[str, str] = {
+    "critical": "page",
+    "alarm": "page",
+    "error": "notify-silent",
+    "warning": "tracked-only",
+    "info": "tracked-only",
+    "dynamic": "dynamic",
+}
+
+
 def row_yaml(source: str, severity: str) -> str:
+    tier = _SUGGESTED_TIER.get(severity, "page")
     return (
         f"  - class: {class_name_for(source)}\n"
         f"    source: {source}\n"
         f"    severities: [{severity}]\n"
         f"    intake: bus\n"
         f"    response: drain-queue\n"
+        f"    # tier suggested from severity={severity!r}; CONFIRM it against\n"
+        f"    # actionability -- page only if something is BROKEN and cannot\n"
+        f"    # wait for the next console look (alpha-engine-config-I6751).\n"
+        f"    tier: {tier}\n"
     )
 
 

--- a/infrastructure/overseer/playbooks.schema.json
+++ b/infrastructure/overseer/playbooks.schema.json
@@ -1,86 +1,140 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Nousergon Overseer playbook registry v1",
-  "description": "Contract for infrastructure/overseer/playbooks.yaml (alpha-engine-config-I2823). Additive-only evolution: new fields must be optional; renames/removals require a schema_version bump. The optional `liveness` (per-playbook) and `watch_plane_liveness` (top-level) blocks (alpha-engine-config-I2831) drive the registry-driven overseer-liveness-probe — added additively, schema_version unchanged. The optional `trigger_type` discriminant (alpha-engine-config-I2928 Phase 3) models a second trigger topology for `routed: false` inventory-only entries that have NO Lambda at all (pure GitHub Actions cron, e.g. the gate-due-sweep.yml daily job) — it defaults to `lambda_dispatch` when absent, so every entry written before this field existed remains valid unchanged; `github_actions_cron` entries require `workflow_file`/`repo` instead of the executor_*/kill_switch_env fields.",
+  "description": "Contract for infrastructure/overseer/playbooks.yaml (alpha-engine-config-I2823). Additive-only evolution: new fields must be optional; renames/removals require a schema_version bump. The optional `liveness` (per-playbook) and `watch_plane_liveness` (top-level) blocks (alpha-engine-config-I2831) drive the registry-driven overseer-liveness-probe \u2014 added additively, schema_version unchanged. The optional `trigger_type` discriminant (alpha-engine-config-I2928 Phase 3) models a second trigger topology for `routed: false` inventory-only entries that have NO Lambda at all (pure GitHub Actions cron, e.g. the gate-due-sweep.yml daily job) \u2014 it defaults to `lambda_dispatch` when absent, so every entry written before this field existed remains valid unchanged; `github_actions_cron` entries require `workflow_file`/`repo` instead of the executor_*/kill_switch_env fields.",
   "type": "object",
-  "required": ["schema_version", "playbooks"],
+  "required": [
+    "schema_version",
+    "playbooks"
+  ],
   "additionalProperties": false,
   "properties": {
-    "schema_version": { "const": 1 },
+    "schema_version": {
+      "const": 1
+    },
     "playbooks": {
       "type": "object",
       "minProperties": 1,
-      "propertyNames": { "pattern": "^[a-z0-9-]{1,40}$" },
+      "propertyNames": {
+        "pattern": "^[a-z0-9-]{1,40}$"
+      },
       "additionalProperties": {
         "type": "object",
         "required": [
-          "description", "tier", "routed", "enabled",
-          "concurrency_domain", "supports_drill"
+          "description",
+          "tier",
+          "routed",
+          "enabled",
+          "concurrency_domain",
+          "supports_drill"
         ],
         "additionalProperties": false,
         "properties": {
-          "description": { "type": "string", "minLength": 10 },
-          "tier": { "enum": ["T0", "T1", "T2", "T3"] },
-          "routed": { "type": "boolean" },
-          "enabled": { "type": "boolean" },
-          "trigger_type": {
-            "enum": ["lambda_dispatch", "github_actions_cron"],
-            "description": "Discriminant for the entry's trigger topology. Defaults to lambda_dispatch when absent — every entry written before this field existed stays valid unchanged (additive-only evolution). github_actions_cron marks entries with NO Lambda at all (pure GHA cron); those require workflow_file/repo instead of the executor_*/kill_switch_env fields."
+          "description": {
+            "type": "string",
+            "minLength": 10
           },
-          "executor_function": { "type": "string", "pattern": "^alpha-engine-[a-z0-9-]+$" },
-          "executor_lambda_dir": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "tier": {
+            "enum": [
+              "T0",
+              "T1",
+              "T2",
+              "T3"
+            ]
+          },
+          "routed": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "trigger_type": {
+            "enum": [
+              "lambda_dispatch",
+              "github_actions_cron"
+            ],
+            "description": "Discriminant for the entry's trigger topology. Defaults to lambda_dispatch when absent \u2014 every entry written before this field existed stays valid unchanged (additive-only evolution). github_actions_cron marks entries with NO Lambda at all (pure GHA cron); those require workflow_file/repo instead of the executor_*/kill_switch_env fields."
+          },
+          "executor_function": {
+            "type": "string",
+            "pattern": "^alpha-engine-[a-z0-9-]+$"
+          },
+          "executor_lambda_dir": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
           "benign_reasons": {
             "type": "array",
-            "items": { "type": "string", "pattern": "^[a-z_]+$" },
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z_]+$"
+            },
             "minItems": 1
           },
-          "charter": { "type": "string" },
-          "concurrency_domain": { "type": "string" },
-          "supports_drill": { "type": "boolean" },
-          "triggers": { "$ref": "#/$defs/triggers" },
+          "charter": {
+            "type": "string"
+          },
+          "concurrency_domain": {
+            "type": "string"
+          },
+          "supports_drill": {
+            "type": "boolean"
+          },
+          "triggers": {
+            "$ref": "#/$defs/triggers"
+          },
           "on_concurrent": {
-            "enum": ["defer", "skip"],
-            "description": "config-#5286 — what the dispatcher does when a concurrency collision is detected. 'defer' schedules a delayed re-invoke (sf-watch defer-not-drop pattern); 'skip' returns concurrent_skip immediately (ci-watch, alert-drain pattern). Must match the executor's actual behavior; the registry test pins this to the executor's literals."
+            "enum": [
+              "defer",
+              "skip"
+            ],
+            "description": "config-#5286 \u2014 what the dispatcher does when a concurrency collision is detected. 'defer' schedules a delayed re-invoke (sf-watch defer-not-drop pattern); 'skip' returns concurrent_skip immediately (ci-watch, alert-drain pattern). Must match the executor's actual behavior; the registry test pins this to the executor's literals."
           },
           "attempt_ceiling": {
             "type": "integer",
             "minimum": 1,
-            "description": "config-#5286 — maximum number of dispatch attempts before the executor stops retrying. For 'defer' semantics, this is the defer generation cap (sf-watch: 3). For 'skip' semantics, this is 1 — skip on first collision with no retry. The overseer-dispatcher injects this into the executor payload; the executor's own hardcoded default is the fallback for non-router invocation paths."
+            "description": "config-#5286 \u2014 maximum number of dispatch attempts before the executor stops retrying. For 'defer' semantics, this is the defer generation cap (sf-watch: 3). For 'skip' semantics, this is 1 \u2014 skip on first collision with no retry. The overseer-dispatcher injects this into the executor payload; the executor's own hardcoded default is the fallback for non-router invocation paths."
           },
           "lease_seconds": {
             "type": "integer",
             "minimum": 1,
-            "description": "config-#5286 — duration in seconds for the concurrency lock lease. For tag-based instance locks (the fleet's standard pattern), this is the TTL before the lock is considered stale. Optional — absent means the lock is instance-lifetime-based (exists until the EC2 instance terminates)."
+            "description": "config-#5286 \u2014 duration in seconds for the concurrency lock lease. For tag-based instance locks (the fleet's standard pattern), this is the TTL before the lock is considered stale. Optional \u2014 absent means the lock is instance-lifetime-based (exists until the EC2 instance terminates)."
           },
           "drill_isolation": {
             "type": "boolean",
-            "description": "config-#5286 — whether drill runs are structurally isolated from real dispatch collisions. When true, a drill's effective dispatch key never collides with a real dispatch key (e.g. a 'drill-' prefix on run_date). When false or absent, drills share the same concurrency domain as real dispatches."
+            "description": "config-#5286 \u2014 whether drill runs are structurally isolated from real dispatch collisions. When true, a drill's effective dispatch key never collides with a real dispatch key (e.g. a 'drill-' prefix on run_date). When false or absent, drills share the same concurrency domain as real dispatches."
           },
           "custom_executor": {
             "type": "boolean",
-            "description": "config-#5286 — escape hatch for playbooks whose dispatch logic is genuinely bespoke and cannot be expressed through registry semantics. When true, the overseer-dispatcher skips injecting dispatch-semantics fields (the executor manages its own concurrency/attempts/lease/drill behavior entirely). Default: false when absent. Groom is the canonical permanent holdout (its pace/demand/tier logic predates and cannot be expressed through the instance-level dispatch primitives)."
+            "description": "config-#5286 \u2014 escape hatch for playbooks whose dispatch logic is genuinely bespoke and cannot be expressed through registry semantics. When true, the overseer-dispatcher skips injecting dispatch-semantics fields (the executor manages its own concurrency/attempts/lease/drill behavior entirely). Default: false when absent. Groom is the canonical permanent holdout (its pace/demand/tier logic predates and cannot be expressed through the instance-level dispatch primitives)."
           },
-          "kill_switch_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
+          "kill_switch_env": {
+            "type": "string",
+            "pattern": "^[A-Z0-9_]+$"
+          },
           "model": {
             "type": "string",
             "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$",
-            "description": "config-I3293 — the model this playbook's agent runs (provider-agnostic since alpha-engine-config-I4478; was claude-only, which could not express the fleet's DeepSeek-primary policy). LIVE config, not documentation: the overseer-dispatcher injects it into the executor payload as `model`; executors thread it to the run script. The run script's inline default is the fallback only for non-router invocation paths. Required (via registry test, not schema) on every routed playbook whose executor launches a claude-CLI agent."
+            "description": "config-I3293 \u2014 the model this playbook's agent runs (provider-agnostic since alpha-engine-config-I4478; was claude-only, which could not express the fleet's DeepSeek-primary policy). LIVE config, not documentation: the overseer-dispatcher injects it into the executor payload as `model`; executors thread it to the run script. The run script's inline default is the fallback only for non-router invocation paths. Required (via registry test, not schema) on every routed playbook whose executor launches a claude-CLI agent."
           },
           "wake": {
             "type": "array",
-            "items": { "type": "string", "minLength": 10 },
+            "items": {
+              "type": "string",
+              "minLength": 10
+            },
             "minItems": 1,
-            "description": "config-I3293 — human-readable enumeration of everything that launches this playbook's agent (eventbridge rules, scheduler schedules, event-time dispatch paths). Names of scheduler:/eventbridge: resources mentioned here should also appear in a liveness check; the registry test pins the drain-schedule set."
+            "description": "config-I3293 \u2014 human-readable enumeration of everything that launches this playbook's agent (eventbridge rules, scheduler schedules, event-time dispatch paths). Names of scheduler:/eventbridge: resources mentioned here should also appear in a liveness check; the registry test pins the drain-schedule set."
           },
           "cadence": {
             "type": "string",
             "minLength": 5,
-            "description": "config-I3293 — one-line answer to 'is there a scheduled wake, and when' (e.g. 'event-driven only', '4x daily 04:00/10:00/16:00/22:00 UTC + event-time on freshness criticals')."
+            "description": "config-I3293 \u2014 one-line answer to 'is there a scheduled wake, and when' (e.g. 'event-driven only', '4x daily 04:00/10:00/16:00/22:00 UTC + event-time on freshness criticals')."
           },
           "workflow_file": {
             "type": "string",
             "pattern": "^\\.github/workflows/[a-z0-9_-]+\\.ya?ml$",
-            "description": "Path (in `repo`) to the GitHub Actions workflow file that IS this entry's trigger — only meaningful when trigger_type is github_actions_cron."
+            "description": "Path (in `repo`) to the GitHub Actions workflow file that IS this entry's trigger \u2014 only meaningful when trigger_type is github_actions_cron."
           },
           "repo": {
             "type": "string",
@@ -90,42 +144,77 @@
           "schedule_cron": {
             "type": "string",
             "minLength": 9,
-            "description": "Literal cron expression from the workflow_file's `on.schedule`, for humans reading the registry — not parsed/enforced by tooling."
+            "description": "Literal cron expression from the workflow_file's `on.schedule`, for humans reading the registry \u2014 not parsed/enforced by tooling."
           },
           "sibling_probe_function": {
             "type": "string",
             "pattern": "^alpha-engine-[a-z0-9-]+$",
-            "description": "config#4474 — name of a dedicated sibling Lambda probe that covers this playbook's liveness independently (e.g. canary-replay-liveness-probe). When set, the registry's cadence→liveness contract test accepts this as proof of alternative coverage instead of requiring a run_window or invocation-success check in this entry's liveness block."
+            "description": "config#4474 \u2014 name of a dedicated sibling Lambda probe that covers this playbook's liveness independently (e.g. canary-replay-liveness-probe). When set, the registry's cadence\u2192liveness contract test accepts this as proof of alternative coverage instead of requiring a run_window or invocation-success check in this entry's liveness block."
           },
           "execution_surface": {
-            "enum": ["spot", "lambda", "laptop-launchd"],
-            "description": "config-I4993 G17 — the execution substrate this playbook runs on. 'spot' (EC2 spot instance, the fleet default), 'lambda' (serverless function invocation), 'laptop-launchd' (local macOS launchd agent running from the working tree — the laptop janitor and usage-tracker agents). Absent defaults to 'spot' for backwards compatibility (every entry written before this field existed)."
+            "enum": [
+              "spot",
+              "lambda",
+              "laptop-launchd"
+            ],
+            "description": "config-I4993 G17 \u2014 the execution substrate this playbook runs on. 'spot' (EC2 spot instance, the fleet default), 'lambda' (serverless function invocation), 'laptop-launchd' (local macOS launchd agent running from the working tree \u2014 the laptop janitor and usage-tracker agents). Absent defaults to 'spot' for backwards compatibility (every entry written before this field existed)."
           },
-          "liveness": { "$ref": "#/$defs/liveness_block" }
+          "liveness": {
+            "$ref": "#/$defs/liveness_block"
+          }
         },
         "allOf": [
           {
-            "if": { "properties": { "routed": { "const": true } } },
-            "then": { "required": ["benign_reasons"] }
-          },
-          {
             "if": {
-              "not": {
-                "properties": { "trigger_type": { "const": "github_actions_cron" } },
-                "required": ["trigger_type"]
+              "properties": {
+                "routed": {
+                  "const": true
+                }
               }
             },
             "then": {
-              "required": ["executor_function", "executor_lambda_dir", "kill_switch_env"]
+              "required": [
+                "benign_reasons"
+              ]
             }
           },
           {
             "if": {
-              "properties": { "trigger_type": { "const": "github_actions_cron" } },
-              "required": ["trigger_type"]
+              "not": {
+                "properties": {
+                  "trigger_type": {
+                    "const": "github_actions_cron"
+                  }
+                },
+                "required": [
+                  "trigger_type"
+                ]
+              }
             },
             "then": {
-              "required": ["workflow_file", "repo"]
+              "required": [
+                "executor_function",
+                "executor_lambda_dir",
+                "kill_switch_env"
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "trigger_type": {
+                  "const": "github_actions_cron"
+                }
+              },
+              "required": [
+                "trigger_type"
+              ]
+            },
+            "then": {
+              "required": [
+                "workflow_file",
+                "repo"
+              ]
             }
           }
         ]
@@ -134,13 +223,27 @@
     "t1_automations": {
       "type": "array",
       "minItems": 0,
-      "description": "T1 authority tier — named deterministic remediations for known-shape failures (overseer-policy.md §6). Each entry is a reviewed, non-agentic automation the alert-drain charter executes BEFORE T2 classification. Promotion requires ≥3 occurrences, deterministic remediation, verifiable success predicate, rollback path, and a reviewed authorizing issue. Demotion is automatic: ≥max_consecutive_failures predicate failures → entry disabled + finding filed. Runtime state (consecutive_failure count, demotion status) is tracked in the drain carryover ledger, NOT here — this file is the static registry.",
+      "description": "T1 authority tier \u2014 named deterministic remediations for known-shape failures (overseer-policy.md \u00a76). Each entry is a reviewed, non-agentic automation the alert-drain charter executes BEFORE T2 classification. Promotion requires \u22653 occurrences, deterministic remediation, verifiable success predicate, rollback path, and a reviewed authorizing issue. Demotion is automatic: \u2265max_consecutive_failures predicate failures \u2192 entry disabled + finding filed. Runtime state (consecutive_failure count, demotion status) is tracked in the drain carryover ledger, NOT here \u2014 this file is the static registry.",
       "items": {
         "type": "object",
-        "required": ["name", "description", "authorized_by", "added", "match", "remediation_steps", "success_predicate", "rollback", "max_consecutive_failures"],
+        "required": [
+          "name",
+          "description",
+          "authorized_by",
+          "added",
+          "match",
+          "remediation_steps",
+          "success_predicate",
+          "rollback",
+          "max_consecutive_failures"
+        ],
         "dependentRequired": {
-          "reauthorized_at": ["reauthorized_by"],
-          "reauthorized_by": ["reauthorized_at"]
+          "reauthorized_at": [
+            "reauthorized_by"
+          ],
+          "reauthorized_by": [
+            "reauthorized_at"
+          ]
         },
         "additionalProperties": false,
         "properties": {
@@ -152,12 +255,12 @@
           "description": {
             "type": "string",
             "minLength": 20,
-            "description": "What this automation handles — human-readable scope statement."
+            "description": "What this automation handles \u2014 human-readable scope statement."
           },
           "authorized_by": {
             "type": "string",
             "pattern": "^[a-z0-9-]+-I[0-9]+$",
-            "description": "Reviewed issue authorizing this T1 promotion (overseer-policy.md §6 requirement)."
+            "description": "Reviewed issue authorizing this T1 promotion (overseer-policy.md \u00a76 requirement)."
           },
           "added": {
             "type": "string",
@@ -166,7 +269,9 @@
           },
           "match": {
             "type": "object",
-            "required": ["alert_class"],
+            "required": [
+              "alert_class"
+            ],
             "additionalProperties": false,
             "properties": {
               "alert_class": {
@@ -177,8 +282,17 @@
               "severities": {
                 "type": "array",
                 "minItems": 1,
-                "items": { "enum": ["info", "warning", "error", "critical", "alarm", "dynamic"] },
-                "description": "Optional — limit to specific severities. When absent, matches all severities of the alert_class."
+                "items": {
+                  "enum": [
+                    "info",
+                    "warning",
+                    "error",
+                    "critical",
+                    "alarm",
+                    "dynamic"
+                  ]
+                },
+                "description": "Optional \u2014 limit to specific severities. When absent, matches all severities of the alert_class."
               },
               "key_contains": {
                 "type": "string",
@@ -191,7 +305,7 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 10,
-            "description": "Deterministic steps the drain agent executes when this automation matches. Each step must be mechanical — no agent judgment, no branching. Steps are executed in order; any step that fails (cannot be completed mechanically) is a predicate failure.",
+            "description": "Deterministic steps the drain agent executes when this automation matches. Each step must be mechanical \u2014 no agent judgment, no branching. Steps are executed in order; any step that fails (cannot be completed mechanically) is a predicate failure.",
             "items": {
               "type": "string",
               "minLength": 10
@@ -199,7 +313,10 @@
           },
           "success_predicate": {
             "type": "object",
-            "required": ["description", "check"],
+            "required": [
+              "description",
+              "check"
+            ],
             "additionalProperties": false,
             "properties": {
               "description": {
@@ -216,7 +333,9 @@
           },
           "rollback": {
             "type": "object",
-            "required": ["description"],
+            "required": [
+              "description"
+            ],
             "additionalProperties": false,
             "properties": {
               "description": {
@@ -231,49 +350,148 @@
             "minimum": 1,
             "maximum": 10,
             "default": 2,
-            "description": "Number of consecutive FAILED outcomes before automatic demotion to T2 + finding filed (overseer-policy.md §6). config-I8686 (Brian ruling 2026-08-26): a run resolves to exactly one of verified / declined / failed, and ONLY `failed` — the automation could not EVALUATE its predicate (crash, timeout, unreadable input, malformed payload) — increments this counter. `declined` (the predicate was evaluated and is not satisfied) is the automation giving the CORRECT answer and is silent on the counter in both directions. Collapsing the two demotes an automation precisely when the fleet is broken, which is when its coverage is worth most."
+            "description": "Number of consecutive FAILED outcomes before automatic demotion to T2 + finding filed (overseer-policy.md \u00a76). config-I8686 (Brian ruling 2026-08-26): a run resolves to exactly one of verified / declined / failed, and ONLY `failed` \u2014 the automation could not EVALUATE its predicate (crash, timeout, unreadable input, malformed payload) \u2014 increments this counter. `declined` (the predicate was evaluated and is not satisfied) is the automation giving the CORRECT answer and is silent on the counter in both directions. Collapsing the two demotes an automation precisely when the fleet is broken, which is when its coverage is worth most."
           },
           "reauthorized_at": {
             "type": "string",
             "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-            "description": "config-I8686 — the date this automation was re-authorized after a demotion. The drain voids any demotion recorded in the carryover ledger with `demoted_at` earlier than this date, resetting the counter. Re-authorization is therefore a reviewed, merged registry diff rather than a hand-edit of ledger state in S3, which is what §6's 'a reviewed issue authorizing it' actually requires. Requires `reauthorized_by`."
+            "description": "config-I8686 \u2014 the date this automation was re-authorized after a demotion. The drain voids any demotion recorded in the carryover ledger with `demoted_at` earlier than this date, resetting the counter. Re-authorization is therefore a reviewed, merged registry diff rather than a hand-edit of ledger state in S3, which is what \u00a76's 'a reviewed issue authorizing it' actually requires. Requires `reauthorized_by`."
           },
           "reauthorized_by": {
             "type": "string",
             "pattern": "^[a-z0-9-]+-I[0-9]+$",
-            "description": "config-I8686 — the reviewed issue carrying the re-authorization ruling. Required whenever `reauthorized_at` is set."
+            "description": "config-I8686 \u2014 the reviewed issue carrying the re-authorization ruling. Required whenever `reauthorized_at` is set."
           },
-          "triggers": { "$ref": "#/$defs/triggers" }
+          "triggers": {
+            "$ref": "#/$defs/triggers"
+          }
         }
       }
     },
-    "watch_plane_liveness": { "$ref": "#/$defs/liveness_block" },
+    "watch_plane_liveness": {
+      "$ref": "#/$defs/liveness_block"
+    },
     "alert_classes": {
       "type": "array",
       "minItems": 1,
-      "description": "config-I3211 — one row per distinct fleet notification class: which intake path the overseer sees it on and the declared response. intake:none rows MUST carry migration_issue or operator_reason (no undeclared drain-blind class).",
+      "description": "config-I3211 \u2014 one row per distinct fleet notification class: which intake path the overseer sees it on and the declared response. intake:none rows MUST carry migration_issue or operator_reason (no undeclared drain-blind class).",
       "items": {
         "type": "object",
-        "required": ["class", "source", "severities", "intake", "response"],
+        "required": [
+          "class",
+          "source",
+          "severities",
+          "intake",
+          "response",
+          "tier"
+        ],
         "additionalProperties": false,
         "properties": {
-          "class": { "type": "string", "pattern": "^[a-z0-9_]{3,60}$" },
-          "source": { "type": "string", "minLength": 3 },
+          "class": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]{3,60}$"
+          },
+          "source": {
+            "type": "string",
+            "minLength": 3
+          },
           "severities": {
             "type": "array",
             "minItems": 1,
-            "items": { "enum": ["info", "warning", "error", "critical", "alarm", "dynamic"] }
+            "items": {
+              "enum": [
+                "info",
+                "warning",
+                "error",
+                "critical",
+                "alarm",
+                "dynamic"
+              ]
+            }
           },
-          "intake": { "enum": ["bus", "cw-alarm", "none"] },
-          "response": { "type": "string", "pattern": "^(drain-queue|operator|playbook:[a-z0-9-]+)$" },
-          "migration_issue": { "type": "string", "pattern": "^[a-z0-9-]+-I[0-9]+$" },
-          "operator_reason": { "type": "string", "minLength": 15 }
+          "intake": {
+            "enum": [
+              "bus",
+              "cw-alarm",
+              "none"
+            ]
+          },
+          "response": {
+            "type": "string",
+            "pattern": "^(drain-queue|operator|playbook:[a-z0-9-]+)$"
+          },
+          "migration_issue": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+-I[0-9]+$"
+          },
+          "operator_reason": {
+            "type": "string",
+            "minLength": 15
+          },
+          "tier": {
+            "enum": [
+              "page",
+              "notify-silent",
+              "tracked-only",
+              "dynamic"
+            ],
+            "description": "alpha-engine-config-I6751 Phase 1 (subsumes I6293). The DELIVERY tier, decided by actionability, not by the severity string. `page` = broken now, email + Telegram buzz. `notify-silent` = degraded/suboptimal or a lifecycle notice \u2014 Telegram silent, no email. `tracked-only` = hygiene/conformance/drift \u2014 zero notification; the drain's disposition issue IS the remediation path (observability-policy.md 7.4). `dynamic` = resolved per emission from the runtime severity (critical->page, error->notify-silent, warning/info->tracked-only), for rows whose `severities` is [dynamic] or whose seriousness genuinely varies with the observed facts (7.1: derived where derivable). Suppression is a DELIVERY decision only: every tier still emits its full signal set, its console state and its bus event (7.2a)."
+          },
+          "page_after_consecutive": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "alpha-engine-config-I6751. Consecutive detections of the SAME condition (same identity_key) required before a `page`-tier emission actually pages; earlier detections deliver at `notify-silent`. Default 1. DERIVED from the emitting job's cadence, never hand-listed per timer: 1 when the job's cadence exceeds the 60-minute operator-response floor, 2 when it does not \u2014 a job whose own next attempt lands before a human could act has not yet produced an actionable-now condition. Measured 2026-09-09: one failed run of the hourly metron-deploy-drift timer paged CRITICAL at 18:07 and INFO-RESOLVED at 19:07 for a condition that self-healed with no action available."
+          },
+          "episode_overrides": {
+            "type": "array",
+            "minItems": 1,
+            "description": "alpha-engine-config-I6751. Ordered per-EPISODE tier overrides for a class that is legitimately two conditions sharing one source -- the EOD reconciler's scheduled vendor substitution vs a genuinely bad provisional print (I10360), a crucible-v2 fault-injection replay vs a live failure (I10366). The FIRST entry whose every `when` key matches the emitter's `episode_attributes` exactly wins; nothing matching leaves the row's own `tier`. Adding an entry is a ROUTING DECISION -- no row declares one today, and both known candidates are on the Decision Queue.",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "when",
+                "tier"
+              ],
+              "properties": {
+                "when": {
+                  "type": "object",
+                  "minProperties": 1
+                },
+                "tier": {
+                  "enum": [
+                    "page",
+                    "notify-silent",
+                    "tracked-only"
+                  ]
+                },
+                "reason": {
+                  "type": "string",
+                  "minLength": 15
+                }
+              }
+            }
+          }
         },
-        "if": { "properties": { "intake": { "const": "none" } } },
+        "if": {
+          "properties": {
+            "intake": {
+              "const": "none"
+            }
+          }
+        },
         "then": {
           "anyOf": [
-            { "required": ["migration_issue"] },
-            { "required": ["operator_reason"] }
+            {
+              "required": [
+                "migration_issue"
+              ]
+            },
+            {
+              "required": [
+                "operator_reason"
+              ]
+            }
           ]
         }
       }
@@ -283,15 +501,24 @@
     "triggers": {
       "type": "array",
       "minItems": 1,
-      "description": "alpha-engine-config-I7056 — the machine-readable form of `wake`. `wake` is prose for a human and cannot be joined; this can. It is what lets infrastructure/overseer/arming.py join a playbook to infrastructure/automation_pause.json and to live AWS, which is the only way to tell a playbook DELIBERATELY paused (Brian ruling 2026-08-07, alpha-engine-config-I6617) from one that is simply broken — both emit nothing, and observability-policy.md §8.3 forbids reporting either as the other. Optional and additive: entries written before this field existed stay schema-valid, but arming.py reports any unit lacking it as `undeclared-no-triggers`, which is loud rather than blank.",
+      "description": "alpha-engine-config-I7056 \u2014 the machine-readable form of `wake`. `wake` is prose for a human and cannot be joined; this can. It is what lets infrastructure/overseer/arming.py join a playbook to infrastructure/automation_pause.json and to live AWS, which is the only way to tell a playbook DELIBERATELY paused (Brian ruling 2026-08-07, alpha-engine-config-I6617) from one that is simply broken \u2014 both emit nothing, and observability-policy.md \u00a78.3 forbids reporting either as the other. Optional and additive: entries written before this field existed stay schema-valid, but arming.py reports any unit lacking it as `undeclared-no-triggers`, which is loud rather than blank.",
       "items": {
         "type": "object",
-        "required": ["surface"],
+        "required": [
+          "surface"
+        ],
         "additionalProperties": false,
         "properties": {
           "surface": {
-            "enum": ["events", "scheduler", "github-actions", "event-time", "parent", "none"],
-            "description": "Which trigger plane this leg lives on. `events` (EventBridge rule) and `scheduler` (EventBridge Scheduler schedule) are DIFFERENT APIs, not aliases, and the two names match automation_pause.py's own vocabulary — they are the only surfaces whose live state arming.py can read. Every other value is reported `unjoinable` WITH its reason rather than silently assumed armed."
+            "enum": [
+              "events",
+              "scheduler",
+              "github-actions",
+              "event-time",
+              "parent",
+              "none"
+            ],
+            "description": "Which trigger plane this leg lives on. `events` (EventBridge rule) and `scheduler` (EventBridge Scheduler schedule) are DIFFERENT APIs, not aliases, and the two names match automation_pause.py's own vocabulary \u2014 they are the only surfaces whose live state arming.py can read. Every other value is reported `unjoinable` WITH its reason rather than silently assumed armed."
           },
           "name": {
             "type": "string",
@@ -315,14 +542,20 @@
           "depends_on": {
             "type": "array",
             "minItems": 1,
-            "description": "alpha-engine-config-I9045 — for a leg with no AWS trigger resource of its own (`surface: event-time`), the AWS resources whose live state IS this leg's arming. Measured 2026-08-28: alert-drain's four Scheduler schedules were all DISABLED and it ran every day off its event-time leg, which arming.py could only report `unjoinable` because `reason` said so in prose. With this, the leg resolves to `armed-via-dependency` or `dark-via-dependency`, and trigger_descriptions.py can stamp `[wakes: <playbook>]` onto the dispatching rule so the linkage is legible from `aws events list-rules` alone.",
+            "description": "alpha-engine-config-I9045 \u2014 for a leg with no AWS trigger resource of its own (`surface: event-time`), the AWS resources whose live state IS this leg's arming. Measured 2026-08-28: alert-drain's four Scheduler schedules were all DISABLED and it ran every day off its event-time leg, which arming.py could only report `unjoinable` because `reason` said so in prose. With this, the leg resolves to `armed-via-dependency` or `dark-via-dependency`, and trigger_descriptions.py can stamp `[wakes: <playbook>]` onto the dispatching rule so the linkage is legible from `aws events list-rules` alone.",
             "items": {
               "type": "object",
-              "required": ["surface", "name"],
+              "required": [
+                "surface",
+                "name"
+              ],
               "additionalProperties": false,
               "properties": {
                 "surface": {
-                  "enum": ["events", "scheduler"],
+                  "enum": [
+                    "events",
+                    "scheduler"
+                  ],
                   "description": "Only probeable surfaces may be depended on. A dependency whose own state cannot be read would move the blank rather than remove it."
                 },
                 "name": {
@@ -339,118 +572,238 @@
       "description": "A set of read-only liveness checks the overseer-liveness-probe runs for this playbook (or, at top level, for the cross-cutting intake/dispatcher plane). Each check is a discriminated union on `type`.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["checks"],
+      "required": [
+        "checks"
+      ],
       "properties": {
         "checks": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/check" }
+          "items": {
+            "$ref": "#/$defs/check"
+          }
         }
       }
     },
     "check": {
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "oneOf": [
         {
           "additionalProperties": false,
-          "required": ["type", "rule_name"],
+          "required": [
+            "type",
+            "rule_name"
+          ],
           "properties": {
-            "type": { "const": "eventbridge_rule" },
-            "rule_name": { "type": "string", "minLength": 1 },
-            "event_bus_name": { "type": "string", "minLength": 1 },
-            "expect_enabled": { "type": "boolean" },
-            "expect_target_function": { "type": "string", "pattern": "^alpha-engine-[a-z0-9-]+$" },
-            "expect_target_queue": { "type": "string", "minLength": 1 },
+            "type": {
+              "const": "eventbridge_rule"
+            },
+            "rule_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "event_bus_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expect_enabled": {
+              "type": "boolean"
+            },
+            "expect_target_function": {
+              "type": "string",
+              "pattern": "^alpha-engine-[a-z0-9-]+$"
+            },
+            "expect_target_queue": {
+              "type": "string",
+              "minLength": 1
+            },
             "expect_state_machines": {
               "type": "array",
               "minItems": 1,
-              "items": { "type": "string", "minLength": 1 }
-            }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "state_machines"],
-          "properties": {
-            "type": { "const": "state_machines_exist" },
-            "state_machines": {
-              "type": "array",
-              "minItems": 1,
-              "items": { "type": "string", "minLength": 1 }
-            }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "function"],
-          "properties": {
-            "type": { "const": "lambda_active" },
-            "function": { "type": "string", "pattern": "^alpha-engine-[a-z0-9-]+$" },
-            "report_kill_switch": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
-            "launch_config": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["ami_env", "security_group_env", "subnets_env"],
-              "properties": {
-                "ami_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
-                "security_group_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" },
-                "subnets_env": { "type": "string", "pattern": "^[A-Z0-9_]+$" }
+              "items": {
+                "type": "string",
+                "minLength": 1
               }
             }
           }
         },
         {
           "additionalProperties": false,
-          "required": ["type", "queue_name"],
+          "required": [
+            "type",
+            "state_machines"
+          ],
           "properties": {
-            "type": { "const": "sqs_queue_exists" },
-            "queue_name": { "type": "string", "minLength": 1 },
-            "expect_dlq": { "type": "string", "minLength": 1 }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "dlq_name", "report_prefix"],
-          "properties": {
-            "type": { "const": "sqs_dlq_content" },
-            "dlq_name": { "type": "string", "minLength": 1 },
-            "sample_max": { "type": "integer", "minimum": 1 },
-            "report_prefix": { "type": "string", "minLength": 1 }
+            "type": {
+              "const": "state_machines_exist"
+            },
+            "state_machines": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
           }
         },
         {
           "additionalProperties": false,
           "required": [
-            "type", "label", "artifact_prefix",
-            "ceiling_min", "margin_min", "lookback_hours", "schedule"
+            "type",
+            "function"
           ],
           "properties": {
-            "type": { "const": "run_window" },
-            "label": { "type": "string", "minLength": 1 },
-            "artifact_prefix": { "type": "string", "minLength": 1 },
-            "run_start_field": {
-              "description": "OPTIONAL, default 'run_start'. Name of the artifact field holding the run's start timestamp (ISO-8601). The fleet's run artifacts do NOT share one schema: the groom artifact carries 'run_start', the alert-drain ledger carries 'started_at'. An in-window artifact missing the DECLARED field raises rather than being skipped — the silent skip made 100% of mature alert-drain triggers read as silent deaths while the drain was running normally (false pages 2026-07-29). Retire once G16 (alpha-engine-config-I5284) unifies the execution artifact.",
+            "type": {
+              "const": "lambda_active"
+            },
+            "function": {
+              "type": "string",
+              "pattern": "^alpha-engine-[a-z0-9-]+$"
+            },
+            "report_kill_switch": {
+              "type": "string",
+              "pattern": "^[A-Z0-9_]+$"
+            },
+            "launch_config": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ami_env",
+                "security_group_env",
+                "subnets_env"
+              ],
+              "properties": {
+                "ami_env": {
+                  "type": "string",
+                  "pattern": "^[A-Z0-9_]+$"
+                },
+                "security_group_env": {
+                  "type": "string",
+                  "pattern": "^[A-Z0-9_]+$"
+                },
+                "subnets_env": {
+                  "type": "string",
+                  "pattern": "^[A-Z0-9_]+$"
+                }
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "queue_name"
+          ],
+          "properties": {
+            "type": {
+              "const": "sqs_queue_exists"
+            },
+            "queue_name": {
               "type": "string",
               "minLength": 1
             },
-            "decision_record_prefix": { "type": "string", "minLength": 1 },
-            "ceiling_min": { "type": "integer", "minimum": 1 },
-            "margin_min": { "type": "integer", "minimum": 0 },
-            "lookback_hours": { "type": "integer", "minimum": 1 },
+            "expect_dlq": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "dlq_name",
+            "report_prefix"
+          ],
+          "properties": {
+            "type": {
+              "const": "sqs_dlq_content"
+            },
+            "dlq_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sample_max": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "report_prefix": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "label",
+            "artifact_prefix",
+            "ceiling_min",
+            "margin_min",
+            "lookback_hours",
+            "schedule"
+          ],
+          "properties": {
+            "type": {
+              "const": "run_window"
+            },
+            "label": {
+              "type": "string",
+              "minLength": 1
+            },
+            "artifact_prefix": {
+              "type": "string",
+              "minLength": 1
+            },
+            "run_start_field": {
+              "description": "OPTIONAL, default 'run_start'. Name of the artifact field holding the run's start timestamp (ISO-8601). The fleet's run artifacts do NOT share one schema: the groom artifact carries 'run_start', the alert-drain ledger carries 'started_at'. An in-window artifact missing the DECLARED field raises rather than being skipped \u2014 the silent skip made 100% of mature alert-drain triggers read as silent deaths while the drain was running normally (false pages 2026-07-29). Retire once G16 (alpha-engine-config-I5284) unifies the execution artifact.",
+              "type": "string",
+              "minLength": 1
+            },
+            "decision_record_prefix": {
+              "type": "string",
+              "minLength": 1
+            },
+            "ceiling_min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "margin_min": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "lookback_hours": {
+              "type": "integer",
+              "minimum": 1
+            },
             "productive_when": {
-              "description": "OPTIONAL. An OR of clauses over the run artifact's own fields; an in-window artifact matching NONE of them is reported as a DEAD run (a box that booted and wrote an artifact while doing no work) — distinct from a MISSING artifact. Omit to keep existence-only semantics. Each clause is {field, <op>} with op in gt|ge|lt|le|eq; an operator outside that set RAISES in _rw_clause_holds rather than silently leaving the clause unsatisfied.",
+              "description": "OPTIONAL. An OR of clauses over the run artifact's own fields; an in-window artifact matching NONE of them is reported as a DEAD run (a box that booted and wrote an artifact while doing no work) \u2014 distinct from a MISSING artifact. Omit to keep existence-only semantics. Each clause is {field, <op>} with op in gt|ge|lt|le|eq; an operator outside that set RAISES in _rw_clause_holds rather than silently leaving the clause unsatisfied.",
               "type": "array",
               "minItems": 1,
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["field"],
+                "required": [
+                  "field"
+                ],
                 "minProperties": 2,
                 "maxProperties": 2,
                 "properties": {
-                  "field": { "type": "string", "minLength": 1 },
-                  "gt": {}, "ge": {}, "lt": {}, "le": {}, "eq": {}
+                  "field": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "gt": {},
+                  "ge": {},
+                  "lt": {},
+                  "le": {},
+                  "eq": {}
                 }
               }
             },
@@ -460,16 +813,34 @@
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["hour", "minute", "dows"],
+                "required": [
+                  "hour",
+                  "minute",
+                  "dows"
+                ],
                 "properties": {
-                  "hour": { "type": "integer", "minimum": 0, "maximum": 23 },
-                  "minute": { "type": "integer", "minimum": 0, "maximum": 59 },
+                  "hour": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 23
+                  },
+                  "minute": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 59
+                  },
                   "dows": {
                     "type": "array",
                     "minItems": 1,
-                    "items": { "type": "integer", "minimum": 0, "maximum": 6 }
+                    "items": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 6
+                    }
                   },
-                  "label": { "type": "string" }
+                  "label": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -477,74 +848,167 @@
         },
         {
           "additionalProperties": false,
-          "required": ["type", "schedule_name"],
+          "required": [
+            "type",
+            "schedule_name"
+          ],
           "properties": {
-            "type": { "const": "scheduler_schedule_exists" },
-            "schedule_name": { "type": "string", "minLength": 1 },
-            "expect_enabled": { "type": "boolean" }
+            "type": {
+              "const": "scheduler_schedule_exists"
+            },
+            "schedule_name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expect_enabled": {
+              "type": "boolean"
+            }
           }
         },
         {
           "additionalProperties": false,
-          "required": ["type", "pipelines", "response_window_min", "lookback_hours"],
+          "required": [
+            "type",
+            "pipelines",
+            "response_window_min",
+            "lookback_hours"
+          ],
           "properties": {
-            "type": { "const": "sf_watch_invocation_success" },
+            "type": {
+              "const": "sf_watch_invocation_success"
+            },
             "pipelines": {
               "type": "array",
               "minItems": 1,
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["state_machine", "watch_prefix"],
+                "required": [
+                  "state_machine",
+                  "watch_prefix"
+                ],
                 "properties": {
-                  "state_machine": { "type": "string", "minLength": 1 },
-                  "watch_prefix": { "type": "string", "minLength": 1 }
+                  "state_machine": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "watch_prefix": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             },
-            "response_window_min": { "type": "integer", "minimum": 1 },
-            "lookback_hours": { "type": "integer", "minimum": 1 }
+            "response_window_min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "lookback_hours": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         },
         {
           "additionalProperties": false,
-          "required": ["type", "family", "dispatch_prefix", "completion_prefix", "response_window_min", "lookback_hours"],
+          "required": [
+            "type",
+            "family",
+            "dispatch_prefix",
+            "completion_prefix",
+            "response_window_min",
+            "lookback_hours"
+          ],
           "properties": {
-            "type": { "const": "dispatch_invocation_success" },
-            "family": { "type": "string", "minLength": 1 },
-            "dispatch_prefix": { "type": "string", "minLength": 1 },
-            "completion_prefix": { "type": "string", "minLength": 1 },
-            "completion_key_field": { "type": "string", "minLength": 1 },
-            "response_window_min": { "type": "integer", "minimum": 1 },
-            "lookback_hours": { "type": "integer", "minimum": 1 }
+            "type": {
+              "const": "dispatch_invocation_success"
+            },
+            "family": {
+              "type": "string",
+              "minLength": 1
+            },
+            "dispatch_prefix": {
+              "type": "string",
+              "minLength": 1
+            },
+            "completion_prefix": {
+              "type": "string",
+              "minLength": 1
+            },
+            "completion_key_field": {
+              "type": "string",
+              "minLength": 1
+            },
+            "response_window_min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "lookback_hours": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         },
         {
           "additionalProperties": false,
-          "required": ["type", "dispatch_ledger_prefix", "response_window_min", "lookback_hours"],
+          "required": [
+            "type",
+            "dispatch_ledger_prefix",
+            "response_window_min",
+            "lookback_hours"
+          ],
           "properties": {
-            "type": { "const": "agent_dispatch_completeness" },
-            "dispatch_ledger_prefix": { "type": "string", "minLength": 1 },
-            "response_window_min": { "type": "integer", "minimum": 1 },
-            "lookback_hours": { "type": "integer", "minimum": 1 },
-            "ssm_retention_days": { "type": "integer", "minimum": 1, "maximum": 60 }
+            "type": {
+              "const": "agent_dispatch_completeness"
+            },
+            "dispatch_ledger_prefix": {
+              "type": "string",
+              "minLength": 1
+            },
+            "response_window_min": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "lookback_hours": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "ssm_retention_days": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60
+            }
           }
         },
         {
           "additionalProperties": false,
-          "required": ["type", "alarms"],
+          "required": [
+            "type",
+            "alarms"
+          ],
           "properties": {
-            "type": { "const": "alarm_coverage" },
+            "type": {
+              "const": "alarm_coverage"
+            },
             "alarms": {
               "type": "array",
               "minItems": 1,
               "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["name_pattern", "alarm_action_pattern"],
+                "required": [
+                  "name_pattern",
+                  "alarm_action_pattern"
+                ],
                 "properties": {
-                  "name_pattern": { "type": "string", "minLength": 1 },
-                  "alarm_action_pattern": { "type": "string", "minLength": 1 },
+                  "name_pattern": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "alarm_action_pattern": {
+                    "type": "string",
+                    "minLength": 1
+                  },
                   "max_insufficient_data_hours": {
                     "type": "integer",
                     "minimum": 1,
@@ -552,7 +1016,11 @@
                   },
                   "expect_state": {
                     "type": "string",
-                    "enum": ["OK", "ALARM", "INSUFFICIENT_DATA"],
+                    "enum": [
+                      "OK",
+                      "ALARM",
+                      "INSUFFICIENT_DATA"
+                    ],
                     "default": "ALARM"
                   }
                 }

--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -749,16 +749,22 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
   - class: executor_optimizer_shadow_rebalance
     source: "alpha-engine/executor/optimizer_shadow.py"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: shadow-optimizer divergence, named in I6751's NOTIFY-SILENT row.
+    tier: notify-silent
   - class: executor_order_book_rationale_write
     source: "alpha-engine/executor/main.py"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
 
   # ── backtester (crucible-backtester) ──
   - class: backtester_executor_opt_rejected
@@ -766,27 +772,39 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: guardrail-HELD is the system working. Named in I6751's
+    # TRACKED-ONLY row.
+    tier: tracked-only
   - class: backtester_empty_param_sweep
     source: "alpha-engine-backtester/backtest.py"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: backtester_stance_drift
     source: "alpha-engine-backtester/analysis/stance_distribution.py"
     severities: [error]
     intake: bus
     response: drain-queue
+    # DECLARED: stance drift is named in I6751's NOTIFY-SILENT row (suboptimal,
+    # not broken).
+    tier: notify-silent
   - class: backtester_cost_anomaly
     source: "alpha-engine-backtester/analysis/cost_report.py"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: backtester_champion_promotion
     # I3302 rename complete: code now emits the canonical alpha-engine-backtester/ prefix.
     source: "alpha-engine-backtester/optimizer/champion_promotion.py::run_weekly_evaluation"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: backtester_producer_arena
     # alpha-engine-config-I9318: the R-slot (selection-producer) arena cycle.
     # Fires only when the cycle comes out `unmeasurable` or `unservable` — i.e.
@@ -800,6 +818,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
     operator_reason: >-
       The R-slot arena could not promote or defend the live producer_champion
       pointer on evidence (unmeasurable or unservable). drain-queue is the
@@ -810,16 +830,23 @@ alert_classes:
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: backtester_pit_parity
     source: "alpha-engine-backtester/pit_parity"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: point-in-time parity divergence is a measurement-quality
+    # finding.
+    tier: notify-silent
   - class: backtester_input_quality
     source: "alpha-engine-backtester/analysis/input_quality.py"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: input-quality degradation — suboptimal results, not a halt.
+    tier: notify-silent
 
   # ── predictor (crucible-predictor) ──
   - class: predictor_risk_model_persist
@@ -827,21 +854,29 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: predictor_model_zoo
     source: "alpha-engine-predictor/training/model_zoo.py::run_rotation_and_select"
     severities: [info, warning, critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: predictor_predictions_write
     source: "alpha-engine-predictor/inference/stages/write_output.py::write_predictions"
     severities: [warning, critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: predictor_observe_calibration
     source: "predictor.inference.observe_calibration"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: calibration drift, named in I6751's NOTIFY-SILENT row.
+    tier: notify-silent
   - class: predictor_shadow_leaderboard_unmeasurable_arm
     # alpha-engine-config-I9336 (crucible-predictor-PR587): a registered
     # stage=challenger arm (e.g. sota-directional-combine, the champion-arch
@@ -858,6 +893,11 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: the row's own comment already argues this — a
+    # measurement-coverage signal that 'must not page the one operator chat'.
+    # The tier field is where that intent finally binds instead of being a
+    # comment the delivery path never read.
+    tier: tracked-only
   - class: predictor_inference
     # alpha-engine-config-I7740 (operator ruling 2026-08-21): new registry
     # row for a previously-undeclared source. One source string covers
@@ -873,6 +913,8 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
   - class: deploy_notification_predictor
     # config#3305 static-chokepoint registration: predictor deploy scripts
     # that call ``krepis.alerts publish --source <path>/deploy.sh``.
@@ -880,6 +922,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
 
   # ── research (crucible-research) ──
   # alpha-engine-config-I8177 (crucible-research-PR724). The weekly
@@ -895,21 +939,29 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: research_score_aggregator_gap
     source: "research:score_aggregator"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_archive_writer_quarantine
     source: "research:archive_writer"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: research_daemon_down
     source: "research:alerts_handler"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   # config#3305 static-chokepoint registration: crucible-research
   # ``publish_observe_alert`` call sites detected during the cross-repo
   # completeness sweep. All are secondary observability (non-fatal, no
@@ -920,21 +972,29 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_challenger_producers
     source: "research:challenger_producers"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_producer_leaderboard_alerts
     source: "research:producer_leaderboard"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_scanner_leaderboard_alerts
     source: "research:scanner_leaderboard"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_cuts_leaderboard_alerts
     # alpha-engine-config-I7752 static-chokepoint registration: the cuts
     # leaderboard build is observe-only and swallows its own exception
@@ -946,6 +1006,8 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_cut_promotion_alerts
     # alpha-engine-config-I7876 static-chokepoint registration: the scanner-cut
     # promotion engine (crucible-research/lambda/scanner_handler.py, calling
@@ -960,6 +1022,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: research_spec_promotion_alerts
     # alpha-engine-config-I9273 static-chokepoint registration. The scanner
     # SPEC slot's promotion engine (crucible-research/scoring/spec_promotion.py
@@ -979,6 +1043,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
     # overseer-policy.md invariant 4 (alpha-engine-config-I8991): a pageable
     # class is a CLOSED LOOP or a TRACKED GAP, and there is no third state.
     # This is the tracked gap, deliberately, rather than an operator_reason.
@@ -1011,6 +1077,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: research_corpus_stats_alerts
     # alpha-engine-config-I7896 static-chokepoint registration. Emitted by
     # crucible-research/lambda/aggregate_costs_handler.py::_refresh_corpus_stats
@@ -1030,16 +1098,22 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_experiment_record_alerts
     source: "research:experiment_record"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_thinktank_daily_alerts
     source: "research:thinktank_daily"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   # alpha-engine-config-I9282 (crucible-research-PR762). The Think Tank
   # challenger arm writes its leaderboard evidence
   # (signals_shadow/thinktank_coverage/{date}/signals.json) ONLY when its
@@ -1056,6 +1130,8 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_signals_envelope_rejected
     # NOTE: this class emits via ``alerts.publish`` with explicit
     # ``severity="error"`` (not ``publish_observe_alert``), so its
@@ -1065,11 +1141,15 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: research_signals_envelope_handler_observe_alerts
     source: "signals_envelope_handler:*"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_experiment_record
     # config#3305 static-chokepoint registration: ``publish_observe_alert``
     # for experiment_record emission failures (secondary observability, never
@@ -1078,6 +1158,8 @@ alert_classes:
     severities: [info, warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: research_thinktank_daily
     # config#3305 static-chokepoint registration: thinktank daily run outcome
     # notification (DEGRADED/ok — secondary observability, not a gating check).
@@ -1085,6 +1167,8 @@ alert_classes:
     severities: [info, warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: deploy_notification_research
     # config#3305 static-chokepoint registration: research deploy scripts that
     # call ``krepis.alerts publish --source <path>/deploy.sh``.
@@ -1092,6 +1176,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
 
   # ── data plane (nousergon-data) ──
   - class: data_constituents_drift
@@ -1099,6 +1185,9 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # DECLARED dynamic: non-severe constituents drift is TRACKED-ONLY per the
+    # matrix; a severe (critical) drift is a data-integrity break and pages.
+    tier: dynamic
   - class: data_stage_output_sweep
     # alpha-engine-config-I7752 static-chokepoint registration: the per-run
     # stage-output verdict (validators/stage_output_sweep.py). Severity is
@@ -1108,36 +1197,56 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # DECLARED dynamic: the per-run verdict is `error` when the run has defects
+    # and `warn` otherwise, and a DEGRADED run that still produced its artifact
+    # is tracked-only work (tonight's data-collector 'Collection finished
+    # DEGRADED' page). Resolved per emission.
+    tier: dynamic
   - class: data_phase_marker_sweep
     source: "alpha-engine-data/validators/phase_marker_sweep.py"
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
   - class: data_spot_quota_fallback
     source: "data-spot-dispatcher._launch_instance"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: the launch SUCCEEDED on fallback. Named in I6751's
+    # NOTIFY-SILENT/TRACKED-ONLY discussion as 'spot-quota fallback (succeeded
+    # on fallback)'; it is capacity-planning backlog, not an incident.
+    tier: tracked-only
   - class: lib_spot_quota_fallback
     source: "nousergon_lib.spot_dispatch.launch_with_fallback"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: same condition as data_spot_quota_fallback, from the shared-lib
+    # dispatcher.
+    tier: tracked-only
   - class: canary_replay_liveness
     source: "canary-replay-liveness-probe"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: pipeline_watchdog_stuck_sf
     source: "alpha-engine-pipeline-watchdog"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: overseer_dispatch_escalation
     source: "overseer-dispatcher"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: freshness_monitor_staleness
     # CRITICALs additionally trigger EVENT-TIME drain dispatch per the
     # artifact registry's remediation declarations (config-I3282) — this is
@@ -1146,11 +1255,16 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: playbook:alert-drain
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
   - class: data_sf_definition_drift
     source: "alpha-engine-data/infrastructure/step-functions/check-definition-drift.py"
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # DECLARED: SF-definition drift is conformance, named in I6751's
+    # TRACKED-ONLY row.
+    tier: tracked-only
   - class: deploy_notification_data_plane
     # config#3305 static-chokepoint registration: data-plane deploy scripts
     # that call ``krepis.alerts publish --source <path>/deploy.sh``.
@@ -1158,6 +1272,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: deploy_notification_changelog
     # config#3305 static-chokepoint registration: changelog mirror deploy
     # script that calls ``krepis.alerts publish``.
@@ -1165,6 +1281,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: check_systemd_unit_drift
     # config-I3211 backstop registration (alpha-engine-config#5715): installed
     # systemd units on a box diverge from what the repo expects. Emitter
@@ -1177,6 +1295,9 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # DECLARED: conformance drift — backlog work, nothing broken. I6751 matrix
+    # names systemd-unit-drift in the TRACKED-ONLY row.
+    tier: tracked-only
   - class: boot_pull
     # config-I3211 backstop registration (alpha-engine-config#5714 / #4793):
     # boot-time repo pull on a box failed, risking stale code at session start.
@@ -1190,6 +1311,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
 
   # ── metron ──
   - class: metron_reconciliation
@@ -1200,6 +1323,8 @@ alert_classes:
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
   - class: metron_deploy
     # alpha-engine-config-I7740 (operator ruling 2026-08-21): new registry
     # row for a previously-undeclared source. Observed: deploy FAILED at
@@ -1208,6 +1333,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: metron_deploy_drift
     # alpha-engine-config-I8991: metron-deploy-drift.timer (hourly,
     # metron/api/services/deploy_drift.py::report) correctly detected the box
@@ -1236,6 +1363,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
     migration_issue: alpha-engine-config-I8991
 
   # ── groom (alpha-engine-config emitter) ──
@@ -1244,6 +1373,8 @@ alert_classes:
     severities: [error, warning]
     intake: bus
     response: drain-queue
+    # DECLARED: groom lifecycle, named in I6751's NOTIFY-SILENT row.
+    tier: notify-silent
 
   # ── CloudWatch alarms (blanket row — the tap covers every alarm) ──
   - class: cw_alarms_all
@@ -1256,6 +1387,8 @@ alert_classes:
     severities: [alarm]
     intake: cw-alarm
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
 
   # ── infra (box health + deploy-on-merge — config-I3211 alert-drain registry) ──
   # Both emitters were added without declaring a class; the config-I3211
@@ -1266,11 +1399,24 @@ alert_classes:
     severities: [warning, critical]
     intake: bus
     response: drain-queue
+    # DECLARED dynamic + `page_after_consecutive` below: a single failed run of
+    # an HOURLY timer that its own next run repairs is not actionable-now.
+    # Measured 2026-09-09: metron-deploy-drift failed once at 18:07 (git
+    # ls-remote exit 128) and succeeded at 19:07, paging Brian CRITICAL then
+    # INFO-RESOLVED for a condition that self-healed in 59 minutes. Same shape
+    # as the 2026-08-28 five-CRITICAL/five-RESOLVED episode.
+    tier: dynamic
+    # box-health runs hourly (cadence 60min <= the 60min operator-response
+    # floor), so its own next run precedes any human action: PAGE only when the
+    # condition survives two consecutive runs.
+    page_after_consecutive: 2
   - class: deploy_on_merge
     source: "deploy-on-merge"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: scan_unlisted_state
     # TRACKED-ONLY tier (routing epic config-I6751, re-route config-I6752):
     # hygiene finding, emitted `--severity warning --no-sns` — silent Telegram
@@ -1281,6 +1427,9 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: the epic's Phase-0 trigger example. Hygiene finding; the drain's
+    # disposition issue IS the remediation path (observability-policy.md §7.4).
+    tier: tracked-only
 
   # ── CLI-shaped emitters the config-I6753 chokepoint extension surfaced ──
   # These predate the extension; every one emitted through the krepis CLI,
@@ -1290,41 +1439,57 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # derived: warning/info only, automated response declared
+    tier: tracked-only
   - class: reboot_if_needed
     source: "reboot-if-needed"
     severities: [dynamic]
     intake: bus
     response: drain-queue
+    # DECLARED: a pending-reboot notice is scheduled maintenance, not a break.
+    tier: tracked-only
   - class: deploy_notification_backtester_concordance
     source: "alpha-engine-backtester/infrastructure/deploy_concordance.sh"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: deploy_notification_backtester_counterfactual
     source: "alpha-engine-backtester/infrastructure/deploy_counterfactual.sh"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: deploy_notification_backtester_health
     source: "alpha-engine-backtester/infrastructure/deploy_health.sh"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: eod_snapshot_existence_check
     source: "alpha-engine-eod-snapshot-existence-check"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: alpha_engine_preopen_deploy_readiness_probe
     source: "alpha-engine-preopen-deploy-readiness-probe"
     severities: [critical]
     intake: bus
     response: drain-queue
+    # derived: critical/alarm-capable
+    tier: page
   - class: weekly_sf_recovery_metric
     source: "nousergon-data/scripts/weekly_sf_recovery_metric.py"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: executor_zero_entries_alarm
     # In-process emitter merged to crucible-executor while the drift
     # chokepoint was dead on infra (config-I6753) — caught by the revived
@@ -1333,6 +1498,8 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
 
   # ── laptop LLM-routing plane (claude-code-config, config-I6753) ──
   # All four call sites previously omitted the REQUIRED `publish` subcommand,
@@ -1343,21 +1510,45 @@ alert_classes:
     severities: [error]
     intake: bus
     response: drain-queue
+    # DECLARED: the canary's own defects (alpha-engine-config-I9314 / I9486) are
+    # the dominant firing condition and are already tracked; one of tonight's
+    # two pages self-labelled 'CANARY DEFECT (not a router fault)'. A router
+    # fault that is real reaches the operator through llm_router_reload_health
+    # and the router SLI, not here.
+    #
+    # This row also owns the `cache_floor: mechanism-ceiling` verdict added by
+    # claude-code-config-PR246 (2026-09-09). That verdict means the PROVIDER's
+    # cache mechanism cannot meet the declared floor -- `ultra`'s mechanism is
+    # `automatic` (M2, best-effort, ~40-70% per call, measured in I9486) -- so
+    # it is a known standing property, recurring on every run until I9486 is
+    # ruled, and nothing Brian can act on tonight. It needs no row of its own:
+    # the tier is a property of the emitting SOURCE, and PR246 does not change
+    # the source string.
+    tier: tracked-only
   - class: llm_egress_proxy_sli
     source: "llm-egress-proxy"
     severities: [error]
     intake: bus
     response: drain-queue
+    # DECLARED: an SLI breach is degraded-not-broken; the proxy fails CLOSED, so
+    # a real outage surfaces as the consumer's own error, which pages on its own
+    # class.
+    tier: notify-silent
   - class: llm_router_reload_health
     source: "llm-router-reload"
     severities: [error]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
   - class: litellm_proxy_degraded_start
     source: "litellm-proxy-shim"
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: started-degraded is a degraded-results condition; the router's
+    # own health class pages when routing actually fails.
+    tier: notify-silent
   - class: router_degraded_mode_drill
     # alpha-engine-config-I7740 (operator ruling 2026-08-21): new registry
     # row for a previously-undeclared source.
@@ -1365,6 +1556,9 @@ alert_classes:
     severities: [warning]
     intake: bus
     response: drain-queue
+    # DECLARED: a DRILL. A drill result is conformance evidence, never an
+    # outage.
+    tier: tracked-only
 
   # ── DRAIN-BLIND rows (every one carries its migration or declaration) ──
   - class: executor_emergency_shutdown
@@ -1372,30 +1566,44 @@ alert_classes:
     severities: [critical]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     migration_issue: alpha-engine-config-I2908   # highest-value migration: a live emergency shutdown is invisible to the overseer today
   - class: substrate_health_raw_sns
     source: "raw-sns:nousergon_lib/transparency.py"
     severities: [error]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     migration_issue: alpha-engine-config-I2908
   - class: predictor_drift_raw_sns
     source: "raw-sns:predictor/monitoring/drift_detector.py"
     severities: [dynamic]
     intake: none
     response: operator
+    # derived: severities [dynamic] — resolved per emission
+    tier: dynamic
     migration_issue: alpha-engine-config-I2908
   - class: ci_runner_lambda_raw_telegram
     source: "raw-telegram:ci-runner-dispatcher-lambdas"
     severities: [error]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     migration_issue: alpha-engine-config-I2909
   - class: governance_script_raw_telegram
     source: "raw-telegram:operator_triage_digest|neon_usage_monitor|check_doc_staleness"
     severities: [info, warning, critical]
     intake: none
     response: operator
+    # DECLARED: budget/pace and doc-staleness governance pings. Tonight's Neon
+    # usage PACE notice came from this class as email. Hygiene + spend — the
+    # matrix's TRACKED-ONLY row. NOTE: raw-telegram emitter, so the krepis
+    # chokepoint cannot enforce this tier today; Phase 3
+    # (alpha-engine-config-I2909-class migration) is what makes it binding.
+    tier: tracked-only
     operator_reason: >-
       Deliberate hermetic governance pings (no repo imports by design);
       doc-staleness auto-verify loop tracked separately (config-I3061).
@@ -1404,12 +1612,19 @@ alert_classes:
     severities: [info, error, warning]
     intake: none
     response: operator
+    # DECLARED: groom dispatch lifecycle — same 2026-08-03 ruling as
+    # sf_completion_telegram.
+    tier: notify-silent
     migration_issue: alpha-engine-config-I2928
   - class: sf_completion_telegram
     source: "flow-doctor:sf-telegram-notifier"
     severities: [dynamic]
     intake: none
     response: operator
+    # DECLARED: lifecycle notice under Brian's 2026-08-03 ruling (buzz only for
+    # started / stopped-early / finished); failures route via sf-watch, not this
+    # notifier.
+    tier: notify-silent
     operator_reason: >-
       Informational SF-completion notices (T0 class by definition — failures
       route via sf-watch, not this notifier).
@@ -1418,6 +1633,10 @@ alert_classes:
     severities: [warning]
     intake: none
     response: operator
+    # DECLARED: I6751's matrix names 'expense/spend notices (weekly digest)' as
+    # TRACKED-ONLY verbatim. `response: operator` would derive PAGE; spend
+    # review has no actionable-now step.
+    tier: tracked-only
     operator_reason: Budget-usage notice; page-only by design (no automated response exists or is wanted for spend review).
 
   # ── Telegram-only notify_via_flow_doctor emitters (config-I3513 audit, alpha-engine-config-I3683) ──
@@ -1431,6 +1650,8 @@ alert_classes:
     severities: [info, warning, error]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     operator_reason: >-
       Monday pre-open GO/NO-GO integrity page (Telegram-only by design; the
       Saturday-sf integrity verdict is independent of the watch plane — a silent
@@ -1440,6 +1661,8 @@ alert_classes:
     severities: [error]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     operator_reason: >-
       Watch-plane wiring/liveness probe findings (Telegram-only by design;
       the probe IS the watch-plane's own health-check — routing its findings
@@ -1449,6 +1672,8 @@ alert_classes:
     severities: [error, info]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     operator_reason: >-
       Mid-run spot-reclaim escalation (error) + bounded-relaunch note (info),
       Telegram-only by design (the reclaim action IS the repair; no drain-queue
@@ -1458,6 +1683,8 @@ alert_classes:
     severities: [error, info]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     operator_reason: >-
       Fleet-SF watch receipts (info) + budget-exhaustion escalation (error).
       Telegram-only by design: these are runtime watch-plane operational notices
@@ -1468,6 +1695,8 @@ alert_classes:
     severities: [critical, warning, info]
     intake: none
     response: operator
+    # derived: response=operator (no automated path exists, §7.4)
+    tier: page
     operator_reason: >-
       EC2/GHA migration-runner outcome notices (info=noop/success,
       warning=refused-probe, critical=failure). Telegram-only by design: this
@@ -1478,12 +1707,17 @@ alert_classes:
     severities: [info]
     intake: none
     response: operator
+    # DECLARED: digests are the surface, not a page. `response: operator` would
+    # derive PAGE.
+    tier: notify-silent
     operator_reason: Informational digests via the krepis email chokepoint; console deep-links are the response surface.
   - class: predictor_retrain_email
     source: "email:backtester/analysis/retrain_alert.py"
     severities: [warning]
     intake: none
     response: operator
+    # DECLARED: a retrain RECOMMENDATION is backlog work with a known remedy.
+    tier: tracked-only
     migration_issue: alpha-engine-config-I3302   # also bypasses the email chokepoint itself
 
   # -- console (nousergon-console) --
@@ -1509,6 +1743,8 @@ alert_classes:
     severities: [error, info]
     intake: bus
     response: drain-queue
+    # derived: error-capable, automated response declared
+    tier: notify-silent
     # overseer-policy.md invariant 4 (alpha-engine-config-I8991/I8996): a
     # pageable class needs a declared disposition, and `response: drain-queue`
     # alone is not one -- it says the drain SEES the event, not what the drain

--- a/infrastructure/overseer/publish_alert_tier_registry.py
+++ b/infrastructure/overseer/publish_alert_tier_registry.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Publish the alert-class DELIVERY TIER registry that `krepis.alerts` routes on.
+
+alpha-engine-config-I6751 Phase 1 (subsumes I6293).
+
+WHY AN ARTIFACT AND NOT A COPY IN krepis
+----------------------------------------
+`krepis` is a PyPI library with no dependency on this repo, and the emitters it
+serves run on Lambdas, spot boxes and the laptop — none of which check this
+repository out. The alternative to publishing is a hand-kept tier table inside
+krepis, which is a recorded fleet bug class: `alpha-engine-config-I10121`, where
+`iam-drift-check` needed a hand-written allowlist twin of a source it could have
+read and reddened `main` four times in three days before the twin was deleted.
+So the registry stays a single file in this repo and is PUBLISHED; krepis reads
+the published object and never carries a second copy.
+
+The shape is deliberately the one `sync-llm-model-registry.yml` and
+`sync-artifact-registry.yml` already use (shared-code-policy, third adoption of
+the pattern: a validated registry in the repo, published to the bucket the
+consumer reads, with a scheduled arm that asserts repo == S3 so "the publish
+never fired" and "the publish fired and worked" are different shapes).
+
+WHY `alpha-engine-research`
+---------------------------
+`krepis.alerts` ALREADY reads and writes that bucket on every deduped publish
+(`DEFAULT_DEDUP_BUCKET`, `_alerts/_dedup/`). Every identity that can emit a
+fleet alert can therefore already read this object: no new bucket, no new IAM
+grant, no new failure mode on the alerting path. A new bucket would have added a
+grant to ~20 execution roles for one small JSON file.
+
+WHY IT VERIFIES ITS OWN WRITE
+-----------------------------
+`principles.md` §2.3 — detect, act, VERIFY, close. An `aws s3 cp` that exits 0
+is an event; the read-back is the effect. A failed verification is a non-zero
+exit, so a publish that did not land reddens the workflow rather than being
+inferred from an exit code that only proves a request was accepted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+import jsonschema
+import yaml
+
+logger = logging.getLogger("publish_alert_tier_registry")
+
+HERE = Path(__file__).resolve().parent
+PLAYBOOKS = HERE / "playbooks.yaml"
+SCHEMA = HERE / "playbooks.schema.json"
+
+#: Must match `krepis.alert_tiers.REGISTRY_BUCKET` / `REGISTRY_OBJECT`. The
+#: producer and the consumer resolve ONE string pair, or the emitters read an
+#: object nothing publishes to and every source resolves `page` — loud, but
+#: wrong, and it would restore exactly the 37-emails-a-day baseline this closes.
+REGISTRY_BUCKET = "alpha-engine-research"
+REGISTRY_OBJECT = "overseer/alert_tier_registry.json"
+
+#: Bumped only on a breaking shape change. `krepis.alert_tiers` refuses a
+#: version it does not know and falls back to PAGE — loudly, never silently.
+SCHEMA_VERSION = 1
+
+
+def build_document(playbooks_path: Path = PLAYBOOKS) -> dict:
+    """Distil `alert_classes` into the routing document krepis consumes.
+
+    Raises on a malformed registry rather than publishing a partial one: this
+    is a PRODUCER, and a half-written routing table silently downgrades real
+    pages (`~/Development/CLAUDE.md`, *Fail loud and fast*).
+    """
+    raw = playbooks_path.read_text()
+    doc = yaml.safe_load(raw)
+    jsonschema.validate(doc, json.loads(SCHEMA.read_text()))
+
+    entries = []
+    for row in doc["alert_classes"]:
+        entry = {
+            "class": row["class"],
+            "source": row["source"],
+            "tier": row["tier"],
+            "severities": row["severities"],
+        }
+        if "page_after_consecutive" in row:
+            entry["page_after_consecutive"] = row["page_after_consecutive"]
+        if "episode_overrides" in row:
+            entry["episode_overrides"] = row["episode_overrides"]
+        entries.append(entry)
+
+    sources = [e["source"] for e in entries]
+    dupes = sorted({s for s in sources if sources.count(s) > 1})
+    # A duplicated source is not fatal — `metron` is knowingly shared by two
+    # classes (alpha-engine-config-I8995, awaiting a ruling) — but the resolver
+    # must not pick between them silently, so the collision is carried in the
+    # document and the consumer takes the STRICTEST tier of the colliding rows.
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_digest": "sha256:" + hashlib.sha256(raw.encode()).hexdigest(),
+        "colliding_sources": dupes,
+        "entries": entries,
+    }
+
+
+def publish(document: dict, *, bucket: str, obj: str, dry_run: bool) -> int:
+    body = json.dumps(document, indent=2, sort_keys=True).encode()
+    if dry_run:
+        sys.stdout.write(body.decode() + "\n")
+        return 0
+    s3 = boto3.client("s3")
+    s3.put_object(Bucket=bucket, Key=obj, Body=body,
+                  ContentType="application/json")
+    # Read-back verification. Compare the SOURCE DIGEST, not the bytes: the
+    # document carries `generated_at`, so a byte compare would be a tautology
+    # on the write we just made and would fail against any concurrent run.
+    got = json.loads(s3.get_object(Bucket=bucket, Key=obj)["Body"].read())
+    if got.get("source_digest") != document["source_digest"]:
+        logger.error(
+            "alert-tier registry read-back MISMATCH at s3://%s/%s: wrote "
+            "source_digest=%s, read %s. Every fleet emitter routes on this "
+            "object; a stale one silently downgrades pages.",
+            bucket, obj, document["source_digest"], got.get("source_digest"),
+        )
+        return 1
+    logger.info(
+        "published %d alert-class tiers to s3://%s/%s (digest %s), read-back OK",
+        len(document["entries"]), bucket, obj, document["source_digest"],
+    )
+    return 0
+
+
+def assert_in_sync(*, bucket: str, obj: str) -> int:
+    """Scheduled arm: assert the published object still matches the repo."""
+    document = build_document()
+    s3 = boto3.client("s3")
+    got = json.loads(s3.get_object(Bucket=bucket, Key=obj)["Body"].read())
+    if got.get("source_digest") != document["source_digest"]:
+        logger.error(
+            "alert-tier registry DRIFT: s3://%s/%s carries source_digest=%s, "
+            "the repo says %s. The publish arm did not fire, or something else "
+            "wrote that object.", bucket, obj, got.get("source_digest"),
+            document["source_digest"],
+        )
+        return 1
+    logger.info("alert-tier registry in sync (%s)", document["source_digest"])
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--bucket", default=REGISTRY_BUCKET)
+    ap.add_argument("--object", dest="obj", default=REGISTRY_OBJECT)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the document, write nothing")
+    ap.add_argument("--assert-in-sync", action="store_true",
+                    help="verify the published object matches the repo; publish nothing")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if args.assert_in_sync:
+        return assert_in_sync(bucket=args.bucket, obj=args.obj)
+    return publish(build_document(), bucket=args.bucket, obj=args.obj,
+                   dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alert_tier_registry.py
+++ b/tests/test_alert_tier_registry.py
@@ -1,0 +1,146 @@
+"""Every alert class declares a delivery tier — alpha-engine-config-I6751.
+
+These are the tests that make the tier field load-bearing rather than
+decorative. The schema already REQUIRES `tier` on every row; these assert the
+things a schema cannot:
+
+* the published document is the shape `krepis.alert_tiers` reads,
+* the producer/consumer string pair is one string pair,
+* no row silently declares a tier that would route a genuinely-broken class
+  into silence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+OVERSEER = Path(__file__).resolve().parents[1] / "infrastructure" / "overseer"
+PLAYBOOKS = OVERSEER / "playbooks.yaml"
+
+TIERS = {"page", "notify-silent", "tracked-only", "dynamic"}
+
+
+@pytest.fixture(scope="module")
+def rows() -> list[dict]:
+    return yaml.safe_load(PLAYBOOKS.read_text())["alert_classes"]
+
+
+def test_every_alert_class_declares_a_tier(rows):
+    missing = [r["class"] for r in rows if "tier" not in r]
+    assert missing == [], (
+        "alert_classes rows with no `tier`: "
+        f"{missing}. A row with no tier cannot be routed, so krepis.alert_tiers "
+        "pages for it and records registry drift — loud, but not the intent."
+    )
+    bad = [(r["class"], r["tier"]) for r in rows if r["tier"] not in TIERS]
+    assert bad == []
+
+
+def test_dynamic_tier_is_only_used_where_severity_is_a_runtime_fact(rows):
+    """`dynamic` says the seriousness varies with the observed facts.
+
+    observability-policy.md 7.1 — derived where derivable. A row whose
+    severities are a fixed single value has a derivable tier and must declare
+    it, or `dynamic` becomes the shrug that puts severity back in charge.
+    """
+    offenders = [
+        r["class"] for r in rows
+        if r["tier"] == "dynamic" and len(set(r["severities"])) == 1
+        and r["severities"][0] != "dynamic"
+    ]
+    assert offenders == [], (
+        f"rows declaring tier: dynamic on a single fixed severity: {offenders}"
+    )
+
+
+def test_no_critical_only_class_is_routed_to_tracked_only(rows):
+    """A class that can ONLY fire at critical/alarm is not hygiene.
+
+    This is the assertion that stops the tier field from becoming a mute
+    switch. A genuinely-broken condition may be held by
+    `page_after_consecutive`, never by a tier declaration.
+    """
+    offenders = [
+        r["class"] for r in rows
+        if r["tier"] == "tracked-only"
+        and set(r["severities"]) <= {"critical", "alarm"}
+    ]
+    assert offenders == [], (
+        f"critical-only classes declared tracked-only: {offenders}"
+    )
+
+
+def test_page_after_consecutive_is_a_positive_integer(rows):
+    for r in rows:
+        if "page_after_consecutive" in r:
+            assert isinstance(r["page_after_consecutive"], int)
+            assert r["page_after_consecutive"] >= 1
+            assert r["tier"] in ("page", "dynamic"), (
+                f"{r['class']}: a consecutive-detection gate on a non-paging "
+                f"tier does nothing"
+            )
+
+
+def test_published_document_matches_the_consumer_contract():
+    """The producer and `krepis.alert_tiers` resolve ONE bucket/object pair."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "publish_alert_tier_registry", OVERSEER / "publish_alert_tier_registry.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    doc = mod.build_document()
+    assert doc["schema_version"] == 1
+    assert doc["source_digest"].startswith("sha256:")
+    assert len(doc["entries"]) == len(
+        yaml.safe_load(PLAYBOOKS.read_text())["alert_classes"]
+    )
+    for entry in doc["entries"]:
+        assert set(entry) <= {
+            "class", "source", "tier", "severities", "page_after_consecutive",
+            "episode_overrides",
+        }
+        assert entry["tier"] in TIERS
+
+    # Serialisable exactly as published — a document that cannot round-trip
+    # through JSON reaches the consumer as a registry-unavailable fail-upward.
+    json.loads(json.dumps(doc))
+
+    # The consumer contract, asserted as LITERALS rather than by importing
+    # krepis. The installed krepis on any given runner may predate the
+    # consumer (this repo does not pin it in lockstep), and an
+    # `importorskip` that skips is a contract test that never ran — which is
+    # how a producer and its consumer drift apart while CI is green.
+    assert mod.REGISTRY_BUCKET == "alpha-engine-research"
+    assert mod.REGISTRY_OBJECT == "overseer/alert_tier_registry.json"
+    assert mod.SCHEMA_VERSION == 1
+
+    krepis_tiers = pytest.importorskip("krepis.alert_tiers")
+    if hasattr(krepis_tiers, "REGISTRY_BUCKET"):
+        assert mod.REGISTRY_BUCKET == krepis_tiers.REGISTRY_BUCKET
+        assert mod.REGISTRY_OBJECT == krepis_tiers.REGISTRY_OBJECT
+        assert mod.SCHEMA_VERSION == krepis_tiers.SUPPORTED_SCHEMA_VERSION
+
+
+def test_a_tracked_only_row_still_declares_an_intake_or_a_reason(rows):
+    """Suppression is a delivery decision, never a recording one (7.2a).
+
+    A tracked-only row whose intake is `none` AND which carries no
+    operator_reason / migration_issue would be suppressed on the channel and
+    invisible to the response plane — the exact trade the policy forbids.
+    """
+    offenders = [
+        r["class"] for r in rows
+        if r["tier"] == "tracked-only" and r["intake"] == "none"
+        and not (r.get("operator_reason") or r.get("migration_issue"))
+    ]
+    assert offenders == [], (
+        f"tracked-only rows that are also drain-blind with no declaration: "
+        f"{offenders}"
+    )

--- a/tests/test_artifact_registry_coverage.py
+++ b/tests/test_artifact_registry_coverage.py
@@ -97,6 +97,21 @@ EXPECTED_PER_FILE_PUT_COUNTS: dict[str, int] = {
     # alpha-engine-config-PR7225; pinned here so this repo's guard is honest
     # about the new PUT site either way.
     "validators/stage_output_sweep.py": 1,
+    # alpha-engine-config-I6751 — the distilled alert-tier registry,
+    # s3://alpha-engine-research/overseer/alert_tier_registry.json. One PUT per
+    # publish run (on merge, plus the daily --assert-in-sync arm).
+    #
+    # Freshness-relevant, so it is a registry row rather than a grandfathered
+    # prefix, and this artifact is the sharpest case for that treatment in the
+    # whole table: `krepis.alerts` reads it to decide DELIVERY. A stale document
+    # does not degrade a report someone reads later — it silently routes live
+    # pages by an obsolete tier map, which is the failure this whole epic exists
+    # to end. The consumer's own posture is fail-loud-to-PAGE when the document
+    # cannot be read, so an ABSENT key is safe; a SILENTLY OLD one is not, and
+    # only freshness catches that. The row rides an alpha-engine-config PR;
+    # pinned here first so this repo's guard is honest about the new PUT site
+    # either way, per the I5718 and I7167 precedent above.
+    "infrastructure/overseer/publish_alert_tier_registry.py": 1,
     # alpha-engine-config-I8189 — the declared-pause lane set,
     # s3://alpha-engine-research/ops/checks/automation-pause-reconcile/paused_lanes.json.
     # One PUT per daily pause-reconcile.yml run (09:50 UTC), from


### PR DESCRIPTION
## What

Every one of the 92 `alert_classes` rows in `infrastructure/overseer/playbooks.yaml` now carries `tier: page | notify-silent | tracked-only | dynamic`, and the distilled routing document is published to the S3 object `krepis.alerts` reads on every fleet alert.

**alpha-engine-config-I6751 Phase 1. Subsumes alpha-engine-config-I6293** (which tracked adding the field alone).

## Why now

Brian pasted a batch of seven alerts on 2026-09-09 with "lets fix, permanently" — his **sixth alert-batch session in four days** (09-06, 09-07, 09-08 ×3, 09-09). At least five of the seven were misrouted under a matrix he approved on 2026-08-10.

Measured (CloudWatch `AWS/SNS NumberOfMessagesPublished`, 2026-09-02 → 09-09): **261 messages to the three topics that email cipher813@gmail.com** — `alpha-engine-alerts` 194, `crucible-v2-pages` 54, `alpha-engine-alarm-backstop` 13. ~37/day. The 14-day daily series on `alpha-engine-alerts` alone: 16, 34, 24, 53, 38, 48, 35, 25, 30, 38, 22, 13, 31, 16 — never below 13. All three email subscriptions carry `FilterPolicy: null`, so severity has never reached the inbox at all.

## The derivation rule

Derived where derivable (observability-policy.md §7.1), declared where the derivation gives the wrong **actionability** answer:

| Row shape | Derived tier |
|---|---|
| `response: operator` | `page` — no automated path exists (§7.4) |
| `drain-queue` + critical/alarm-capable | `page` |
| `drain-queue` + error-capable | `notify-silent` |
| `drain-queue` + warning/info only | `tracked-only` |
| `severities: [dynamic]` | `dynamic` — resolved per emission |

**25 rows are declared**, each with an inline comment naming why. Result: **18 page · 35 notify-silent · 30 tracked-only · 9 dynamic**.

## Also here

- **`publish_alert_tier_registry.py`** — distils the rows to `s3://alpha-engine-research/overseer/alert_tier_registry.json` and **verifies its own write by reading the object back**. The registry is deliberately NOT vendored into krepis: a hand-kept twin of a readable source is `alpha-engine-config-I10121`'s bug class.
- **`sync-alert-tier-registry.yml`** — publish+readback on merge, and a daily `--assert-in-sync` arm so "the publish never fired" and "the publish fired and worked" are different shapes (principles.md §2.7).
- **`alert_class_pr_guard.py`** now emits `tier:` in the row template it suggests for a newly-detected source, with a comment telling the author to confirm it against actionability rather than accept the severity-derived guess.
- **`page_after_consecutive`** (schema field, derived from the emitting job's cadence against a 60-minute operator-response floor; declared on `box_health` only). Measured 2026-09-09: one failed run of the hourly `metron-deploy-drift` timer (`git ls-remote` exit 128 at 18:07) paged CRITICAL then INFO-RESOLVED at 19:07 for a condition that self-healed in 59 minutes.
- **`episode_overrides`** (schema field, **zero declared**) so a class that is legitimately two conditions — a scheduled vendor substitution vs a bad print (I10360), a fault-injection replay vs a live failure (I10366) — can be retiered per episode once each is ruled.

## What is NOT suppressed

Every tier still writes its SNS record, its console state and its bus event. Suppression is a **delivery** decision, never a recording one (observability-policy.md §7.2a).

## Tests

`tests/test_alert_tier_registry.py` — every row tiered; `dynamic` only where severity is a runtime fact; **no critical-only class may be declared `tracked-only`** (the assertion that stops the tier field from becoming a mute switch); a `tracked-only` row may not also be drain-blind with no declaration; producer/consumer string pair asserted as literals rather than via an `importorskip` that skips.

Full suite: **7168 passed, 14 skipped** locally.

## Cross-repo

| PR | Role | Merge order |
|---|---|---|
| **nousergon-data-PR (this)** | the registry + publisher | **1st** |
| `krepis-PR214` | the consumer | 2nd |
| `alpha-engine-config-PR10379` | the Phase-4 ratio + digest | 3rd |
| `nous-ergon-ops-PR1161` | governance rows | any time |

Merge this first: until the object exists, krepis fails **upward** and every source pages — which is today's behaviour, so the intermediate state is safe.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szz1Xdg5AgKAH1CkVxWDe3
