### PR TITLE
fix(ci): assume dedicated registry-sync role for alert-tier sync

### DIFF
--- a/.github/workflows/sync-alert-tier-registry.yml
+++ b/.github/workflows/sync-alert-tier-registry.yml
@@ -38,9 +38,16 @@ name: Sync alert tier registry to S3
 # `registry_drift`. That is today's behaviour (37 emails a day), which is loud
 # and recoverable — the opposite direction would be silent.
 #
-# IAM: `github-actions-lambda-deploy` already carries s3:PutObject/GetObject on
-# arn:aws:s3:::alpha-engine-research/* (the same grant the artifact-registry
-# and model-registry syncs use). No IAM change accompanies this workflow.
+# IAM: a dedicated least-privilege role, `nousergon-data-registry-sync`
+# (nous-ergon-ops-PR<TBD>, alpha-engine-config-I10453). This workflow
+# previously assumed the fleet-wide `github-actions-lambda-deploy` and this
+# comment previously claimed that role "already carries s3:PutObject/GetObject
+# on arn:aws:s3:::alpha-engine-research/*" — that claim was FALSE, measured by
+# AccessDenied on every run since merge: the push arm denied s3:PutObject on
+# overseer/alert_tier_registry.json, and the schedule arm's GetObject on a
+# not-yet-published key came back AccessDenied on s3:ListBucket (no grant on
+# either action for this key existed on the shared role). The dedicated role
+# holds s3:PutObject + s3:GetObject on exactly this one key, nothing else.
 
 on:
   push:
@@ -78,7 +85,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
-          role-to-assume: arn:aws:iam::711398986525:role/github-actions-lambda-deploy
+          role-to-assume: arn:aws:iam::711398986525:role/nousergon-data-registry-sync
           aws-region: us-east-1
 
       - name: Set up Python 3.12


### PR DESCRIPTION
## Summary

- `sync-alert-tier-registry.yml` has failed 3/3 runs since merge (push + two schedule runs) assuming `github-actions-lambda-deploy`, whose own header comment falsely claimed it "already carries s3:PutObject/GetObject on `arn:aws:s3:::alpha-engine-research/*`" — measured `AccessDenied` on both arms. `krepis.alert_tiers` routes every alert source to `page` while the registry object is missing.
- Swaps `role-to-assume` to `arn:aws:iam::711398986525:role/nousergon-data-registry-sync` (companion PR: nous-ergon-ops-PR — see below) and replaces the false IAM comment with the true statement (dedicated role, one key, no wildcards).

## Merge order — this PR is blocked on the companion PR's role existing

1. **nous-ergon-ops PR** (adds `infrastructure/iam/nousergon-data-registry-sync/`) merges first, or at minimum the role must be CREATED before this PR merges — the applier's own `apply.sh` has no create-or-skip path for a role that doesn't exist, and its identity deliberately lacks `iam:CreateRole`.
2. Verify the role exists: `AWS_PROFILE=ne-admin aws iam get-role --role-name nousergon-data-registry-sync --query Role.Arn --output text` → `arn:aws:iam::711398986525:role/nousergon-data-registry-sync`.
3. This PR merges. `sync-alert-tier-registry.yml`'s next push run (or the 13:20 UTC daily schedule) assumes the new role.
4. Verify live: `aws s3api head-object --bucket alpha-engine-research --key overseer/alert_tier_registry.json` → 200, and the next `sync-alert-tier-registry.yml` run is green.

A cross-repo `Closes`/`Fixes` keyword is inert here — the tracker `alpha-engine-config-I10453` lives in a different repo. That issue is closed by hand once step 4 is verified.

## Test plan

- [x] `python3 -m pytest tests/test_alert_tier_registry.py tests/test_no_local_iam_tree_references.py -q` — 85 passed.
- [x] `python3 -m pytest tests/ -q -k "workflow or governance or observability or authority or registry"` — 283 passed.
- [ ] Companion nous-ergon-ops PR merged and role confirmed live (step 2 above) before merging this.
- [ ] Next `sync-alert-tier-registry.yml` run green; `head-object` on the registry key returns 200.

Refs alpha-engine-config-I10453.

Prepared by: Claude Fable 5.1 via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMrf6UbUhbb417YxTpyADp