### PR TITLE
fix(sweep): resolve the producer-chosen `*` key segment; bump lib to v0.124.119 (alpha-engine-config-I10200)

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -84,7 +84,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -84,7 +84,7 @@ jobs:
         # those are for other subsystems; alerts.publish needs none of them).
         # Same pin as requirements.txt so this step's nousergon_lib.alerts
         # behavior never drifts from the rest of the repo's alerting.
-        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119"
+        run: pip install "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120"
 
       - name: Verify SF definitions match live + S3-staged copies (config#2391)
         run: python3 infrastructure/step-functions/check-definition-drift.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN microdnf install -y git && microdnf clean all
 # requirements file so the [flow_doctor]-only install above isn't
 # overridden by the [arcticdb,flow_doctor,rag] extras pinned for EC2.
 COPY requirements.txt ${LAMBDA_TASK_ROOT}/
-RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119" && \
+RUN pip install --no-cache-dir "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120" && \
     grep -vE "^#|^$|^pytest|^python-dotenv|^boto3|^botocore|^s3transfer|^nousergon-lib" requirements.txt > /tmp/req-lambda.txt && \
     pip install --no-cache-dir -r /tmp/req-lambda.txt && \
     rm -rf /root/.cache/pip /tmp/req-lambda.txt

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-dispatcher/requirements.txt
@@ -8,6 +8,6 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # krepis>=0.15.0: matching ec2_spot extra_tags floor + fleet_events emission.
 krepis>=0.15.0

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.10.2

--- a/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/alert-drain-liveness-probe/requirements.txt
@@ -1,5 +1,5 @@
 # config#3173 — flow-doctor forum-topic routing, same pin as
 # sf-watch-reclaim-sweep-handler / ci-watch-liveness-probe (this Lambda mirrors
 # their reclaim-checker exactly).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.10.2

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/requirements.txt
@@ -6,7 +6,7 @@ boto3>=1.34.0
 # ci-watch-dispatcher). No [flow-doctor] extra needed — this Lambda sends no
 # Telegram of its own (see index.py docstring: the on-box runner sends the
 # outcome-specific receipt once the migration concludes).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-dispatcher/requirements.txt
@@ -10,5 +10,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.14.0

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/canary-replay-liveness-probe/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # already unique per ISO week — no hand-rolled fingerprint/clear state needed).
 # Root-pin lockstep (tests/test_lib_pin_lockstep.py) — no exemption needed,
 # this Lambda uses no spot_dispatch feature requiring a newer tag.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.14.0

--- a/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/ci-watch-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.14.0

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/data-spot-dispatcher/requirements.txt
@@ -2,7 +2,7 @@
 boto3>=1.34.0
 # config#1767 — ec2_spot launch chokepoint. Bumped to v0.124.5 for config#2698
 # (SpotQuotaExceededError availability via krepis.ec2_spot / krepis.alerts).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/eod-backstop/requirements.txt
+++ b/infrastructure/lambdas/eod-backstop/requirements.txt
@@ -5,4 +5,4 @@
 # pin coherent across sibling Lambdas avoids divergence on lib-side helpers.
 # (The package imports as ``nousergon_lib`` at this pin — the rename from
 # ``alpha_engine_lib`` landed at 0.60.0 and siblings are now on v0.83.0.)
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
+++ b/infrastructure/lambdas/eod-snapshot-existence-check/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-watchdog-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
+++ b/infrastructure/lambdas/eod-success-friday-shell-trigger/requirements.txt
@@ -1,4 +1,4 @@
 # Pinned to match sf-telegram-notifier/requirements.txt — both Lambdas share
 # the same alpha-engine-data lib substrate; keeping the pin coherent across
 # sibling Lambdas avoids divergence on lib-side date helpers.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # terminate_on_failure). Pinned in LOCKSTEP with this repo's root
 # requirements.txt (tests/test_lib_pin_lockstep.py) rather than carrying its own
 # exemption: this Lambda depends on no feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # krepis.spot_bootstrap.render_bootstrap() renders this box's watchdog units,
 # hard-runtime timer, interpreter install and public clone. Same lockstep rule:
 # a floor 45 minors below what the handler imports is a pin that says nothing

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # terminate_on_failure). Pinned in LOCKSTEP with this repo's root
 # requirements.txt (tests/test_lib_pin_lockstep.py) rather than carrying its own
 # exemption: this Lambda depends on no feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # krepis.spot_bootstrap.render_bootstrap() renders this box's watchdog units,
 # hard-runtime timer, interpreter install and public clone. Same lockstep rule:
 # a floor 45 minors below what the handler imports is a pin that says nothing

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/expense-collector/requirements.txt
+++ b/infrastructure/lambdas/expense-collector/requirements.txt
@@ -2,4 +2,4 @@
 # over-budget pacing alert. Pinned to v0.83.0, matching the other single-topic
 # (OPS_HEALTH-only, no CRITICAL) flow-doctor consumers in this fleet (e.g.
 # saturday-integrity-sentinel, sf-watch-reclaim-sweep-handler, pipeline-watchdog).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/freshness-monitor/index.py
+++ b/infrastructure/lambdas/freshness-monitor/index.py
@@ -96,6 +96,10 @@ from nousergon_lib.artifact_freshness import (
     CheckResult,
     check_freshness,
     cycle_completion,
+    has_wildcard_segment,
+    key_pattern,
+    key_suffix,
+    listable_prefix,
     resolve_current_cycle,
 )
 from nousergon_lib.trading_calendar import last_closed_trading_day, previous_trading_day
@@ -1471,7 +1475,15 @@ def _prefix_has_ever_been_written(
     given up is the failure this whole function is shaped to avoid.
     """
     template = spec.s3_key_template
-    head = template.split("{", 1)[0]
+    # `listable_prefix` stops at the first `{` OR the producer-chosen `*`
+    # segment (alpha-engine-config-I10200). Deriving the head with a bare
+    # `split("{")` here got `oos_rows/*/` for the dated row and the WHOLE
+    # template — literal `*` and all — for `oos_rows/*/latest.parquet`, so the
+    # LIST ran against a prefix no object can start with, returned KeyCount 0,
+    # and this function answered "never written" about an artifact that had
+    # existed since 2026-09-05. Borrowed from the lib rather than re-derived:
+    # three resolvers must agree about this grammar (`policy-shared-code`).
+    head = listable_prefix(template)
     if head.endswith("/"):
         prefix = head
     elif "/" in head:
@@ -1479,16 +1491,28 @@ def _prefix_has_ever_been_written(
     else:
         prefix = head
     if not prefix:
-        prefix = result.canonical_key or template
+        prefix = result.observed_key or template
+
+    # The authoritative test for a wildcard template is the compiled shape —
+    # its coarse suffix (`.parquet`) would sweep in every sibling diagnostic
+    # under `predictor/diagnostics/`, which is the same over-match that made
+    # `research_self_test` read never_written=False off a populated
+    # `research/` prefix (config-I7622 follow-up).
+    pattern = key_pattern(template) if has_wildcard_segment(template) else None
 
     # Everything after the LAST placeholder — e.g. "/self_test.json" for
     # `research/{date}/self_test.json`. A template ending at a directory
     # boundary (`groom/{date}/`) has no distinguishing trailing segment, so
     # prefix membership IS the question there and the cheap MaxKeys=1 path is
     # the right one.
-    suffix = template.rsplit("}", 1)[-1] if "{" in template else ""
+    suffix = key_suffix(template) if "{" in template else ""
     if not suffix.strip("/"):
         suffix = ""
+    if pattern is not None:
+        # A wildcard row always needs the matching scan, never the MaxKeys=1
+        # prefix-membership shortcut: prefix membership is exactly the
+        # question it cannot answer.
+        suffix = suffix or "/"
 
     try:
         if not suffix:
@@ -1504,7 +1528,11 @@ def _prefix_has_ever_been_written(
                 kwargs["ContinuationToken"] = token
             resp = s3_client.list_objects_v2(**kwargs)
             for obj in resp.get("Contents") or []:
-                if str(obj.get("Key", "")).endswith(suffix):
+                key = str(obj.get("Key", ""))
+                if pattern is not None:
+                    if pattern.match(key) is not None:
+                        return True
+                elif key.endswith(suffix):
                     return True
             if not resp.get("IsTruncated"):
                 return False

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/requirements.txt
+++ b/infrastructure/lambdas/freshness-monitor/requirements.txt
@@ -1,6 +1,6 @@
 # config#1747 — flow-doctor forum-topic routing for SLA-miss alerts.
 # Substrate bumped to v0.85.0 for event_driven cadence + liveness_via (config#1718/#1726).
 # Bumping this is a substrate-change PR — not a code-only refresh.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.15.0
 pyyaml>=6.0

--- a/infrastructure/lambdas/freshness-monitor/test_handler.py
+++ b/infrastructure/lambdas/freshness-monitor/test_handler.py
@@ -5448,3 +5448,90 @@ def test_the_complete_line_publishes_the_phase_breakdown(
     for token in ("registry_load=", "producer_inventory=", "spec_loop=",
                   "post_loop=", "total=", "list_cache="):
         assert token in line, (token, line)
+
+
+# ── The producer-chosen `*` segment (alpha-engine-config-I10200) ─────────────
+#
+# A registry row may declare one path segment whose value the PRODUCER chooses
+# at write time — `predictor/diagnostics/oos_rows/*/{date}.parquet`, scoped by
+# the model FAMILY under alpha-engine-config-I9378 so a parallel zoo spec
+# cannot overwrite the champion's diagnostic.
+#
+# `_prefix_has_ever_been_written` derived its prefix with a bare
+# `template.split("{")`, which yields `oos_rows/*/` for the dated row and the
+# WHOLE template — literal `*` and all — for `oos_rows/*/latest.parquet`. Both
+# LIST against a prefix no object can start with, return nothing, and answer
+# "never written" about an artifact that has existed since 2026-09-05. A
+# never_written row does not page (see `_alert_decision`), so the wrong answer
+# here is the one that silences a real absence.
+
+
+def _wildcard_spec(index_mod, template="predictor/diagnostics/oos_rows/*/{date}.parquet"):
+    from nousergon_lib.artifact_freshness import ArtifactSpec, CheckResult
+    spec = ArtifactSpec(
+        artifact_id="predictor_oos_rows_dated", s3_bucket="alpha-engine-research",
+        s3_key_template=template, cadence="saturday_sf",
+        sla_minutes_after_cron=240, severity="warning",
+        owner_repo="alpha-engine-predictor", created_at=date(2025, 1, 1),
+    )
+    result = CheckResult(
+        state="missing", sla_violated_by_minutes=5771,
+        canonical_key="predictor/diagnostics/oos_rows/*/2026-09-04.parquet",
+        reason="no instance found",
+    )
+    return spec, result
+
+
+def test_wildcard_probe_lists_the_prefix_before_the_star(monkeypatch):
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _wildcard_spec(index)
+    stub = _ListStub(pages=[{"Contents": [], "IsTruncated": False}])
+    index._prefix_has_ever_been_written(stub, spec, result)
+    assert stub.calls[0]["Prefix"] == "predictor/diagnostics/oos_rows/"
+
+
+def test_wildcard_probe_lists_the_prefix_for_a_placeholderless_template(monkeypatch):
+    """`oos_rows/*/latest.parquet` carries no brace at all, so the old
+    `split("{")` head was the entire template including the literal `*`."""
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _wildcard_spec(
+        index, template="predictor/diagnostics/oos_rows/*/latest.parquet",
+    )
+    stub = _ListStub(pages=[{"Contents": [], "IsTruncated": False}])
+    index._prefix_has_ever_been_written(stub, spec, result)
+    assert stub.calls[0]["Prefix"] == "predictor/diagnostics/oos_rows/"
+
+
+def test_wildcard_probe_finds_the_live_instance(monkeypatch):
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _wildcard_spec(index)
+    stub = _ListStub(pages=[{
+        "Contents": [
+            {"Key": "predictor/diagnostics/oos_rows/v3.0-meta/2026-09-04.parquet"},
+        ],
+        "IsTruncated": False,
+    }])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is True
+
+
+def test_wildcard_probe_does_not_count_a_sibling_diagnostic(monkeypatch):
+    """A coarse `.parquet` suffix filter would sweep in every sibling under
+    `predictor/diagnostics/` — the config-I7622 over-match, one level down."""
+    import importlib
+    import index
+    importlib.reload(index)
+    spec, result = _wildcard_spec(index)
+    stub = _ListStub(pages=[{
+        "Contents": [
+            {"Key": "predictor/diagnostics/oos_rows/v3.0-meta/summary.json"},
+            {"Key": "predictor/diagnostics/oos_rows/2026-09-04.parquet"},
+        ],
+        "IsTruncated": False,
+    }])
+    assert index._prefix_has_ever_been_written(stub, spec, result) is False

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/friday-shell-run-report/requirements.txt
+++ b/infrastructure/lambdas/friday-shell-run-report/requirements.txt
@@ -2,4 +2,4 @@
 # trading_day fallback when an execution name lacks the friday-shell-{date}
 # prefix). Pinned to match the sibling eod-success-friday-shell-trigger Lambda
 # so the two Friday-shell-run Lambdas share one lib-date substrate.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
+++ b/infrastructure/lambdas/overseer-liveness-probe/requirements.txt
@@ -3,7 +3,7 @@
 # forum-topic routing + bundled flow_doctor_telegram.py, so the same known-good
 # pin. (Routing this probe's OWN alerts onto the nousergon-alerts intake bus via
 # a krepis>=0.15.0 bump is alpha-engine-config-I2846's scope, not this refactor.)
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.10.2
 # Registry parsing (infrastructure/overseer/playbooks.yaml bundled at deploy).
 pyyaml>=6.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.15.0

--- a/infrastructure/lambdas/pipeline-watchdog/requirements.txt
+++ b/infrastructure/lambdas/pipeline-watchdog/requirements.txt
@@ -1,4 +1,4 @@
 # config#1742 T2 — flow-doctor forum-topic routing for pipeline-watchdog alerts.
 # trading_calendar + alerts.publish (SNS-only; Telegram via flow_doctor_telegram).
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.15.0

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
+++ b/infrastructure/lambdas/preopen-deploy-readiness-probe/requirements.txt
@@ -6,4 +6,4 @@
 #     SNS fan-out to alpha-engine-alerts
 # Pinned to match the current sibling-Lambda pin (config#1787-adjacent
 # lockstep discipline — keep sibling Lambdas' lib pin coherent).
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
+++ b/infrastructure/lambdas/saturday-integrity-sentinel/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Monday GO/NO-GO sentinel.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.15.0

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.10.2

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for Fleet-SF Watch receipts.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.10.2

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/requirements.txt
@@ -83,4 +83,4 @@ boto3>=1.34.0
 # `flow-doctor` right: the sweep that fixed that symbol never looked for a
 # SECOND underscored extra, and scripts/lint_extras.py never opened this file
 # at all (it globbed the repo root only). Both are fixed in this PR.
-nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor,github-app] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
+++ b/infrastructure/lambdas/sf-telegram-notifier/requirements.txt
@@ -1,3 +1,3 @@
 # config#1742 T2 — flow-doctor forum-topic routing for SF start/stop pings.
-nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.15.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 krepis>=0.14.0

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/requirements.txt
@@ -19,5 +19,5 @@ boto3>=1.34.0
 # (account-wide spot quota, e.g. MaxSpotInstanceCountExceeded) the same way
 # it already does for SpotCapacityExhausted — bumped to the latest v0.124.5
 # tag to pick that up.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 krepis>=0.14.0

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
+++ b/infrastructure/lambdas/spot-orphan-reaper/requirements.txt
@@ -5,4 +5,4 @@ boto3>=1.34.0
 # CI-watch incomplete-reap alert. No [flow-doctor] extra needed: this Lambda
 # sends exactly one alert shape, not the full multi-topic forum substrate
 # other Lambdas route through. Same pin as scheduled-groom-dispatcher.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/thinktank-spot-dispatcher/requirements.txt
@@ -6,4 +6,4 @@ boto3>=1.34.0
 # running_instance_ids / terminate_on_failure) plus SpotProbeError, all of
 # which have been present since v0.106.0 — so there is no feature floor above
 # root here and no reason to carve an exemption. Bump in lockstep with root.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -10,4 +10,4 @@
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
 # v0.124.88. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
+++ b/infrastructure/lambdas/weekly-coverage-sweep/requirements.txt
@@ -10,4 +10,4 @@
 # FLOOR, not a preference: coverage.py and completion_marker.py first exist in
 # v0.124.88. A lower pin makes this handler fail its import and return
 # outcome=unavailable every week — which pages honestly, but detects nothing.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
+++ b/infrastructure/lambdas/weekly-freshness-spot-dispatcher/requirements.txt
@@ -5,7 +5,7 @@ boto3>=1.34.0
 # lockstep with this repo's root requirements.txt (tests/test_lib_pin_lockstep.py)
 # rather than carrying its own exemption — this Lambda has no dependency on a
 # feature ahead of what root already pins.
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # I7372: krepis.spot_bootstrap.render_bootstrap() is now the source of this
 # Lambda's remote bootstrap. `--max-runtime-seconds`, `extra_clones` and the
 # strict interpreter block first shipped in 0.59.6, and `>=0.14.0` let the

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,7 +16,7 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # alpha-engine-config-I8155: this Lambda records its own coverage verdict via
 # krepis.stage_coverage. Pin the released contract that refuses a blank SF
 # execution run_date and uses no cycle-date fallback.

--- a/infrastructure/lambdas/weekly-preflight/requirements.txt
+++ b/infrastructure/lambdas/weekly-preflight/requirements.txt
@@ -16,7 +16,7 @@
 # only the LAMBDA_CAPABILITIES profile (AWS control plane), and every check
 # needing more is reported status="skip" rather than executed.
 aws-assume-role-lib
-nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # alpha-engine-config-I8155: this Lambda records its own coverage verdict via
 # krepis.stage_coverage. Pin the released contract that refuses a blank SF
 # execution run_date and uses no cycle-date fallback.

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.15.1
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120

--- a/requirements-daily-news.txt
+++ b/requirements-daily-news.txt
@@ -30,4 +30,4 @@ anyio>=4.15.1
 tenacity>=9.1.4
 pyyaml>=6.0.3
 voyageai>=0.5.0
-nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[rag,flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,7 @@ arcticdb>=6.25.0
 # unrelated feature ahead of v0.124.115 — nousergon-lib-PR399/I10230's LLM
 # endpoint probe lift) so this pin and the Lambda pins below stay in
 # lockstep with the rest of the repo's already-bumped v0.124.116 dependents.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.116
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,7 @@ arcticdb>=6.25.0
 # unrelated feature ahead of v0.124.115 — nousergon-lib-PR399/I10230's LLM
 # endpoint probe lift) so this pin and the Lambda pins below stay in
 # lockstep with the rest of the repo's already-bumped v0.124.116 dependents.
-nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.119
+nousergon-lib[arcticdb,flow-doctor,rag,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
 # krepis floor: sf_preflight.py reads the operator pricing override
 # (cost/model_pricing.yaml) via nousergon_lib.cost -> krepis.cost.PriceCard,
 # which is extra="forbid". config#1332 adds the cache_create_1h_per_1m field,

--- a/tests/test_stage_output_sweep.py
+++ b/tests/test_stage_output_sweep.py
@@ -1615,3 +1615,233 @@ class TestGatedRowBothPolarities:
             head=_head_from({key: "error:403 AccessDenied"}), cycle_date=RUN_DATE,
         )[0]
         assert f["verdict"] == sos.UNMEASURED
+
+
+# ---------------------------------------------------------------------------
+# The producer-chosen ``*`` segment (alpha-engine-config-I10200)
+# ---------------------------------------------------------------------------
+#
+# `crucible-predictor` rescoped `predictor/diagnostics/oos_rows/…` by the model
+# FAMILY under alpha-engine-config-I9378 so a parallel zoo spec could not
+# overwrite the champion's diagnostic. The registry's flat row then made this
+# sweep report `PredictorTraining` MISSING for the 2026-09-04 cycle while
+# `oos_rows/v3.0-meta/2026-09-04.parquet` had existed since 2026-09-05 — one of
+# the three findings holding `alpha-engine-stage-coverage-findings` in ALARM.
+#
+# A resolved key carrying `*` is a PATTERN and cannot be head-ed, so it is
+# resolved by listing. What these tests pin hardest is what the resolution must
+# NOT do: clear the row off the unscoped key (the shape I9378 removed), and
+# report a listing it could not complete as an absent artifact.
+
+_OOS_DATED = "predictor/diagnostics/oos_rows/*/{date}.parquet"
+_OOS_LATEST = "predictor/diagnostics/oos_rows/*/latest.parquet"
+
+
+def _find_from(mapping):
+    """Build a ``find`` callable from ``{key: last_modified | 'error:<why>'}``.
+
+    Matches the pattern the same way :func:`stage_output_sweep._newest_match`
+    does — compiled shape, newest survivor — without an S3 client, so the
+    verdict branches stay reachable. A mapping VALUE beginning ``error:``
+    makes the whole listing fail, which is the branch that must not render as
+    ``absent``.
+    """
+
+    def find(bucket, pattern):
+        compiled = sos._wildcard_support()["key_pattern"](pattern)
+        newest_key, newest_lm = "", None
+        for key, value in mapping.items():
+            if isinstance(value, str) and value.startswith("error:"):
+                return "error", value[len("error:"):], ""
+            if compiled.match(key) is None:
+                continue
+            if newest_lm is None or value > newest_lm:
+                newest_lm, newest_key = value, key
+        if newest_lm is None:
+            return "absent", None, ""
+        return "found", newest_lm, newest_key
+
+    return find
+
+
+class TestWildcardSegment:
+    def _one(self, template, objects, *, find=True, **kw):
+        decls = sos.declared_outputs(
+            [_row("a", template, "PredictorTraining")], pipeline=PIPELINE,
+        )
+        kw.setdefault("execution_start", EXEC_START)
+        kw.setdefault("cycle_date", RUN_DATE)
+        return sos.evaluate(
+            decls,
+            run_date=RUN_DATE,
+            head=_head_from({}),
+            find=_find_from(objects) if find else None,
+            **kw,
+        )[0]
+
+    def test_resolve_key_passes_the_wildcard_through(self):
+        assert sos.resolve_key(
+            _OOS_DATED, run_date=RUN_DATE, cycle_date=RUN_DATE,
+        ) == f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet"
+
+    def test_resolve_key_rejects_an_illegal_wildcard_shape(self):
+        """A malformed row is `unmeasured` with a reason naming the template —
+        not a pattern that silently matches the wrong set."""
+        for bad in (
+            "predictor/diagnostics/oos_rows/*",
+            "predictor/diagnostics/oos_rows/**/x.parquet",
+            "a/*/b/*/{date}.parquet",
+            "a/v*/{date}.parquet",
+        ):
+            assert sos.resolve_key(
+                bad, run_date=RUN_DATE, cycle_date=RUN_DATE,
+            ) is None, bad
+
+    def test_the_2026_09_04_shaped_case_reports_wrote(self):
+        """The Closes-when of I10200 on this side of the cascade."""
+        key = f"predictor/diagnostics/oos_rows/v3.0-meta/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {key: EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.WROTE
+        # The pattern says where it was expected; `key` says which instance
+        # the verdict was taken over, so the verdict is verifiable by hand.
+        assert f["pattern"] == f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet"
+        assert f["key"] == key
+
+    def test_latest_pointer_row_resolves_too(self):
+        key = "predictor/diagnostics/oos_rows/v3.0-meta/latest.parquet"
+        f = self._one(_OOS_LATEST, {key: EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.WROTE
+        assert f["key"] == key
+
+    def test_the_unscoped_key_does_not_clear_the_scoped_row(self):
+        """The flat key is the shape I9378 REMOVED, to stop a zoo run
+        overwriting the champion's diagnostic. Finding one must not be read as
+        the stage having written the scoped artifact."""
+        flat = f"predictor/diagnostics/oos_rows/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {flat: EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.MISSING
+        assert f["key"] is None
+
+    def test_a_sibling_diagnostic_does_not_clear_the_row(self):
+        sibling = f"predictor/diagnostics/xsec_sd/v3.0-meta/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {sibling: EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.MISSING
+
+    def test_another_cycles_instance_does_not_clear_this_run(self):
+        """The pattern is anchored to THIS run's cycle date — only the
+        producer's segment is free. A recency match would let last week's
+        instance clear this week's silent stage."""
+        other = "predictor/diagnostics/oos_rows/v3.0-meta/2026-07-04.parquet"
+        f = self._one(_OOS_DATED, {other: EXEC_START + timedelta(hours=2)})
+        assert f["verdict"] == sos.MISSING
+
+    def test_newest_matching_family_wins(self):
+        older = f"predictor/diagnostics/oos_rows/v3.0-meta/{RUN_DATE}.parquet"
+        newer = f"predictor/diagnostics/oos_rows/v4.0-zoo/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {
+            older: EXEC_START + timedelta(hours=1),
+            newer: EXEC_START + timedelta(hours=3),
+        })
+        assert f["verdict"] == sos.WROTE
+        assert f["key"] == newer
+
+    def test_stale_instance_is_still_stale(self):
+        key = f"predictor/diagnostics/oos_rows/v3.0-meta/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {key: EXEC_START - timedelta(days=30)})
+        assert f["verdict"] == sos.STALE
+
+    def test_listing_failure_is_unmeasured_not_missing(self):
+        key = f"predictor/diagnostics/oos_rows/v3.0-meta/{RUN_DATE}.parquet"
+        f = self._one(_OOS_DATED, {key: "error:AccessDenied"})
+        assert f["verdict"] == sos.UNMEASURED
+        assert "AccessDenied" in f["detail"]
+
+    def test_no_lister_supplied_is_unmeasured_not_missing(self):
+        """A caller that cannot list cannot answer these rows. Saying so is
+        the only honest option — head-ing a literal `*` would 404 and report a
+        confident, permanent, entirely false `missing`."""
+        f = self._one(_OOS_DATED, {}, find=False)
+        assert f["verdict"] == sos.UNMEASURED
+        assert "*" in f["detail"]
+
+    def test_fixed_key_rows_never_reach_the_lister(self):
+        """The wildcard path must not move a single existing row's verdict."""
+        decls = sos.declared_outputs(
+            [_row("a", "b/{date}.json", "Backtester")], pipeline=PIPELINE,
+        )
+
+        def _explode(bucket, pattern):  # pragma: no cover - must not be called
+            raise AssertionError("a fixed-key row must be head-ed, not listed")
+
+        f = sos.evaluate(
+            decls,
+            run_date=RUN_DATE,
+            head=_head_from({f"b/{RUN_DATE}.json": EXEC_START}),
+            find=_explode,
+            execution_start=EXEC_START,
+            cycle_date=RUN_DATE,
+        )[0]
+        assert f["verdict"] == sos.WROTE
+        assert f["pattern"] is None
+
+
+class TestNewestMatchAgainstS3:
+    """`_newest_match` itself, against a stubbed paginator."""
+
+    def _s3(self, objects, *, pages=None, raises=None):
+        class _Paginator:
+            def paginate(self, **kwargs):
+                if raises is not None:
+                    raise raises
+                contents = [
+                    {"Key": k, "LastModified": v}
+                    for k, v in objects.items()
+                    if k.startswith(kwargs["Prefix"])
+                ]
+                return iter(pages if pages is not None else [{"Contents": contents}])
+
+        class _S3:
+            def get_paginator(self, name):
+                assert name == "list_objects_v2"
+                return _Paginator()
+
+        return _S3()
+
+    def test_lists_the_prefix_before_the_star(self):
+        key = f"predictor/diagnostics/oos_rows/v3.0-meta/{RUN_DATE}.parquet"
+        state, lm, found = sos._newest_match(
+            self._s3({key: EXEC_START}),
+            "alpha-engine-research",
+            f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet",
+        )
+        assert (state, lm, found) == ("found", EXEC_START, key)
+
+    def test_empty_prefix_is_absent(self):
+        state, lm, found = sos._newest_match(
+            self._s3({}),
+            "alpha-engine-research",
+            f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet",
+        )
+        assert (state, lm, found) == ("absent", None, "")
+
+    def test_list_error_is_an_error_not_absent(self):
+        state, detail, found = sos._newest_match(
+            self._s3({}, raises=RuntimeError("boom")),
+            "alpha-engine-research",
+            f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet",
+        )
+        assert state == "error"
+        assert "boom" in detail
+
+    def test_truncated_scan_is_an_error_not_absent(self):
+        """S3 lists lexically, so the keys past the cap are not a random
+        sample — and 'I could not see the whole prefix' is not evidence the
+        artifact is missing (alpha-engine-config-I7617)."""
+        state, detail, found = sos._newest_match(
+            self._s3({}, pages=[{"Contents": []} for _ in range(5)]),
+            "alpha-engine-research",
+            f"predictor/diagnostics/oos_rows/*/{RUN_DATE}.parquet",
+            cap_pages=2,
+        )
+        assert state == "error"
+        assert "scan cap" in detail

