### PR TITLE
feat: register router-spend-export alert class (nous-ergon-ops-PR1212)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1559,6 +1559,23 @@ alert_classes:
     # DECLARED: a DRILL. A drill result is conformance evidence, never an
     # outage.
     tier: tracked-only
+  - class: router_spend_export_pricing_zero
+    # alpha-engine-config-I10548 (nous-ergon-ops-PR1212): new registry row
+    # for a previously-undeclared source. router-spend-export's daily export
+    # fires this at warning severity when it finds a model_served with
+    # tokens recorded but $0.0000 spend against a registry row that carries
+    # a non-zero price card (deployed-but-unpriced, e.g. glm-5.2-direct
+    # before alpha-engine-config-PR10549) -- invisible spend, not free usage.
+    source: "router-spend-export"
+    severities: [warning]
+    intake: bus
+    response: drain-queue
+    # DECLARED: a correctness/observability defect in the router's OWN price
+    # config, never an outage -- nothing is down, no call is failing. Worth a
+    # human's attention (it hides real spend from every cost surface) but not
+    # tonight's page; it clears on its own once the generator emits a price
+    # for the row (alpha-engine-config-PR10549 is exactly that fix).
+    tier: notify-silent
 
   # ── DRAIN-BLIND rows (every one carries its migration or declaration) ──
   - class: executor_emergency_shutdown


### PR DESCRIPTION
## Why

`nous-ergon-ops-PR1212` (Refs `alpha-engine-config-I10548`) adds a new `krepis.alerts.publish(source="router-spend-export", ...)` call site: `router_spend_export.py`'s new daily pricing check warns when a model recorded tokens at $0.0000 spend against a registry row that carries a non-zero price card (the exact defect `alpha-engine-config-I10548` reports — invisible spend, not free usage). `alert-class-pr-guard.yml` on that PR fails until this source has an `alert_classes` row here (per that guard's own design, an OPEN companion PR here already satisfies it — no merge-order dependency).

## What

New row `router_spend_export_pricing_zero` in `infrastructure/overseer/playbooks.yaml::alert_classes`, `source: "router-spend-export"`, `severities: [warning]`, `tier: notify-silent` — a correctness/observability defect in the router's own price config, never an outage; it clears on its own once the priced generator (`alpha-engine-config-PR10549`, the fix this whole arc is about) lands and the router restarts against it.

## Tests

```
python3 -m pytest tests/test_alert_class_pr_guard.py tests/test_alert_class_registry_drift.py tests/test_alert_class_response_gap.py tests/test_alert_message_lint.py -q
137 passed
python3 -m pytest tests/test_alert_tier_registry.py tests/test_groom_cycle_notifications.py tests/test_overseer_playbook_registry.py tests/test_overseer_arming.py tests/test_trigger_surface_drift.py -q
124 passed
```

Refs alpha-engine-config-I10548
nous-ergon-ops-PR1212 (the call site this row unblocks)

Prepared by: Claude Sonnet 5 via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMrf6UbUhbb417YxTpyADp