### PR TITLE
fix(sf-telegram-notifier): floor_calibration samples the poll span, not the dispatch (alpha-engine-config-I10574)

### DIFF
--- a/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/execution_digest.py
@@ -46,9 +46,33 @@ STATE_DURATION_FLOORS_SEC: Mapping[str, int] = {
     # non-zero floor to set.
     "WaitForMorningEnrich": 25 * 60,
     "WaitForDataPhase1": 67 * 60,
-    "RAGIngestion": 10 * 60,
-    "PredictorTraining": 20 * 60,
-    "Backtester": 10 * 60,
+    # RAGIngestion / PredictorTraining / Backtester RENAMED to their
+    # WaitForX poll companions 2026-09-12 (alpha-engine-config-I10574) — same
+    # defect class as WaitForMorningEnrich/WaitForDataPhase1 above, just not
+    # caught in the same pass. Each of these three names a DISPATCH Task
+    # (fires an SSM/spot command and returns) that measures 0.2-0.3s on every
+    # execution that reaches it; the real multi-minute-to-hour workload runs
+    # in a poll loop entered immediately after under "WaitForRAGIngestion" /
+    # "WaitForPredictorTraining" / "WaitForBacktester" — confirmed against the
+    # one genuine EventBridge-triggered SUCCEEDED execution in the account's
+    # full history carrying these states (9b34ac0f.../2026-08-08):
+    #   PredictorTraining 0.197s -> WaitForPredictorTraining 422s (7m2s)
+    #   RAGIngestion       0.189s -> WaitForRAGIngestion       1057s (17m37s)
+    #   Backtester         0.238s -> WaitForBacktester          663s (11m3s)
+    # The floor values below are UNCHANGED (not recalibrated) — only the key
+    # each floors now names is corrected. The account's SUCCEEDED-execution
+    # history for this state machine has exactly one canonical (EventBridge-
+    # triggered, name matching `<uuid>_<uuid>`) execution, below
+    # floor_calibration.MIN_SAMPLES — floor_calibration.py now filters
+    # ad hoc watch-rerun/offcycle-shell/friday-shell/recovery reruns out of
+    # the weekly machine's genuine population (they run a different,
+    # shorter bootstrap/skip path — see floor_calibration.py module
+    # docstring), so these three (and the two above) correctly report
+    # "unmeasurable" rather than a fabricated recommendation until more
+    # genuine canonical runs accumulate.
+    "WaitForRAGIngestion": 10 * 60,
+    "WaitForPredictorTraining": 20 * 60,
+    "WaitForBacktester": 10 * 60,
     # Was "ModelZooRotation", a state no definition has had for some time —
     # the rotation is ModelZooSelect -> ModelZooTrainMap ("ModelZooResolve"
     # is a phase LABEL in an error extractor, not a state),
@@ -134,11 +158,11 @@ DIGEST_STATE_ORDER: Tuple[str, ...] = (
     # workload lead the order instead.
     "WaitForMorningEnrich",
     "WaitForDataPhase1",
-    "RAGIngestion",
+    "WaitForRAGIngestion",
     "ResearchPredictorParallel",
-    "PredictorTraining",
+    "WaitForPredictorTraining",
     "DataPhase2",
-    "Backtester",
+    "WaitForBacktester",
     # "Parity" and "ModelZooRotation" were stale: the states were split into
     # the names below and this list was never updated, so both entries
     # ordered nothing for however long that has been true.
@@ -452,11 +476,18 @@ def build_state_durations(
         floor_breach = bool(floor is not None and secs < floor)
         attestation_failed = False
         if not is_preflight and s3_client is not None:
-            if name == "PredictorTraining" and name in durations_sec:
+            # alpha-engine-config-I10574: was "PredictorTraining" /
+            # "Backtester" (the dispatch states, renamed off
+            # STATE_DURATION_FLOORS_SEC above) — the attestation trigger
+            # must follow the same rename or it silently stops firing:
+            # dispatch names still appear in durations_sec (their own ~0.2s
+            # span), so a stale name here would attest against a row that
+            # completed before the real work even started.
+            if name == "WaitForPredictorTraining" and name in durations_sec:
                 attestation_failed = not _attest_predictor_training(
                     s3_client, execution_start=execution_start
                 )
-            elif name == "Backtester" and run_date and name in durations_sec:
+            elif name == "WaitForBacktester" and run_date and name in durations_sec:
                 attestation_failed = not _attest_backtester(
                     s3_client,
                     run_date=run_date,

--- a/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/floor_calibration.py
@@ -44,12 +44,54 @@ broken run into the distribution. Where no companion key is declared, this
 module computes on raw duration and says so — DECLARED rather than inferred,
 same discipline ``execution_digest.py`` already applies to
 ``TERMINAL_ERROR_HANDLING_STATES`` / ``WORK_STATES_ON_TERMINAL_PATHS``.
+
+MEASURE THE SAME SPAN THE NOTIFIER FLOORS (alpha-engine-config-I10574). Every
+name in ``STATE_TO_STATE_MACHINE`` MUST be the exact state name that carries
+the workload span — never a dispatch Task that fires an SSM/spot command and
+returns in under a second while the real work runs in a polled child.
+``execution_digest.parse_task_state_durations`` (first-entry -> last-exit,
+the same function both this module and the live notifier call) is span-
+correct once pointed at the right name; pointed at a dispatch name it
+faithfully reports the dispatch's own ~0.2s duration, which is correct and
+useless. Measured live against the one genuine EventBridge-triggered
+SUCCEEDED ne-weekly-freshness-pipeline execution in the account's full
+history carrying these states (name
+9b34ac0f-5e2f-f70b-d668-61b4c4751654_6fb6adf9-55fa-4426-6d06-79e4579bcaff,
+2026-08-08): ``RAGIngestion``/``PredictorTraining``/``Backtester`` each enter
+and exit in 0.19-0.24s, immediately followed by
+``WaitForRAGIngestion``/``WaitForPredictorTraining``/``WaitForBacktester``
+poll loops spanning 1057s/422s/663s — the same dispatch-then-poll shape
+``WaitForMorningEnrich``/``WaitForDataPhase1`` were already renamed to track
+under alpha-engine-config-I10545. ``execution_digest.STATE_DURATION_FLOORS_SEC``
+carries the corresponding rename; see that file's comment for the measured
+values.
+
+CANONICAL EXECUTIONS ONLY, FOR THE WEEKLY MACHINE (alpha-engine-config-
+I10574). ``ne-weekly-freshness-pipeline``'s SUCCEEDED-execution history is
+NOT one population: alongside the daily EventBridge-triggered execution (name
+`<uuid>_<uuid>` — two UUID-shaped segments joined by "_", the only shape that
+trigger produces), the same history carries `watch-rerun-*`,
+`offcycle-shell-*`, `friday-shell-*`, `recovery-*` and bare-single-UUID ad hoc
+reruns/backfills. Measured across all 48 SUCCEEDED executions in the
+account's full history (2026-09-12): every ad hoc execution's
+WaitForMorningEnrich/WaitForDataPhase1 span was 30-151s (one to a handful of
+poll iterations — these reruns skip already-processed phases and their
+bootstrap legitimately returns fast), while the ONE canonical execution in
+that same history spans 1662s/2417s. Averaging the two populations together
+is exactly how ``min_genuine`` landed on 30.0s (the bare poll interval) for
+both states in the first `--check` run that had permission to reach live
+history (I10574) — a genuine value from a non-representative population, not
+a wrong measurement of the right one. ``_CANONICAL_EXECUTION_NAME_RE`` scopes
+this filter to the weekly machine only (``STATE_TO_STATE_MACHINE`` values in
+``_CANONICAL_NAME_SCOPED_MACHINES``); the weekday pipelines' own ad hoc-
+execution population, if any, is undocumented and out of scope here.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import re
 import statistics
 import sys
 from dataclasses import dataclass
@@ -73,14 +115,36 @@ STATE_TO_STATE_MACHINE: Mapping[str, str] = {
     # the workload.
     "WaitForMorningEnrich": "ne-weekly-freshness-pipeline",
     "WaitForDataPhase1": "ne-weekly-freshness-pipeline",
-    "RAGIngestion": "ne-weekly-freshness-pipeline",
-    "PredictorTraining": "ne-weekly-freshness-pipeline",
-    "Backtester": "ne-weekly-freshness-pipeline",
+    # alpha-engine-config-I10574: was "RAGIngestion" / "PredictorTraining" /
+    # "Backtester" — same dispatch-vs-poll defect as the two above, caught a
+    # PR later. See the module docstring's "MEASURE THE SAME SPAN" section.
+    "WaitForRAGIngestion": "ne-weekly-freshness-pipeline",
+    "WaitForPredictorTraining": "ne-weekly-freshness-pipeline",
+    "WaitForBacktester": "ne-weekly-freshness-pipeline",
     "ModelZooTrainMap": "ne-weekly-freshness-pipeline",
     "PollMorningEnrichSpot": "ne-preopen-trading-pipeline",
     "PollMorningArcticAppendSpot": "ne-preopen-trading-pipeline",
     "Scanner": "ne-preopen-trading-pipeline",
 }
+
+#: Weekly-machine executions whose NAME does not match this pattern are ad
+#: hoc reruns/backfills (`watch-rerun-*`, `offcycle-shell-*`,
+#: `friday-shell-*`, `recovery-*`, bare single UUIDs), not the daily
+#: EventBridge-triggered run — see the module docstring's "CANONICAL
+#: EXECUTIONS ONLY" section. The trigger names every execution it starts
+#: `<uuid>_<uuid>`: two UUID-shaped segments joined by "_".
+_CANONICAL_EXECUTION_NAME_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_"
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+#: State machines whose SUCCEEDED-execution history mixes ad hoc reruns with
+#: the scheduled trigger (measured true for the weekly machine only —
+#: I10574). Scoped deliberately: applying an unmeasured filter to the
+#: weekday machines would silently change PollMorningEnrichSpot/
+#: PollMorningArcticAppendSpot's already-recalibrated (I10164) sample
+#: population for no measured reason.
+_CANONICAL_NAME_SCOPED_MACHINES = frozenset({"ne-weekly-freshness-pipeline"})
 
 #: States whose Task output carries a companion SSM-poll-result dict (the raw
 #: ssm:GetCommandInvocation shape: Status/ResponseCode/StatusDetails/
@@ -131,6 +195,14 @@ class FloorRecommendation:
     max_sec: Optional[float] = None
     recommended_floor_sec: Optional[int] = None
     basis: str = ""
+    #: Which HistoryEvent pair was measured (I10574 deliverable 3) — always
+    #: this shape today, named explicitly rather than left implicit so a
+    #: --check reader never has to open this module to know what a number
+    #: means.
+    event_pair: str = ""
+    #: Human-readable breakdown of WHY excluded samples were excluded (e.g.
+    #: "3 zero-duration, 5 non-canonical-execution") — "" when n_excluded==0.
+    exclusion_breakdown: str = ""
 
     @property
     def is_drift(self) -> bool:
@@ -150,15 +222,30 @@ def collect_state_duration_samples(
     *,
     fetch_history: Any,
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Per-state list of ``{"duration_sec": float, "poll_status": Optional[str]}``
-    samples across every SUCCEEDED execution of ``state_machine_arn``.
+    """Per-state list of ``{"duration_sec": float, "poll_status": Optional[str],
+    "exclusion_reason": Optional[str]}`` samples across every SUCCEEDED
+    execution of ``state_machine_arn``.
 
     ``fetch_history(sf_client, execution_arn) -> List[dict]`` is injected
     (rather than calling ``execution_digest.fetch_execution_history``
     directly) so tests can supply canned event lists without a live SF
     execution to point at — the same shape ``build_execution_digest`` already
     takes ``sf_client``/``s3_client`` as parameters for.
+
+    ``exclusion_reason`` is set here (never inferred later by
+    ``compute_recommendation`` alone) for the two reasons this function can
+    already see from one execution's events without needing the poll-status
+    cross-check: a zero-duration sample (a dispatch Task, not the poll span —
+    see module docstring "MEASURE THE SAME SPAN"), and a non-canonical
+    execution name on a machine in ``_CANONICAL_NAME_SCOPED_MACHINES`` (an ad
+    hoc rerun/backfill — see "CANONICAL EXECUTIONS ONLY"). A poll-status
+    exclusion (state has a ``KNOWN_POLL_STATUS_KEYS`` entry) is layered on
+    top by ``compute_recommendation``, which is the only place that already
+    special-cases it.
     """
+    machine_name = state_machine_arn.rsplit(":", 1)[-1]
+    canonical_only = machine_name in _CANONICAL_NAME_SCOPED_MACHINES
+
     samples: Dict[str, List[Dict[str, Any]]] = {name: [] for name in state_names}
     paginator = sf_client.get_paginator("list_executions")
     executions: List[dict] = []
@@ -166,20 +253,41 @@ def collect_state_duration_samples(
         executions.extend(page.get("executions", []))
 
     for execution in executions:
+        exec_name = execution.get("name") or ""
+        non_canonical = canonical_only and not _CANONICAL_EXECUTION_NAME_RE.match(exec_name)
         events = fetch_history(sf_client, execution["executionArn"])
         durations = parse_task_state_durations(events)
         last_outputs = _last_task_outputs(events, state_names)
         for name in state_names:
             if name not in durations:
                 continue
+            duration = durations[name]
             poll_status = None
             poll_key = KNOWN_POLL_STATUS_KEYS.get(name)
             if poll_key:
                 output = last_outputs.get(name)
                 if isinstance(output, dict):
                     poll_status = (output.get(poll_key) or {}).get("Status")
+            exclusion_reason: Optional[str] = None
+            if duration <= 0:
+                exclusion_reason = (
+                    "zero-duration sample — this Task fires a dispatch "
+                    "(SSM/spot command) and returns; the workload runs in a "
+                    "companion poll state, not here"
+                )
+            elif non_canonical:
+                exclusion_reason = (
+                    f"non-canonical execution name {exec_name!r} — an ad hoc "
+                    "rerun/backfill/offcycle-shell, not the scheduled "
+                    "EventBridge-triggered run; its bootstrap/skip semantics "
+                    "differ from a genuine weekly pass"
+                )
             samples[name].append(
-                {"duration_sec": durations[name], "poll_status": poll_status}
+                {
+                    "duration_sec": duration,
+                    "poll_status": poll_status,
+                    "exclusion_reason": exclusion_reason,
+                }
             )
     return samples
 
@@ -213,22 +321,59 @@ def compute_recommendation(
 ) -> FloorRecommendation:
     """One state's recommendation, from its collected samples.
 
-    ``samples`` items carry ``duration_sec`` and (when the state has a
-    ``KNOWN_POLL_STATUS_KEYS`` entry) ``poll_status``. GENUINE samples are
-    those with no companion key declared (raw duration is all there is) OR
-    ``poll_status == "Success"``. A companion key present with a non-Success
-    status is EXCLUDED from the genuine set, never averaged in.
+    ``samples`` items carry ``duration_sec``, an optional ``exclusion_reason``
+    set by ``collect_state_duration_samples`` (zero-duration or non-canonical
+    execution — see that function's docstring), and (when the state has a
+    ``KNOWN_POLL_STATUS_KEYS`` entry) ``poll_status``. A sample is GENUINE
+    only when it carries no ``exclusion_reason`` AND (no companion poll key
+    is declared OR ``poll_status == "Success"``). Every excluded sample keeps
+    its reason — never silently dropped, never averaged in.
     """
     has_poll_key = state_name in KNOWN_POLL_STATUS_KEYS
-    if has_poll_key:
-        genuine = [s["duration_sec"] for s in samples if s.get("poll_status") == "Success"]
-        excluded = [s for s in samples if s.get("poll_status") != "Success"]
-    else:
-        genuine = [s["duration_sec"] for s in samples]
-        excluded = []
+    genuine: List[float] = []
+    excluded: List[Mapping[str, Any]] = []
+    reason_counts: Dict[str, int] = {}
+
+    for s in samples:
+        reason = s.get("exclusion_reason")
+        bucket = "zero-duration" if reason and "zero-duration" in reason else (
+            "non-canonical-execution" if reason and "non-canonical" in reason else None
+        )
+        if reason is None and s.get("duration_sec", 0) <= 0:
+            # Defense in depth: collect_state_duration_samples already tags
+            # this, but compute_recommendation never trusts an upstream
+            # caller to have done so — a 0s sample is excluded here
+            # unconditionally (I10574 deliverable 1).
+            reason = (
+                "zero-duration sample — this Task fires a dispatch "
+                "(SSM/spot command) and returns; the workload runs in a "
+                "companion poll state, not here"
+            )
+            bucket = "zero-duration"
+        if reason is None and has_poll_key and s.get("poll_status") != "Success":
+            reason = (
+                f"poll_status={s.get('poll_status')!r} (not 'Success') — a "
+                "broken-but-SUCCEEDED run"
+            )
+            bucket = "poll-status-failure"
+        if reason is None:
+            genuine.append(s["duration_sec"])
+        else:
+            excluded.append(s)
+            reason_counts[bucket or "other"] = reason_counts.get(bucket or "other", 0) + 1
 
     n_genuine = len(genuine)
     n_excluded = len(excluded)
+    exclusion_breakdown = (
+        ", ".join(f"{count} {bucket}" for bucket, count in sorted(reason_counts.items()))
+        if reason_counts
+        else ""
+    )
+    event_pair = (
+        f"TaskStateEntered/TaskStateExited on '{state_name}' "
+        "(stateEnteredEventDetails.name / stateExitedEventDetails.name), "
+        "first entry -> last exit"
+    )
 
     if n_genuine < MIN_SAMPLES:
         return FloorRecommendation(
@@ -237,6 +382,8 @@ def compute_recommendation(
             current_floor_sec=current_floor_sec,
             n_genuine=n_genuine,
             n_excluded=n_excluded,
+            event_pair=event_pair,
+            exclusion_breakdown=exclusion_breakdown,
             basis=(
                 f"only {n_genuine} genuine sample(s), below MIN_SAMPLES={MIN_SAMPLES} — "
                 "no recommendation computed; floor left as-is and recorded unmeasurable, "
@@ -263,6 +410,8 @@ def compute_recommendation(
             median_sec=median_sec,
             p90_sec=p90_sec,
             max_sec=max_sec,
+            event_pair=event_pair,
+            exclusion_breakdown=exclusion_breakdown,
             basis=(
                 f"spread max/min = {max_sec / min_sec:.4f} < {DEGENERATE_SPREAD_RATIO} — "
                 "distribution implausibly tight (a synthetic/backfill-only sample set, or a "
@@ -292,6 +441,8 @@ def compute_recommendation(
         p90_sec=p90_sec,
         max_sec=max_sec,
         recommended_floor_sec=recommended,
+        event_pair=event_pair,
+        exclusion_breakdown=exclusion_breakdown,
         basis=(
             f"recommended = round(min_genuine * (1-{MARGIN})) = "
             f"round({min_sec:.1f} * {1 - MARGIN}) = {recommended}s; "
@@ -323,7 +474,10 @@ def compute_all_recommendations(
 
 
 def render_report(recommendations: Sequence[FloorRecommendation]) -> str:
-    lines = ["state,status,current_floor_sec,n_genuine,n_excluded,recommended_floor_sec,basis"]
+    lines = [
+        "state,status,current_floor_sec,n_genuine,n_excluded,recommended_floor_sec,"
+        "event_pair,exclusion_breakdown,basis"
+    ]
     for rec in recommendations:
         lines.append(
             ",".join(
@@ -334,6 +488,8 @@ def render_report(recommendations: Sequence[FloorRecommendation]) -> str:
                     str(rec.n_genuine),
                     str(rec.n_excluded),
                     "" if rec.recommended_floor_sec is None else str(rec.recommended_floor_sec),
+                    f'"{rec.event_pair}"',
+                    f'"{rec.exclusion_breakdown}"',
                     f'"{rec.basis}"',
                 ]
             )

--- a/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py
@@ -42,9 +42,12 @@ def test_parse_task_state_durations_computes_wall_clock():
 
 
 def test_floor_breach_detected_when_under_minimum():
+    # alpha-engine-config-I10574: "PredictorTraining" is the dispatch state
+    # (never floored — see STATE_DURATION_FLOORS_SEC); the floor sits on its
+    # companion poll state, "WaitForPredictorTraining".
     start = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
     rows = build_state_durations(
-        {"PredictorTraining": 120},
+        {"WaitForPredictorTraining": 120},
         is_preflight=False,
         execution_start=start,
         run_date="2026-07-04",
@@ -58,7 +61,7 @@ def test_floor_breach_detected_when_under_minimum():
 def test_preflight_suppresses_floor_breach():
     start = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
     rows = build_state_durations(
-        {"PredictorTraining": 30},
+        {"WaitForPredictorTraining": 30},
         is_preflight=True,
         execution_start=start,
         run_date=None,
@@ -205,6 +208,8 @@ def test_format_digest_sorts_anomalies_visually():
 
 
 def test_build_execution_digest_hollow_on_fast_predictor():
+    # alpha-engine-config-I10574: floored/attested on "WaitForPredictorTraining"
+    # (the poll state), not "PredictorTraining" (the dispatch state).
     start_ms = 1_700_000_000_000
     sf = MagicMock()
     base = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc)
@@ -213,12 +218,12 @@ def test_build_execution_digest_hollow_on_fast_predictor():
             {
                 "type": "TaskStateEntered",
                 "timestamp": base,
-                "stateEnteredEventDetails": {"name": "PredictorTraining"},
+                "stateEnteredEventDetails": {"name": "WaitForPredictorTraining"},
             },
             {
                 "type": "TaskStateExited",
                 "timestamp": _ts(base, 90),
-                "stateExitedEventDetails": {"name": "PredictorTraining"},
+                "stateExitedEventDetails": {"name": "WaitForPredictorTraining"},
             },
         ],
     }
@@ -232,8 +237,8 @@ def test_build_execution_digest_hollow_on_fast_predictor():
     )
     assert hollow is True
     assert detailed_cause is None
-    assert any("PredictorTraining" in line for line in lines)
-    assert STATE_DURATION_FLOORS_SEC["PredictorTraining"] == 20 * 60
+    assert any("WaitForPredictorTraining" in line for line in lines)
+    assert STATE_DURATION_FLOORS_SEC["WaitForPredictorTraining"] == 20 * 60
 
 
 def test_parse_run_date_from_execution_name_extracts_iso_date():

--- a/infrastructure/lambdas/sf-telegram-notifier/test_floor_calibration.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_floor_calibration.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import floor_calibration as fc
 from floor_calibration import (
     DEGENERATE_SPREAD_RATIO,
     MARGIN,
@@ -231,6 +232,302 @@ def test_collect_state_duration_samples_extracts_poll_status():
     sample = samples["PollMorningArcticAppendSpot"][0]
     assert sample["duration_sec"] == pytest.approx(930.0)
     assert sample["poll_status"] == "Failed"
+
+
+# ── the real weekly-execution fixture (alpha-engine-config-I10574) ──────
+
+
+import json as _json
+from datetime import datetime as _datetime
+from pathlib import Path as _Path
+
+_WEEKLY_FIXTURE = (
+    _Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "sf_history_weekly_canonical_2026-08-08.json"
+)
+
+
+def _weekly_canonical_history() -> list[dict]:
+    """The real 2026-08-08 ne-weekly-freshness-pipeline execution
+    (9b34ac0f-5e2f-f70b-d668-61b4c4751654_6fb6adf9-55fa-4426-6d06-79e4579bcaff),
+    redacted to TaskStateEntered/TaskStateExited events only (type, state
+    name, timestamp — no payload; the source history was fetched with
+    ``includeExecutionData=False``, so no payload was ever present).
+
+    This is the ONE genuine EventBridge-triggered SUCCEEDED execution in the
+    account's full history carrying RAGIngestion/PredictorTraining/Backtester
+    — the run alpha-engine-config-I10574's finding was measured against.
+    """
+    events = _json.loads(_WEEKLY_FIXTURE.read_text())
+    for e in events:
+        e["timestamp"] = _datetime.fromisoformat(e["timestamp"])
+    return events
+
+
+def test_real_weekly_history_dispatch_states_sample_to_zero():
+    """Reproduces the reported defect: sampling the DISPATCH state names
+    (the pre-fix STATE_TO_STATE_MACHINE keys) yields 0s for all three —
+    exactly the nonsense `min_genuine=0.0` alpha-engine-config-I10574 reported."""
+    events = _weekly_canonical_history()
+    durations = fc.parse_task_state_durations(events)
+    assert durations["RAGIngestion"] == 0
+    assert durations["PredictorTraining"] == 0
+    assert durations["Backtester"] == 0
+
+
+def test_real_weekly_history_poll_states_sample_to_the_genuine_multi_minute_span():
+    """The fix: sampling the companion WaitForX poll states (the corrected
+    STATE_TO_STATE_MACHINE keys) recovers the real workload span."""
+    events = _weekly_canonical_history()
+    durations = fc.parse_task_state_durations(events)
+    assert durations["WaitForRAGIngestion"] == 1057
+    assert durations["WaitForPredictorTraining"] == 421
+    assert durations["WaitForBacktester"] == 662
+    # WaitForMorningEnrich / WaitForDataPhase1 (already correctly named pre-
+    # I10574) are also genuinely multi-minute in this execution.
+    assert durations["WaitForMorningEnrich"] == 1662
+    assert durations["WaitForDataPhase1"] == 2417
+
+
+def test_collect_state_duration_samples_end_to_end_on_the_real_fixture():
+    """collect_state_duration_samples, driven end-to-end against the real
+    fixture through a canonical execution name, must recover the genuine
+    span for every renamed state and mark it as a non-zero sample."""
+    events = _weekly_canonical_history()
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {
+            "executions": [
+                {
+                    "executionArn": "arn:exec:1",
+                    "name": (
+                        "9b34ac0f-5e2f-f70b-d668-61b4c4751654_"
+                        "6fb6adf9-55fa-4426-6d06-79e4579bcaff"
+                    ),
+                }
+            ]
+        }
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = fc.collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        [
+            "WaitForRAGIngestion",
+            "WaitForPredictorTraining",
+            "WaitForBacktester",
+            "WaitForMorningEnrich",
+            "WaitForDataPhase1",
+        ],
+        fetch_history=fake_fetch,
+    )
+    for name, expected in (
+        ("WaitForRAGIngestion", 1057),
+        ("WaitForPredictorTraining", 421),
+        ("WaitForBacktester", 662),
+        ("WaitForMorningEnrich", 1662),
+        ("WaitForDataPhase1", 2417),
+    ):
+        assert len(samples[name]) == 1, name
+        sample = samples[name][0]
+        assert sample["duration_sec"] == expected, name
+        assert sample["exclusion_reason"] is None, name  # canonical name, non-zero
+
+
+# ── zero-duration exclusion (I10574 deliverable 1) ───────────────────────
+
+
+def test_zero_duration_sample_excluded_never_averaged_in():
+    """A 0-second sample (a dispatch Task, not the workload span) is
+    excluded with a named reason, never counted as genuine — regardless of
+    KNOWN_POLL_STATUS_KEYS, and even when it would otherwise clear
+    MIN_SAMPLES."""
+    genuine_durations = [600.0 + i for i in range(MIN_SAMPLES + 5)]
+    samples = [{"duration_sec": d, "poll_status": None, "exclusion_reason": None} for d in genuine_durations]
+    samples += [
+        {"duration_sec": 0.0, "poll_status": None, "exclusion_reason": None}
+        for _ in range(5)
+    ]
+    rec = compute_recommendation("SomeDispatchState", samples, current_floor_sec=500)
+    assert rec.n_genuine == len(genuine_durations)
+    assert rec.n_excluded == 5
+    assert rec.min_sec == pytest.approx(600.0)
+    assert "zero-duration" in rec.exclusion_breakdown
+
+
+def test_collect_state_duration_samples_tags_zero_duration_with_a_reason():
+    from datetime import datetime, timezone
+
+    base = datetime(2026, 8, 8, 10, 0, 0, tzinfo=timezone.utc)
+    events = [_entered("RAGIngestion", base), _exited("RAGIngestion", base, {})]
+
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {"executions": [{"executionArn": "arn:exec:1", "name": "exec-1"}]}
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        ["RAGIngestion"],
+        fetch_history=fake_fetch,
+    )
+    sample = samples["RAGIngestion"][0]
+    assert sample["duration_sec"] == 0
+    assert "zero-duration" in sample["exclusion_reason"]
+
+
+# ── canonical-execution-name filter (I10574 deliverable "measure the same
+#    span"'s companion defect — averaging ad hoc reruns into "genuine") ───
+
+
+def test_non_canonical_weekly_execution_excluded_with_a_named_reason():
+    """watch-rerun-*/offcycle-shell-*/etc. executions of the weekly machine
+    are tagged non-canonical and excluded — their bootstrap/skip semantics
+    differ from the scheduled EventBridge-triggered run (I10574)."""
+    from datetime import datetime, timezone
+
+    base = datetime(2026, 8, 28, 10, 0, 0, tzinfo=timezone.utc)
+    events = [
+        _entered("WaitForMorningEnrich", base),
+        _exited("WaitForMorningEnrich", base, {}),
+    ]
+    # duration is 0 in this minimal fixture (same enter/exit timestamp) —
+    # give it a non-zero span so the zero-duration exclusion doesn't mask
+    # which reason actually fired.
+    from datetime import timedelta
+
+    events = [
+        _entered("WaitForMorningEnrich", base),
+        _exited("WaitForMorningEnrich", base + timedelta(seconds=151), {}),
+    ]
+
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {"executions": [{"executionArn": "arn:exec:1", "name": "watch-rerun-2026-08-28-13"}]}
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = fc.collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        ["WaitForMorningEnrich"],
+        fetch_history=fake_fetch,
+    )
+    sample = samples["WaitForMorningEnrich"][0]
+    assert sample["duration_sec"] == 151
+    assert "non-canonical" in sample["exclusion_reason"]
+
+
+def test_canonical_execution_name_not_excluded():
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 8, 8, 9, 0, 0, tzinfo=timezone.utc)
+    events = [
+        _entered("WaitForMorningEnrich", base),
+        _exited("WaitForMorningEnrich", base + timedelta(seconds=1662), {}),
+    ]
+
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {
+            "executions": [
+                {
+                    "executionArn": "arn:exec:1",
+                    "name": (
+                        "9b34ac0f-5e2f-f70b-d668-61b4c4751654_"
+                        "6fb6adf9-55fa-4426-6d06-79e4579bcaff"
+                    ),
+                }
+            ]
+        }
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = fc.collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-weekly-freshness-pipeline",
+        ["WaitForMorningEnrich"],
+        fetch_history=fake_fetch,
+    )
+    sample = samples["WaitForMorningEnrich"][0]
+    assert sample["exclusion_reason"] is None
+
+
+def test_canonical_name_filter_scoped_to_weekly_machine_only():
+    """The weekday machine (ne-preopen-trading-pipeline) is NOT subject to
+    the canonical-name filter — it is unmeasured there and scoping it
+    narrowly avoids silently changing PollMorningEnrichSpot/
+    PollMorningArcticAppendSpot's already-recalibrated (I10164) population."""
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 8, 8, 9, 0, 0, tzinfo=timezone.utc)
+    events = [
+        _entered("PollMorningEnrichSpot", base),
+        _exited("PollMorningEnrichSpot", base + timedelta(seconds=200), {}),
+    ]
+
+    sf_client = MagicMock()
+    sf_client.get_paginator.return_value.paginate.return_value = [
+        {"executions": [{"executionArn": "arn:exec:1", "name": "some-ad-hoc-name"}]}
+    ]
+
+    def fake_fetch(_client, _arn):
+        return events
+
+    samples = fc.collect_state_duration_samples(
+        sf_client,
+        "arn:aws:states:us-east-1:711398986525:stateMachine:ne-preopen-trading-pipeline",
+        ["PollMorningEnrichSpot"],
+        fetch_history=fake_fetch,
+    )
+    sample = samples["PollMorningEnrichSpot"][0]
+    assert sample["exclusion_reason"] is None
+
+
+# ── --check output names the event pair measured (I10574 deliverable 3) ──
+
+
+def test_recommendation_names_the_measured_event_pair():
+    samples = _samples([600.0 + i for i in range(MIN_SAMPLES + 5)])
+    rec = compute_recommendation("WaitForRAGIngestion", samples, current_floor_sec=600)
+    assert "WaitForRAGIngestion" in rec.event_pair
+    assert "TaskStateEntered" in rec.event_pair
+    assert "TaskStateExited" in rec.event_pair
+
+
+def test_render_report_includes_event_pair_and_exclusion_breakdown_columns():
+    report = render_report(
+        [
+            FloorRecommendation(
+                state_name="A",
+                status="ok",
+                current_floor_sec=90,
+                n_genuine=20,
+                n_excluded=2,
+                min_sec=100.0,
+                recommended_floor_sec=85,
+                basis="x",
+                event_pair="TaskStateEntered/TaskStateExited on 'A'",
+                exclusion_breakdown="2 zero-duration",
+            )
+        ]
+    )
+    assert "event_pair" in report and "exclusion_breakdown" in report
+    assert "TaskStateEntered/TaskStateExited on 'A'" in report
+    assert "2 zero-duration" in report
 
 
 def test_run_check_wires_every_state_machine():

--- a/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
+++ b/infrastructure/lambdas/sf-telegram-notifier/test_handler.py
@@ -438,7 +438,12 @@ def test_format_duration_handles_missing_timestamps():
 
 
 def test_succeeded_hollow_predictor_training_flags_loud(reset_send_message):
-    """config#1672: implausibly fast PredictorTraining → HOLLOW-SUSPECT + loud push."""
+    """config#1672: implausibly fast PredictorTraining → HOLLOW-SUSPECT + loud push.
+
+    alpha-engine-config-I10574: floored/rendered on "WaitForPredictorTraining"
+    (the poll state) — "PredictorTraining" is the dispatch state, never
+    floored, so a fast dispatch alone would not be an anomaly.
+    """
     from datetime import datetime, timezone
 
     base = datetime(2026, 7, 3, 12, 0, 0, tzinfo=timezone.utc)
@@ -447,19 +452,19 @@ def test_succeeded_hollow_predictor_training_flags_loud(reset_send_message):
             {
                 "type": "TaskStateEntered",
                 "timestamp": base,
-                "stateEnteredEventDetails": {"name": "PredictorTraining"},
+                "stateEnteredEventDetails": {"name": "WaitForPredictorTraining"},
             },
             {
                 "type": "TaskStateExited",
                 "timestamp": base.replace(minute=2),
-                "stateExitedEventDetails": {"name": "PredictorTraining"},
+                "stateExitedEventDetails": {"name": "WaitForPredictorTraining"},
             },
         ],
     }
     result = index.handler(_event("SUCCEEDED"), None)
     text = _telegram_mod.send_message.call_args.args[0]
     assert "HOLLOW-SUSPECT" in text
-    assert "PredictorTraining" in text
+    assert "WaitForPredictorTraining" in text
     assert "⚠️" in text
     assert result["hollow_suspect"] is True
     assert result["silent"] is False

--- a/tests/fixtures/sf_history_weekly_canonical_2026-08-08.json
+++ b/tests/fixtures/sf_history_weekly_canonical_2026-08-08.json
@@ -1,0 +1,5868 @@
+[
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:00:49.365000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WeeklyRunDayGate"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:00:55.477000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WeeklyRunDayGate"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:00:55.477000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "LibPinDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:00:56.183000-07:00",
+    "stateExitedEventDetails": {
+      "name": "LibPinDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:00:56.183000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "PipelineContractCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:00:56.456000-07:00",
+    "stateExitedEventDetails": {
+      "name": "PipelineContractCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:00:56.456000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvaluatorDeployDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:00:59.290000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvaluatorDeployDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:00:59.290000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvaluatorDirectorDeployDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:01:02.129000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvaluatorDirectorDeployDriftCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:01:02.129000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "AcquireMutex"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:01:02.278000-07:00",
+    "stateExitedEventDetails": {
+      "name": "AcquireMutex"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:01:02.278000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "DispatchWeeklyFreshnessSpot"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:01:22.768000-07:00",
+    "stateExitedEventDetails": {
+      "name": "DispatchWeeklyFreshnessSpot"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:01:22.768000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:01:22.944000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:01:53.012000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:01:53.148000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:02:23.207000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:02:23.364000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:02:53.426000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:02:53.624000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklyFreshnessSpotBootstrap"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:02:53.624000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "SubstrateHealthGate"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:02:57.993000-07:00",
+    "stateExitedEventDetails": {
+      "name": "SubstrateHealthGate"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:02:57.993000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "MorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:02:58.221000-07:00",
+    "stateExitedEventDetails": {
+      "name": "MorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:02:58.221000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:02:58.373000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:03:28.441000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:03:28.581000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:03:58.644000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:03:58.792000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:04:28.863000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:04:29.001000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:04:59.077000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:04:59.264000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:05:29.370000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:05:29.523000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:05:59.576000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:05:59.721000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:06:29.781000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:06:29.999000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:07:00.062000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:07:00.221000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:07:30.282000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:07:30.433000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:08:00.500000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:08:00.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:08:30.699000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:08:30.872000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:09:00.935000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:09:01.086000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:09:31.145000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:09:31.292000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:10:01.355000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:10:01.471000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:10:31.545000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:10:31.692000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:11:01.757000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:11:01.899000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:11:31.963000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:11:32.106000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:12:02.168000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:12:02.295000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:12:32.363000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:12:32.522000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:13:02.588000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:13:02.740000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:13:32.800000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:13:32.934000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:14:03.005000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:14:03.147000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:14:33.215000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:14:33.365000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:15:03.430000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:15:03.574000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:15:33.670000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:15:33.832000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:16:03.908000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:16:04.050000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:16:34.116000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:16:34.262000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:17:04.320000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:17:04.459000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:17:34.532000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:17:34.718000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:18:04.782000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:18:04.922000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:18:34.990000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:18:35.140000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:19:05.213000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:19:05.418000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:19:35.484000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:19:35.617000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:20:05.678000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:20:05.792000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:20:35.848000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:20:35.992000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:21:06.042000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:21:06.168000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:21:36.244000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:21:36.424000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:22:06.479000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:22:06.630000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:22:36.689000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:22:36.839000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:23:06.906000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:23:07.035000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:23:37.100000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:23:37.287000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:24:07.356000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:24:07.507000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:24:37.605000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:24:37.756000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:25:07.822000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:25:07.960000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:25:38.034000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:25:38.181000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:26:08.244000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:26:08.425000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:26:38.492000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:26:38.638000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:27:08.745000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:27:08.893000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:27:38.960000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:27:39.096000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:28:09.165000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:28:09.312000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:28:39.370000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:28:39.509000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:29:09.576000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:29:09.715000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:29:39.775000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:29:39.904000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:30:09.960000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:30:10.154000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:30:40.229000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:30:40.461000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForMorningEnrich"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:30:40.461000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "DataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:30:40.717000-07:00",
+    "stateExitedEventDetails": {
+      "name": "DataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:30:40.717000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:30:40.868000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:31:10.931000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:31:11.110000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:31:41.185000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:31:41.323000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:32:11.388000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:32:11.531000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:32:41.591000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:32:41.731000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:33:11.789000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:33:11.960000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:33:42.048000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:33:42.169000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:34:12.265000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:34:12.405000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:34:42.473000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:34:42.660000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:35:12.727000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:35:12.886000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:35:42.963000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:35:43.098000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:36:13.161000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:36:13.364000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:36:43.456000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:36:43.611000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:37:13.663000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:37:13.779000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:37:43.848000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:37:43.990000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:38:14.052000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:38:14.196000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:38:44.269000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:38:44.413000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:39:14.468000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:39:14.613000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:39:44.679000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:39:44.823000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:40:14.890000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:40:15.019000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:40:45.088000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:40:45.231000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:41:15.285000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:41:15.423000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:41:45.482000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:41:45.614000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:42:15.671000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:42:15.814000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:42:45.878000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:42:46.013000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:43:16.081000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:43:16.216000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:43:46.279000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:43:46.429000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:44:16.496000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:44:16.717000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:44:46.782000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:44:46.965000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:45:17.025000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:45:17.198000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:45:47.258000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:45:47.405000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:46:17.465000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:46:17.595000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:46:47.661000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:46:47.817000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:47:17.888000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:47:18.058000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:47:48.118000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:47:48.258000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:48:18.317000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:48:18.494000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:48:48.560000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:48:48.690000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:49:18.754000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:49:18.910000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:49:48.978000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:49:49.159000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:50:19.270000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:50:19.448000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:50:49.519000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:50:49.645000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:51:19.708000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:51:19.842000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:51:49.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:51:50.021000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:52:20.069000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:52:20.189000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:52:50.249000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:52:50.394000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:53:20.454000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:53:20.580000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:53:50.642000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:53:50.793000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:54:20.847000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:54:20.965000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:54:51.028000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:54:51.163000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:55:21.221000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:55:21.356000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:55:51.416000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:55:51.546000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:56:21.618000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:56:21.747000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:56:51.810000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:56:51.931000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:57:21.995000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:57:22.123000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:57:52.182000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:57:52.315000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:58:22.381000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:58:22.513000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:58:52.571000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:58:52.687000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:59:22.763000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:59:22.894000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T02:59:52.959000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T02:59:53.095000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:00:23.158000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:00:23.314000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:00:53.370000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:00:53.527000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:01:23.593000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:01:23.739000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:01:53.811000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:01:53.947000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:02:24.006000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:02:24.167000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:02:54.282000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:02:54.609000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:03:24.717000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:03:24.858000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:03:54.974000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:03:55.129000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:04:25.196000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:04:25.336000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:04:55.392000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:04:55.523000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:05:25.585000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:05:25.727000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:05:55.792000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:05:55.923000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:06:25.984000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:06:26.127000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:06:56.187000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:06:56.336000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:07:26.400000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:07:26.535000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:07:56.594000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:07:56.743000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:08:26.798000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:08:26.931000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:08:56.989000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:08:57.120000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:09:27.179000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:09:27.347000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:09:57.409000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:09:57.596000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:10:27.663000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:10:27.786000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:10:57.845000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:10:58.075000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase1"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:10:58.075000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Scanner"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:10:58.075000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "PredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:10:58.272000-07:00",
+    "stateExitedEventDetails": {
+      "name": "PredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:10:58.272000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:10:58.434000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:11:58.498000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:11:58.631000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:12:58.706000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:12:58.843000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:13:38.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Scanner"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:13:38.210000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "RegimeSubstrate"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:13:44.865000-07:00",
+    "stateExitedEventDetails": {
+      "name": "RegimeSubstrate"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:13:44.865000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "SignalsEnvelope"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:13:58.914000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:13:59.060000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:14:59.131000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:14:59.291000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:15:35.093000-07:00",
+    "stateExitedEventDetails": {
+      "name": "SignalsEnvelope"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:15:35.093000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ChallengerShadow"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:15:59.354000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:15:59.516000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:16:59.574000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:16:59.724000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:17:59.789000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:00-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorTraining"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:00-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ResolveZooSpecs"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:00.159000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ResolveZooSpecs"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:00.159000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitResolveZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:00.302000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitResolveZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:07.518000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ChallengerShadow"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:07.518000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "RAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:07.707000-07:00",
+    "stateExitedEventDetails": {
+      "name": "RAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:07.707000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:07.844000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.371000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitResolveZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:15.593000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitResolveZoo"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.593000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.593000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.593000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.593000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateExitedEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateExitedEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateExitedEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateExitedEventDetails": {
+      "name": "TrainSpecDispatch"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:15.847000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:16.002000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:16.002000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:16.002000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:16.002000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:18:37.910000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:18:38.051000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:08.137000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:08.268000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:16.064000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:16.064000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:16.064000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:16.064000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:16.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:16.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:16.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:16.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:19:38.323000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:19:38.488000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:08.559000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:08.694000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:16.267000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:16.267000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:16.267000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:16.267000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:16.416000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:16.416000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:16.416000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:16.416000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:20:38.761000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:20:38.896000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:08.972000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:09.108000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:16.483000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:16.483000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:16.483000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:16.483000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:16.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:16.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:16.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:16.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:21:39.170000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:21:39.289000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:09.344000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:09.451000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:16.688000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:16.688000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:16.688000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:16.688000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:16.830000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:16.830000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:16.830000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:16.830000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:22:39.531000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:22:39.675000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:09.735000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:09.882000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:16.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:16.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:16.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:16.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:17.125000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:17.125000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:17.125000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:17.125000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:23:39.953000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:23:40.091000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:10.147000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:10.288000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:17.186000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:17.186000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:17.186000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:17.186000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:17.320000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:17.320000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:17.320000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:17.320000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:24:40.343000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:24:40.465000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:10.523000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:10.656000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.384000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.384000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.384000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.384000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:17.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:17.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:17.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:17.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitTrainSpec"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.634000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ModelZooSelect"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:17.902000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ModelZooSelect"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:17.902000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:18.019000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:25:40.718000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:25:40.857000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:26:10.919000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:26:11.041000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:26:18.079000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:26:18.197000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:26:41.104000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:26:41.276000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:27:11.335000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:27:11.474000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:27:18.258000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:27:18.384000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:27:41.538000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:27:41.678000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:28:11.735000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:28:11.863000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:28:18.450000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:28:18.647000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForModelZoo"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:28:41.936000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:28:42.087000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:29:12.168000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:29:12.307000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:29:42.370000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:29:42.507000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:30:12.538000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:30:12.666000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:30:42.724000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:30:42.862000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:31:12.926000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:31:13.052000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:31:43.116000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:31:43.257000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:32:13.324000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:32:13.455000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:32:43.509000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:32:43.652000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:33:13.707000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:33:13.830000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:33:43.890000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:33:44.032000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:34:14.092000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:34:14.232000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:34:44.300000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:34:44.444000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:35:14.511000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:35:14.658000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:35:44.722000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:35:44.904000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForRAGIngestion"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:35:44.904000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ThinkTankCoverage"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:36:04.266000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ThinkTankCoverage"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:36:04.266000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:36:04.413000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:37:04.479000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:37:04.628000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:38:04.704000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:38:04.848000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:39:04.917000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:39:05.044000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:40:05.166000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:40:05.304000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:41:05.387000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:41:05.518000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:42:05.580000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:42:05.696000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:43:05.772000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:43:05.916000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:44:05.981000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:44:06.124000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:45:06.206000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:45:06.340000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:46:06.419000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:46:06.558000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:47:06.613000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:47:06.757000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:48:06.829000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:48:06.969000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:49:07.020000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:49:07.151000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:50:07.220000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:50:07.414000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForThinkTank"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:50:07.414000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "RegimeRetrospectiveEval"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:50:15.761000-07:00",
+    "stateExitedEventDetails": {
+      "name": "RegimeRetrospectiveEval"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:50:15.761000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "DataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:50:15.976000-07:00",
+    "stateExitedEventDetails": {
+      "name": "DataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:50:15.976000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:50:16.113000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:50:46.179000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:50:46.330000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:51:16.395000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:51:16.525000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:51:46.600000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:51:46.748000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:52:16.817000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:52:16.947000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:52:47.005000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:52:47.196000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForDataPhase2"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:52:47.196000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvalJudgeSubmitWeekly"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:52:57.272000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvalJudgeSubmitWeekly"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:53:57.339000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvalJudgePoll"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:54:10.044000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvalJudgePoll"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:55:10.107000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvalJudgePoll"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:55:10.471000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvalJudgePoll"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:55:10.471000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvalJudgeProcess"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:57:00.648000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvalJudgeProcess"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:57:00.648000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "EvalRollingMean"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:57:26.939000-07:00",
+    "stateExitedEventDetails": {
+      "name": "EvalRollingMean"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:57:26.939000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "RationaleClustering"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T03:57:36.829000-07:00",
+    "stateExitedEventDetails": {
+      "name": "RationaleClustering"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T03:57:36.829000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ReplayConcordance"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:12:36.912000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ReplayConcordance"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:12:36.912000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Counterfactual"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:13:33.038000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Counterfactual"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:13:33.038000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "AggregateCosts"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:13:36.523000-07:00",
+    "stateExitedEventDetails": {
+      "name": "AggregateCosts"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:13:36.523000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Backtester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:13:36.761000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Backtester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:13:36.761000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:13:36.916000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:14:36.979000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:14:37.171000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:15:37.237000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:15:37.385000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:16:37.456000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:16:37.606000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:17:37.665000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:17:37.810000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:18:37.848000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:18:37.985000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:19:38.055000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:19:38.193000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:20:38.255000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:20:38.390000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:21:38.456000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:21:38.586000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:22:38.658000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:22:38.825000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:23:38.889000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:23:39.031000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:24:39.089000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:24:39.307000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForBacktester"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:24:39.307000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "PredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:24:39.549000-07:00",
+    "stateExitedEventDetails": {
+      "name": "PredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:24:39.549000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:24:39.718000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:25:39.784000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:25:39.920000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:26:39.992000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:26:40.169000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:27:40.290000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:27:40.492000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:28:40.603000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:28:40.739000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:29:40.805000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:29:40.965000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:30:41.072000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:30:41.204000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:31:41.274000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:31:41.423000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:32:41.586000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:32:41.736000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:33:41.823000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:33:42.015000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:34:42.081000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:34:42.213000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:35:42.292000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:35:42.443000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:36:42.513000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:36:42.709000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPredictorBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:36:42.709000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "PortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:36:42.931000-07:00",
+    "stateExitedEventDetails": {
+      "name": "PortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:36:42.931000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:36:43.063000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:37:43.148000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:37:43.296000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:38:43.354000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:38:43.491000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:39:43.564000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:39:43.720000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:40:43.788000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:40:43.945000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:41:44.007000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:41:44.148000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:42:44.222000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:42:44.390000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:43:44.483000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:43:44.620000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:44:44.693000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:44:44.844000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:45:44.924000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:45:45.071000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:46:45.152000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:46:45.288000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:47:45.356000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:47:45.513000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:48:45.586000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:48:45.741000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:49:45.819000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:49:46.003000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:50:46.065000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:50:46.209000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:51:46.299000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:51:46.517000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:52:46.587000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:52:46.763000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:53:46.838000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:53:46.976000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:54:47.085000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:54:47.291000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:55:47.375000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:55:47.520000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:56:47.582000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:56:47.745000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:57:47.865000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:57:48.024000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:58:48.091000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:58:48.238000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:59:48.318000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:59:48.522000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForPortfolioOptimizerBacktest"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:59:48.522000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Parity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:59:49.115000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Parity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T04:59:49.115000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T04:59:49.256000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:00:49.321000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:00:49.452000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:01:49.527000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:01:49.685000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:02:49.752000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:02:49.890000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:03:49.957000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:03:50.094000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:04:50.156000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:04:50.295000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:05:50.353000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:05:50.500000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:06:50.560000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:06:50.697000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:07:50.845000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:07:50.986000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:08:51.053000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:08:51.192000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:09:51.263000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:09:51.451000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:10:51.522000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:10:51.698000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:11:51.768000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:11:51.914000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:12:51.985000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:12:52.140000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:13:52.205000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:13:52.358000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:14:52.429000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:14:52.571000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:15:52.642000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:15:52.786000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:16:52.856000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:16:53.002000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:17:53.080000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:17:53.233000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:18:53.306000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:18:53.445000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:19:53.519000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:19:53.655000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:20:53.715000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:20:53.866000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:21:53.947000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:21:54.081000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:22:54.147000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:22:54.285000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:23:54.349000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:23:54.491000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:24:54.540000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:24:54.690000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:25:54.773000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:25:54.934000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:26:55.008000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:26:55.148000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:27:55.232000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:27:55.378000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:28:55.448000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:28:55.595000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:29:55.664000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:29:55.807000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:30:55.881000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:30:56.066000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:31:56.165000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:31:56.318000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:32:56.388000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:32:56.524000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:33:56.589000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:33:56.729000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:34:56.794000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:34:56.980000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:35:57.062000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:35:57.216000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:36:57.290000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:36:57.415000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:37:57.493000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:37:57.639000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:38:57.700000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:38:57.835000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:39:57.893000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:39:58.032000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:40:58.112000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:40:58.265000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:41:58.337000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:41:58.481000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:42:58.549000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:42:58.717000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:43:58.783000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:43:58.932000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:44:58.996000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:44:59.141000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:45:59.207000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:45:59.331000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:46:59.400000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:46:59.531000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:47:59.609000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:47:59.758000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:48:59.823000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:48:59.975000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:50:00.038000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:50:00.184000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:51:00.250000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:51:00.399000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:52:00.480000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:52:00.626000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:53:00.687000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:53:00.834000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:54:00.896000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:54:01.042000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:55:01.107000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:55:01.243000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:56:01.302000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:56:01.466000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:57:01.540000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:57:01.721000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:58:01.792000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:58:01.946000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T05:59:02.016000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T05:59:02.154000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:00:02.230000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:00:02.377000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:01:02.479000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:01:02.634000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:02:02.706000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:02:02.884000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:03:02.957000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:03:03.122000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:04:03.186000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:04:03.326000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:05:03.393000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:05:03.542000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:06:03.610000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:06:03.801000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForParity"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:06:03.801000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Evaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:06:04.011000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Evaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:06:04.011000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:06:04.171000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:07:04.246000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:07:04.449000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:08:04.514000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:08:04.662000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:09:04.722000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:09:04.869000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:10:04.936000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:10:05.088000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:11:05.153000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:11:05.328000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:12:05.382000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:12:05.519000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:13:05.585000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:13:05.736000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:05.808000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:06.030000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForEvaluator"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:06.030000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "SaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:06.225000-07:00",
+    "stateExitedEventDetails": {
+      "name": "SaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:06.225000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForSaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:06.377000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForSaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:36.436000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForSaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:36.638000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForSaturdayHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:36.638000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:36.835000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:14:36.835000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:14:36.975000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:15:07.107000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WaitForWeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:15:07.298000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WaitForWeeklySubstrateHealthCheck"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:15:07.298000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "ReportCard"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:15:43.801000-07:00",
+    "stateExitedEventDetails": {
+      "name": "ReportCard"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:15:43.801000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "Director"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:20:43.895000-07:00",
+    "stateExitedEventDetails": {
+      "name": "Director"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:20:43.895000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "PublishDirectorDegraded"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:20:44.069000-07:00",
+    "stateExitedEventDetails": {
+      "name": "PublishDirectorDegraded"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:20:44.069000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "NotifyCompleteHealthDegraded"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:20:44.210000-07:00",
+    "stateExitedEventDetails": {
+      "name": "NotifyCompleteHealthDegraded"
+    }
+  },
+  {
+    "type": "TaskStateEntered",
+    "timestamp": "2026-08-08T06:20:44.210000-07:00",
+    "stateEnteredEventDetails": {
+      "name": "WriteCompletionMarker"
+    }
+  },
+  {
+    "type": "TaskStateExited",
+    "timestamp": "2026-08-08T06:20:44.396000-07:00",
+    "stateExitedEventDetails": {
+      "name": "WriteCompletionMarker"
+    }
+  }
+]


### PR DESCRIPTION
## Finding (alpha-engine-config-I10574)

`floor_calibration.py --check` reported nonsense floors on 2026-09-12 (run 34715654687):

```
WaitForMorningEnrich  current 1500s  n_genuine=10  min_genuine=30.0   recommended 26s
WaitForDataPhase1     current 4020s  n_genuine=10  min_genuine=30.0   recommended 26s
RAGIngestion          current  600s  n_genuine=11  min_genuine=0.0    recommended 0s
PredictorTraining     current 1200s  n_genuine=11  min_genuine=0.0    recommended 0s
Backtester            current  600s  n_genuine=15  min_genuine=0.0    recommended 0s
```

**Root cause, measured live** (`AWS_PROFILE=ne-admin` against `ne-weekly-freshness-pipeline`'s full SUCCEEDED-execution history, 48 executions, 2026-09-12):

1. **Wrong event pair.** `RAGIngestion` / `PredictorTraining` / `Backtester` are DISPATCH Task states (fire an SSM/spot command, return in 0.19-0.24s) — exactly the shape `WaitForMorningEnrich`/`WaitForDataPhase1` were already renamed off of under `alpha-engine-config-I10545`. The real workload runs in a poll loop entered immediately after, under `WaitForRAGIngestion` / `WaitForPredictorTraining` / `WaitForBacktester`. Measured against the one genuine EventBridge-triggered SUCCEEDED execution in the account's full history carrying these states (`9b34ac0f-5e2f-f70b-d668-61b4c4751654_6fb6adf9-55fa-4426-6d06-79e4579bcaff`, 2026-08-08):

   | dispatch (wrong) | span | poll companion (correct) | span |
   |---|---|---|---|
   | RAGIngestion | 0.189s | WaitForRAGIngestion | 1057s (17m37s) |
   | PredictorTraining | 0.197s | WaitForPredictorTraining | 421s (7m1s) |
   | Backtester | 0.238s | WaitForBacktester | 662s (11m2s) |

2. **Non-representative execution population.** `ne-weekly-freshness-pipeline`'s SUCCEEDED history mixes the daily EventBridge-triggered execution (name `<uuid>_<uuid>`) with ad hoc `watch-rerun-*` / `offcycle-shell-*` / `friday-shell-*` / `recovery-*` reruns and bare-UUID manual invocations, whose bootstrap/skip semantics differ (they skip already-processed phases). Measured: every ad hoc execution's `WaitForMorningEnrich`/`WaitForDataPhase1` span was 30-151s (one to a handful of poll iterations); the one canonical execution spans 1662s/2417s. Averaging both populations together is exactly how `min_genuine` landed on 30.0s (the bare poll interval) for both states.

## Fix

- `execution_digest.STATE_DURATION_FLOORS_SEC` / `DIGEST_STATE_ORDER`: renamed `RAGIngestion → WaitForRAGIngestion`, `PredictorTraining → WaitForPredictorTraining`, `Backtester → WaitForBacktester` (floor values unchanged — no genuine recalibration basis exists yet, see below). Also fixed `build_state_durations`'s S3-attestation trigger, which hardcoded the OLD dispatch names and would have silently stopped attesting once the floor rename landed.
- `floor_calibration.STATE_TO_STATE_MACHINE`: same rename.
- `collect_state_duration_samples` now tags every sample with an `exclusion_reason` (never silently dropped): a 0-duration sample ("this Task fires a dispatch... the workload runs in a companion poll state, not here"), or — scoped to `ne-weekly-freshness-pipeline` only via `_CANONICAL_EXECUTION_NAME_RE` — a non-canonical execution name. `compute_recommendation` independently re-enforces the zero-duration exclusion (defense in depth) and reports an `exclusion_breakdown` count per reason.
- `FloorRecommendation` carries a new `event_pair` field naming exactly which HistoryEvent pair was measured for every state (deliverable 3), rendered as new CSV columns in `render_report`.
- New fixture `tests/fixtures/sf_history_weekly_canonical_2026-08-08.json` — the real 2026-08-08 canonical execution, redacted to `{type, name, timestamp}` only (fetched with `includeExecutionData=False`, so no payload was ever present).

## Corrected `--check` output (live, `AWS_PROFILE=ne-admin`, 2026-09-12)

```
state,status,current_floor_sec,n_genuine,n_excluded,recommended_floor_sec,event_pair,exclusion_breakdown,basis
WaitForMorningEnrich,unmeasurable,1500,1,9,,"TaskStateEntered/TaskStateExited on 'WaitForMorningEnrich' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","9 non-canonical-execution","only 1 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
WaitForDataPhase1,unmeasurable,4020,1,9,,"TaskStateEntered/TaskStateExited on 'WaitForDataPhase1' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","9 non-canonical-execution","only 1 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
WaitForRAGIngestion,unmeasurable,600,1,10,,"TaskStateEntered/TaskStateExited on 'WaitForRAGIngestion' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","10 non-canonical-execution","only 1 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
WaitForPredictorTraining,unmeasurable,1200,1,10,,"TaskStateEntered/TaskStateExited on 'WaitForPredictorTraining' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","10 non-canonical-execution","only 1 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
WaitForBacktester,unmeasurable,600,1,14,,"TaskStateEntered/TaskStateExited on 'WaitForBacktester' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","14 non-canonical-execution","only 1 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
ModelZooTrainMap,unmeasurable,480,0,0,,"TaskStateEntered/TaskStateExited on 'ModelZooTrainMap' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","","only 0 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
PollMorningEnrichSpot,unmeasurable,90,0,37,,"TaskStateEntered/TaskStateExited on 'PollMorningEnrichSpot' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","37 poll-status-failure","only 0 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
PollMorningArcticAppendSpot,unmeasurable,1200,0,37,,"TaskStateEntered/TaskStateExited on 'PollMorningArcticAppendSpot' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","37 poll-status-failure","only 0 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
Scanner,unmeasurable,60,7,0,,"TaskStateEntered/TaskStateExited on 'Scanner' (stateEnteredEventDetails.name / stateExitedEventDetails.name), first entry -> last exit","","only 7 genuine sample(s), below MIN_SAMPLES=10 — no recommendation computed; floor left as-is and recorded unmeasurable, never defaulted to 0 and never dropped from the report"
(exit 0 — "every floor is within tolerance or unmeasurable")
```

Given the account's SUCCEEDED history has exactly one canonical weekly execution carrying these states (n=1 < `MIN_SAMPLES=10`), every renamed/affected state now correctly reports `unmeasurable` — honest given the data, not the fabricated `drift_loosen`/`0.0` this issue reported. `sf-arn-drift-check.yml`'s `floor_calibration_drift` step exits 0 whenever nothing is `drift_*`/`degenerate` — `unmeasurable` does not fail the check.

## Test plan

- `python3 -m pytest infrastructure/lambdas/sf-telegram-notifier/test_floor_calibration.py infrastructure/lambdas/sf-telegram-notifier/test_execution_digest.py infrastructure/lambdas/sf-telegram-notifier/test_handler.py infrastructure/lambdas/sf-telegram-notifier/test_terminal_delivery_guarantee.py -q` → 122 passed.
- `python3 -m pytest infrastructure/lambdas/sf-telegram-notifier/test_flow_doctor_fleet_wiring.py -q` (run separately) → 1 passed. Run together with the others in one pytest session it fails with `ImportError: cannot import name 'fleet_telegram_notifier_dicts' from 'nousergon_lib.flow_doctor_fleet' (unknown location)` — confirmed **pre-existing test-order pollution unrelated to this change** (present on `main`, reproduces with none of this PR's files touched; the same import succeeds cleanly in isolation and outside pytest). Not fixed here — out of scope for I10574 and this PR touches only `floor_calibration.py`/`execution_digest.py`/their tests. Also pre-existing and out of scope: `test_eod_artifact_verification.py` fails collection (`ModuleNotFoundError: No module named 'eod_artifact_verification'` — the module file does not exist in this repo at all, unrelated to this change).
- `python3 floor_calibration.py --check` run locally with `AWS_PROFILE=ne-admin` (read-only) — output above.

Repo has no `uv.lock`; ran with bare `python3 -m pytest` per this repo's own `tests/` convention (the `infrastructure/lambdas/*` dirs run standalone, outside `pyproject.toml`'s `testpaths`).

## Collateral finding — filed separately

The corrected `--check` output above also surfaces `PollMorningEnrichSpot`/`PollMorningArcticAppendSpot` reporting `n_genuine=0` with `37 poll-status-failure` each — `execution_digest.fetch_execution_history` hardcodes `includeExecutionData=False`, so the `KNOWN_POLL_STATUS_KEYS` poll-status extraction these two states depend on has never worked through the automated `--check` path (their I10164 floors were derived from a one-off manual analysis, not this mechanism). Pre-existing, unrelated to this PR's changes, out of scope here. Filed as **alpha-engine-config-I10591**.

## Not done / follow-up

`WaitForRAGIngestion`/`WaitForPredictorTraining`/`WaitForBacktester`'s floors (600/1200/600s) are UNCHANGED, not recalibrated — the account has only one genuine canonical sample for them (n=1 < MIN_SAMPLES=10), so no recalibration basis exists yet. Once more canonical Saturday runs SUCCEED, the automated weekly `--check` will recalibrate them on its own (that is the loop this module exists to close) — no separate tracked item needed.

Refs alpha-engine-config-I10574, alpha-engine-config-I9345 (cross-repo — GitHub only honors closing keywords for an issue in the PR's own repo; neither auto-closes on this PR's merge. I10574 should be closed by hand once this merges, citing this PR and the corrected `--check` output above as verification; I9345 auto-clears via the sched-health sweep once `sf-arn-drift-check.yml` is green on `main`).

Prepared by: Claude Fable 5.1 (claude-fable-5-1) via [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8mzZ8rZ8b6DE3XuMrNXJW
