### PR TITLE
Move I6984 paused_alarms re_exam to 2026-10-12 backstop

### DIFF
--- a/infrastructure/automation_pause.json
+++ b/infrastructure/automation_pause.json
@@ -90,91 +90,91 @@
   "paused_alarms": {
     "_why": "alpha-engine-config-I7174. Nine watch-plane/liveness alarms fire `no datapoints were received ... treated as [Breaching]` for no reason other than that the component they watch is deliberately off under the 2026-08-07/2026-08-12 rulings above - the alarm has no input telling it 'gated off by declaration' from 'upstream died' (sf-pipeline-policy.md 2.6 rule 1). Each entry here names the alarm and the `watches` triggers whose presence in `paused`/`pending` (module.paused_names()) is what JUSTIFIES silencing it - never a free-text trigger name that no checker reads, the exact defect the `_reactive-notifier-rules` prose key already cost this file once. `pause_reconcile.py::alarm_entries()`/`automation_pause.py::alarm_entries()` compute justification live from `watches`, so un-pausing a trigger (removing/moving its entry out of `paused`) makes its alarm's entry here stop being justified on the VERY NEXT read - no second edit, no separate AWS CLI command. `automation_pause.py --enforce` then (a) disables actions on a justified-but-armed alarm and (b) RE-ENABLES actions on an alarm whose entry is no longer justified - (b) is deliberately NOT a mirror of the trigger-enforce asymmetry (`enforce()` never re-enables a paused TRIGGER, because that would restart scheduled work unattended); re-arming an alarm only resumes paging, so the same asymmetry does not apply. Silencing is `disable-alarm-actions`, never `delete-alarms`: history and config survive so coverage can be reconstructed later (property 1). `pause_reconcile.py --check` grades the same two directions read-only and its `--publish` row always lists every currently-justified entry as a declared, bounded gap (property 2) rather than omitting it. EVERY entry additionally carries `issue` and `re_exam` (alpha-engine-config-I8047, Brian ruling 2026-08-21 option (b)). The 14 alarms in this block were disabled BY HAND from the laptop on 2026-08-13/14 (CloudTrail `DisableAlarmActions`, principal `AWSReservedSSO_AdministratorAccess/cipher813`), following the 2026-08-12 groomer/Overseer pause. Brian ruled the mute stands and must be DECLARED and SELF-EXPIRING rather than undone. `watches` grades whether the RESOURCE condition still holds; `issue` + `re_exam` grade whether the REASON still holds, which is the condition that actually rots (alpha-engine-config-I8090). `issue` names the OPEN ruling whose closure ends the pause \u2014 a closed owning issue means either the pause ended (these must be re-armed) or it was closed without the work, and both are loud. `re_exam` is the date past which the suppression is no longer justified by anything. Neither field feeds `alarm_justified()` and neither can move live state: `enforce()` must never re-arm the response plane's own alarms unattended on a calendar tick \u2014 that is Brian's ruling to revisit (`principles.md` 2.5). `automation_pause.py` enforces that both fields are PRESENT and well-formed (offline, no credential); `alpha-engine-config`'s `suppression-declaration-sweep` grades them against the clock and the tracker, because only a job running in the tracker repo can resolve an issue's state. ADDENDUM (alpha-engine-config-I8712): this block may hold BOTH treat_missing_data values — a component's breaching and notBreaching sibling probes are commonly declared together, watching the same trigger — but the silencing requirement above (`--check` grading `alarm-unexpectedly-enabled`/`alarm-stale-disabled`, `--enforce` flipping actions) applies ONLY to the `breaching` population: only a breaching alarm can false-page from a paused trigger's silence, so only a breaching alarm has anything to be silenced FOR. A notBreaching entry's live ActionsEnabled is never graded here; whether a notBreaching mute is separately DECLARED still falls to `alarm_coverage_findings()`'s `alarm-undeclared-silence` scan, which covers every alarm regardless of missing-data treatment. `alpha-engine-ssm-reachability-probe-unreachable` below is the worked example: notBreaching, live ActionsEnabled=True, and that live state was never wrong.",
     "alpha-engine-watch-plane-canary-replay-liveness-probe-invocations-floor": {
-      "reason": "invocations-floor on the overseer canary-replay liveness probe; silenced while alpha-engine-canary-replay-liveness-probe-tick is paused.",
+      "reason": "invocations-floor on the overseer canary-replay liveness probe; silenced while alpha-engine-canary-replay-liveness-probe-tick is paused. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-canary-replay-liveness-probe-tick"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor": {
-      "reason": "invocations-floor on the ci-watch-liveness-probe reclaim leg (config#3173, mirrors sf-watch's two reclaim legs); silenced while both ci-watch reclaim rules are paused.",
+      "reason": "invocations-floor on the ci-watch-liveness-probe reclaim leg (config#3173, mirrors sf-watch's two reclaim legs); silenced while both ci-watch reclaim rules are paused. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-ci-watch-spot-interruption",
         "alpha-engine-ci-watch-instance-terminated"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-errors": {
-      "reason": "sf-watch liveness-probe Errors; silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984) disabling sf-watch while the three scheduled pipelines are made reliable by hand.",
+      "reason": "sf-watch liveness-probe Errors; silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984) disabling sf-watch while the three scheduled pipelines are made reliable by hand. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-throttles": {
-      "reason": "sf-watch liveness-probe Throttles; same ruling and same watched triggers as alpha-engine-watch-plane-sf-watch-liveness-probe-errors.",
+      "reason": "sf-watch liveness-probe Throttles; same ruling and same watched triggers as alpha-engine-watch-plane-sf-watch-liveness-probe-errors. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-ssm-reachability-probe-dead": {
-      "reason": "SSM reachability probe deadman; silenced while alpha-engine-ssm-reachability-probe-5min is paused.",
+      "reason": "SSM reachability probe deadman; silenced while alpha-engine-ssm-reachability-probe-5min is paused. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-ssm-reachability-probe-5min"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-ssm-reachability-probe-unreachable": {
-      "reason": "SSM reachability probe unreachable-count; same watched trigger as alpha-engine-ssm-reachability-probe-dead, but treat_missing_data=notBreaching (alpha-engine-ssm-reachability-probe-dead is the breaching sibling that actually needs silencing). Its ActionsEnabled state is not graded by --check/--enforce (alpha-engine-config-I8712); it is declared here only so the mute-or-not-mute of this alarm has a record, per the paused_alarms._why ADDENDUM above.",
+      "reason": "SSM reachability probe unreachable-count; same watched trigger as alpha-engine-ssm-reachability-probe-dead, but treat_missing_data=notBreaching (alpha-engine-ssm-reachability-probe-dead is the breaching sibling that actually needs silencing). Its ActionsEnabled state is not graded by --check/--enforce (alpha-engine-config-I8712); it is declared here only so the mute-or-not-mute of this alarm has a record, per the paused_alarms._why ADDENDUM above. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-ssm-reachability-probe-5min"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-errors": {
-      "reason": "overseer liveness-probe Errors. Period=28800 with treat_missing_data=breaching, so an 8h window with no invocation latches ALARM - and the probe's only two triggers are paused. Added 2026-08-14 (alpha-engine-config-I7023): this alarm and its two siblings were the four still paging Brian after the I7174 reconciler silenced the rest, because the I7174 entry list was built from the alarms observed in ALARM on 2026-08-13 and these read OK at that moment - the backstop responder was re-invoking the probe on every firing (alpha-engine-config-I7330), manufacturing the datapoint that cleared them.",
+      "reason": "overseer liveness-probe Errors. Period=28800 with treat_missing_data=breaching, so an 8h window with no invocation latches ALARM - and the probe's only two triggers are paused. Added 2026-08-14 (alpha-engine-config-I7023): this alarm and its two siblings were the four still paging Brian after the I7174 reconciler silenced the rest, because the I7174 entry list was built from the alarms observed in ALARM on 2026-08-13 and these read OK at that moment - the backstop responder was re-invoking the probe on every firing (alpha-engine-config-I7330), manufacturing the datapoint that cleared them. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-throttles": {
-      "reason": "overseer liveness-probe Throttles; same shape, same window and same paused triggers as the Errors sibling above. Added 2026-08-14 (alpha-engine-config-I7023).",
+      "reason": "overseer liveness-probe Throttles; same shape, same window and same paused triggers as the Errors sibling above. Added 2026-08-14 (alpha-engine-config-I7023). Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor": {
-      "reason": "invocations-floor on the overseer liveness probe. This is the alarm whose ENTIRE job is detecting a probe that stopped running, so while the probe is deliberately stopped it can only report the pause back to us. Added 2026-08-14 (alpha-engine-config-I7023).",
+      "reason": "invocations-floor on the overseer liveness probe. This is the alarm whose ENTIRE job is detecting a probe that stopped running, so while the probe is deliberately stopped it can only report the pause back to us. Added 2026-08-14 (alpha-engine-config-I7023). Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-overseer-liveness-0650-daily",
         "alpha-engine-overseer-liveness-1450-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor": {
-      "reason": "invocations-floor on the sf-watch liveness probe. Its -errors and -throttles siblings were declared under I7174 and this one was not, so it stayed armed on the same paused triggers - the family-completeness check added with this entry is what makes that shape impossible to repeat. Silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984); re-exam 2026-09-09, same predicate as the sf-watch entries it watches.",
+      "reason": "invocations-floor on the sf-watch liveness probe. Its -errors and -throttles siblings were declared under I7174 and this one was not, so it stayed armed on the same paused triggers - the family-completeness check added with this entry is what makes that shape impossible to repeat. Silenced under Brian's 2026-08-12 ruling (alpha-engine-config-I6984); re-exam 2026-09-09, same predicate as the sf-watch entries it watches. Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.",
       "watches": [
         "alpha-engine-sf-watch-liveness-0645-daily",
         "alpha-engine-sf-watch-liveness-1445-daily"
       ],
       "issue": "alpha-engine-config-I6984",
-      "re_exam": "2026-09-09"
+      "re_exam": "2026-10-12"
     },
     "alpha-engine-watch-plane-alert-drain-liveness-probe-invocations-floor": {
       "reason": "invocations-floor on the overseer alert-drain liveness probe; treat_missing_data=breaching is correct when alert-drain is supposed to run and wrong while it is declared off (Brian 2026-08-23: response-plane pause includes the drain; same watches as pre-I8110).",


### PR DESCRIPTION
## Sweep failure

`alpha-engine-config/.github/workflows/suppression-declaration-sweep.yml` has failed daily since 2026-09-10 (alpha-engine-config-I10451). Error, e.g.:

alpha-engine-watch-plane-sf-watch-liveness-probe-throttles: re_exam 2026-09-09 passed 3 day(s) ago. The suppression is no longer justified by anything written down. Re-arm it, or re-rule it with a new date and the reason it moved.

Ten `infrastructure/automation_pause.json :: paused_alarms` rows, all owned by `alpha-engine-config-I6984`, carried `re_exam: "2026-09-09"`, which passed.

## Ruling context

`I6984` is Brian's 2026-08-12 ruling pausing the groomer and Overseer response plane "if and when the core products are healthy enough." That issue's own backstop re-exam is 2026-10-12. On 2026-09-12 Brian re-affirmed the pause (only the Dependabot merge lane was restored).

Per that context: every `paused_alarms` row owned by `I6984` with `re_exam` on or before 2026-09-12 moves to `re_exam: "2026-10-12"` (I6984's own backstop), with this sentence appended to `reason`:

> Re-examined 2026-09-12: pause re-affirmed by Brian (only merge-drain restored); re_exam moved to I6984's own backstop 2026-10-12.

No other field or row touched.

## Rows moved (re_exam 2026-09-09 -> 2026-10-12)

- alpha-engine-watch-plane-canary-replay-liveness-probe-invocations-floor
- alpha-engine-watch-plane-ci-watch-liveness-probe-invocations-floor
- alpha-engine-watch-plane-sf-watch-liveness-probe-errors
- alpha-engine-watch-plane-sf-watch-liveness-probe-throttles
- alpha-engine-ssm-reachability-probe-dead
- alpha-engine-ssm-reachability-probe-unreachable
- alpha-engine-watch-plane-overseer-liveness-probe-errors
- alpha-engine-watch-plane-overseer-liveness-probe-throttles
- alpha-engine-watch-plane-overseer-liveness-probe-invocations-floor
- alpha-engine-watch-plane-sf-watch-liveness-probe-invocations-floor

## Rows NOT touched

- The four rows already at `re_exam: "2026-10-12"` (alert-drain-liveness-probe-invocations-floor, overseer-intake-age, overseer-intake-dlq-depth, overseer-intake-dlq-severe-content) — not yet passed, left as-is.
- No `paused_alarms` row is owned by any issue other than `alpha-engine-config-I6984` — grep of every `"issue"` key in the file confirms all 14 rows share that owner, so there is no other-owner row to report or exclude.

## Test plan

- `python3 -c "import json; json.load(open('infrastructure/automation_pause.json'))"` — valid JSON.
- `git diff --stat` — 20 insertions / 20 deletions (2 lines x 10 rows), confined to the moved rows.
- `.venv/bin/python3 -m pytest tests/test_automation_pause.py tests/test_automation_pause_breaching_split.py tests/test_automation_pause_alert.py tests/test_pause_reconcile.py tests/test_overseer_arming.py tests/test_weekly_sf_silence_deadman.py -q` (via the shared repo's venv, since this worktree has none) — 238 passed, 1 pre-existing skip.
- `alpha-engine-config/scripts/suppression_declaration_sweep.py --report`, pointed at this worktree's file via `PAUSE_MANIFEST_URL=file://<path>` — the exact check that has been failing: now `14 declared alarm suppression(s), 0 stale`, exit 0.
- `alpha-engine-config/scripts/test_suppression_declaration_sweep.py -q` — 10 passed.
- `automation_pause.py --check`/`--enforce` were NOT run — both touch AWS (subprocess to the AWS CLI), out of scope for this local-only verification.

Refs alpha-engine-config-I10451, alpha-engine-config-I6984 (cross-repo; the `Refs`/`Closes` keyword is inert across repos — GitHub only auto-closes an issue in the PR's own repo, and `alpha-engine-config` is a different repo from this one. Those issues need closing by hand, in the same turn as this PR's merge, with a comment naming this PR and stating the sweep was verified clean.)

Prepared by: Claude Fable 5.1 (claude-fable-5-1) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8mzZ8rZ8b6DE3XuMrNXJW
