### PR TITLE
fix(lambdas): requirement_pin strips inline comments from pip pins (alpha-engine-config-I10337)

### DIFF
--- a/infrastructure/lambdas/_shared/run_handler_tests.sh
+++ b/infrastructure/lambdas/_shared/run_handler_tests.sh
@@ -74,6 +74,49 @@
 #     config against the REAL fleet spec — then fails on import. It passes
 #     alone and fails in a full run, i.e. the result depended on collection
 #     order. Separate processes make each file's answer its own.
+# requirement_pin REQUIREMENTS_FILE PACKAGE
+#   Prints the FIRST line of REQUIREMENTS_FILE matching ^PACKAGE, with any
+#   inline `# ...` comment and trailing whitespace stripped, so it is safe to
+#   hand to `pip install` as a command-line argument. Exits non-zero (and
+#   prints a message to stderr) if no line matches.
+#
+# WHY (alpha-engine-config-I10337, eval-judge-spot-dispatcher run 34711758231
+# and 34312894868): eight deploy.sh scripts each did
+#   KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+# and passed the WHOLE matched line — including a legitimate lockstep-bump
+# trailing comment like
+#   krepis==0.59.54  # bumped 0.59.41 -> 0.59.54: ... alpha-engine-config-I10226
+# — straight to `pip install` as an argument. A requirements FILE tolerates an
+# inline comment; a pip command-line ARGUMENT does not:
+#   ERROR: Invalid requirement: 'krepis==0.59.54  # bumped ... run 34309659890'
+# eval-judge-spot-dispatcher's pin happened to carry a comment on the day this
+# was found; the other seven sites carry the identical unguarded grep and
+# break the next time a lockstep bump annotates THEIR pin. One helper closes
+# the class instead of patching the one instance.
+#
+# Also fails loud on a missing pin: the old `grep | head -1` silently produced
+# an EMPTY string when nothing matched, which `run_handler_tests` would then
+# happily install as "pytest" with no extra requirement at all — a missing pin
+# read as "no extra deps needed" instead of as the config error it is.
+requirement_pin() {
+  local req_file="$1" pkg="$2"
+  local line
+  line="$(grep -E "^${pkg}" "${req_file}" | head -1)"
+  if [[ -z "${line}" ]]; then
+    echo "requirement_pin: no '${pkg}' requirement found in ${req_file}" >&2
+    return 1
+  fi
+  # Strip a trailing inline comment (the lockstep-bump annotation convention)
+  # and any whitespace left dangling before it.
+  line="${line%%#*}"
+  line="${line%"${line##*[![:space:]]}"}"
+  if [[ -z "${line}" ]]; then
+    echo "requirement_pin: '${pkg}' line in ${req_file} is comment-only after stripping" >&2
+    return 1
+  fi
+  echo "${line}"
+}
+
 run_handler_tests() {
   local script_dir="$1"; shift
   local test_file="${script_dir}/test_handler.py"

--- a/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/alert-drain-dispatcher/deploy.sh
@@ -159,8 +159,8 @@ print('index.py syntax OK')
 "
 
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package ------------------------------------------------------------

--- a/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/arctic-migration-dispatcher/deploy.sh
@@ -108,8 +108,8 @@ print('index.py syntax OK')
 # before `import index` (see test_handler.py).
 
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package: pip install deps (Lambda-safe) + zip handler --------------

--- a/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/ci-watch-dispatcher/deploy.sh
@@ -116,8 +116,8 @@ print('index.py syntax OK')
 # krepis are installed for real by the shared gate into its own scratch dir — NOT the
 # caller's global site-packages, not bundled into the Lambda zip.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------

--- a/infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh
@@ -122,7 +122,7 @@ source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
 # minimal-set half of the helper's declared deploy.sh-vs-ci.yml contract. boto3
 # is deliberately absent: the helper never installs it implicitly, and index.py
 # reaches AWS only through the stubbed spot_dispatch chokepoint.
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}"
 
 # ----- 1. Package: pip install deps (Lambda-safe) + zip handler --------------

--- a/infrastructure/lambdas/overseer-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/overseer-dispatcher/deploy.sh
@@ -69,7 +69,7 @@ print('index.py syntax OK')
 
 # ----- 0b. Preflight handler unit tests --------------------------------------
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}"
 
 # ----- 1. Package: pip install deps + zip handler + bundle registry ---------