--- a/validators/stage_output_sweep.py
+++ b/validators/stage_output_sweep.py
@@ -105,6 +105,25 @@ always in the alarming direction. The verdict set keeps the two apart:
                   DID get written still reports ``wrote``: the downgrade only
                   ever applies to a would-be ``missing``/``stale``
 
+## The producer-chosen ``*`` segment
+
+A registry row may declare one path segment whose value the PRODUCER chooses
+at write time and no consumer can derive — a single literal ``*`` occupying
+one whole segment (alpha-engine-config-I10200). The live instance is
+``predictor/diagnostics/oos_rows/*/{date}.parquet``, scoped by the model
+FAMILY under alpha-engine-config-I9378 so a parallel zoo spec cannot
+overwrite the champion's diagnostic.
+
+Such a resolved key is a PATTERN and cannot be head-ed, so it is resolved by
+listing the fixed prefix before the ``*`` and taking the NEWEST instance
+matching the pattern — with the ordinary placeholders already substituted, so
+the match is anchored to this run's cycle date and only the producer's segment
+is free. The verdict logic then runs unchanged: the row is held to exactly the
+same standard as a fixed key. Zero matches is ``missing``; a listing that
+could not complete is ``unmeasured``; and **never** a fallback to the
+unscoped key, which would resurrect the overwrite hazard I9378 exists to
+prevent.
+
 ``unmeasured`` is deliberately NOT silent. Absence of a measurement is a
 first-class finding with its own exit code and its own alert, because the
 alternative — a sweep that reports 0 defects because it could not look — is the
@@ -472,6 +491,15 @@ def resolve_key(
     ``artifact_freshness._format_key``, the second being a semantic name for
     the same tick. ``{run_date}`` resolves to the SF's own ``$.run_date``.
 
+    A literal ``*`` segment — the producer-chosen segment, the registry's way
+    of declaring "one segment whose value the PRODUCER picks and no consumer
+    can derive" (alpha-engine-config-I10200) — passes through untouched. The
+    result is then a PATTERN, not a key, and :func:`evaluate` resolves it by
+    listing rather than head-ing; see :func:`_newest_match`. The grammar is
+    validated here (one whole segment, never the last) so a malformed row
+    reports ``unmeasured`` with a reason naming the template, rather than
+    producing a pattern that silently matches the wrong set.
+
     Returns ``None`` — meaning ``unmeasured``, never ``missing`` — when the
     template needs a cycle date that could not be resolved, or carries any
     OTHER placeholder (``{cycle_label}``, an hour bucket, anything added
@@ -479,6 +507,25 @@ def resolve_key(
     report a confident, permanent, entirely false ``missing``: the most
     convincing wrong finding this sweep could produce.
     """
+    support = _wildcard_support()
+    if "*" in template:
+        if support is None:
+            logger.error(
+                "Template %r carries the producer-chosen '*' segment but "
+                "nousergon_lib.artifact_freshness is unavailable — reporting "
+                "unmeasured rather than head-ing a literal '*', which would "
+                "404 and report a confident false missing",
+                template,
+            )
+            return None
+        try:
+            support["validate_key_template"](template)
+        except Exception as exc:  # noqa: BLE001 - any illegal shape is unmeasured
+            logger.error(
+                "Template %r has an unresolvable wildcard shape (%s) — "
+                "unmeasured, not missing", template, exc,
+            )
+            return None
     resolved = template
     for name in set(_PLACEHOLDER_RE.findall(template)):
         if name in ("date", "trading_day"):
@@ -635,6 +682,112 @@ def declared_outputs(
     return out
 
 
+def _wildcard_support() -> dict[str, Any] | None:
+    """The ``s3_key_template`` grammar, borrowed from ``nousergon_lib``.
+
+    The producer-chosen ``*`` segment is the REGISTRY's grammar, and three
+    independent resolvers have to agree about it: this sweep, the freshness
+    monitor, and ``alpha-engine-config``'s registry validator. A third
+    hand-rolled copy of "where does the prefix stop, what does the wildcard
+    match, which shapes are illegal" is ``policy-shared-code``'s duplication
+    failure, so the definition lives once in
+    :mod:`nousergon_lib.artifact_freshness` and is imported here.
+
+    Imported lazily and returned as ``None`` on failure, matching
+    :func:`resolve_cycle_date`: this module is deliberately import-light and
+    runs in contexts (a bare spot box, a unit test) where the lib may be
+    absent. ``None`` renders every wildcard row ``unmeasured`` — loud, and
+    never a head of a literal ``*``.
+    """
+    try:
+        from nousergon_lib.artifact_freshness import (  # noqa: PLC0415
+            has_wildcard_segment,
+            key_pattern,
+            listable_prefix,
+            validate_key_template,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "nousergon_lib.artifact_freshness unavailable (%s) — every "
+            "registry row carrying the producer-chosen '*' segment will "
+            "report unmeasured rather than be checked against a guess", exc,
+        )
+        return None
+    return {
+        "has_wildcard_segment": has_wildcard_segment,
+        "key_pattern": key_pattern,
+        "listable_prefix": listable_prefix,
+        "validate_key_template": validate_key_template,
+    }
+
+
+def _newest_match(
+    s3_client: Any, bucket: str, pattern: str, *, cap_pages: int = 64
+) -> tuple[str, Any, str]:
+    """Resolve a ``*``-bearing key PATTERN to its newest existing instance.
+
+    Returns ``(state, detail, key)`` with the same three-way state as
+    :func:`_head` — ``("found", last_modified, key)``,
+    ``("absent", None, "")``, ``("error", reason, "")`` — so
+    :func:`evaluate`'s verdict logic is identical either way and a wildcard
+    row is held to exactly the same standard as a fixed one.
+
+    The pattern is the template with the ordinary placeholders already
+    substituted, so the match is anchored to THIS run's cycle date and only
+    the producer-chosen segment is free. That is deliberately stricter than
+    the freshness monitor's recency model over the same rows: the monitor asks
+    "is any instance younger than the cadence clock", this sweep asks "did the
+    stage that ran in THIS EXECUTION write the key it declares", and answering
+    the second with the first would let last week's instance clear this week's
+    silent stage.
+
+    **A truncated listing is an error, never ``absent``.** S3 lists
+    lexically, so the keys past the cap are not a random sample — and
+    "I could not see the whole prefix" is not evidence the artifact is
+    missing (the class alpha-engine-config-I7617 was filed about).
+    """
+    support = _wildcard_support()
+    if support is None:
+        return "error", "nousergon_lib.artifact_freshness unavailable", ""
+    try:
+        compiled = support["key_pattern"](pattern)
+        prefix = support["listable_prefix"](pattern)
+    except Exception as exc:  # noqa: BLE001
+        return "error", f"unresolvable pattern {pattern!r}: {exc}", ""
+
+    newest_key = ""
+    newest_lm = None
+    try:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        for page_index, page in enumerate(
+            paginator.paginate(Bucket=bucket, Prefix=prefix)
+        ):
+            if page_index >= cap_pages:
+                return (
+                    "error",
+                    f"LIST of {prefix!r} exceeded the {cap_pages}-page scan "
+                    f"cap; keys list lexically so the objects past the cap "
+                    f"are the newest — this is an unanswered question, not an "
+                    f"absent artifact (alpha-engine-config-I7617)",
+                    "",
+                )
+            for obj in page.get("Contents") or []:
+                key = obj.get("Key") or ""
+                if compiled.match(key) is None:
+                    continue
+                last_modified = obj.get("LastModified")
+                if last_modified is None:
+                    continue
+                if newest_lm is None or last_modified > newest_lm:
+                    newest_lm, newest_key = last_modified, key
+    except Exception as exc:  # noqa: BLE001
+        return "error", f"{type(exc).__name__}: {exc}", ""
+
+    if newest_lm is None:
+        return "absent", None, ""
+    return "found", newest_lm, newest_key
+
+
 def _head(s3_client: Any, bucket: str, key: str) -> tuple[str, Any]:
     """HEAD one key.
 
@@ -663,6 +816,7 @@ def evaluate(
     run_date: str,
     execution_start: datetime | None,
     head: Callable[[str, str], tuple[str, Any]],
+    find: Callable[[str, str], tuple[str, Any, str]] | None = None,
     entered_stages: frozenset[str] | None = None,
     cycle_date: str | None = None,
     run_mode: str | None = None,
@@ -680,6 +834,16 @@ def evaluate(
         head: ``(bucket, key) -> (state, detail)``, injected so the decision
             logic is testable without S3 and so the failing branch can actually
             be exercised.
+        find: ``(bucket, pattern) -> (state, detail, key)`` for a resolved key
+            carrying the producer-chosen ``*`` segment
+            (alpha-engine-config-I10200) — a pattern cannot be head-ed, so it
+            is resolved by listing the fixed prefix and taking the newest
+            instance matching the pattern. States mirror ``head``, so the
+            verdict logic below is identical either way. ``None`` (no lister
+            supplied) makes every wildcard row ``unmeasured``: a caller that
+            cannot list cannot answer those rows, and saying so is the only
+            honest option — head-ing a literal ``*`` would 404 and report a
+            confident, permanent, entirely false ``missing``.
         entered_stages: the stages that actually entered this execution, when
             known. ``None`` means unknown, and then NO stage is marked
             ``skipped`` — "I don't know which stages ran" must never become
@@ -714,6 +878,10 @@ def evaluate(
             "bucket": declaration["bucket"],
             "severity": declaration.get("severity", "warning"),
             "key": None,
+            # Non-None only for a row whose resolved key carries the
+            # producer-chosen '*' segment: the pattern that was matched,
+            # alongside `key`, which then names the instance actually found.
+            "pattern": None,
             "last_modified": None,
             "detail": None,
         }
@@ -760,7 +928,25 @@ def evaluate(
         ):
             continue
 
-        state, detail = head(declaration["bucket"], key)
+        if "*" in key:
+            if find is None:
+                finding["verdict"] = UNMEASURED
+                finding["detail"] = (
+                    f"resolved key {key!r} carries the producer-chosen '*' "
+                    f"segment and no object lister was supplied, so this row "
+                    f"cannot be resolved by a HEAD — unmeasured, not missing "
+                    f"(alpha-engine-config-I10200)"
+                )
+                findings.append(finding)
+                continue
+            state, detail, observed = find(declaration["bucket"], key)
+            # The pattern says where the artifact was expected; the observed
+            # key says which instance the verdict was taken over. Reporting
+            # only the pattern would leave the verdict unverifiable by hand.
+            finding["pattern"] = key
+            finding["key"] = observed or None
+        else:
+            state, detail = head(declaration["bucket"], key)
 
         if state == "error":
             finding["verdict"] = UNMEASURED
@@ -949,6 +1135,7 @@ def sweep(
         run_date=run_date,
         execution_start=execution_start,
         head=lambda b, k: _head(s3_client, b, k),
+        find=lambda b, k: _newest_match(s3_client, b, k),
         entered_stages=entered_stages,
         cycle_date=cycle_date,
         run_mode=run_mode,


### PR DESCRIPTION
## Why

`ARTIFACT_REGISTRY.yaml` can now declare a key whose path carries one **producer-chosen segment** — a single literal `*` occupying one whole path segment (`nousergon-lib-PR403`, `alpha-engine-config-I10200`). The live instance is `predictor/diagnostics/oos_rows/*/{date}.parquet`, scoped by the model FAMILY under `alpha-engine-config-I9378` so a parallel zoo spec cannot overwrite the champion's diagnostic.

Two consumers in this repo have to learn it, and **one of them was wrong in the silencing direction.**

## What changed

### `validators/stage_output_sweep`

A resolved key carrying `*` is a PATTERN and cannot be head-ed. New `_newest_match` LISTs the fixed prefix and takes the newest instance matching the compiled shape, returning `_head`'s same three-way state so `evaluate`'s verdict logic is **identical either way** — a wildcard row is held to exactly the same standard as a fixed one.

The pattern is anchored to THIS run's cycle date, only the producer's segment free. That is deliberately stricter than the freshness monitor's recency model over the same rows: this sweep asks "did the stage that ran in THIS EXECUTION write the key it declares", and answering it with "is any instance recent" would let last week's instance clear this week's silent stage.

- no lister supplied → `unmeasured`, never `missing`
- a truncated listing → `unmeasured`, never `missing` (`config-I7617`'s class: S3 lists lexically, so the keys past the cap are not a random sample)
- findings carry both `pattern` and the observed `key`, so a verdict over a wildcard row stays verifiable by hand

### `infrastructure/lambdas/freshness-monitor` — the silencing bug

`_prefix_has_ever_been_written` derived its prefix with a bare `template.split("{")`. That yields `oos_rows/*/` for the dated row and **the whole template, literal `*` and all**, for `oos_rows/*/latest.parquet`. Both LIST a prefix no object can start with, return nothing, and answer "never written" about an artifact that has existed since 2026-09-05.

**A `never_written` row does not page** (`_alert_decision`). So this was the wrong answer that silences a real absence — the direction that matters. Now uses the lib's `listable_prefix`, and for a wildcard row the compiled shape rather than a coarse `.parquet` suffix that would sweep in every sibling diagnostic under `predictor/diagnostics/` (`config-I7622`'s over-match, one level down).

### Shared, not re-derived

The grammar is imported from `nousergon_lib.artifact_freshness`. Three independent resolvers must agree about "where does the prefix stop, what does the wildcard match, which shapes are illegal", and a third hand-rolled copy is `policy-shared-code`'s duplication failure. The import is lazy and `None` on failure, matching `resolve_cycle_date`: this module is deliberately import-light, and an absent lib renders every wildcard row `unmeasured` rather than head-ing a literal `*`.

### Lib pin

v0.124.116 → **v0.124.119** across all 32 declarations in lockstep — `requirements.txt`, `requirements-daily-news.txt`, every per-Lambda `requirements.txt`, `Dockerfile`, `deploy-infrastructure.yml`.

## Testing

15 new tests in `tests/test_stage_output_sweep.py`, 4 in `infrastructure/lambdas/freshness-monitor/test_handler.py`. The load-bearing negatives: the unscoped flat key does **not** clear the scoped row (it is the shape I9378 removed — accepting it would resurrect the overwrite hazard), a sibling diagnostic does not, another cycle's instance does not, a listing failure is `unmeasured` not `missing`, and a fixed-key row never reaches the lister at all.

Full suite: **7210 passed, 19 skipped** (run against the `nousergon-lib` branch on `PYTHONPATH`, since v0.124.119 is not published yet). Lambda file: 221 passed.

## Merge order — lib → data → config

1. `nousergon-lib-PR403` — **merge first.** Merging publishes; its merge-time autobump produces v0.124.119, which is what the pins here name.
2. **this PR**
3. `alpha-engine-config-PR10538` — `validate_artifact_registry.py` accepts the form; the two `predictor_oos_rows_*` rows are re-declared with the real shape.

## Red by design until `nousergon-lib-PR403` merges

The lib pin here names **v0.124.119, which does not exist yet** — `nousergon-lib-PR403`'s merge-time autobump publishes it. Until then every check that installs the pin fails with "no matching distribution".

- **Which:** the pip-install-bearing checks (`pytest`, `pip-audit`, the deploy preflights).
- **Why the pin is not a TODO placeholder instead:** a placeholder string would fail the lockstep guard the same way while *also* being a value nobody can act on, and it would have to be edited between Brian's two merge clicks. A concrete pin is wrong for minutes and then right forever.
- **Assumption, stated:** v0.124.119 is the next patch. `nousergon-lib` `main` is at v0.124.118 and PR403 is the only open PR there. If another lib PR merges first, this pin is off by one, CI stays red, and the fix is a one-line bump — loud, not silent.
- **Unblocking step:** merge `nousergon-lib-PR403`, then re-run this PR's checks. No commit needed here if the assumption holds.

## What this needs from Brian

Merge `nousergon-lib-PR403` first, re-run this PR's checks, then merge this. Nothing to run after either merge.

Refs `alpha-engine-config-I10200`. A `Closes` keyword is inert across repositories, so I10200 is closed by hand once the next weekly sweep reports `PredictorTraining` as neither a finding nor `UNMEASURED`.

Prepared by: Claude Opus 5 (1M context) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMrf6UbUhbb417YxTpyADp
