### PR TITLE
fix(sf-telegram-notifier): floors on the wait states, stop truncating long weekly histories

### DIFF
--- a/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
@@ -22,9 +22,30 @@ S3_BUCKET = "alpha-engine-research"
 # pipeline state names only, and not one preopen or postclose state appears
 # in either.
 STATE_DURATION_FLOORS_SEC: Mapping[str, int] = {
-    # Weekly — ne-weekly-freshness-pipeline
-    "MorningEnrich": 15 * 60,
-    "DataPhase1": 15 * 60,
+    # Weekly — ne-weekly-freshness-pipeline. Floors sit on the POLL states
+    # (WaitForMorningEnrich / WaitForDataPhase1), not the SSM sendCommand
+    # DISPATCH states (MorningEnrich / DataPhase1) — same defect class as the
+    # weekday PollMorningEnrichSpot/PollMorningArcticAppendSpot floors below:
+    # a dispatch Task returns in well under a second having only sent the
+    # command, so a floor there fires on every healthy run. RECALIBRATED
+    # 2026-09-12 (alpha-engine-config-I10545): the prior 15m floors sat on
+    # "MorningEnrich" / "DataPhase1" and breached on every run unconditionally
+    # — measured directly on the 09-12 execution
+    # (51f6aa74-939a-ba89-22a6-751c65d5f9e3_1067770b-6b63-aa1b-8b21-891b904fcdd0):
+    # MorningEnrich 0.22s, DataPhase1 0.24s, both always ~0s. The real
+    # workload is the poll loop; measured first-entry->last-exit span of the
+    # poll states across the last four canonical weekly runs (2026-08-22,
+    # 08-29, 09-05, 09-12):
+    #   WaitForMorningEnrich: 31.7 / 34.3 / 35.3 / 35.3 min (min 31.7min = 1902s)
+    #   WaitForDataPhase1:    83.6 / 87.2 / 88.2 / 103.4 min (min 83.6min = 5016s)
+    # New floors, ~20% below each measured minimum (n=4, smaller sample than
+    # the weekday recalibrations above, so the wider margin): WaitForMorningEnrich
+    # 1902*0.8=1521.6s -> 1500s (25m, ~21% below); WaitForDataPhase1
+    # 5016*0.8=4012.8s -> 4020s (67m, ~19.8% below). The dispatch states'
+    # floors are dropped entirely — an always-~0s state has no plausible
+    # non-zero floor to set.
+    "WaitForMorningEnrich": 25 * 60,
+    "WaitForDataPhase1": 67 * 60,
     "RAGIngestion": 10 * 60,
     "PredictorTraining": 20 * 60,
     "Backtester": 10 * 60,
@@ -107,9 +128,12 @@ STATE_DURATION_FLOORS_SEC: Mapping[str, int] = {
 # Display order for digest lines. States NOT listed here still render — they
 # sort after these, longest-running first. See _sort_key.
 DIGEST_STATE_ORDER: Tuple[str, ...] = (
-    # Weekly
-    "MorningEnrich",
-    "DataPhase1",
+    # Weekly. "MorningEnrich" / "DataPhase1" (the dispatch states) are
+    # deliberately NOT listed here (alpha-engine-config-I10545) — they carry
+    # no information, always ~0s. The poll states that actually span the
+    # workload lead the order instead.
+    "WaitForMorningEnrich",
+    "WaitForDataPhase1",
     "RAGIngestion",
     "ResearchPredictorParallel",
     "PredictorTraining",
@@ -478,14 +502,55 @@ def format_digest_lines(
     return lines
 
 
+# alpha-engine-config-I10545: a long weekly run's raw GetExecutionHistory is
+# NOT a handful of pages — the 2026-09-12 ne-weekly-freshness-pipeline
+# execution (51f6aa74-939a-ba89-22a6-751c65d5f9e3_1067770b-6b63-aa1b-8b21-
+# 891b904fcdd0) took 42 pages / 8916 events to reach its last event, because
+# the API pages by response SIZE (~1MB), not by a fixed event count — passing
+# maxResults=1000 does not guarantee anything close to 1000 events per page.
+# The old max_pages=20 cap silently truncated that execution's history well
+# before WaitForDataPhase1's true last exit, so parse_task_state_durations
+# (already first-entry->last-exit, not the bug) computed a real but WRONG
+# short span from a partial history — the digest rendered "WaitForDataPhase1
+# 34m ✓" against a true 103.35m span, a confidently-wrong number rather than
+# an honestly-incomplete one. 150 pages is ~3.6x the measured 42-page need,
+# generous headroom against a still-longer future run without letting a
+# truly runaway/malformed execution loop unbounded.
+_MAX_HISTORY_PAGES = 150
+
+# Rendered when fetch_execution_history exhausts _MAX_HISTORY_PAGES with more
+# history still unread. A truncated history can only UNDERSTATE durations for
+# any state whose last exit fell past the cutoff, so this must force the
+# digest into its anomaly path rather than let a partial computation render
+# a plain "✓" (alpha-engine-config-I10545) — the same "confidently wrong is
+# worse than honestly incomplete" standard last_workload_state_entered's own
+# docstring states for the HandleFailure exclusion.
+HISTORY_TRUNCATED_LINE = (
+    "_(history truncated at {pages} pages — durations below may be understated)_"
+)
+
+
 def fetch_execution_history(
     sf_client: Any,
     execution_arn: str,
     *,
-    max_pages: int = 20,
-) -> List[dict]:
+    max_pages: Optional[int] = None,
+) -> Tuple[List[dict], bool]:
+    """Returns ``(events, truncated)``. ``truncated`` is True only when
+    ``max_pages`` was exhausted with a ``nextToken`` still outstanding —
+    never inferred from event count, since a genuinely short execution's
+    history legitimately fits in one page.
+
+    ``max_pages`` defaults to the module-level ``_MAX_HISTORY_PAGES``,
+    resolved at CALL time rather than bound as a literal default — so tests
+    (and any future recalibration) can override the module constant without
+    also having to pass it through every call site.
+    """
+    if max_pages is None:
+        max_pages = _MAX_HISTORY_PAGES
     events: List[dict] = []
     token: Optional[str] = None
+    truncated = False
     for _ in range(max_pages):
         kwargs: dict[str, Any] = {
             "executionArn": execution_arn,
@@ -499,12 +564,14 @@ def fetch_execution_history(
         if not token:
             break
     else:
+        truncated = bool(token)
         logger.warning(
-            "execution history pagination capped at %s pages for %s",
+            "execution history pagination capped at %s pages for %s (truncated=%s)",
             max_pages,
             execution_arn,
+            truncated,
         )
-    return events
+    return events, truncated
 
 
 # The ssm-liveness-poller poll-result contract (README.md at
@@ -590,7 +657,7 @@ def build_execution_digest(
     if not execution_arn:
         return ["_(digest unavailable: missing executionArn)_"], False, None
     try:
-        events = fetch_execution_history(sf_client, execution_arn)
+        events, truncated = fetch_execution_history(sf_client, execution_arn)
     except Exception as exc:  # noqa: BLE001
         logger.error("get_execution_history failed for %s: %s", execution_arn, exc)
         return ["_(digest unavailable: history fetch failed)_"], False, None
@@ -605,9 +672,17 @@ def build_execution_digest(
         run_date=run_date,
         s3_client=s3_client,
     )
+    lines = format_digest_lines(rows, last_entered=last_workload_state_entered(events))
     hollow = any(r.anomaly for r in rows) if not is_preflight else False
+    if truncated:
+        # A truncated history can only understate a duration, never overstate
+        # one — so a truncated-but-otherwise-clean row set is still a
+        # confidently wrong "healthy" digest unless this forces the anomaly
+        # path (alpha-engine-config-I10545).
+        lines.append(HISTORY_TRUNCATED_LINE.format(pages=_MAX_HISTORY_PAGES))
+        hollow = True
     return (
-        format_digest_lines(rows, last_entered=last_workload_state_entered(events)),
+        lines,
         hollow,
         detailed_failure_cause,
     )

--- a/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
@@ -67,8 +67,12 @@ ACCOUNT_ID = "711398986525"
 #: names in one list with no machine-readable split, so this module names the
 #: split explicitly rather than re-deriving it from comment boundaries.
 STATE_TO_STATE_MACHINE: Mapping[str, str] = {
-    "MorningEnrich": "ne-weekly-freshness-pipeline",
-    "DataPhase1": "ne-weekly-freshness-pipeline",
+    # alpha-engine-config-I10545: was "MorningEnrich" / "DataPhase1" (the
+    # always-~0s dispatch states) — renamed to match
+    # STATE_DURATION_FLOORS_SEC's move to the poll states that actually span
+    # the workload.
+    "WaitForMorningEnrich": "ne-weekly-freshness-pipeline",
+    "WaitForDataPhase1": "ne-weekly-freshness-pipeline",
     "RAGIngestion": "ne-weekly-freshness-pipeline",
     "PredictorTraining": "ne-weekly-freshness-pipeline",
     "Backtester": "ne-weekly-freshness-pipeline",
@@ -338,9 +342,21 @@ def render_report(recommendations: Sequence[FloorRecommendation]) -> str:
 
 
 def _default_fetch_history(sf_client: Any, execution_arn: str) -> List[dict]:
+    # alpha-engine-config-I10545: fetch_execution_history now returns
+    # (events, truncated) so callers can surface truncation; this adapter
+    # keeps collect_state_duration_samples' injected
+    # ``fetch_history(sf_client, execution_arn) -> List[dict]`` contract
+    # unchanged. Calibration is a batch/offline tool over many executions —
+    # a truncated sample here silently understates one execution's duration
+    # rather than corrupting a live alert, and floor_calibration.py's own
+    # min-based recommendation logic is naturally robust to an UNDERSTATED
+    # outlier (it would only pull the recommended floor down, not mask a
+    # genuinely broken run); a live truncation is caught where it matters,
+    # in execution_digest.build_execution_digest.
     from execution_digest import fetch_execution_history
 
-    return fetch_execution_history(sf_client, execution_arn)
+    events, _truncated = fetch_execution_history(sf_client, execution_arn)
+    return events
 
 
 def run_check(sf_client: Any) -> List[FloorRecommendation]:

--- a/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
@@ -12,6 +12,7 @@ from execution_digest import (
     STATE_DURATION_FLOORS_SEC,
     build_execution_digest,
     build_state_durations,
+    fetch_execution_history,
     format_digest_lines,
     parse_run_date_from_execution_name,
     parse_task_state_durations,
@@ -148,6 +149,51 @@ def test_poll_morning_arctic_append_spot_floor_still_catches_a_confirmed_broken_
     assert rows[0].anomaly is True
 
 
+def test_weekly_wait_floors_recalibrated_off_the_poll_states_not_dispatch():
+    # alpha-engine-config-I10545: the prior floors sat on "MorningEnrich" /
+    # "DataPhase1" (the SSM dispatch Task states), which enter+exit in well
+    # under a second every run (measured 0.22s / 0.24s on the 2026-09-12
+    # execution) — a floor there breaches unconditionally. Floors now sit on
+    # the poll states that actually span the workload, ~20% below the
+    # measured minimum across the last four canonical weekly runs (min
+    # WaitForMorningEnrich 31.7min=1902s, min WaitForDataPhase1 83.6min=5016s).
+    assert "MorningEnrich" not in STATE_DURATION_FLOORS_SEC
+    assert "DataPhase1" not in STATE_DURATION_FLOORS_SEC
+    assert STATE_DURATION_FLOORS_SEC["WaitForMorningEnrich"] == 25 * 60
+    assert STATE_DURATION_FLOORS_SEC["WaitForDataPhase1"] == 67 * 60
+
+
+def test_weekly_wait_floors_clear_the_measured_minimum_genuine_runs():
+    # The slowest-to-clear genuine minimums measured (31.7min / 83.6min) must
+    # not breach the new floors.
+    start = datetime(2026, 9, 12, 12, 0, 0, tzinfo=timezone.utc)
+    rows = build_state_durations(
+        {"WaitForMorningEnrich": int(31.7 * 60), "WaitForDataPhase1": int(83.6 * 60)},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-09-12",
+        s3_client=None,
+    )
+    assert all(not r.floor_breach for r in rows)
+
+
+def test_dispatch_state_duration_still_renders_with_no_floor():
+    # The dispatch states are dropped from STATE_DURATION_FLOORS_SEC, not
+    # from the digest entirely — no whitelist filter (alpha-engine-config-
+    # I6857): a state absent from the floor mapping renders with no floor,
+    # it is never dropped.
+    start = datetime(2026, 9, 12, 12, 0, 0, tzinfo=timezone.utc)
+    rows = build_state_durations(
+        {"MorningEnrich": 0},
+        is_preflight=False,
+        execution_start=start,
+        run_date="2026-09-12",
+        s3_client=None,
+    )
+    assert rows[0].floor_sec is None
+    assert rows[0].floor_breach is False
+
+
 def test_format_digest_sorts_anomalies_visually():
     rows = [
         StateDuration("Backtester", 600, 600, False, False),
@@ -210,6 +256,101 @@ def test_parse_run_date_from_execution_name_returns_none_without_a_date():
 def test_parse_run_date_from_execution_name_returns_none_for_empty_input():
     assert parse_run_date_from_execution_name(None) is None
     assert parse_run_date_from_execution_name("") is None
+
+
+# ── History pagination must not silently truncate a re-entered state's span
+#   (alpha-engine-config-I10545) ───────────────────────────────────────────
+#
+# Live 2026-09-12: ne-weekly-freshness-pipeline's WaitForDataPhase1 (a Task
+# state re-entered every ~15s across a 103.35min poll loop) produced 8916
+# raw history events across 42 pages. The old max_pages=20 cap silently
+# dropped everything past page 20 — parse_task_state_durations is correctly
+# first-entry->last-exit, but fed a truncated event list it computes a real,
+# short, WRONG span (34m instead of 103.35m), and the digest rendered it with
+# a plain "✓". These tests guard both that a legitimately large history is no
+# longer truncated at the old cap, and that when the (much higher, but still
+# finite) new cap IS exhausted, the digest says so instead of asserting ✓.
+
+
+def _paged_history_client(total_pages: int, events_per_page: int = 3):
+    """A MagicMock sf_client whose get_execution_history hands back
+    `total_pages` pages before nextToken goes empty."""
+    sf = MagicMock()
+    pages = []
+    for i in range(total_pages):
+        page_events = [
+            {
+                "type": "TaskStateEntered",
+                "timestamp": _ts(datetime(2026, 9, 12, tzinfo=timezone.utc), i * events_per_page + j),
+                "stateEnteredEventDetails": {"name": f"Filler{i}-{j}"},
+            }
+            for j in range(events_per_page)
+        ]
+        resp = {"events": page_events}
+        if i < total_pages - 1:
+            resp["nextToken"] = f"token-{i}"
+        pages.append(resp)
+    sf.get_execution_history.side_effect = pages
+    return sf
+
+
+def test_fetch_execution_history_paginates_past_the_old_twenty_page_cap():
+    # 25 pages exceeds the OLD max_pages=20 cap but is well inside the new
+    # default (_MAX_HISTORY_PAGES=150, headroom over the measured 42-page
+    # need). Every event across every page must come back, untruncated.
+    sf = _paged_history_client(total_pages=25, events_per_page=3)
+    events, truncated = fetch_execution_history(sf, "arn:exec")
+    assert len(events) == 25 * 3
+    assert truncated is False
+    assert sf.get_execution_history.call_count == 25
+
+
+def test_fetch_execution_history_reports_truncation_when_pages_exhausted():
+    # More pages exist (nextToken never runs out) than the caller's max_pages
+    # budget — the exact shape of the real 2026-09-12 run under the old cap.
+    sf = MagicMock()
+    sf.get_execution_history.return_value = {
+        "events": [{"type": "TaskStateEntered", "timestamp": datetime.now(timezone.utc),
+                     "stateEnteredEventDetails": {"name": "Filler"}}],
+        "nextToken": "always-more",
+    }
+    events, truncated = fetch_execution_history(sf, "arn:exec", max_pages=5)
+    assert truncated is True
+    assert sf.get_execution_history.call_count == 5
+
+
+def test_build_execution_digest_announces_truncation_and_forces_hollow(monkeypatch):
+    import execution_digest as ed
+
+    monkeypatch.setattr(ed, "_MAX_HISTORY_PAGES", 2)
+    base = datetime(2026, 9, 12, tzinfo=timezone.utc)
+    sf = MagicMock()
+    sf.get_execution_history.return_value = {
+        "events": [
+            {
+                "type": "TaskStateEntered",
+                "timestamp": base,
+                "stateEnteredEventDetails": {"name": "Backtester"},
+            },
+            {
+                "type": "TaskStateExited",
+                "timestamp": _ts(base, 600),
+                "stateExitedEventDetails": {"name": "Backtester"},
+            },
+        ],
+        "nextToken": "always-more",
+    }
+    lines, hollow, _cause = build_execution_digest(
+        execution_arn="arn:exec",
+        is_preflight=False,
+        execution_start_ms=int(base.timestamp() * 1000),
+        run_date="2026-09-12",
+        sf_client=sf,
+        s3_client=None,
+    )
+    # A truncated history can only understate — never a silent ✓.
+    assert hollow is True
+    assert any("truncated" in line for line in lines)
 
 
 def test_history_fetch_failure_surfaces_marker():


### PR DESCRIPTION
## What

`sf-telegram-notifier`'s weekly-pipeline duration floors sat on the SSM
dispatch Task states (`MorningEnrich`/`DataPhase1`), which always enter+exit
in under a second — every healthy weekly run rendered `⚠️(floor 15m)` on
both. Floors now sit on `WaitForMorningEnrich`/`WaitForDataPhase1`, the poll
states that actually span the workload.

Investigating why the digest also rendered a WRONG number for the wait
states themselves (`WaitForDataPhase1 34m` against a true 103.35min span,
measured directly from Step Functions) found the real bug:
`fetch_execution_history` capped pagination at 20 pages and silently
returned a partial event list on exhaustion. The 2026-09-12
`ne-weekly-freshness-pipeline` execution's full history is 8916 events
across 42 pages (GetExecutionHistory pages by response size, not event
count). `parse_task_state_durations` is already correctly
first-entry→last-exit (not last-entry-only) — fed a truncated history it
computed a real, short, wrong span that rendered with a plain `✓`.

## Changes

1. `STATE_DURATION_FLOORS_SEC`: dropped `MorningEnrich`/`DataPhase1` (no
   plausible non-zero floor on an always-~0s state); added
   `WaitForMorningEnrich` (25m, ~20% below the measured 31.7min minimum) and
   `WaitForDataPhase1` (67m, ~20% below the measured 83.6min minimum), across
   the last four canonical weekly runs (2026-08-22, 08-29, 09-05, 09-12).
2. `DIGEST_STATE_ORDER`: dispatch-state entries replaced with the wait-state
   names.
3. `fetch_execution_history`: pagination cap raised 20 → 150 pages (~3.6x the
   measured 42-page need); on exhaustion the digest now appends an explicit
   `_(history truncated...)_` line and forces `hollow_suspect=True` instead of
   only logging a warning — a truncated history can only understate a
   duration, so it must never render a plain `✓`.
4. `floor_calibration.py`: `STATE_TO_STATE_MACHINE` renamed to match; its
   `fetch_history` adapter unwraps the new `(events, truncated)` return
   (calibration is offline/batch over many executions — a truncated sample
   there only pulls a recommended floor down, not masks a live alert, so it
   is not wired to force anything there).

## Tests

`test_execution_digest.py`: floor values, dispatch-state-still-renders-
unfloored (no whitelist), pagination past the old 20-page cap, truncation
forces hollow + announces itself. `test_floor_calibration.py`'s existing
`STATE_TO_STATE_MACHINE` coverage tests pass with the renamed keys. Full
per-lambda suite run individually (matching CI's isolated-interpreter
pattern): `test_execution_digest.py` 43, `test_floor_calibration.py` 14,
`test_handler.py` 39, `test_terminal_delivery_guarantee.py` 16,
`test_eod_artifact_verification.py` 14, `test_flow_doctor_fleet_wiring.py` 1
— all green.

## Deploy path

`deploy-sf-telegram-notifier.yml` auto-deploys Lambda **code only** on merge
to `main`, path-filtered on
`infrastructure/lambdas/sf-telegram-notifier/**` — this PR's whole diff is
inside that path, so no operator step is needed after merge.

## Refs

Refs alpha-engine-config-I10545. Cross-repo `Closes`/`Fixes` is inert for
this tracker (the issue lives in `alpha-engine-config`, the code here) — the
issue will be closed by hand once this merges and the fix is verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMrf6UbUhbb417YxTpyADp