--- a/infrastructure/lambdas/pipeline-watchdog/deploy.sh
+++ b/infrastructure/lambdas/pipeline-watchdog/deploy.sh
@@ -111,8 +111,8 @@ source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
 # requirements.txt and hand them to the shared runner — the shape
 # saturday-sf-watch-dispatcher/deploy.sh already uses, so the test venv
 # matches what the function actually ships rather than a subset of it.
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" boto3 "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 LAMBDAS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/saturday-sf-watch-dispatcher/deploy.sh
@@ -98,8 +98,8 @@ print('index.py syntax OK')
 # dir — NOT the caller's global site-packages, not bundled into the
 # Lambda zip.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" boto3 "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------

--- a/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/scheduled-groom-dispatcher/deploy.sh
@@ -238,7 +238,7 @@ print('index.py syntax OK')
 # caller's global site-packages, not bundled into the Lambda zip. (krepis was
 # removed 2026-07-14 with the pace gate — usage pacing dismantled.)
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
 run_handler_tests "${SCRIPT_DIR}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------

--- a/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
+++ b/infrastructure/lambdas/sf-watch-spot-dispatcher/deploy.sh
@@ -136,8 +136,8 @@ print('index.py syntax OK')
 # krepis are installed for real by the shared gate into its own scratch dir — NOT the
 # caller's global site-packages, not bundled into the Lambda zip.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
-KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
+KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
 run_handler_tests "${SCRIPT_DIR}" "${KREPIS_REQ}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Package: pip install deps + zip handler ---------------------------

--- a/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
+++ b/infrastructure/lambdas/spot-orphan-reaper/deploy.sh
@@ -95,7 +95,7 @@ print('index.py syntax OK')
 # import-guard pattern) — NOT the caller's global site-packages, not bundled
 # into the Lambda zip.
 source "${SCRIPT_DIR}/../_shared/run_handler_tests.sh"
-NOUSERGON_LIB_REQ=$(grep -E '^nousergon-lib' "${SCRIPT_DIR}/requirements.txt" | head -1)
+NOUSERGON_LIB_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" nousergon-lib)
 run_handler_tests "${SCRIPT_DIR}" "${NOUSERGON_LIB_REQ}"
 
 # ----- 1. Bootstrap (first-time only) ---------------------------------------

