### PR TITLE
Add crucible-v2/heartbeat alert-class rows (alpha-engine-config-I10593)

### DIFF
--- a/infrastructure/overseer/playbooks.yaml
+++ b/infrastructure/overseer/playbooks.yaml
@@ -1196,6 +1196,47 @@ alert_classes:
     # derived: error-capable, automated response declared
     tier: notify-silent
 
+  # ── crucible v2 (crucible/alerts.py) ──
+  # alpha-engine-config-I10593. `crucible.alerts` publishes the daily v2
+  # heartbeat through krepis with source="crucible-v2/heartbeat"
+  # (crucible/alerts.py ~line 2018; dedup_key=heartbeat:{trading_day}).
+  # severity is `info` on a normal proof-of-life beat and `error` when a
+  # prefix is unwatched, the subscriber set is empty, or the cost ledgers
+  # diverge — three distinct real findings, not a lifecycle notice. Until
+  # 2026-09-11 the write was swallowed by an IAM denial (I10093); the first
+  # delivery after the grant paged as an unregistered class (fail-upward
+  # default, correct behaviour for a source with no row — do not change the
+  # publisher). The matrix's derived tier->severity default (`dynamic`: info
+  # ->tracked-only, error->notify-silent, critical->page) does not fit here:
+  # this heartbeat's `error` case is a real actionable break and must PAGE,
+  # not just buzz silently, so the class is split into two rows keyed by
+  # severity rather than declared [dynamic] — mirroring the
+  # data_spot_quota_fallback / lib_spot_quota_fallback split-by-condition
+  # shape elsewhere in this file, applied here to severity instead of source.
+  - class: crucible_v2_heartbeat_info
+    # DECLARED: a normal daily beat is proof of life only — heartbeat/tracked-
+    # only tier, never a page. Same shape as groom_lifecycle_bus_events' info
+    # case (informational lifecycle heartbeat, zero defect surface).
+    source: "crucible-v2/heartbeat"
+    severities: [info]
+    intake: bus
+    response: drain-queue
+    tier: tracked-only
+  - class: crucible_v2_heartbeat_error
+    # DECLARED: `error` here names one of three real findings (unwatched
+    # prefix, empty subscriber set, or cost-ledger divergence) — each is
+    # actionable-now, so unlike the info case this PAGES.
+    source: "crucible-v2/heartbeat"
+    severities: [error]
+    intake: bus
+    response: drain-queue
+    tier: page
+    operator_reason: >-
+      Deliberate page-by-design (alpha-engine-config-I10593), not a tracked
+      gap: an unwatched prefix, an empty alert-subscriber set, or a diverged
+      cost ledger are each an actionable-now break in crucible v2's
+      observability surface, not a lifecycle notice like the info case above.
+
   # ── data plane (nousergon-data) ──
   - class: data_constituents_drift
     source: "alpha-engine-data/validators/constituents_drift_check.py"


### PR DESCRIPTION
## Summary

`crucible.alerts` publishes the daily v2 heartbeat through krepis with `source="crucible-v2/heartbeat"` (`crucible/alerts.py` ~line 2018; `info` = proof of life, `error` when a prefix is unwatched, the subscriber set is empty, or the cost ledgers diverge; `dedup_key=heartbeat:{trading_day}`). With no row in `infrastructure/overseer/playbooks.yaml`, every daily heartbeat pages Brian as an unregistered class (fail-upward default) since the 2026-09-11 IAM grant unblocked the publish.

Adds two `alert_classes` rows keyed by severity, since the registry's `dynamic` tier default (`error`->`notify-silent`) would under-page this class's real error findings:

- `crucible_v2_heartbeat_info` — `severities: [info]`, `tier: tracked-only` (proof of life, never pages).
- `crucible_v2_heartbeat_error` — `severities: [error]`, `tier: page`, with an `operator_reason` declaring this a deliberate page-by-design (not a tracked gap) per overseer-policy.md invariant 4.

Does not touch the publisher — the fail-upward default is correct behaviour for an unregistered class.

## Cross-repo

Tracked in `alpha-engine-config-I10593` (nousergon/alpha-engine-config). GitHub's closing keywords only auto-close an issue in the PR's own repo, so this PR does **not** auto-close it — the issue will be closed by hand once merged, citing this PR and the verified closes-when below.

**Closes-when:** the next `crucible-v2/heartbeat` delivery logs no "no row in the alert-class registry" line, and the `info` emission does not page (checked against `/crucible/heartbeat` the following day).

## Test plan

- [x] `infrastructure/overseer/playbooks.yaml` validates against `infrastructure/overseer/playbooks.schema.json` (`jsonschema.validate`, passed).
- [x] `tests/test_overseer_playbook_registry.py`, `tests/test_alert_class_pr_guard.py`, `tests/test_alert_class_registry_drift.py`, `tests/test_alert_tier_registry.py`, `tests/test_alert_class_response_gap.py`, `tests/test_trigger_surface_drift.py` — 154 passed, 1 skipped.
- [x] Full suite `pytest tests/ -q --ignore=tests/integration` — 6525 passed, 1 pre-existing unrelated failure (`tests/test_stage_output_sweep.py::TestWildcardSegment::test_resolve_key_passes_the_wildcard_through`, reproduces identically on `main` — `nousergon_lib.artifact_freshness` missing `has_wildcard_segment`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMrf6UbUhbb417YxTpyADp