--- a/tests/test_requirement_pin_strips_inline_comments.py
+++ b/tests/test_requirement_pin_strips_inline_comments.py
@@ -1,0 +1,156 @@
+"""`requirement_pin` (infrastructure/lambdas/_shared/run_handler_tests.sh), EXECUTED.
+
+WHY (alpha-engine-config-I10337, eval-judge-spot-dispatcher runs 34711758231
+and 34312894868): eight deploy.sh scripts each did
+
+    KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
+
+and handed the WHOLE matched requirements.txt line — trailing lockstep-bump
+comment included — to `run_handler_tests`, which installs it as a bare pip
+command-line argument. A requirements FILE tolerates an inline `# ...`
+comment; a pip argument does not:
+
+    ERROR: Invalid requirement: 'krepis==0.59.54  # bumped 0.59.41 -> 0.59.54:
+    nousergon-lib v0.124.116 (root requirements.txt) floors krepis>=0.59.52;
+    alpha-engine-config-I10226 lockstep gap, run 34309659890'
+
+eval-judge-spot-dispatcher's pin happened to carry the comment on the day
+this broke; the other seven sites (and the co-located `nousergon-lib` pins in
+six of them) carried the identical unguarded `grep | head -1` and would break
+the next time a lockstep bump annotated THEIR line. `requirement_pin` is the
+one place this now lives.
+
+These tests execute the real shell function (sourced from the real file, not
+a copy) against real fixture requirements.txt files — a test asserting on the
+shell SOURCE would pass against the broken version too, since the broken
+version also contains the string `head -1`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HELPER = _REPO_ROOT / "infrastructure" / "lambdas" / "_shared" / "run_handler_tests.sh"
+
+
+def _run_requirement_pin(req_body: str, pkg: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    req_file = tmp_path / "requirements.txt"
+    req_file.write_text(textwrap.dedent(req_body))
+    script = f'source "{_HELPER}"\nrequirement_pin "{req_file}" "{pkg}"\n'
+    return subprocess.run(  # noqa: S603
+        ["bash", "-c", script],  # noqa: S607
+        capture_output=True, text=True, check=False,
+    )
+
+
+def test_strips_trailing_inline_comment(tmp_path: Path) -> None:
+    """The exact eval-judge-spot-dispatcher shape: a lockstep-bump comment
+    after two spaces must not survive into the printed pin."""
+    body = """\
+        nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
+        krepis==0.59.54  # bumped 0.59.41 -> 0.59.54: nousergon-lib v0.124.116 (root requirements.txt) floors krepis>=0.59.52; alpha-engine-config-I10226 lockstep gap, run 34309659890
+    """
+    result = _run_requirement_pin(body, "krepis", tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "krepis==0.59.54"
+
+
+def test_line_without_a_comment_is_unchanged(tmp_path: Path) -> None:
+    body = """\
+        nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
+        krepis>=0.59.6
+    """
+    result = _run_requirement_pin(body, "krepis", tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "krepis>=0.59.6"
+
+
+def test_matches_first_of_multiple_and_ignores_bracket_extras(tmp_path: Path) -> None:
+    """`nousergon-lib[flow-doctor] @ git+...` (pipeline-watchdog's actual pin
+    shape) must still match `^nousergon-lib` the way the old grep did."""
+    body = """\
+        nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120
+        krepis>=0.15.0
+    """
+    result = _run_requirement_pin(body, "nousergon-lib", tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "nousergon-lib[flow-doctor] @ git+https://github.com/nousergon/nousergon-lib@v0.124.120"
+
+
+def test_missing_package_fails_loud(tmp_path: Path) -> None:
+    """The old `grep | head -1` silently produced an empty string on no
+    match, which `run_handler_tests` would then install as nothing extra at
+    all — a missing pin read as 'no deps needed'. The helper must exit
+    non-zero instead."""
+    body = "nousergon-lib @ git+https://github.com/nousergon/nousergon-lib@v0.124.120\n"
+    result = _run_requirement_pin(body, "krepis", tmp_path)
+    assert result.returncode != 0
+    assert "no 'krepis' requirement found" in result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_bare_name_with_trailing_comment_still_prints_the_bare_name(tmp_path: Path) -> None:
+    """An unpinned-but-declared line (`krepis  # TODO pin this properly`) is a
+    valid pip spec once the comment is stripped — the package name alone —
+    and must not be reported as an error just because nothing follows it."""
+    body = "krepis  # TODO pin this properly\n"
+    result = _run_requirement_pin(body, "krepis", tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "krepis"
+
+
+@pytest.mark.parametrize("pkg", ["krepis", "nousergon-lib"])
+def test_real_lambda_requirements_files_parse_clean(pkg: str, tmp_path: Path) -> None:
+    """Run the helper against every real requirements.txt under
+    infrastructure/lambdas that declares this package, and confirm the
+    printed pin is a valid pip requirement spec (no stray `#`)."""
+    lambdas_dir = _REPO_ROOT / "infrastructure" / "lambdas"
+    checked = 0
+    for req_file in lambdas_dir.glob("*/requirements.txt"):
+        text = req_file.read_text()
+        if not any(line.strip().startswith(pkg) for line in text.splitlines()):
+            continue
+        script = f'source "{_HELPER}"\nrequirement_pin "{req_file}" "{pkg}"\n'
+        result = subprocess.run(  # noqa: S603
+            ["bash", "-c", script],  # noqa: S607
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode == 0, f"{req_file}: {result.stderr}"
+        pin = result.stdout.strip()
+        assert "#" not in pin, f"{req_file}: pin still carries a comment: {pin!r}"
+        checked += 1
+    assert checked > 0, f"no lambda requirements.txt declared {pkg} — glob or fixture drifted"
+
+
+def test_no_deploy_script_still_hand_rolls_the_unguarded_grep() -> None:
+    """Guard against the class coming back: no `infrastructure/lambdas/*/deploy.sh`
+    may reach for `grep -E '^krepis'` / `grep -E '^nousergon-lib'` (or any
+    quoting variant of the same pattern) directly — every pin must go through
+    `requirement_pin`, which strips the inline comment before the value ever
+    becomes a pip argument."""
+    out = subprocess.run(  # noqa: S603
+        ["git", "ls-files", "infrastructure/lambdas/*/deploy.sh"],  # noqa: S607
+        cwd=_REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    paths = [_REPO_ROOT / line for line in out.stdout.split() if line]
+    assert paths, "no deploy.sh discovered — the glob or cwd is wrong"
+
+    offenders: list[str] = []
+    for path in paths:
+        body = path.read_text()
+        for needle in ("grep -E '^krepis'", "grep -E '^nousergon-lib'",
+                       'grep -E "^krepis"', 'grep -E "^nousergon-lib"'):
+            if needle in body:
+                offenders.append(f"{path.parent.name}: still has `{needle}`")
+    assert not offenders, (
+        "deploy.sh scripts hand-rolling a requirement-pin grep instead of using "
+        "the shared requirement_pin helper (alpha-engine-config-I10337):\n  "
+        + "\n  ".join(offenders)
+        + "\n\nUse:\n"
+        '  KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)\n'
+    )


### PR DESCRIPTION
## What / why

`deploy-eval-judge-spot-dispatcher.yml` `push_main` runs `34711758231` and
`34312894868` failed at the code-only test-dep install:

```
ERROR: Invalid requirement: 'krepis==0.59.54  # bumped 0.59.41 -> 0.59.54:
nousergon-lib v0.124.116 (root requirements.txt) floors krepis>=0.59.52;
alpha-engine-config-I10226 lockstep gap, run 34309659890'
```

Cause: `infrastructure/lambdas/eval-judge-spot-dispatcher/deploy.sh` did

```bash
KREPIS_REQ=$(grep -E '^krepis' "${SCRIPT_DIR}/requirements.txt" | head -1)
```

and passed the **whole matched requirements.txt line** — inline lockstep-bump
comment included — straight to `pip` as a command-line argument via
`run_handler_tests`. A pip requirements **file** tolerates an inline `# ...`
comment; a pip command-line **argument** does not.

## The class

The identical unguarded `grep -E '^krepis'` / `grep -E '^nousergon-lib'` line
existed in **ten** `deploy.sh` scripts (16 call sites total — eight scripts
grep both `krepis` and the co-located `nousergon-lib` pin):

- alert-drain-dispatcher, arctic-migration-dispatcher, ci-watch-dispatcher,
  eval-judge-spot-dispatcher, overseer-dispatcher, pipeline-watchdog,
  saturday-sf-watch-dispatcher, sf-watch-spot-dispatcher — the eight named in
  `alpha-engine-config-I10337`
- scheduled-groom-dispatcher, spot-orphan-reaper — found by the same-class
  sweep over every `infrastructure/lambdas/*/deploy.sh`, same unguarded
  `nousergon-lib` grep

Only eval-judge's pin carried a comment on the day this broke; every other
site was one lockstep-bump annotation away from the same failure.

## Fix

One shared helper, `requirement_pin(req_file, pkg)` in
`infrastructure/lambdas/_shared/run_handler_tests.sh` (sourced immediately
before every one of these call sites already): prints the first matching
requirements.txt line with any inline `# ...` comment and trailing
whitespace stripped, and **exits non-zero with a clear message** if no line
matches — the old `grep | head -1` silently produced an empty string on no
match, which `run_handler_tests` would then treat as "no extra deps needed"
instead of the config error it is.

All 16 call sites now read, e.g.:

```bash
KREPIS_REQ=$(requirement_pin "${SCRIPT_DIR}/requirements.txt" krepis)
```

## Test plan

- `tests/test_requirement_pin_strips_inline_comments.py` (new) executes the
  real shell function (sourced from the real file) against fixture and real
  lambda `requirements.txt` files: trailing-comment stripped, no-comment
  line unchanged, bracket-extras pin form (`nousergon-lib[flow-doctor] @
  ...`), missing-package fails loud, bare-name-with-comment still a valid
  pip spec, every real `requirements.txt` declaring `krepis`/`nousergon-lib`
  parses clean through the helper, and a guard that no
  `infrastructure/lambdas/*/deploy.sh` still contains the raw
  `grep -E '^krepis'` / `grep -E '^nousergon-lib'` pattern.
- Reproduced the original failure directly: the pre-fix pin string crashes
  pip's requirement parser (`packaging.markers` exception, same class as the
  reported `Invalid requirement` error); the post-fix pin parses clean.
- `bash -n` on all 11 changed scripts — all pass.
- `shellcheck` on `run_handler_tests.sh` (clean) and the two new call sites
  (only pre-existing unrelated `SC1091`/`SC2064` notes, none introduced).
- `.venv/bin/python3 -m pytest tests/ -k "deploy or lambda or shared or
  requirement"` — 822 passed, 4 skipped, no regressions.

Refs alpha-engine-config-I10337 (cross-repo — the closing keyword is inert
for that tracker; the issue will be closed by hand once the live
`deploy-eval-judge-spot-dispatcher.yml` run on this fix is verified green).

## Post-merge

Merging this PR triggers `deploy-eval-judge-spot-dispatcher.yml` (paths
filter on its `deploy.sh`) — that run is the live verification of the fix.

---

Prepared by: Claude Fable 5.1 (claude-fable-5-1) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8mzZ8rZ8b6DE3XuMrNXJW
